### PR TITLE
Fix a crash when trying to delete a poi

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ UNRELEASED
 ----------
 
 * Fix APIv3 single page endpoint for multiple translation versions
+* Fix error when deleting a poi that is used by an event
 
 
 2021.12.0-beta

--- a/integreat_cms/cms/templates/pois/poi_form.html
+++ b/integreat_cms/cms/templates/pois/poi_form.html
@@ -215,13 +215,31 @@
                         {% if perms.cms.delete_poi %}
                             <div>
                                 <label>{% trans 'Delete location' %}</label>
-                                <button title="{% trans 'Delete location' %}" class="btn confirmation-button w-full btn-red"
-                                    data-confirmation-title="{{ delete_dialog_title }}"
-                                    data-confirmation-text="{{ delete_dialog_text }}"
-                                    data-confirmation-subject="{{ poi_form.instance|poi_translation_title:language }}"
-                                    data-action="{% url 'delete_poi' poi_id=poi_form.instance.id region_slug=region.slug language_slug=language.slug %}">
-                                    <i data-feather="trash-2" class="mr-2"></i> {% trans 'Delete this location' %}
-                                </button>
+                                {% if poi_form.instance.events.exists %}
+                                    <div class="bg-orange-100 border-l-4 border-orange-500 text-orange-500 px-4 py-3 mb-5" role="alert">
+                                        <p>
+                                            {% trans 'You cannot delete a location which is referenced by an event.' %}<br>
+                                            {% blocktrans count counter=poi_form.instance.events.count trimmed %}
+                                                To delete this location, you have to delete this event first:
+                                            {% plural %}
+                                                To delete this location, you have to delete these events first:
+                                            {% endblocktrans %}
+                                        </p>
+                                    </div>
+                                    {% for event in poi_form.instance.events.all %}
+                                        <a href="{% url 'edit_event' event_id=event.id region_slug=region.slug language_slug=language.slug %}" class="block pt-2 hover:underline">
+                                            <i data-feather="edit" class="mr-2"></i> {{ event.best_translation.title }}
+                                        </a>
+                                    {% endfor %}
+                                {% else %}
+                                    <button title="{% trans 'Delete location' %}" class="btn confirmation-button w-full btn-red"
+                                            data-confirmation-title="{{ delete_dialog_title }}"
+                                            data-confirmation-text="{{ delete_dialog_text }}"
+                                            data-confirmation-subject="{{ poi_form.instance|poi_translation_title:language }}"
+                                            data-action="{% url 'delete_poi' poi_id=poi_form.instance.id region_slug=region.slug language_slug=language.slug %}">
+                                        <i data-feather="trash-2" class="mr-2"></i> {% trans 'Delete this location' %}
+                                    </button>
+                                {% endif %}
                             </div>
                         {% endif %}
                     {% endif %}

--- a/integreat_cms/cms/templates/pois/poi_list_archived_row.html
+++ b/integreat_cms/cms/templates/pois/poi_list_archived_row.html
@@ -57,13 +57,19 @@
             <i data-feather="refresh-ccw"></i>
         </button>
         {% if perms.cms.delete_poi %}
-            <button title="{% trans 'Delete location' %}" class="confirmation-button btn-icon"
-                data-confirmation-title="{{ delete_dialog_title }}"
-                data-confirmation-text="{{ delete_dialog_text }}"
-                data-confirmation-subject="{{ poi_translation.title }}"
-                data-action="{% url 'delete_poi' poi_id=poi.id region_slug=region.slug language_slug=language.slug %}">
-                <i data-feather="trash-2"></i>
-            </button>
+            {% if poi.events.exists %}
+                <button title="{% trans 'You cannot delete a location which is used by an event.' %}&#013;{% trans 'This also involves archived events.' %}" class="btn-icon" disabled>
+                    <i data-feather="trash-2"></i>
+                </button>
+            {% else %}
+                <button title="{% trans 'Delete location' %}" class="confirmation-button btn-icon"
+                    data-confirmation-title="{{ delete_dialog_title }}"
+                    data-confirmation-text="{{ delete_dialog_text }}"
+                    data-confirmation-subject="{{ poi_translation.title }}"
+                    data-action="{% url 'delete_poi' poi_id=poi.id region_slug=region.slug language_slug=language.slug %}">
+                    <i data-feather="trash-2"></i>
+                </button>
+            {% endif %}
         {% endif %}
     </td>
 </tr>

--- a/integreat_cms/cms/templates/pois/poi_list_row.html
+++ b/integreat_cms/cms/templates/pois/poi_list_row.html
@@ -95,13 +95,19 @@
             <i data-feather="archive"></i>
         </button>
         {% if perms.cms.delete_poi %}
-            <button title="{% trans 'Delete location' %}" class="confirmation-button btn-icon"
-                data-confirmation-title="{{ delete_dialog_title }}"
-                data-confirmation-text="{{ delete_dialog_text }}"
-                data-confirmation-subject="{{ poi_translation.title }}"
-                data-action="{% url 'delete_poi' poi_id=poi.id region_slug=region.slug language_slug=language.slug %}">
-                <i data-feather="trash-2"></i>
-            </button>
+            {% if poi.events.exists %}
+                <button title="{% trans 'You cannot delete a location which is used by an event.' %}&#013;{% trans 'This also involves archived events.' %}" class="btn-icon" disabled>
+                    <i data-feather="trash-2"></i>
+                </button>
+            {% else %}
+                <button title="{% trans 'Delete location' %}" class="confirmation-button btn-icon"
+                    data-confirmation-title="{{ delete_dialog_title }}"
+                    data-confirmation-text="{{ delete_dialog_text }}"
+                    data-confirmation-subject="{{ poi_translation.title }}"
+                    data-action="{% url 'delete_poi' poi_id=poi.id region_slug=region.slug language_slug=language.slug %}">
+                    <i data-feather="trash-2"></i>
+                </button>
+            {% endif %}
         {% endif %}
     </td>
 </tr>

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-05 10:03+0000\n"
+"POT-Creation-Date: 2022-01-05 10:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -4769,13 +4769,24 @@ msgstr "Ort archivieren"
 msgid "Archive this location"
 msgstr "Diesen Ort archivieren"
 
-#: cms/templates/pois/poi_form.html:217 cms/templates/pois/poi_form.html:218
-#: cms/templates/pois/poi_list_archived_row.html:60
-#: cms/templates/pois/poi_list_row.html:98
+#: cms/templates/pois/poi_form.html:217 cms/templates/pois/poi_form.html:235
+#: cms/templates/pois/poi_list_archived_row.html:65
+#: cms/templates/pois/poi_list_row.html:103
 msgid "Delete location"
 msgstr "Ort löschen"
 
-#: cms/templates/pois/poi_form.html:223
+#: cms/templates/pois/poi_form.html:221
+msgid "You cannot delete a location which is referenced by an event."
+msgstr ""
+"Der Ort kann nicht gelöscht werden, da er von einem Event verwendet wird."
+
+#: cms/templates/pois/poi_form.html:222
+msgid "To delete this location, you have to delete this event first:"
+msgid_plural "To delete this location, you have to delete these events first:"
+msgstr[0] "Löschen Sie zuerst diese Veranstaltung, um den Ort zu löschen:"
+msgstr[1] "Löschen Sie zuerst diese Veranstaltungen, um den Ort zu löschen:"
+
+#: cms/templates/pois/poi_form.html:240
 msgid "Delete this location"
 msgstr "Diesen Ort löschen"
 
@@ -4804,6 +4815,18 @@ msgstr "Noch keine Orte vorhanden."
 #: cms/templates/pois/poi_list_archived.html:42
 msgid "No locations archived yet."
 msgstr "Noch keine Orte archiviert."
+
+#: cms/templates/pois/poi_list_archived_row.html:61
+#: cms/templates/pois/poi_list_row.html:99
+msgid "You cannot delete a location which is used by an event."
+msgstr ""
+"Der Ort kann nicht gelöscht werden, da er von einer Veranstaltung verwendet "
+"wird."
+
+#: cms/templates/pois/poi_list_archived_row.html:61
+#: cms/templates/pois/poi_list_row.html:99
+msgid "This also involves archived events."
+msgstr "Dies betrifft auch archivierte Veranstaltungen."
 
 #: cms/templates/pois/poi_list_row.html:82
 msgid "Open location in web app"
@@ -6397,6 +6420,9 @@ msgstr ""
 
 #~ msgid "All users"
 #~ msgstr "Alle Benutzer"
+
+#~ msgid "To delete this location, you have to delete this events first:"
+#~ msgstr "Löschen sie diese Veranstaltungen erst, um den Ort zu löschen:"
 
 #~ msgid "Missing"
 #~ msgstr "Fehlt"


### PR DESCRIPTION
# Short Description
Before this pr, the server crashed when trying to delete a poi that is referenced by an event. 
This pr disables deleting pois that are still used by at least one event

Co-authored-by: philip popien <membralala@users.noreply.github.com>
Co-authored-by: MizukiTemma <MizukiTemma@users.noreply.github.com>
