### PR TITLE
Show package version at bottom navigation sidebar

### DIFF
--- a/integreat_cms/cms/templates/_base.html
+++ b/integreat_cms/cms/templates/_base.html
@@ -256,6 +256,9 @@
             {% endif %}
         {% endif %}
     </div>
+    <div class="p-2 text-center absolute inset-x-0 bottom-0 bg-gray-700">
+        {% trans 'Version' %}: {{ version }}
+    </div>
 </nav>
 <main class="relative min-h-screen flex pl-56 pt-14 bg-gray-100">
     <div class="flex-1 min-w-0 p-6">

--- a/integreat_cms/core/context_processors.py
+++ b/integreat_cms/core/context_processors.py
@@ -1,0 +1,18 @@
+"""
+Context processors pass additional variables to templates (see :ref:`context-processors`).
+"""
+from integreat_cms import __version__
+
+
+# pylint: disable=unused-variable
+def version_processor(request):
+    """
+    This context processor injects the current package version into the template context.
+
+    :param request: The current http request
+    :type request: ~django.http.HttpRequest
+
+    :return: The currently installed version of this package
+    :rtype: dict
+    """
+    return {"version": __version__}

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -190,6 +190,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "integreat_cms.core.context_processors.version_processor",
             ],
             "debug": DEBUG,
         },

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-19 19:42+0000\n"
+"POT-Creation-Date: 2022-01-21 14:16+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -3091,6 +3091,19 @@ msgstr "Organisationen"
 msgid "Offer Templates"
 msgstr "Angebots-Vorlagen"
 
+#: cms/templates/_base.html:260 cms/templates/events/event_form.html:132
+#: cms/templates/imprint/imprint_form.html:104
+#: cms/templates/imprint/imprint_revisions.html:20
+#: cms/templates/imprint/imprint_sbs.html:57
+#: cms/templates/imprint/imprint_sbs.html:114
+#: cms/templates/imprint/imprint_sbs.html:124
+#: cms/templates/pages/page_form.html:156
+#: cms/templates/pages/page_revisions.html:24
+#: cms/templates/pages/page_sbs.html:64 cms/templates/pages/page_sbs.html:121
+#: cms/templates/pages/page_sbs.html:126 cms/templates/pois/poi_form.html:121
+msgid "Version"
+msgstr "Version"
+
 #: cms/templates/_raw.html:10
 msgid "Integreat Editorial System"
 msgstr "Integreat Redaktionssystem"
@@ -3559,19 +3572,6 @@ msgstr "Zur Überprüfung vorlegen"
 #: cms/templates/pois/poi_form.html:69
 msgid "Create Translation"
 msgstr "Übersetzung erstellen"
-
-#: cms/templates/events/event_form.html:132
-#: cms/templates/imprint/imprint_form.html:104
-#: cms/templates/imprint/imprint_revisions.html:20
-#: cms/templates/imprint/imprint_sbs.html:57
-#: cms/templates/imprint/imprint_sbs.html:114
-#: cms/templates/imprint/imprint_sbs.html:124
-#: cms/templates/pages/page_form.html:156
-#: cms/templates/pages/page_revisions.html:24
-#: cms/templates/pages/page_sbs.html:64 cms/templates/pages/page_sbs.html:121
-#: cms/templates/pages/page_sbs.html:126 cms/templates/pois/poi_form.html:121
-msgid "Version"
-msgstr "Version"
 
 #: cms/templates/events/event_form.html:183
 #: cms/templates/pois/poi_form.html:170


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
When we have different instances of CMS servers deployed (production, cms-test, cms-dev), it's probably handy to see the installed version of the cms at a glance, especially for bug reports etc.
I hope the placement at the bottom of the navigation bar is not too obtrusive from a UI/UX perspective...

### Proposed changes
<!-- Describe this PR in more detail. -->

- Show version at bottom navigation sidebar
