### PR TITLE
Allow pip package to be installed with python3.8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
 	License :: OSI Approved :: Apache Software License
 	Operating System :: OS Independent
 	Programming Language :: Python :: 3
+	Programming Language :: Python :: 3.8
 	Programming Language :: Python :: 3.9
 	Framework :: Django
 	Framework :: Django :: 3.2
@@ -65,7 +66,7 @@ install_requires =
 	six
 	webauthn
 	xhtml2pdf
-python_requires = ~=3.9
+python_requires = >=3.8
 include_package_data = True
 scripts = integreat_cms/integreat-cms-cli
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
We don't have any reason to think python3.8 wouldn't work, only python3.7 and below are guaranteed to fail due to the requirement of webauthn

### Proposed changes
<!-- Describe this PR in more detail. -->
- Allow pip package to be installed with python3.8

