### PR TITLE
Fix tag in comparison with previous release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,7 +325,8 @@ jobs:
           command: |
             PREV_TAG=$(git describe --abbrev=0 --tags "${CIRCLE_TAG}^") || true
             CHANGELOG+=$(awk -v RS='\n\n\n' 'NR==2 {print $0}' CHANGELOG.md | tail -n +4)
-            echo "export PREV_TAG=${PREV_TAG}\nexport CHANGELOG=\"${CHANGELOG}\"" >> $BASH_ENV
+            echo "export PREV_TAG=\"${PREV_TAG}\"" >> $BASH_ENV
+            echo "export CHANGELOG=\"${CHANGELOG}\"" >> $BASH_ENV
       - run:
           name: Create release as Deliverino app
           command: pipenv run ./.circleci/scripts/create_release.py -p "${DELIVERINO_ACCESS_TOKEN}" "${CIRCLE_TAG}" "${PREV_TAG}" "${CHANGELOG}" ./dist/integreat-cms-*.tar.gz


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
In our [latest GitHub release](https://github.com/digitalfabrik/integreat-cms/releases/tag/2021.12.0-beta), the comparison with the previous tag didn't work as expected. Instead of 

> Compare changes: 2021.11.0-beta → 2021.12.0-beta

it initially showed:

> Compare changes: 2021.11.0-betanexport → 2021.12.0-beta

So presumably, passing the environment variables in CircleCI didn't work correctly.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Write two separate export statements instead of one
