### PR TITLE
Fix bug when creating a new offer template

### DIFF
--- a/integreat_cms/cms/views/offer_templates/offer_template_view.py
+++ b/integreat_cms/cms/views/offer_templates/offer_template_view.py
@@ -83,7 +83,7 @@ class OfferTemplateView(TemplateView):
             # Save form
             form.save()
             # Add the success message and redirect to the edit page
-            if offer_template_instance:
+            if not offer_template_instance:
                 messages.success(
                     request,
                     _('Offer template "{}" was successfully created').format(
@@ -98,5 +98,6 @@ class OfferTemplateView(TemplateView):
                 request,
                 _('Offer template "{}" was successfully saved').format(form.instance),
             )
+            form = OfferTemplateForm(instance=form.instance)
 
         return render(request, self.template_name, {"form": form, **self.base_context})


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes a tiny bug, where a wrong type was passed, when creating a new offer template as admin

### Proposed changes
<!-- Describe this PR in more detail. -->
- Change cleaned_post_data from ```dict``` to ```str``` 
