### PR TITLE
Fix crash when replacing a file without thumbnail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ UNRELEASED
 * Fix dependency versions for production setup
 * Fully functional media library in selection window
 * Align language flags and translation status icons
+* Fix error when replacing media files without thumbnail
 
 
 2021.11.0-beta

--- a/integreat_cms/cms/forms/media/replace_media_file_form.py
+++ b/integreat_cms/cms/forms/media/replace_media_file_form.py
@@ -39,9 +39,6 @@ class ReplaceMediaFileForm(CustomModelForm):
         """
         Initialize UploadMediaFileForm form
 
-        :param data: submitted POST data
-        :type data: dict
-
         :param data: A dictionary-like object containing all given HTTP POST parameters
         :type data: django.http.QueryDict
 
@@ -60,7 +57,9 @@ class ReplaceMediaFileForm(CustomModelForm):
         self.fields["thumbnail"].required = False
 
         self.original_file_path = instance.file.path
-        self.original_thumbnail_path = getattr(instance.thumbnail, "path", None)
+        self.original_thumbnail_path = (
+            instance.thumbnail.path if instance.thumbnail else None
+        )
 
     def clean(self):
         """

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-12-15 10:40+0000\n"
+"POT-Creation-Date: 2021-12-15 15:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1650,7 +1650,7 @@ msgstr ""
 msgid "A directory with the name \"{}\" already exists."
 msgstr "Ein Ordner mit diesem Namen existiert bereits"
 
-#: cms/forms/media/replace_media_file_form.py:89
+#: cms/forms/media/replace_media_file_form.py:88
 msgid ""
 "The file type of the new file ({}) does not match the original file's type "
 "({})."


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr fixes a crash when a user attempts to replace a file in the media library that has no thumbnail.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Check if the file has a valid thumbnail before accessing its path

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1062 
