### PR TITLE
Add region name to MatomoException token message

### DIFF
--- a/integreat_cms/cms/utils/matomo_api_manager.py
+++ b/integreat_cms/cms/utils/matomo_api_manager.py
@@ -47,6 +47,7 @@ class MatomoApiManager:
         :param region: The region this Matomo API Manager connects to
         :type region: ~integreat_cms.cms.models.regions.region.Region
         """
+        self.region_name = region.name
         self.matomo_token = region.matomo_token
         self.matomo_id = region.matomo_id
         self.languages = region.active_languages
@@ -140,7 +141,9 @@ class MatomoApiManager:
             return response[0]
         except IndexError as e:
             # If no id is returned, there is no user with the given access token
-            raise MatomoException("The access token is not correct.") from e
+            raise MatomoException(
+                f"The access token for {self.region_name} is not correct."
+            ) from e
 
     async def get_total_visits_async(self, query_params):
         """

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-23 04:49+0000\n"
+"POT-Creation-Date: 2022-01-24 09:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1559,7 +1559,7 @@ msgid "Language"
 msgstr "Sprache"
 
 #: cms/forms/feedback/region_feedback_filter_form.py:17
-#: cms/utils/matomo_api_manager.py:208 cms/utils/matomo_api_manager.py:338
+#: cms/utils/matomo_api_manager.py:211 cms/utils/matomo_api_manager.py:341
 msgid "All languages"
 msgstr "Alle Sprachen"
 
@@ -5346,7 +5346,7 @@ msgstr ""
 msgid "Your username is:"
 msgstr "Ihr Benutzername lautet:"
 
-#: cms/utils/matomo_api_manager.py:387 cms/utils/matomo_api_manager.py:392
+#: cms/utils/matomo_api_manager.py:390 cms/utils/matomo_api_manager.py:395
 msgid "CW"
 msgstr "KW"
 


### PR DESCRIPTION
### Short description
When access to Matomo is denied, a mail with the error message is dispatched. But due to missing region name/id it is not possible to fix the prohblem.


### Proposed changes
Add the region name to the error message.