### PR TITLE
Changes language tabs, fixes #1030

### DIFF
--- a/integreat_cms/cms/templates/pages/page_form.html
+++ b/integreat_cms/cms/templates/pages/page_form.html
@@ -55,11 +55,11 @@
             {% endif %}
         </div>
         <div class="flex flex-wrap flex-col flex-grow pr-2 w-2/3">
-            <ul class="flex flex-wrap items-end pl-4">
+            <ul class="flex flex-wrap flex-wrap-reverse items-end pl-4">
                 {% for other_language in languages %}
-                    <li class="mr-1 {% if other_language == language %}z-10{% endif %}" style="margin-bottom: -2px">
-                        <div class="bg-white text-blue-500 {% if other_language != language %}hover:bg-blue-500 hover:text-white{% endif %} border-l-2 border-t-2 border-r-2 border-blue-500 font-bold rounded-t-lg">
-                            <div class="border-b-2 border-white">
+                    <li class="mr-1 mt-1 {% if other_language == language %}z-10{% endif %}" style="margin-bottom: -2px">
+                        <div class=" {% if other_language != language %} bg-blue-500 border-blue-500 text-white {% else %} bg-white text-blue-500 hover:bg-blue-500 hover:text-white {% endif %} border-l-2 border-t-2 border-r-2 border-blue-500 font-bold rounded-t-lg">
+                            <div class="{% if other_language == language %} border-b-2 border-white {% endif %}" >
                                 {% if other_language == language %}
                                     <div class="{{ language.slug }} px-4">
                                         {% if page %}
@@ -130,17 +130,23 @@
                         </div>
                     </li>
                 {% endfor %}
-                {% if page_translation_form.instance.id %}
-                    <li class="self-start ml-auto px-2">
-                        {% trans 'Version' %}:
-                        {{ page_translation_form.instance.version }}
-                        (<a href="{% url 'page_revisions' page_id=page.id region_slug=region.slug language_slug=language.slug %}"
-                            class="text-blue-500 hover:underline">{% trans 'Show versions' %}</a>)
-                    </li>
-                {% endif %}
+
             </ul>
             <div class="w-full mb-4 rounded border-2 border-blue-500 bg-white flex-auto">
                 <div class="w-full p-4">
+                    <!-- Version -->
+                    <div class="flex justify-end">
+                        <ul class="mr-8">
+                            {% if page_translation_form.instance.id %}
+                                <li class="self-start ml-auto">
+                                    {% trans 'Version' %}:
+                                    {{ page_translation_form.instance.version }}
+                                    (<a href="{% url 'page_revisions' page_id=page.id region_slug=region.slug language_slug=language.slug %}"
+                                        class="text-blue-500 hover:underline">{% trans 'Show versions' %}</a>)
+                                </li>
+                                {% endif %}
+                            </ul>
+                    </div>
                     <div class="flex justify-between">
                         <label for="{{ page_translation_form.title.id_for_label }}"
                             data-slugify-url="{% url 'slugify_ajax' region_slug=region.slug language_slug=language.slug model_type='page' %}{% if page_form.instance.id %}?model_id={{ page_form.instance.id }}{% endif %}">

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-23 19:24+0000\n"
+"POT-Creation-Date: 2021-12-03 10:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1287,7 +1287,7 @@ msgstr "Versteckt"
 
 #: cms/constants/region_status.py:18 cms/models/pages/page.py:270
 #: cms/models/pages/page_translation.py:377 cms/models/regions/region.py:456
-#: cms/templates/pages/page_form.html:153
+#: cms/templates/pages/page_form.html:159
 #: cms/templates/pages/page_tree_archived_node.html:13
 msgid "Archived"
 msgstr "Archiviert"
@@ -1588,7 +1588,7 @@ msgstr "Kategorie"
 #: cms/templates/imprint/imprint_sbs.html:116
 #: cms/templates/imprint/imprint_sbs.html:125
 #: cms/templates/linkcheck/links_by_filter.html:52
-#: cms/templates/pages/page_form.html:151
+#: cms/templates/pages/page_form.html:157
 #: cms/templates/pages/page_revisions.html:50
 #: cms/templates/pages/page_sbs.html:66 cms/templates/pages/page_sbs.html:123
 #: cms/templates/pages/page_sbs.html:128 cms/templates/pages/page_tree.html:77
@@ -3623,7 +3623,7 @@ msgstr "Übersetzung erstellen"
 #: cms/templates/imprint/imprint_sbs.html:57
 #: cms/templates/imprint/imprint_sbs.html:114
 #: cms/templates/imprint/imprint_sbs.html:124
-#: cms/templates/pages/page_form.html:135
+#: cms/templates/pages/page_form.html:142
 #: cms/templates/pages/page_revisions.html:24
 #: cms/templates/pages/page_sbs.html:64 cms/templates/pages/page_sbs.html:121
 #: cms/templates/pages/page_sbs.html:126 cms/templates/pois/poi_form.html:108
@@ -3905,7 +3905,7 @@ msgid "No feedback available yet."
 msgstr "Noch kein Feedback vorhanden."
 
 #: cms/templates/generic_confirmation_dialog.html:11
-#: cms/templates/pages/page_form.html:174
+#: cms/templates/pages/page_form.html:180
 msgid "Warning"
 msgstr "Warnung"
 
@@ -3947,7 +3947,7 @@ msgid "Create imprint"
 msgstr "Impressum erstellen"
 
 #: cms/templates/imprint/imprint_form.html:106
-#: cms/templates/pages/page_form.html:138
+#: cms/templates/pages/page_form.html:145
 msgid "Show versions"
 msgstr "Versionen anzeigen"
 
@@ -3962,18 +3962,18 @@ msgstr "Link zum Impressum"
 #: cms/templates/imprint/imprint_form.html:117
 #: cms/templates/imprint/imprint_sbs.html:63
 #: cms/templates/imprint/imprint_sbs.html:120
-#: cms/templates/pages/page_form.html:167
+#: cms/templates/pages/page_form.html:173
 msgid "Copy to clipboard"
 msgstr "In die Zwischenablage kopieren"
 
 #: cms/templates/imprint/imprint_form.html:115
 #: cms/templates/imprint/imprint_sbs.html:127
-#: cms/templates/pages/page_form.html:165
+#: cms/templates/pages/page_form.html:171
 msgid "Short URL"
 msgstr "Kurz-URL"
 
 #: cms/templates/imprint/imprint_form.html:141
-#: cms/templates/pages/page_form.html:291
+#: cms/templates/pages/page_form.html:297
 #: cms/templates/regions/region_list.html:25
 #: cms/templates/settings/user.html:93
 msgid "Actions"
@@ -4035,7 +4035,7 @@ msgid "Side-by-Side view"
 msgstr "Side-by-Side-Ansicht"
 
 #: cms/templates/imprint/imprint_form.html:200
-#: cms/templates/pages/page_form.html:377
+#: cms/templates/pages/page_form.html:383
 msgid "Direction of translation"
 msgstr "Übersetzungsrichtung"
 
@@ -4141,7 +4141,7 @@ msgid "Not saved yet"
 msgstr "Noch nicht gespeichert"
 
 #: cms/templates/imprint/imprint_sbs.html:133
-#: cms/templates/pages/page_form.html:227 cms/templates/pages/page_sbs.html:143
+#: cms/templates/pages/page_form.html:233 cms/templates/pages/page_sbs.html:143
 msgid "Implications on other translations"
 msgstr "Auswirkungen auf andere Übersetzungen"
 
@@ -4461,44 +4461,44 @@ msgstr "Neue Übersetzung erstellen"
 msgid "Create new page"
 msgstr "Neue Seite erstellen"
 
-#: cms/templates/pages/page_form.html:155
+#: cms/templates/pages/page_form.html:161
 #: cms/templates/pages/page_tree_archived_node.html:17
 msgid "Archived, because a parent page is archived"
 msgstr "Archiviert, weil eine übergeordnete Seite archiviert ist"
 
-#: cms/templates/pages/page_form.html:175
+#: cms/templates/pages/page_form.html:181
 msgid "Translation in progress"
 msgstr "Übersetzung wird durchgeführt"
 
-#: cms/templates/pages/page_form.html:183
+#: cms/templates/pages/page_form.html:189
 msgid "Abort translation process"
 msgstr "Übersetzungsprozess abbrechen"
 
-#: cms/templates/pages/page_form.html:221
+#: cms/templates/pages/page_form.html:227
 msgid "Minor edit"
 msgstr "Geringfügige Änderung"
 
-#: cms/templates/pages/page_form.html:237
+#: cms/templates/pages/page_form.html:243
 msgid "Settings of the page"
 msgstr "Einstellungen der Seite"
 
-#: cms/templates/pages/page_form.html:244
+#: cms/templates/pages/page_form.html:250
 msgid "Positioning"
 msgstr "Anordnung"
 
-#: cms/templates/pages/page_form.html:249
+#: cms/templates/pages/page_form.html:255
 msgid "Order"
 msgstr "Reihenfolge"
 
-#: cms/templates/pages/page_form.html:255
+#: cms/templates/pages/page_form.html:261
 msgid "Embed live content"
 msgstr "Live-Inhalte einbinden"
 
-#: cms/templates/pages/page_form.html:267
+#: cms/templates/pages/page_form.html:273
 msgid "Additional permissions for this page"
 msgstr "Zusätzliche Berechtigungen für diese Seite"
 
-#: cms/templates/pages/page_form.html:268
+#: cms/templates/pages/page_form.html:274
 msgid ""
 "This affects only users, who don't have the permission to change arbitrary "
 "pages anyway."
@@ -4506,18 +4506,18 @@ msgstr ""
 "Dies betrifft nur Benutzer, die nicht ohnehin die Berechtigung haben, "
 "beliebige Seiten zu ändern."
 
-#: cms/templates/pages/page_form.html:298
-#: cms/templates/pages/page_form.html:299
-#: cms/templates/pages/page_form.html:307
+#: cms/templates/pages/page_form.html:304
+#: cms/templates/pages/page_form.html:305
+#: cms/templates/pages/page_form.html:313
 #: cms/templates/pages/page_tree_archived_node.html:80
 msgid "Restore page"
 msgstr "Seite wiederherstellen"
 
-#: cms/templates/pages/page_form.html:304
+#: cms/templates/pages/page_form.html:310
 msgid "Restore this page"
 msgstr "Diese Seite wiederherstellen"
 
-#: cms/templates/pages/page_form.html:310
+#: cms/templates/pages/page_form.html:316
 msgid "To restore this page, you have to restore its parent page:"
 msgid_plural ""
 "To restore this page, you have to restore all its archived parent pages:"
@@ -4528,31 +4528,31 @@ msgstr[1] ""
 "Um diese Seite wiederherzustellen, müssen Sie alle ihre archivierten "
 "übergeordneten Seiten wiederherstellen:"
 
-#: cms/templates/pages/page_form.html:323
-#: cms/templates/pages/page_form.html:324
+#: cms/templates/pages/page_form.html:329
+#: cms/templates/pages/page_form.html:330
 #: cms/templates/pages/page_tree_node.html:129
 msgid "Archive page"
 msgstr "Seite archivieren"
 
-#: cms/templates/pages/page_form.html:330
+#: cms/templates/pages/page_form.html:336
 msgid "Archive this page"
 msgstr "Diese Seite archivieren"
 
-#: cms/templates/pages/page_form.html:334
-#: cms/templates/pages/page_form.html:352
+#: cms/templates/pages/page_form.html:340
+#: cms/templates/pages/page_form.html:358
 #: cms/templates/pages/page_tree_archived_node.html:98
 #: cms/templates/pages/page_tree_node.html:142
 msgid "Delete page"
 msgstr "Seite löschen"
 
-#: cms/templates/pages/page_form.html:338
+#: cms/templates/pages/page_form.html:344
 #: cms/templates/pages/page_tree_archived_node.html:94
 #: cms/templates/pages/page_tree_node.html:138
 #: cms/views/pages/page_actions.py:223
 msgid "You cannot delete a page which has subpages."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
 
-#: cms/templates/pages/page_form.html:339
+#: cms/templates/pages/page_form.html:345
 msgid "To delete this page, you have to delete or move its subpage first:"
 msgid_plural ""
 "To delete this page, you have to delete or move its subpages first:"
@@ -4563,15 +4563,15 @@ msgstr[1] ""
 "Um diese Seite zu löschen, müssen Sie zuerst ihre Unterseiten löschen oder "
 "verschieben:"
 
-#: cms/templates/pages/page_form.html:358
+#: cms/templates/pages/page_form.html:364
 msgid "Delete this page"
 msgstr "Diese Seite löschen"
 
-#: cms/templates/pages/page_form.html:370
+#: cms/templates/pages/page_form.html:376
 msgid "Translator view"
 msgstr "Übersetzeransicht"
 
-#: cms/templates/pages/page_form.html:386
+#: cms/templates/pages/page_form.html:392
 msgid "Show translator view"
 msgstr "Übersetzeransicht anzeigen"
 


### PR DESCRIPTION
### Short description
This PR changes the look and function of the language tabs.


### Proposed changes
So there are four things I changed in order to find a solution. All of this is up for discussion, of course. I just wanted to show you some ideas of what I think can be fixed. 

- Change the order of the language row. Maybe this make a lot of sense - or just makes sense, when there are more than one row. But in case of more than one rows the active tab would be in the bottom row, which is the Windows solutions.
- Change the background color to blue for non-active tabs, change the background-color to white for active tabs. That way it seems like the active tab is merging into the content-card. This is the most common solution I found when I was googling reference for tabs.
- Add some margin, so the tabs don't overlap
- Change the active effect to look more like the hover effect.

I'm aware that all of the proposed changes are just quick fixes for now. For a more sustainable solution in the long run it might be a good idea to involve someone from UI/UX here. 
Maybe we should have a discussion about this in the Mattermost channel. I wasn't sure what the common procedure with such issues is.

Looking forward for ideas and feedback! 

Fixes: #1030 
