### PR TITLE
Improve production setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -91,7 +91,7 @@ jobs:
             - integreat_cms/locale/de/LC_MESSAGES/django.mo
   webpack:
     docker:
-      - image: 'cimg/node:current'
+      - image: 'cimg/node:lts'
     steps:
       - checkout
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,7 +262,7 @@ jobs:
           root: .
           paths:
             - setup.cfg
-            - src/integreat_cms/__init__.py
+            - integreat_cms/__init__.py
   bump-version:
     docker:
       - image: cimg/python:3.7

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,16 @@ graft integreat_cms
 # Exclude the static source files since we only need the compiled files in integreat_cms/static/dist
 prune integreat_cms/static/src
 
+# Exclude media files
+prune integreat_cms/media
+
+# Exclude file-based cache
+prune integreat_cms/cache
+
+# Exclude xliff files
+prune integreat_cms/xliff/upload
+prune integreat_cms/xliff/download
+
 # Exclude development settings
 exclude integreat_cms/core/*_settings.py
 

--- a/dev-tools/fix_dependencies.sh
+++ b/dev-tools/fix_dependencies.sh
@@ -14,7 +14,7 @@ echo "${DEPENDENCY_VERSIONS}"
 # Use python to write the dependencies into the setup.cfg config file
 python3 << EOF
 import configparser
-setup_cfg = configparser.ConfigParser()
+setup_cfg = configparser.ConfigParser(interpolation=None)
 setup_cfg.read("${BASE_DIR}/setup.cfg")
 setup_cfg["options"]["install_requires"] = """${DEPENDENCY_VERSIONS}"""
 with open("${BASE_DIR}/setup.cfg", "w") as setup_cfg_file:

--- a/example-configs/integreat-cms.ini
+++ b/example-configs/integreat-cms.ini
@@ -66,6 +66,8 @@ DB_PORT = <port>
 REDIS_CACHE = True
 # Set this if you want to connect to redis via socket [optional, defaults to None]
 REDIS_UNIX_SOCKET = /var/run/redis/redis-server.sock
+# The location of the file-based cache (e.g. for PDF files) [optional, defaults to "cache" in the application directory]
+FILE_CACHE = /var/cache/integreat-cms
 
 [email]
 # Sender email [optional, defaults to "keineantwort@integreat-app.de"]

--- a/example-configs/integreat-cms.ini
+++ b/example-configs/integreat-cms.ini
@@ -38,6 +38,10 @@ MATOMO_URL = https://statistics.integreat-app.de
 WEBSITE_URL = https://integreat-app.de
 # The url to the wiki [optional, defaults to "https://wiki.integreat-app.de"]
 WIKI_URL = https://wiki.integreat-app.de
+# Any additional allowed hosts besides localhost and the hostname of BASE_URL [optional, defaults to an empty list]
+ALLOWED_HOSTS =
+	cms.tuerantuer.org
+	api.integreat-app.de
 
 [static-files]
 # The directory for static files [required]

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -596,7 +596,10 @@ CACHES = {
     },
     "pdf": {
         "BACKEND": "django.core.cache.backends.filebased.FileBasedCache",
-        "LOCATION": os.path.join(BASE_DIR, "cache/pdf"),
+        "LOCATION": os.path.join(
+            os.environ.get("INTEGREAT_CMS_FILE_CACHE", os.path.join(BASE_DIR, "cache")),
+            "pdf",
+        ),
     },
 }
 

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -226,10 +226,17 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 # SECURITY #
 ############
 
-if not DEBUG:
-    #: This is a security measure to prevent HTTP Host header attacks, which are possible even under many seemingly-safe
-    #: web server configurations (see :setting:`django:ALLOWED_HOSTS` and :ref:`django:host-headers-virtual-hosting`)
-    ALLOWED_HOSTS = [urlparse(BASE_URL).netloc]
+#: This is a security measure to prevent HTTP Host header attacks, which are possible even under many seemingly-safe
+#: web server configurations (see :setting:`django:ALLOWED_HOSTS` and :ref:`django:host-headers-virtual-hosting`)
+ALLOWED_HOSTS = [HOSTNAME, ".localhost", "127.0.0.1", "[::1]"] + list(
+    filter(
+        None,
+        (
+            x.strip()
+            for x in os.environ.get("INTEGREAT_CMS_ALLOWED_HOSTS", "").splitlines()
+        ),
+    )
+)
 
 #: A list of IP addresses, as strings, that allow the :func:`~django.template.context_processors.debug` context
 #: processor to add some variables to the template context.

--- a/integreat_cms/core/wsgi.py
+++ b/integreat_cms/core/wsgi.py
@@ -28,7 +28,7 @@ def application(environ, start_response):
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "integreat_cms.core.settings")
 
     # Read config from config file
-    config = configparser.ConfigParser()
+    config = configparser.ConfigParser(interpolation=None)
     config.read("/etc/integreat-cms.ini")
     for section in config.sections():
         for KEY, VALUE in config.items(section):

--- a/integreat_cms/integreat-cms-cli
+++ b/integreat_cms/integreat-cms-cli
@@ -10,7 +10,7 @@ def read_config():
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "integreat_cms.core.settings")
 
     # Read config from config file
-    config = configparser.ConfigParser()
+    config = configparser.ConfigParser(interpolation=None)
     config.read("/etc/integreat-cms.ini")
     for section in config.sections():
         for KEY, VALUE in config.items(section):

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "private": true,
   "scripts": {
-    "dev": "NODE_ENV=development NODE_OPTIONS=$(test $(node --version | cut -c2- | cut -d. -f1) -ge 17 && echo '--openssl-legacy-provider') webpack watch --mode development --color --stats=errors-warnings",
-    "prod": "NODE_ENV=production NODE_OPTIONS=$(test $(node --version | cut -c2- | cut -d. -f1) -ge 17 && echo '--openssl-legacy-provider') webpack --mode production"
+    "dev": "NODE_ENV=development webpack watch --mode development --color --stats=errors-warnings",
+    "prod": "NODE_ENV=production webpack --mode production"
   },
   "devDependencies": {
     "@babel/cli": "^7.16.0",


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
During my tests with the integreat cms pypi package, I noticed a few small problems:
- If the config file contains a `%`, configparser tries to do a string interpolation
- Some tailwind classes don't seem to be correctly included in the webpack build. This seems to be an issue of NodeJS v17.
- The version in the `__init__.py` was not contained in the final python package because a source path was incorrect
- The file based cache resides inside the virtual environment

### Proposed changes
<!-- Describe this PR in more detail. -->

- Do not interpolate variables with configparser
- Use NodeJS v16 in CircleCI again
- Fix source directory in CircleCI config
- Add option to configure file cache location

