### PR TITLE
Fix crash after creating a new region

### DIFF
--- a/src/cms/models/regions/region.py
+++ b/src/cms/models/regions/region.py
@@ -4,6 +4,7 @@ from html import escape
 from django.contrib.auth import get_user_model
 from django.db import models
 from django.utils import timezone
+from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
 from django.utils.translation import activate
 from django.utils.translation import get_language
@@ -202,7 +203,7 @@ class Region(models.Model):
             "language_tree_nodes__level", "language_tree_nodes__lft"
         )
 
-    @property
+    @cached_property
     def default_language(self):
         """
         This property returns the language :class:`~cms.models.languages.language.Language` which corresponds to the
@@ -214,15 +215,17 @@ class Region(models.Model):
         tree_root = self.language_tree_nodes.filter(level=0).first()
         return tree_root.language if tree_root else None
 
-    @property
+    @cached_property
     def prefix(self):
         """
-        This property returns the administrative division of a region if it's included in the name
+        This property returns the administrative division of a region if it's included in the name.
+        If this region has no default language, this property returns an empty string
 
         :return: The prefix of the region
         :rtype: str
         """
-        if self.administrative_division_included:
+
+        if self.administrative_division_included and self.default_language:
             # Get administrative division in region's default language
             current_language = get_language()
             activate(self.default_language.slug)

--- a/src/locale/de/LC_MESSAGES/django.po
+++ b/src/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-14 09:00+0000\n"
+"POT-Creation-Date: 2021-10-15 11:10+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1281,12 +1281,12 @@ msgstr "Einmalig stattfindende Veranstaltungen"
 msgid "Active"
 msgstr "Aktiv"
 
-#: cms/constants/region_status.py:17 cms/models/regions/region.py:398
+#: cms/constants/region_status.py:17 cms/models/regions/region.py:401
 msgid "Hidden"
 msgstr "Versteckt"
 
 #: cms/constants/region_status.py:18 cms/models/pages/page.py:237
-#: cms/models/pages/page_translation.py:360 cms/models/regions/region.py:401
+#: cms/models/pages/page_translation.py:360 cms/models/regions/region.py:404
 #: cms/templates/pages/page_form.html:153
 #: cms/templates/pages/page_tree_archived_node.html:13
 msgid "Archived"
@@ -1828,7 +1828,7 @@ msgstr "Chat-Nachrichten"
 #: cms/models/pages/imprint_page.py:22 cms/models/pages/page.py:47
 #: cms/models/pois/poi.py:19
 #: cms/models/push_notifications/push_notification.py:18
-#: cms/models/regions/region.py:417
+#: cms/models/regions/region.py:420
 msgid "region"
 msgstr "Region"
 
@@ -1879,7 +1879,7 @@ msgid "events"
 msgstr "Veranstaltungen"
 
 #: cms/models/events/event_translation.py:30
-#: cms/models/pois/poi_translation.py:25 cms/models/regions/region.py:41
+#: cms/models/pois/poi_translation.py:25 cms/models/regions/region.py:42
 msgid "URL parameter"
 msgstr "URL-Parameter"
 
@@ -1907,7 +1907,7 @@ msgstr ""
 
 #: cms/models/events/event_translation.py:42
 #: cms/models/pages/abstract_base_page_translation.py:18
-#: cms/models/pois/poi_translation.py:43 cms/models/regions/region.py:52
+#: cms/models/pois/poi_translation.py:43 cms/models/regions/region.py:53
 msgid "status"
 msgstr "Status"
 
@@ -1980,7 +1980,7 @@ msgstr "Ersteller"
 #: cms/models/pages/abstract_base_page_translation.py:37
 #: cms/models/pois/poi_translation.py:72
 #: cms/models/push_notifications/push_notification_translation.py:37
-#: cms/models/regions/region.py:106 cms/models/users/organization.py:37
+#: cms/models/regions/region.py:107 cms/models/users/organization.py:37
 msgid "modification date"
 msgstr "Änderungsdatum"
 
@@ -2116,7 +2116,7 @@ msgstr "Wenn das Feedback ungelesen ist, ist dieses Feld leer."
 #: cms/models/media/directory.py:34 cms/models/offers/offer_template.py:55
 #: cms/models/pages/abstract_base_page.py:19
 #: cms/models/push_notifications/push_notification.py:41
-#: cms/models/regions/region.py:102 cms/models/users/organization.py:33
+#: cms/models/regions/region.py:103 cms/models/users/organization.py:33
 #: cms/models/users/user_mfa_key.py:37
 msgid "creation date"
 msgstr "Erstellungsdatum"
@@ -2318,7 +2318,7 @@ msgid "language tree nodes"
 msgstr "Sprach-Knoten"
 
 #: cms/models/media/directory.py:15 cms/models/media/media_file.py:119
-#: cms/models/offers/offer_template.py:16 cms/models/regions/region.py:26
+#: cms/models/offers/offer_template.py:16 cms/models/regions/region.py:27
 #: cms/models/users/organization.py:13 cms/models/users/role.py:18
 msgid "name"
 msgstr "Name"
@@ -2371,7 +2371,7 @@ msgstr "Medien-Dateien"
 msgid "slug"
 msgstr "URL-Parameter"
 
-#: cms/models/offers/offer_template.py:24 cms/models/regions/region.py:44
+#: cms/models/offers/offer_template.py:24 cms/models/regions/region.py:45
 msgid "Leave blank to generate unique parameter from name"
 msgstr ""
 "Dieses Feld freilassen, um einen eindeutigen Alias aus dem Namen zu "
@@ -2400,7 +2400,7 @@ msgstr "POST-Parameter"
 msgid "Additional POST data for retrieving the URL."
 msgstr "Zusätzliche POST-Daten zum Abrufen der URL."
 
-#: cms/models/offers/offer_template.py:39 cms/models/regions/region.py:69
+#: cms/models/offers/offer_template.py:39 cms/models/regions/region.py:70
 msgid "Specify as JSON."
 msgstr "Als JSON angeben."
 
@@ -2594,7 +2594,7 @@ msgstr "Leer"
 msgid "street and house number"
 msgstr "Straße und Hausnummer"
 
-#: cms/models/pois/poi.py:24 cms/models/regions/region.py:94
+#: cms/models/pois/poi.py:24 cms/models/regions/region.py:95
 msgid "postal code"
 msgstr "Postleitzahl"
 
@@ -2606,7 +2606,7 @@ msgstr "Stadt"
 msgid "country"
 msgstr "Land"
 
-#: cms/models/pois/poi.py:28 cms/models/regions/region.py:86
+#: cms/models/pois/poi.py:28 cms/models/regions/region.py:87
 msgid "latitude"
 msgstr "Geographische Breite"
 
@@ -2614,7 +2614,7 @@ msgstr "Geographische Breite"
 msgid "The latitude coordinate"
 msgstr "Die Breitengrad-Koordinate"
 
-#: cms/models/pois/poi.py:31 cms/models/regions/region.py:91
+#: cms/models/pois/poi.py:31 cms/models/regions/region.py:92
 msgid "longitude"
 msgstr "Geographische Länge"
 
@@ -2701,89 +2701,89 @@ msgstr "Push-Benachrichtigungs-Übersetzung"
 msgid "push notification translations"
 msgstr "Push-Benachrichtigungs-Übersetzungen"
 
-#: cms/models/regions/region.py:32
+#: cms/models/regions/region.py:33
 msgid "community identification number"
 msgstr "Amtlicher Gemeindeschlüssel"
 
-#: cms/models/regions/region.py:34
+#: cms/models/regions/region.py:35
 msgid ""
 "Number sequence for identifying politically independent administrative units"
 msgstr ""
 "Ziffernfolge zur Identifizierung politisch selbständiger Verwaltungseinheiten"
 
-#: cms/models/regions/region.py:43 cms/models/users/organization.py:19
+#: cms/models/regions/region.py:44 cms/models/users/organization.py:19
 msgid "Unique string identifier without spaces and special characters."
 msgstr "Eindeutiger Bezeichner ohne Leerzeichen und Sonderzeichen."
 
-#: cms/models/regions/region.py:61
+#: cms/models/regions/region.py:62
 msgid "administrative division"
 msgstr "Verwaltungseinheit"
 
-#: cms/models/regions/region.py:65
+#: cms/models/regions/region.py:66
 msgid "aliases"
 msgstr "Aliasnamen"
 
-#: cms/models/regions/region.py:67
+#: cms/models/regions/region.py:68
 msgid "E.g. smaller municipalities in that area."
 msgstr "Z.B. kleinere Gemeinden in der Region."
 
-#: cms/models/regions/region.py:68
+#: cms/models/regions/region.py:69
 msgid "If empty, the CMS will try to fill this automatically."
 msgstr "Wird, wenn leer, automatisch vom CMS befüllt."
 
-#: cms/models/regions/region.py:75
+#: cms/models/regions/region.py:76
 msgid "activate events"
 msgstr "Veranstaltungen aktivieren"
 
-#: cms/models/regions/region.py:76
+#: cms/models/regions/region.py:77
 msgid "Whether or not events are enabled in the region"
 msgstr "Ob Veranstaltungen in der Region aktiviert sind oder nicht"
 
-#: cms/models/regions/region.py:80
+#: cms/models/regions/region.py:81
 msgid "activate push notifications"
 msgstr "Push-Benachrichtigungen aktivieren"
 
-#: cms/models/regions/region.py:81
+#: cms/models/regions/region.py:82
 msgid "Whether or not push notifications are enabled in the region"
 msgstr "Ob Push-Benachrichtigungen in der Region aktiviert sind oder nicht"
 
-#: cms/models/regions/region.py:87
+#: cms/models/regions/region.py:88
 msgid "The latitude coordinate of an approximate center of the region"
 msgstr "Die Breitengrad-Koordinate eines ungefähren Mittelpunkts der Region"
 
-#: cms/models/regions/region.py:92
+#: cms/models/regions/region.py:93
 msgid "The longitude coordinate of an approximate center of the region"
 msgstr "Die Längengrad-Koordinate eines ungefähren Mittelpunkts der Region"
 
-#: cms/models/regions/region.py:97
+#: cms/models/regions/region.py:98
 msgid "email address of the administrator"
 msgstr "E-Mail-Adresse des Administrators"
 
-#: cms/models/regions/region.py:111
+#: cms/models/regions/region.py:112
 msgid "activate statistics"
 msgstr "Statistiken aktivieren"
 
-#: cms/models/regions/region.py:112
+#: cms/models/regions/region.py:113
 msgid "Whether or not statistics are enabled for the region"
 msgstr "Ob Statistiken für die Region aktiviert sind oder nicht"
 
-#: cms/models/regions/region.py:117
+#: cms/models/regions/region.py:118
 msgid "Matomo ID"
 msgstr "Matomo ID"
 
-#: cms/models/regions/region.py:119
+#: cms/models/regions/region.py:120
 msgid "The Matomo ID of this region."
 msgstr "Die Matomo ID dieser region."
 
-#: cms/models/regions/region.py:120
+#: cms/models/regions/region.py:121
 msgid "Will be automatically derived from the Matomo access token."
 msgstr "Wird automatisch vom Matomo Zugangstoken abgeleitet."
 
-#: cms/models/regions/region.py:127
+#: cms/models/regions/region.py:128
 msgid "Matomo authentication token"
 msgstr "Matomo Authentifizierungs-Token"
 
-#: cms/models/regions/region.py:129
+#: cms/models/regions/region.py:130
 msgid ""
 "The secret Matomo access token of the region is used to authenticate in API "
 "requests"
@@ -2791,11 +2791,11 @@ msgstr ""
 "Das geheime Matomo-Zugangs-Token der Region wird zur Authentifizierung bei "
 "API-Anfragen verwendet"
 
-#: cms/models/regions/region.py:135
+#: cms/models/regions/region.py:136
 msgid "activate page-specific permissions"
 msgstr "Seiten-spezifische-Berechtigungen aktivieren"
 
-#: cms/models/regions/region.py:137
+#: cms/models/regions/region.py:138
 msgid ""
 "This allows individual users to be granted the right to edit or publish a "
 "specific page."
@@ -2803,26 +2803,26 @@ msgstr ""
 "Damit kann einzelnen Benutzern das Recht zum Bearbeiten oder Veröffentlichen "
 "einer bestimmten Seite eingeräumt werden."
 
-#: cms/models/regions/region.py:143 cms/models/users/organization.py:24
+#: cms/models/regions/region.py:144 cms/models/users/organization.py:24
 msgid "logo"
 msgstr "Logo"
 
-#: cms/models/regions/region.py:152
+#: cms/models/regions/region.py:153
 msgid "activate author chat"
 msgstr "Autoren-Chat aktivieren"
 
-#: cms/models/regions/region.py:154
+#: cms/models/regions/region.py:155
 msgid ""
 "This gives all users of this region access to the cross-regional author chat."
 msgstr ""
 "Dies gewährt allen Benutzern dieser Region Zugang zum überregionalen Autoren-"
 "Chat."
 
-#: cms/models/regions/region.py:160
+#: cms/models/regions/region.py:161
 msgid "include administrative division into name"
 msgstr "Verwaltungseinheit dem Namen hinzufügen"
 
-#: cms/models/regions/region.py:163
+#: cms/models/regions/region.py:164
 msgid ""
 "Determines whether the administrative division is displayed next to the "
 "region name."
@@ -2830,7 +2830,7 @@ msgstr ""
 "Legt fest, ob die Verwaltungseinheit neben dem Namen der Region angezeigt "
 "wird."
 
-#: cms/models/regions/region.py:166
+#: cms/models/regions/region.py:167
 msgid ""
 "Sorting is always based on the name, independently from the administrative "
 "division."
@@ -2838,11 +2838,11 @@ msgstr ""
 "Sortierungen werden immer auf Grundlage der Namen vorgenommen, unabhängig "
 "von der Verwaltungseinheit."
 
-#: cms/models/regions/region.py:175
+#: cms/models/regions/region.py:176
 msgid "offers"
 msgstr "Angebote"
 
-#: cms/models/regions/region.py:178
+#: cms/models/regions/region.py:179
 msgid ""
 "Integreat offers are extended features apart from pages and events and are "
 "usually offered by a third party."
@@ -2850,7 +2850,7 @@ msgstr ""
 "Integreat Angebote sind erweiterte Funktionen jenseits von Seiten und "
 "Ereignissen und werden in der Regel von Drittanbietern bereitgestellt."
 
-#: cms/models/regions/region.py:181
+#: cms/models/regions/region.py:182
 msgid ""
 "In most cases, the url is an external API endpoint which the frontend apps "
 "can query and render the results inside the Integreat app."
@@ -2859,15 +2859,15 @@ msgstr ""
 "Frontend Anfragen gesendet werden, um die Ergebnisse in der Integreat App "
 "einzubetten."
 
-#: cms/models/regions/region.py:188
+#: cms/models/regions/region.py:189
 msgid "Activate short urls"
 msgstr "Kurz-URLs aktivieren"
 
-#: cms/models/regions/region.py:189
+#: cms/models/regions/region.py:190
 msgid "Please check the box if you want to use short urls."
 msgstr "Kreuzen Sie an, wenn Sie Kurz-URLs benutzen wollen."
 
-#: cms/models/regions/region.py:419 cms/models/users/user.py:28
+#: cms/models/regions/region.py:422 cms/models/users/user.py:28
 msgid "regions"
 msgstr "Regionen"
 


### PR DESCRIPTION
### Short description
This pr fixes a persistent crash after creating a new region with the checkbox 'Include administrative division into name' checked.
The problem is that a newly created region does not have a default language. When the system tries to generate a full name, however, it needs a default language in order to translate the administrative division.

### Proposed changes
This pr fixes the issue by just returning an empty string from the `Region.prefix` method in case no default language was found. 
An alternative would be to make sure that a region always has a default language, but that would require some changes which might not be desired, for example removing the ability to delete the root language in the language tree.

Additionally, this pr removes some unnecessary database queries by using django's `cached_property` decorator. On the language-tree page with a single language, the number of queries drops from 29 to 13.

### Resolved issues
Fixes: #971
