### PR TITLE
Set webpack stats file path in settings

### DIFF
--- a/src/backend/settings.py
+++ b/src/backend/settings.py
@@ -760,6 +760,7 @@ CHANNELS = (("News", "News"),)
 WEBPACK_LOADER = {
     "DEFAULT": {
         "BUNDLE_DIR_NAME": "",
+        "STATS_FILE": os.path.join(BASE_DIR, "../", "webpack-stats.json"),
     }
 }
 


### PR DESCRIPTION
Set the path to the webpack-stats.json file in the settings.py. Does this make sense @melegiul ? It seems we use a different path, but basically this is almost the same as the example in https://github.com/django-webpack/django-webpack-loader#default-configuration.