### PR TITLE
Fix `VariableDoesNotExist` error in region user form

### DIFF
--- a/integreat_cms/cms/templates/users/region/user.html
+++ b/integreat_cms/cms/templates/users/region/user.html
@@ -115,7 +115,7 @@
             <div class="pt-2 pb-4">
                 <button title="{% blocktrans %}Remove this user from region {{ request.region }}{% endblocktrans %}" class="btn confirmation-button btn-red"
                         data-confirmation-title="{% blocktrans %}Please confirm that you really want to remove this user from region {{ request.region }}.{% endblocktrans %}"
-                        data-confirmation-text="{% trans 'The user will keep access to the following regions:' %} {{ user_form.instance|remaining_regions:region|join:', ' }}"
+                        data-confirmation-text="{% trans 'The user will keep access to the following regions:' %} {{ user_form.instance|remaining_regions:request.region|join:', ' }}"
                         data-confirmation-subject="{{ user_form.username.value }}"
                         data-action="{% url 'delete_region_user' region_slug=request.region.slug user_id=user_form.instance.id %}">
                     <i data-feather="trash-2" class="mr-2"></i>


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This error appeared when a region user had more than one region and their user form was opened. The rendering of the deletion-confirmation-popup failed because in commit b4ca14ee3f3b335f7a7f40b0c5fb357016ca8279 I forgot to replace this occurrence of 'region'.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Fix `VariableDoesNotExist` error in region user form


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->
I did not open an issue for it
