### PR TITLE
Fix documentation build

### DIFF
--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -68,7 +68,7 @@ intersphinx_mapping = {
         f"https://docs.python.org/{sys.version_info.major}.{sys.version_info.minor}/",
         None,
     ),
-    "pipenv": ("https://pipenv.pypa.io/en/latest/", None),
+    # "pipenv": ("https://pipenv.pypa.io/en/latest/", None),
     "requests": ("https://requests.readthedocs.io/en/master/", None),
     "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
     "sphinx-rtd-theme": (

--- a/sphinx/virtualenv.rst
+++ b/sphinx/virtualenv.rst
@@ -4,7 +4,7 @@ Virtual Environment (Pipenv)
 
 All python dependencies are installed in a virtual Python environment (see :doc:`tutorial/venv`).
 
-As package manager for the virtual environment we use Pipenv (see :doc:`pipenv:index`)
+As package manager for the virtual environment we use Pipenv
 
 For portability and reproducibility, we use specific version of our dependencies locked in :github-source:`Pipfile.lock`.
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
I thought the pipenv documentation was only temporarily unavailable, but it has been two weeks now and the maintainers do not respond. So I suggest to remove the intersphinx mapping from our documentation.

See also:
- https://github.com/pypa/pipenv/issues/4794
- https://github.com/pypa/pipenv/issues/4805

The disadvantage of doing this now is that the history of our documentation branch will be in the incorrect order if we decide to restart all our failed builds once the pipenv documentation is fixed...

### Proposed changes
<!-- Describe this PR in more detail. -->
- Remove intersphinx mapping to pipenv documentation

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes failing documentation build
