### PR TITLE
Fix install script when clean install cannot remove anything

### DIFF
--- a/dev-tools/install.sh
+++ b/dev-tools/install.sh
@@ -91,7 +91,7 @@ echo "✔ All system requirements are satisfied" | print_success
 if [[ "$*" == *"--clean"* ]]; then
     echo "Removing installed dependencies and compiled static files..." | print_info
     # Report deleted files but only the explicitly deleted directories
-    rm -rfv .venv node_modules "${PACKAGE_DIR:?}/static/dist" | grep -E -- "'.venv'|'node_modules'|'${PACKAGE_DIR}/static/dist'"
+    rm -rfv .venv node_modules "${PACKAGE_DIR:?}/static/dist" | grep -E -- "'.venv'|'node_modules'|'${PACKAGE_DIR}/static/dist'" || true
 fi
 
 # Install npm dependencies


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
If the directories `.venv`, `node_modules` and `integreat_cms/static/dist` do not exist and a clean installation is executed, the script aborts because grep returns a non-zero exit code when no match is found.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Allow the grep command after the `--clean` install to fail
