### PR TITLE
Fix typo in settings file

### DIFF
--- a/src/backend/settings.py
+++ b/src/backend/settings.py
@@ -636,7 +636,7 @@ USE_TZ = True
 # STATIC FILES #
 ################
 
-if "DJANGO_STATIC_PARENT" in os.environ:
+if "DJANGO_STATIC_ROOT" in os.environ:
     STATIC_ROOT = os.environ["DJANGO_STATIC_ROOT"]
 else:
     #: The absolute path to the directory where :mod:`django.contrib.staticfiles` will collect static files for


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
I found a typo in the settings file which caused the static files to not work properly on the dev server

