### PR TITLE
Use TLS for SMTP connection per default

### DIFF
--- a/example-configs/integreat-cms.ini
+++ b/example-configs/integreat-cms.ini
@@ -78,12 +78,16 @@ FILE_CACHE = /var/cache/integreat-cms
 SERVER_EMAIL = <your-email-address>
 # SMTP server [optional, defaults to localhost]
 EMAIL_HOST = <your-smtp-server>
-# SMTP username [required]
+# SMTP username [optional, defaults to SERVER_EMAIL]
 EMAIL_HOST_USER = <your-username>
 # SMTP password [required]
 EMAIL_HOST_PASSWORD = <your-password>
-# SMTP port [optional, defaults to 25]
+# SMTP port [optional, defaults to 587]
 EMAIL_PORT = <your-port>
+# Whether TLS is enabled [optional, defaults to True]
+EMAIL_USE_TLS = True
+# Whether SSL (implicit TLS) is enabled [optional, defaults to False]
+EMAIL_USE_SSL = False
 
 [linkcheck]
 # Whether link check should be disabled [optional, defaults to False]

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -503,6 +503,16 @@ EMAIL_HOST_USER = os.environ.get("INTEGREAT_CMS_EMAIL_HOST_USER", SERVER_EMAIL)
 #: (see :setting:`django:EMAIL_PORT`)
 EMAIL_PORT = int(os.environ.get("INTEGREAT_CMS_EMAIL_PORT", 587))
 
+#: Whether to use a TLS (secure) connection when talking to the SMTP server.
+#: This is used for explicit TLS connections, generally on port 587.
+#: (see :setting:`django:EMAIL_USE_TLS`)
+EMAIL_USE_TLS = bool(strtobool(os.environ.get("INTEGREAT_CMS_EMAIL_USE_TLS", "True")))
+
+#: Whether to use an implicit TLS (secure) connection when talking to the SMTP server.
+#: In most email documentation this type of TLS connection is referred to as SSL. It is generally used on port 465.
+#: (see :setting:`django:EMAIL_USE_SSL`)
+EMAIL_USE_SSL = bool(strtobool(os.environ.get("INTEGREAT_CMS_EMAIL_USE_SSL", "False")))
+
 
 ########################
 # INTERNATIONALIZATION #


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
On the dev system, I noticed that sending emails doesn't work because of an `SMTPNotSupportedError`.
Apparently, `EMAIL_USE_TLS` has to be explicitly activated when trying to send emails via port `587`.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Use TLS for SMTP connection per default
- Allow secure connection type configuration via environment & config file
- Add new settings to example config
