### PR TITLE
Sync language grid width for table header and body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ UNRELEASED
 * Allow configuration via /etc/integreat-cms.ini
 * Fix dependency versions for production setup
 * Fully functional media library in selection window
+* Align language flags and translation status icons
 
 
 2021.11.0-beta

--- a/integreat_cms/cms/templates/events/event_list.html
+++ b/integreat_cms/cms/templates/events/event_list.html
@@ -51,11 +51,13 @@
                 {% endif %}
                 <th class="text-sm text-left uppercase py-3">
                     <div class="lang-grid flags whitespace-nowrap">
-                        {% for lang in languages %}
-                            <a href="{% url 'events' region_slug=region.slug language_slug=lang.slug %}">
-                                <span class="fp fp-rounded fp-{{ lang.primary_country_code }}" title="{{ lang.translated_name }}"></span>
-                            </a>
-                        {% endfor %}
+                        {% spaceless %}
+                            {% for lang in languages %}
+                                <a href="{% url 'events' region_slug=region.slug language_slug=lang.slug %}">
+                                    <span class="fp fp-rounded fp-{{ lang.primary_country_code }}" title="{{ lang.translated_name }}"></span>
+                                </a>
+                            {% endfor %}
+                        {% endspaceless %}
                     </div>
                 </th>
                 <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Status' %}</th>

--- a/integreat_cms/cms/templates/events/event_list_archived.html
+++ b/integreat_cms/cms/templates/events/event_list_archived.html
@@ -34,11 +34,13 @@
                 {% endif %}
                 <th class="text-sm text-left uppercase py-3 px-2">
                     <div class="lang-grid flags whitespace-nowrap">
-                        {% for lang in languages %}
-                            <a href="{% url 'events' region_slug=region.slug language_slug=lang.slug %}">
-                                <span class="fp fp-rounded fp-{{ lang.primary_country_code }}" title="{{ lang.translated_name }}"></span>
-                            </a>
-                        {% endfor %}
+                        {% spaceless %}
+                            {% for lang in languages %}
+                                <a href="{% url 'events' region_slug=region.slug language_slug=lang.slug %}">
+                                    <span class="fp fp-rounded fp-{{ lang.primary_country_code }}" title="{{ lang.translated_name }}"></span>
+                                </a>
+                            {% endfor %}
+                        {% endspaceless %}
                     </div>
                 </th>
                 <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Status' %}</th>

--- a/integreat_cms/cms/templates/events/event_list_archived_row.html
+++ b/integreat_cms/cms/templates/events/event_list_archived_row.html
@@ -26,31 +26,33 @@
             </a>
         </td>
     {% endif %}
-    <td class="py-3 pr-2 text-gray-800 lang-grid">
-        {% for other_language in languages %}
-            <a href="{% url 'edit_event' event_id=event.id region_slug=region.slug language_slug=other_language.slug %}">
-                {% get_translation event other_language.slug as other_translation %}
-                {% if other_translation %}
-                    {% if other_translation.currently_in_translation %}
-                        <span title="{% trans 'Currently in translation' %}">
-                            <i data-feather="clock" class="{% if other_language == language %}text-blue-500{% endif %}"></i>
-                        </span>
-                    {% elif other_translation.is_outdated %}
-                        <span title="{% trans 'Translation outdated' %}">
-                            <i data-feather="alert-triangle" class="{% if other_language == language %}text-yellow-500{% endif %}"></i>
-                        </span>
+    <td class="py-3 pl-2 text-gray-800 lang-grid">
+        {% spaceless %}
+            {% for other_language in languages %}
+                <a href="{% url 'edit_event' event_id=event.id region_slug=region.slug language_slug=other_language.slug %}">
+                    {% get_translation event other_language.slug as other_translation %}
+                    {% if other_translation %}
+                        {% if other_translation.currently_in_translation %}
+                            <span title="{% trans 'Currently in translation' %}">
+                                <i data-feather="clock" class="{% if other_language == language %}text-blue-500{% endif %}"></i>
+                            </span>
+                        {% elif other_translation.is_outdated %}
+                            <span title="{% trans 'Translation outdated' %}">
+                                <i data-feather="alert-triangle" class="{% if other_language == language %}text-yellow-500{% endif %}"></i>
+                            </span>
+                        {% else %}
+                            <span title="{% trans 'Translation up-to-date' %}">
+                                <i data-feather="check" class="{% if other_language == language %}text-green-500{% endif %}"></i>
+                            </span>
+                        {% endif %}
                     {% else %}
-                        <span title="{% trans 'Translation up-to-date' %}">
-                            <i data-feather="check" class="{% if other_language == language %}text-green-500{% endif %}"></i>
+                        <span title="{% trans 'Translation missing' %}">
+                            <i data-feather="x" class="{% if other_language == language %}text-red-500{% endif %}"></i>
                         </span>
                     {% endif %}
-                {% else %}
-                    <span title="{% trans 'Translation missing' %}">
-                        <i data-feather="x" class="{% if other_language == language %}text-red-500{% endif %}"></i>
-                    </span>
-                {% endif %}
-            </a>
-        {% endfor %}
+                </a>
+            {% endfor %}
+        {% endspaceless %}
     </td>
     <td class="py-3 pr-2">
         {{ event_translation.get_status_display }}

--- a/integreat_cms/cms/templates/events/event_list_row.html
+++ b/integreat_cms/cms/templates/events/event_list_row.html
@@ -27,30 +27,32 @@
         </td>
     {% endif %}
     <td class="py-3 pr-2 text-gray-800 lang-grid">
-        {% for other_language in languages %}
-            <a href="{% url 'edit_event' event_id=event.id region_slug=region.slug language_slug=other_language.slug %}">
-                {% get_translation event other_language.slug as other_translation %}
-                {% if other_translation %}
-                    {% if other_translation.currently_in_translation %}
-                        <span title="{% trans 'Currently in translation' %}">
-                            <i data-feather="clock" class="{% if other_language == language %}text-blue-500{% endif %}"></i>
-                        </span>
-                    {% elif other_translation.is_outdated %}
-                        <span title="{% trans 'Translation outdated' %}">
-                            <i data-feather="alert-triangle" class="{% if other_language == language %}text-yellow-500{% endif %}"></i>
-                        </span>
+        {% spaceless %}
+            {% for other_language in languages %}
+                <a href="{% url 'edit_event' event_id=event.id region_slug=region.slug language_slug=other_language.slug %}">
+                    {% get_translation event other_language.slug as other_translation %}
+                    {% if other_translation %}
+                        {% if other_translation.currently_in_translation %}
+                            <span title="{% trans 'Currently in translation' %}">
+                                <i data-feather="clock" class="{% if other_language == language %}text-blue-500{% endif %}"></i>
+                            </span>
+                        {% elif other_translation.is_outdated %}
+                            <span title="{% trans 'Translation outdated' %}">
+                                <i data-feather="alert-triangle" class="{% if other_language == language %}text-yellow-500{% endif %}"></i>
+                            </span>
+                        {% else %}
+                            <span title="{% trans 'Translation up-to-date' %}">
+                                <i data-feather="check" class="{% if other_language == language %}text-green-500{% endif %}"></i>
+                            </span>
+                        {% endif %}
                     {% else %}
-                        <span title="{% trans 'Translation up-to-date' %}">
-                            <i data-feather="check" class="{% if other_language == language %}text-green-500{% endif %}"></i>
+                        <span title="{% trans 'Translation missing' %}">
+                            <i data-feather="x" class="{% if other_language == language %}text-red-500{% endif %}"></i>
                         </span>
                     {% endif %}
-                {% else %}
-                    <span title="{% trans 'Translation missing' %}">
-                        <i data-feather="x" class="{% if other_language == language %}text-red-500{% endif %}"></i>
-                    </span>
-                {% endif %}
-            </a>
-        {% endfor %}
+                </a>
+            {% endfor %}
+        {% endspaceless %}
     </td>
     <td class="py-3 pr-2">
         {{ event_translation.get_status_display }}

--- a/integreat_cms/cms/templates/pages/page_tree.html
+++ b/integreat_cms/cms/templates/pages/page_tree.html
@@ -67,11 +67,13 @@
                 <th class="text-sm text-center uppercase py-3 pr-6 min">{% trans 'Tags' %}</th>
                 <th class="text-sm text-left uppercase py-3 px-2">
                     <div class="lang-grid flags whitespace-nowrap">
-                        {% for lang in languages %}
-                            <a href="{% url 'pages' region_slug=region.slug language_slug=lang.slug %}">
-                                <span class="fp fp-rounded fp-{{ lang.primary_country_code }}" title="{{ lang.translated_name }}"></span>
-                            </a>
-                        {% endfor %}
+                        {% spaceless %}
+                            {% for lang in languages %}
+                                <a href="{% url 'pages' region_slug=region.slug language_slug=lang.slug %}">
+                                    <span class="fp fp-rounded fp-{{ lang.primary_country_code }}" title="{{ lang.translated_name }}"></span>
+                                </a>
+                            {% endfor %}
+                        {% endspaceless %}
                     </div>
                 </th>
                 <th class="text-sm text-left uppercase py-3 pl-2 pr-2">{% trans 'Status' %}</th>

--- a/integreat_cms/cms/templates/pages/page_tree_archived.html
+++ b/integreat_cms/cms/templates/pages/page_tree_archived.html
@@ -42,11 +42,13 @@
                 {% endif %}
                 <th class="text-sm text-left uppercase py-3 px-2">
                     <div class="lang-grid flags whitespace-nowrap">
-                        {% for lang in languages %}
-                            <a href="{% url 'pages' region_slug=region.slug language_slug=lang.slug %}">
-                                <span class="fp fp-rounded fp-{{ lang.primary_country_code }}" title="{{ lang.translated_name }}"></span>
-                            </a>
-                        {% endfor %}
+                        {% spaceless %}
+                            {% for lang in languages %}
+                                <a href="{% url 'pages' region_slug=region.slug language_slug=lang.slug %}">
+                                    <span class="fp fp-rounded fp-{{ lang.primary_country_code }}" title="{{ lang.translated_name }}"></span>
+                                </a>
+                            {% endfor %}
+                        {% endspaceless %}
                     </div>
                 </th>
                 <th class="text-sm text-right uppercase py-3 pl-2 pr-4">{% trans 'Options' %}</th>

--- a/integreat_cms/cms/templates/pages/page_tree_archived_node.html
+++ b/integreat_cms/cms/templates/pages/page_tree_archived_node.html
@@ -43,30 +43,32 @@
     <td class="whitespace-nowrap">
         <div class="block py-3 pl-2 text-gray-800">
             <div class="lang-grid">
-                {% for other_language in languages %}
-                    <a href="{% url 'edit_page' page_id=page.id region_slug=region.slug language_slug=other_language.slug %}">
-                        {% get_translation page other_language.slug as other_translation %}
-                        {% if other_translation %}
-                            {% if other_translation.currently_in_translation %}
-                                <span title="{% trans 'Currently in translation' %}">
-                                    <i data-feather="clock" class="text-gray-800"></i>
-                                </span>
-                            {% elif other_translation.is_outdated %}
-                                <span title="{% trans 'Translation outdated' %}">
-                                    <i data-feather="alert-triangle" class="text-gray-800"></i>
-                                </span>
+                {% spaceless %}
+                    {% for other_language in languages %}
+                        <a href="{% url 'edit_page' page_id=page.id region_slug=region.slug language_slug=other_language.slug %}">
+                            {% get_translation page other_language.slug as other_translation %}
+                            {% if other_translation %}
+                                {% if other_translation.currently_in_translation %}
+                                    <span title="{% trans 'Currently in translation' %}">
+                                        <i data-feather="clock" class="text-gray-800"></i>
+                                    </span>
+                                {% elif other_translation.is_outdated %}
+                                    <span title="{% trans 'Translation outdated' %}">
+                                        <i data-feather="alert-triangle" class="text-gray-800"></i>
+                                    </span>
+                                {% else %}
+                                    <span title="{% trans 'Translation up-to-date' %}">
+                                        <i data-feather="check" class="text-gray-800"></i>
+                                    </span>
+                                {% endif %}
                             {% else %}
-                                <span title="{% trans 'Translation up-to-date' %}">
-                                    <i data-feather="check" class="text-gray-800"></i>
+                                <span title="{% trans 'Translation missing' %}">
+                                    <i data-feather="x" class="text-gray-800"></i>
                                 </span>
                             {% endif %}
-                        {% else %}
-                            <span title="{% trans 'Translation missing' %}">
-                                <i data-feather="x" class="text-gray-800"></i>
-                            </span>
-                        {% endif %}
-                    </a>
-                {% endfor %}
+                        </a>
+                    {% endfor %}
+                {% endspaceless %}
             </div>
         </div>
     </td>

--- a/integreat_cms/cms/templates/pages/page_tree_node.html
+++ b/integreat_cms/cms/templates/pages/page_tree_node.html
@@ -62,38 +62,40 @@
     <td class="whitespace-nowrap">
         <div class="block py-3 pl-2 text-gray-800">
             <div class="lang-grid">
-                {% for other_language in languages %}
-                    <a href="{% url 'edit_page' page_id=page.id region_slug=region.slug language_slug=other_language.slug %}"
-                        class="{{ other_language.slug }}">
-                        {% get_translation page other_language.slug as other_translation %}
-                        <div id="translation-icon">
-                        {% if other_translation %}
-                            {% if other_translation.currently_in_translation %}
+                {% spaceless %}
+                    {% for other_language in languages %}
+                        <a href="{% url 'edit_page' page_id=page.id region_slug=region.slug language_slug=other_language.slug %}"
+                            class="{{ other_language.slug }}">
+                            {% get_translation page other_language.slug as other_translation %}
+                            <div id="translation-icon">
+                            {% if other_translation %}
+                                {% if other_translation.currently_in_translation %}
+                                    <span title="{% trans 'Currently in translation' %}">
+                                        <i data-feather="clock" class="{% if other_language == language %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
+                                    </span>
+                                {% elif other_translation.is_outdated %}
+                                    <span title="{% trans 'Translation outdated' %}">
+                                        <i data-feather="alert-triangle" class="{% if other_language == language %}text-yellow-500{% else %}text-gray-800{% endif %}"></i>
+                                    </span>
+                                {% else %}
+                                    <span title="{% trans 'Translation up-to-date' %}">
+                                        <i data-feather="check" class="{% if other_language == language %}text-green-500{% else %}text-gray-800{% endif %}"></i>
+                                    </span>
+                                {% endif %}
+                            {% else %}
+                                <span title="{% trans 'Translation missing' %}" class="no-trans">
+                                    <i data-feather="x" class="{% if other_language == language %}text-red-500{% else %}text-gray-800{% endif %}"></i>
+                                </span>
+                            {% endif %}
+                            </div>
+                            <div id="ajax-icon" class="hidden">
                                 <span title="{% trans 'Currently in translation' %}">
                                     <i data-feather="clock" class="{% if other_language == language %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
                                 </span>
-                            {% elif other_translation.is_outdated %}
-                                <span title="{% trans 'Translation outdated' %}">
-                                    <i data-feather="alert-triangle" class="{% if other_language == language %}text-yellow-500{% else %}text-gray-800{% endif %}"></i>
-                                </span>
-                            {% else %}
-                                <span title="{% trans 'Translation up-to-date' %}">
-                                    <i data-feather="check" class="{% if other_language == language %}text-green-500{% else %}text-gray-800{% endif %}"></i>
-                                </span>
-                            {% endif %}
-                        {% else %}
-                            <span title="{% trans 'Translation missing' %}" class="no-trans">
-                                <i data-feather="x" class="{% if other_language == language %}text-red-500{% else %}text-gray-800{% endif %}"></i>
-                            </span>
-                        {% endif %}
-                        </div>
-                        <div id="ajax-icon" class="hidden">
-                            <span title="{% trans 'Currently in translation' %}">
-                                <i data-feather="clock" class="{% if other_language == language %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
-                            </span>
-                        </div>
-                    </a>
-                {% endfor %}
+                            </div>
+                        </a>
+                    {% endfor %}
+                {% endspaceless %}
             </div>
         </div>
     </td>

--- a/integreat_cms/cms/templates/pois/poi_list.html
+++ b/integreat_cms/cms/templates/pois/poi_list.html
@@ -41,11 +41,13 @@
                 {% endif %}
                 <th class="text-sm text-left uppercase py-3 pr-2">
                     <div class="lang-grid flags whitespace-nowrap">
-                        {% for lang in languages %}
-                            <a href="{% url 'pois' region_slug=region.slug language_slug=lang.slug %}">
-                                <span class="fp fp-rounded fp-{{ lang.primary_country_code }}" title="{{ lang.translated_name }}"></span>
-                            </a>
-                        {% endfor %}
+                        {% spaceless %}
+                            {% for lang in languages %}
+                                <a href="{% url 'pois' region_slug=region.slug language_slug=lang.slug %}">
+                                    <span class="fp fp-rounded fp-{{ lang.primary_country_code }}" title="{{ lang.translated_name }}"></span>
+                                </a>
+                            {% endfor %}
+                        {% endspaceless %}
                     </div>
                 </th>
                 <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Street' %}</th>

--- a/integreat_cms/cms/templates/pois/poi_list_row.html
+++ b/integreat_cms/cms/templates/pois/poi_list_row.html
@@ -31,30 +31,32 @@
         </td>
     {% endif %}
 	<td class="pr-2 lang-grid">
-        {% for other_language in languages %}
-            <a href="{% url 'edit_poi' poi_id=poi.id region_slug=region.slug language_slug=other_language.slug %}">
-                {% get_translation poi other_language.slug as other_translation %}
-                {% if other_translation %}
-                    {% if other_translation.currently_in_translation %}
-                        <span title="{% trans 'Currently in translation' %}">
-                            <i data-feather="clock"></i>
-                        </span>
-                    {% elif other_translation.is_outdated %}
-                        <span title="{% trans 'Translation outdated' %}">
-                            <i data-feather="alert-triangle"></i>
-                        </span>
+        {% spaceless %}
+            {% for other_language in languages %}
+                <a href="{% url 'edit_poi' poi_id=poi.id region_slug=region.slug language_slug=other_language.slug %}">
+                    {% get_translation poi other_language.slug as other_translation %}
+                    {% if other_translation %}
+                        {% if other_translation.currently_in_translation %}
+                            <span title="{% trans 'Currently in translation' %}">
+                                <i data-feather="clock"></i>
+                            </span>
+                        {% elif other_translation.is_outdated %}
+                            <span title="{% trans 'Translation outdated' %}">
+                                <i data-feather="alert-triangle"></i>
+                            </span>
+                        {% else %}
+                            <span title="{% trans 'Translation up-to-date' %}">
+                                <i data-feather="check"></i>
+                            </span>
+                        {% endif %}
                     {% else %}
-                        <span title="{% trans 'Translation up-to-date' %}">
-                            <i data-feather="check"></i>
+                        <span title="{% trans 'Translation missing' %}">
+                            <i data-feather="x"></i>
                         </span>
                     {% endif %}
-                {% else %}
-                    <span title="{% trans 'Translation missing' %}">
-                        <i data-feather="x"></i>
-                    </span>
-                {% endif %}
-            </a>
-        {% endfor %}
+                </a>
+            {% endfor %}
+        {% endspaceless %}
 	</td>
 	<td class="pr-2">
         <a href="{% url 'edit_poi' poi_id=poi.id region_slug=region.slug language_slug=language.slug %}" class="block">

--- a/integreat_cms/cms/templates/push_notifications/push_notification_list.html
+++ b/integreat_cms/cms/templates/push_notifications/push_notification_list.html
@@ -31,11 +31,13 @@
                 </th>
                 <th class="text-sm text-left uppercase py-3 px-2">
                     <div class="lang-grid flags whitespace-nowrap">
-                        {% for lang in languages %}
-                            <a href="{% url 'push_notifications' region_slug=region.slug language_slug=lang.slug %}">
-                                <span class="fp fp-rounded fp-{{ lang.primary_country_code }}" title="{{ lang.translated_name }}"></span>
-                            </a>
-                        {% endfor %}
+                        {% spaceless %}
+                            {% for lang in languages %}
+                                <a href="{% url 'push_notifications' region_slug=region.slug language_slug=lang.slug %}">
+                                    <span class="fp fp-rounded fp-{{ lang.primary_country_code }}" title="{{ lang.translated_name }}"></span>
+                                </a>
+                            {% endfor %}
+                        {% endspaceless %}
                     </div>
                 </th>
                 <th class="text-sm text-left uppercase py-3 px-2 min">

--- a/integreat_cms/cms/templates/push_notifications/push_notification_list_row.html
+++ b/integreat_cms/cms/templates/push_notifications/push_notification_list_row.html
@@ -15,13 +15,15 @@
 	<td>
 		<div class="block py-3 px-2 text-gray-800">
 			<div class="lang-grid">
-				{% for other_language in languages %}
-				<a href="{% url 'edit_push_notification' push_notification_id=push_notification.id region_slug=region.slug language_slug=other_language.slug %}">
-					{% with pnt=push_notification|translation:other_language %}
-					<i data-feather="{% if pnt %}edit-2{% else %}plus{% endif %}" class="text-gray-800"></i>
-					{% endwith %}
-				</a>
-				{% endfor %}
+				{% spaceless %}
+					{% for other_language in languages %}
+					<a href="{% url 'edit_push_notification' push_notification_id=push_notification.id region_slug=region.slug language_slug=other_language.slug %}">
+						{% with pnt=push_notification|translation:other_language %}
+						<i data-feather="{% if pnt %}edit-2{% else %}plus{% endif %}" class="text-gray-800"></i>
+						{% endwith %}
+					</a>
+					{% endfor %}
+				{% endspaceless %}
 			</div>
 		</div>
 	</td>

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-12-04 00:22+0000\n"
+"POT-Creation-Date: 2021-12-15 10:40+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: cms/constants/administrative_division.py:38
-#: cms/templates/events/event_form.html:262 cms/templates/pois/poi_list.html:53
+#: cms/templates/events/event_form.html:262 cms/templates/pois/poi_list.html:55
 #: cms/templates/pois/poi_list_archived.html:29
 msgid "City"
 msgstr "Stadt"
@@ -1359,8 +1359,8 @@ msgstr "Rechts nach Links"
 #: cms/constants/translation_status.py:10
 #: cms/templates/events/event_form.html:68
 #: cms/templates/events/event_form.html:97
-#: cms/templates/events/event_list_archived_row.html:43
-#: cms/templates/events/event_list_row.html:43
+#: cms/templates/events/event_list_archived_row.html:44
+#: cms/templates/events/event_list_row.html:44
 #: cms/templates/imprint/imprint_form.html:55
 #: cms/templates/imprint/imprint_form.html:84
 #: cms/templates/imprint/imprint_sbs.html:47
@@ -1368,37 +1368,37 @@ msgstr "Rechts nach Links"
 #: cms/templates/pages/page_form.html:76 cms/templates/pages/page_form.html:98
 #: cms/templates/pages/page_form.html:117 cms/templates/pages/page_sbs.html:54
 #: cms/templates/pages/page_sbs.html:104
-#: cms/templates/pages/page_tree_archived_node.html:59
-#: cms/templates/pages/page_tree_node.html:80
+#: cms/templates/pages/page_tree_archived_node.html:60
+#: cms/templates/pages/page_tree_node.html:81
 #: cms/templates/pois/poi_form.html:59 cms/templates/pois/poi_form.html:88
-#: cms/templates/pois/poi_list_row.html:47
+#: cms/templates/pois/poi_list_row.html:48
 msgid "Translation up-to-date"
 msgstr "Übersetzung ist aktuell"
 
 #: cms/constants/translation_status.py:11
 #: cms/templates/events/event_form.html:64
 #: cms/templates/events/event_form.html:93
-#: cms/templates/events/event_list_archived_row.html:35
-#: cms/templates/events/event_list_row.html:35
+#: cms/templates/events/event_list_archived_row.html:36
+#: cms/templates/events/event_list_row.html:36
 #: cms/templates/imprint/imprint_form.html:51
 #: cms/templates/imprint/imprint_form.html:80
 #: cms/templates/imprint/imprint_sbs.html:43
 #: cms/templates/imprint/imprint_sbs.html:93
 #: cms/templates/pages/page_form.html:72 cms/templates/pages/page_form.html:113
 #: cms/templates/pages/page_sbs.html:50 cms/templates/pages/page_sbs.html:100
-#: cms/templates/pages/page_tree_archived_node.html:51
-#: cms/templates/pages/page_tree_node.html:72
-#: cms/templates/pages/page_tree_node.html:91
+#: cms/templates/pages/page_tree_archived_node.html:52
+#: cms/templates/pages/page_tree_node.html:73
+#: cms/templates/pages/page_tree_node.html:92
 #: cms/templates/pois/poi_form.html:55 cms/templates/pois/poi_form.html:84
-#: cms/templates/pois/poi_list_row.html:39
+#: cms/templates/pois/poi_list_row.html:40
 msgid "Currently in translation"
 msgstr "Wird derzeit übersetzt"
 
 #: cms/constants/translation_status.py:12
 #: cms/templates/events/event_form.html:60
 #: cms/templates/events/event_form.html:89
-#: cms/templates/events/event_list_archived_row.html:39
-#: cms/templates/events/event_list_row.html:39
+#: cms/templates/events/event_list_archived_row.html:40
+#: cms/templates/events/event_list_row.html:40
 #: cms/templates/imprint/imprint_form.html:47
 #: cms/templates/imprint/imprint_form.html:76
 #: cms/templates/imprint/imprint_sbs.html:39
@@ -1406,25 +1406,25 @@ msgstr "Wird derzeit übersetzt"
 #: cms/templates/pages/page_form.html:68 cms/templates/pages/page_form.html:94
 #: cms/templates/pages/page_form.html:109 cms/templates/pages/page_sbs.html:46
 #: cms/templates/pages/page_sbs.html:96
-#: cms/templates/pages/page_tree_archived_node.html:55
-#: cms/templates/pages/page_tree_node.html:76
+#: cms/templates/pages/page_tree_archived_node.html:56
+#: cms/templates/pages/page_tree_node.html:77
 #: cms/templates/pois/poi_form.html:51 cms/templates/pois/poi_form.html:80
-#: cms/templates/pois/poi_list_row.html:43
+#: cms/templates/pois/poi_list_row.html:44
 msgid "Translation outdated"
 msgstr "Übersetzung ist veraltet"
 
 #: cms/constants/translation_status.py:13
 #: cms/templates/events/event_form.html:73
 #: cms/templates/events/event_form.html:102
-#: cms/templates/events/event_list_archived_row.html:48
-#: cms/templates/events/event_list_row.html:48
+#: cms/templates/events/event_list_archived_row.html:49
+#: cms/templates/events/event_list_row.html:49
 #: cms/templates/imprint/imprint_form.html:60
 #: cms/templates/imprint/imprint_form.html:89
 #: cms/templates/pages/page_form.html:81 cms/templates/pages/page_form.html:122
-#: cms/templates/pages/page_tree_archived_node.html:64
-#: cms/templates/pages/page_tree_node.html:85
+#: cms/templates/pages/page_tree_archived_node.html:65
+#: cms/templates/pages/page_tree_node.html:86
 #: cms/templates/pois/poi_form.html:64 cms/templates/pois/poi_form.html:93
-#: cms/templates/pois/poi_list_row.html:52
+#: cms/templates/pois/poi_list_row.html:53
 msgid "Translation missing"
 msgstr "Übersetzung fehlt"
 
@@ -1592,8 +1592,8 @@ msgstr "Kategorie"
 
 #: cms/forms/feedback/region_feedback_filter_form.py:30
 #: cms/templates/events/event_form.html:129
-#: cms/templates/events/event_list.html:61
-#: cms/templates/events/event_list_archived.html:44
+#: cms/templates/events/event_list.html:63
+#: cms/templates/events/event_list_archived.html:46
 #: cms/templates/imprint/imprint_form.html:107
 #: cms/templates/imprint/imprint_revisions.html:46
 #: cms/templates/imprint/imprint_sbs.html:59
@@ -1603,7 +1603,7 @@ msgstr "Kategorie"
 #: cms/templates/pages/page_form.html:151
 #: cms/templates/pages/page_revisions.html:50
 #: cms/templates/pages/page_sbs.html:66 cms/templates/pages/page_sbs.html:123
-#: cms/templates/pages/page_sbs.html:128 cms/templates/pages/page_tree.html:77
+#: cms/templates/pages/page_sbs.html:128 cms/templates/pages/page_tree.html:79
 #: cms/templates/pages/page_tree_archived.html:36
 #: cms/templates/pois/poi_form.html:110 cms/templates/pois/poi_list.html:35
 #: cms/templates/pois/poi_list_archived.html:20
@@ -3550,8 +3550,8 @@ msgid "Time range"
 msgstr "Zeitraum"
 
 #: cms/templates/events/_event_filter_form.html:32
-#: cms/templates/events/event_list.html:62
-#: cms/templates/events/event_list_archived.html:45
+#: cms/templates/events/event_list.html:64
+#: cms/templates/events/event_list_archived.html:47
 msgid "Event location"
 msgstr "Veranstaltungsort"
 
@@ -3662,12 +3662,12 @@ msgstr ""
 msgid "Address"
 msgstr "Adresse"
 
-#: cms/templates/events/event_form.html:260 cms/templates/pois/poi_list.html:51
+#: cms/templates/events/event_form.html:260 cms/templates/pois/poi_list.html:53
 #: cms/templates/pois/poi_list_archived.html:27
 msgid "Street"
 msgstr "Straße"
 
-#: cms/templates/events/event_form.html:264 cms/templates/pois/poi_list.html:54
+#: cms/templates/events/event_form.html:264 cms/templates/pois/poi_list.html:56
 #: cms/templates/pois/poi_list_archived.html:30
 msgid "Country"
 msgstr "Land"
@@ -3677,7 +3677,7 @@ msgid "Map"
 msgstr "Karte"
 
 #: cms/templates/events/event_form.html:277
-#: cms/templates/events/event_list_archived_row.html:82
+#: cms/templates/events/event_list_archived_row.html:84
 msgid "Restore event"
 msgstr "Veranstaltung wiederherstellen"
 
@@ -3686,7 +3686,7 @@ msgid "Restore this event"
 msgstr "Diese Veranstaltung wiederherstellen"
 
 #: cms/templates/events/event_form.html:287
-#: cms/templates/events/event_list_row.html:98
+#: cms/templates/events/event_list_row.html:100
 msgid "Archive event"
 msgstr "Veranstaltung archivieren"
 
@@ -3695,8 +3695,8 @@ msgid "Archive this event"
 msgstr "Diese Veranstaltung archivieren"
 
 #: cms/templates/events/event_form.html:300
-#: cms/templates/events/event_list_archived_row.html:91
-#: cms/templates/events/event_list_row.html:107
+#: cms/templates/events/event_list_archived_row.html:93
+#: cms/templates/events/event_list_row.html:109
 msgid "Delete event"
 msgstr "Veranstaltung löschen"
 
@@ -3727,47 +3727,47 @@ msgstr "Filter einblenden"
 msgid "Hide filters"
 msgstr "Filter ausblenden"
 
-#: cms/templates/events/event_list.html:63
-#: cms/templates/events/event_list_archived.html:46
+#: cms/templates/events/event_list.html:65
+#: cms/templates/events/event_list_archived.html:48
 msgid "Start"
 msgstr "Beginn"
 
-#: cms/templates/events/event_list.html:64
-#: cms/templates/events/event_list_archived.html:47
+#: cms/templates/events/event_list.html:66
+#: cms/templates/events/event_list_archived.html:49
 msgid "End"
 msgstr "Ende"
 
-#: cms/templates/events/event_list.html:65
-#: cms/templates/events/event_list_archived.html:48
+#: cms/templates/events/event_list.html:67
+#: cms/templates/events/event_list_archived.html:50
 msgid "Recurrence"
 msgstr "Wiederholung"
 
-#: cms/templates/events/event_list.html:66
-#: cms/templates/events/event_list_archived.html:49
+#: cms/templates/events/event_list.html:68
+#: cms/templates/events/event_list_archived.html:51
 #: cms/templates/languages/language_list.html:29
 #: cms/templates/offer_templates/offer_template_list.html:25
 #: cms/templates/organizations/organization_list.html:23
-#: cms/templates/pages/page_tree.html:79
-#: cms/templates/pages/page_tree_archived.html:52
-#: cms/templates/pois/poi_list.html:55
+#: cms/templates/pages/page_tree.html:81
+#: cms/templates/pages/page_tree_archived.html:54
+#: cms/templates/pois/poi_list.html:57
 #: cms/templates/pois/poi_list_archived.html:31
 #: cms/templates/roles/list.html:20
 msgid "Options"
 msgstr "Optionen"
 
-#: cms/templates/events/event_list.html:79
+#: cms/templates/events/event_list.html:81
 msgid "No events found with these filters."
 msgstr "Keine Veranstaltungen mit diesen Filtern gefunden."
 
-#: cms/templates/events/event_list.html:81
+#: cms/templates/events/event_list.html:83
 msgid "No upcoming events available."
 msgstr "Keine zukünftigen Veranstaltungen vorhanden."
 
-#: cms/templates/events/event_list_archived.html:62
+#: cms/templates/events/event_list_archived.html:64
 msgid "No archived events found with these filters."
 msgstr "Keine archivierten Veranstaltungen mit diesen Filtern gefunden."
 
-#: cms/templates/events/event_list_archived.html:64
+#: cms/templates/events/event_list_archived.html:66
 msgid "No upcoming events archived."
 msgstr "Keine zukünftigen Veranstaltungen archiviert."
 
@@ -3786,27 +3786,27 @@ msgstr "Keine zukünftigen Veranstaltungen archiviert."
 msgid "Translation not available"
 msgstr "Übersetzung nicht verfügbar"
 
-#: cms/templates/events/event_list_archived_row.html:63
-#: cms/templates/events/event_list_row.html:63
+#: cms/templates/events/event_list_archived_row.html:65
+#: cms/templates/events/event_list_row.html:65
 msgid "Not specified"
 msgstr "Nicht festgelegt"
 
-#: cms/templates/events/event_list_archived_row.html:76
-#: cms/templates/events/event_list_row.html:76
+#: cms/templates/events/event_list_archived_row.html:78
+#: cms/templates/events/event_list_row.html:78
 msgid "One-time"
 msgstr "Einmalig"
 
-#: cms/templates/events/event_list_row.html:82
+#: cms/templates/events/event_list_row.html:84
 msgid "Open event in web app"
 msgstr "Veranstaltung in der Web-App öffnen"
 
-#: cms/templates/events/event_list_row.html:86
+#: cms/templates/events/event_list_row.html:88
 msgid "This event cannot be opened in the web app, because it is not public."
 msgstr ""
 "Diese Veranstaltung kann nicht in der Web-App geöffnet werden, weil sie "
 "nicht veröffentlicht ist."
 
-#: cms/templates/events/event_list_row.html:94
+#: cms/templates/events/event_list_row.html:96
 msgid "Duplicate event"
 msgstr "Veranstaltung duplizieren"
 
@@ -3876,7 +3876,7 @@ msgstr "Noch kein technisches Feedback vorhanden."
 #: cms/templates/feedback/admin_feedback_list.html:128
 #: cms/templates/feedback/region_feedback_list.html:121
 #: cms/templates/linkcheck/links_by_filter.html:72
-#: cms/templates/pages/page_tree.html:112
+#: cms/templates/pages/page_tree.html:114
 msgid "Select bulk action"
 msgstr "Mehrfachaktion auswählen"
 
@@ -3899,7 +3899,7 @@ msgstr "Löschen"
 #: cms/templates/feedback/admin_feedback_list.html:135
 #: cms/templates/feedback/region_feedback_list.html:128
 #: cms/templates/linkcheck/links_by_filter.html:80
-#: cms/templates/pages/page_tree.html:131
+#: cms/templates/pages/page_tree.html:133
 msgid "Execute"
 msgstr "Ausführen"
 
@@ -4282,7 +4282,7 @@ msgstr "Erstellt"
 #: cms/templates/languages/language_list.html:28
 #: cms/templates/offer_templates/offer_template_list.html:23
 #: cms/templates/pages/_page_xliff_import_diff.html:36
-#: cms/templates/pages/page_tree.html:78
+#: cms/templates/pages/page_tree.html:80
 #: cms/templates/regions/region_list.html:23
 msgid "Last updated"
 msgstr "Zuletzt aktualisiert"
@@ -4516,7 +4516,7 @@ msgstr ""
 #: cms/templates/pages/page_form.html:298
 #: cms/templates/pages/page_form.html:299
 #: cms/templates/pages/page_form.html:307
-#: cms/templates/pages/page_tree_archived_node.html:80
+#: cms/templates/pages/page_tree_archived_node.html:82
 msgid "Restore page"
 msgstr "Seite wiederherstellen"
 
@@ -4537,7 +4537,7 @@ msgstr[1] ""
 
 #: cms/templates/pages/page_form.html:323
 #: cms/templates/pages/page_form.html:324
-#: cms/templates/pages/page_tree_node.html:129
+#: cms/templates/pages/page_tree_node.html:131
 msgid "Archive page"
 msgstr "Seite archivieren"
 
@@ -4547,14 +4547,14 @@ msgstr "Diese Seite archivieren"
 
 #: cms/templates/pages/page_form.html:334
 #: cms/templates/pages/page_form.html:352
-#: cms/templates/pages/page_tree_archived_node.html:98
-#: cms/templates/pages/page_tree_node.html:142
+#: cms/templates/pages/page_tree_archived_node.html:100
+#: cms/templates/pages/page_tree_node.html:144
 msgid "Delete page"
 msgstr "Seite löschen"
 
 #: cms/templates/pages/page_form.html:338
-#: cms/templates/pages/page_tree_archived_node.html:94
-#: cms/templates/pages/page_tree_node.html:138
+#: cms/templates/pages/page_tree_archived_node.html:96
+#: cms/templates/pages/page_tree_node.html:140
 #: cms/views/pages/page_actions.py:223
 msgid "You cannot delete a page which has subpages."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
@@ -4627,47 +4627,47 @@ msgstr "Sie können Seiten nur in der Standard-Sprache anlegen"
 msgid "Tags"
 msgstr "Tags"
 
-#: cms/templates/pages/page_tree.html:101
+#: cms/templates/pages/page_tree.html:103
 msgid "No pages found with these filters."
 msgstr "Keine Seiten mit diesen Filtern gefunden."
 
-#: cms/templates/pages/page_tree.html:103
+#: cms/templates/pages/page_tree.html:105
 msgid "No pages available yet."
 msgstr "Noch keine Seiten vorhanden."
 
-#: cms/templates/pages/page_tree.html:113
+#: cms/templates/pages/page_tree.html:115
 msgid "Archive pages"
 msgstr "Seiten archivieren"
 
-#: cms/templates/pages/page_tree.html:118
+#: cms/templates/pages/page_tree.html:120
 msgid "Export published pages as PDF"
 msgstr "Veröffentlichte Seiten als PDF exportieren"
 
-#: cms/templates/pages/page_tree.html:125
+#: cms/templates/pages/page_tree.html:127
 msgid "You cannot export XLIFF files for the default language"
 msgstr "Sie können keine XLIFF-Dateien für die Standard-Sprache exportieren"
 
-#: cms/templates/pages/page_tree.html:128
+#: cms/templates/pages/page_tree.html:130
 msgid "Export XLIFF for translation to"
 msgstr "Exportiere XLIFF für Übersetzung nach"
 
-#: cms/templates/pages/page_tree.html:136
+#: cms/templates/pages/page_tree.html:138
 msgid "Import XLIFF files"
 msgstr "XLIFF-Dateien importieren"
 
-#: cms/templates/pages/page_tree.html:137
+#: cms/templates/pages/page_tree.html:139
 msgid "Supported file extensions"
 msgstr "Unterstützte Dateiendungen"
 
-#: cms/templates/pages/page_tree.html:142
+#: cms/templates/pages/page_tree.html:144
 msgid "Select files"
 msgstr "Dateien auswählen"
 
-#: cms/templates/pages/page_tree.html:144
+#: cms/templates/pages/page_tree.html:146
 msgid "and {} other files"
 msgstr "und {} weitere Dateien"
 
-#: cms/templates/pages/page_tree.html:147
+#: cms/templates/pages/page_tree.html:149
 msgid "Import"
 msgstr "Importieren"
 
@@ -4675,7 +4675,7 @@ msgstr "Importieren"
 msgid "Archived Pages"
 msgstr "Archivierte Seiten"
 
-#: cms/templates/pages/page_tree_archived.html:67
+#: cms/templates/pages/page_tree_archived.html:69
 msgid "No pages archived yet."
 msgstr "Noch keine Seiten archiviert."
 
@@ -4694,17 +4694,17 @@ msgstr ""
 "Diese Seite ist archiviert, weil eine ihrer übergeordneten Seiten archiviert "
 "ist."
 
-#: cms/templates/pages/page_tree_archived_node.html:76
+#: cms/templates/pages/page_tree_archived_node.html:78
 msgid "View page"
 msgstr "Seite ansehen"
 
-#: cms/templates/pages/page_tree_archived_node.html:88
+#: cms/templates/pages/page_tree_archived_node.html:90
 msgid "To restore this page, you have to restore its archived parent page."
 msgstr ""
 "Um diese Seite wiederherzustellen, müssen Sie ihre archivierte übergeordnete "
 "Seite wiederherstellen."
 
-#: cms/templates/pages/page_tree_archived_node.html:94
+#: cms/templates/pages/page_tree_archived_node.html:96
 msgid "This also involves non-archived subpages."
 msgstr "Dies betrifft auch nicht-archivierte Unterseiten."
 
@@ -4720,33 +4720,33 @@ msgstr "Drag & drop nicht möglich, wenn Filter aktiv sind"
 msgid "Collapse all subpages"
 msgstr "Alle Unterseiten einklappen"
 
-#: cms/templates/pages/page_tree_node.html:112
+#: cms/templates/pages/page_tree_node.html:114
 msgid "View page as preview"
 msgstr "Seite als Vorschau ansehen"
 
-#: cms/templates/pages/page_tree_node.html:117
+#: cms/templates/pages/page_tree_node.html:119
 msgid "Open page in web app"
 msgstr "Seite in der Web-App öffnen"
 
-#: cms/templates/pages/page_tree_node.html:121
+#: cms/templates/pages/page_tree_node.html:123
 msgid "This page cannot be opened in the web app, because it is not public."
 msgstr ""
 "Diese Seite kann nicht in der Web-App geöffnet werden, weil sie nicht "
 "veröffentlicht ist."
 
-#: cms/templates/pages/page_tree_node.html:125
+#: cms/templates/pages/page_tree_node.html:127
 msgid "Edit page"
 msgstr "Seite bearbeiten"
 
-#: cms/templates/pages/page_tree_node.html:138
+#: cms/templates/pages/page_tree_node.html:140
 msgid "This also involves archived subpages."
 msgstr "Dies betrifft auch archivierte Unterseiten."
 
-#: cms/templates/pages/page_tree_node.html:153
+#: cms/templates/pages/page_tree_node.html:155
 msgid "Copy short link"
 msgstr "Kurz-URL kopieren"
 
-#: cms/templates/pages/page_tree_node.html:157
+#: cms/templates/pages/page_tree_node.html:159
 msgid "You cannot copy a short link of a page which has no translation."
 msgstr "Sie können keine Kurz-URL zu einer fehlenden Übersetzung kopieren."
 
@@ -4797,7 +4797,7 @@ msgid "Restore this location"
 msgstr "Diesen Ort wiederherstellen"
 
 #: cms/templates/pois/poi_form.html:205 cms/templates/pois/poi_form.html:206
-#: cms/templates/pois/poi_list_row.html:90
+#: cms/templates/pois/poi_list_row.html:92
 msgid "Archive location"
 msgstr "Ort archivieren"
 
@@ -4807,7 +4807,7 @@ msgstr "Diesen Ort archivieren"
 
 #: cms/templates/pois/poi_form.html:217 cms/templates/pois/poi_form.html:218
 #: cms/templates/pois/poi_list_archived_row.html:62
-#: cms/templates/pois/poi_list_row.html:98
+#: cms/templates/pois/poi_list_row.html:100
 msgid "Delete location"
 msgstr "Ort löschen"
 
@@ -4820,16 +4820,16 @@ msgstr "Diesen Ort löschen"
 msgid "Archived locations"
 msgstr "Archivierte Orte"
 
-#: cms/templates/pois/poi_list.html:52
+#: cms/templates/pois/poi_list.html:54
 #: cms/templates/pois/poi_list_archived.html:28
 msgid "Postal Code"
 msgstr "Postleitzahl"
 
-#: cms/templates/pois/poi_list.html:66
+#: cms/templates/pois/poi_list.html:68
 msgid "No locations found with these filters."
 msgstr "Keine Orte mit diesen Filtern gefunden."
 
-#: cms/templates/pois/poi_list.html:68
+#: cms/templates/pois/poi_list.html:70
 msgid "No locations available yet."
 msgstr "Noch keine Orte vorhanden."
 
@@ -4837,11 +4837,11 @@ msgstr "Noch keine Orte vorhanden."
 msgid "No locations archived yet."
 msgstr "Noch keine Orte archiviert."
 
-#: cms/templates/pois/poi_list_row.html:82
+#: cms/templates/pois/poi_list_row.html:84
 msgid "Open location in web app"
 msgstr "Ort in der Web-App öffnen"
 
-#: cms/templates/pois/poi_list_row.html:86
+#: cms/templates/pois/poi_list_row.html:88
 msgid ""
 "This location cannot be opened in the web app, because it is not public."
 msgstr ""
@@ -4861,19 +4861,19 @@ msgstr "Speichern & Senden"
 msgid "Channel"
 msgstr "Kanal"
 
-#: cms/templates/push_notifications/push_notification_list.html:42
+#: cms/templates/push_notifications/push_notification_list.html:44
 msgid "Sent"
 msgstr "Gesendet"
 
-#: cms/templates/push_notifications/push_notification_list.html:53
+#: cms/templates/push_notifications/push_notification_list.html:55
 msgid "No push notifications found with these filters."
 msgstr "Keine Push-Benachrichtigungen mit diesen Filter gefunden."
 
-#: cms/templates/push_notifications/push_notification_list.html:55
+#: cms/templates/push_notifications/push_notification_list.html:57
 msgid "No push notifications available yet."
 msgstr "Noch keine Push-Benachrichtigungen vorhanden."
 
-#: cms/templates/push_notifications/push_notification_list_row.html:32
+#: cms/templates/push_notifications/push_notification_list_row.html:34
 msgid "Message not sent yet"
 msgstr "Nachricht noch nicht gesendet"
 

--- a/integreat_cms/static/src/css/style.scss
+++ b/integreat_cms/static/src/css/style.scss
@@ -313,6 +313,7 @@ label:not([for]) {
     text-align: center;
     width: 18.67px;
     display: inline-block;
+    margin-right: 3.5px;
   }
 }
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Sync language grid width for table header and body

### Proposed changes
<!-- Describe this PR in more detail. -->

The problem is that despite both Element nodes (a-html-tags) in the header and in body of the the table have the same width of 18.67px, as inline-block elements they are followed whitespace Text nodes with different widths (4,08331px and 3,36664px)
So I updated the Elements node width so that both header and body have in total the exact same width of 22,0333px

![Screenshot from 2021-12-08 15-33-03](https://user-images.githubusercontent.com/47010475/145226348-4fff6d25-fe59-498c-9ad4-07f998ea993d.png)

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1029
