### PR TITLE
Rename IntegreatAPI bot to DigitalfabrikMember

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,8 +176,8 @@ jobs:
       - run:
           name: Prepare git config
           command: |
-            git config --global user.name IntegreatAPI
-            git config --global user.email 41921676+IntegreatAPI@users.noreply.github.com
+            git config --global user.name DigitalfabrikMember
+            git config --global user.email 41921676+DigitalfabrikMember@users.noreply.github.com
       - run:
           name: Clone existing gh-pages branch into temporary directory
           command: git clone --depth=1 $CIRCLE_REPOSITORY_URL -b $BRANCH $TMP_DIR

--- a/sphinx/continuous-integration.rst
+++ b/sphinx/continuous-integration.rst
@@ -88,7 +88,7 @@ It passes the html documentation in ``docs`` to the :ref:`circleci-deploy-docume
 deploy-documentation
 --------------------
 
-This job authenticates as the user `IntegreatAPI <https://github.com/IntegreatAPI>`_ and commits all changes to the
+This job authenticates as the user `DigitalfabrikMember <https://github.com/DigitalfabrikMember>`_ and commits all changes to the
 documentation to the branch `gh-pages <https://github.com/Integreat/cms-django/tree/gh-pages>`_
 which is then deployed to ``https://integreat.github.io/cms-django/`` by GitHub.
 

--- a/sphinx/documentation.rst
+++ b/sphinx/documentation.rst
@@ -98,7 +98,7 @@ If you want to provide new substitutions, add them to :const:`~conf.rst_epilog`.
 GitHub Pages
 ============
 
-The CircleCI job ``deploy-documentation`` uses the GitHub user `IntegreatAPI <https://github.com/IntegreatAPI>`__ to
+The CircleCI job ``deploy-documentation`` uses the GitHub user `DigitalfabrikMember <https://github.com/DigitalfabrikMember>`__ to
 push all changes to the documentation on the ``develop`` branch to our repository's ``gh-pages`` branch.
 This branch is then automatically deployed to |github-pages-url|.
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Since the name of our bot user changed, we should adapt the new name in our circleci config

