### PR TITLE
Do not send error emails to admins

### DIFF
--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -420,7 +420,7 @@ LOGGING = {
     "loggers": {
         # Loggers of integreat-cms django apps
         "integreat_cms": {
-            "handlers": ["console-colored", "logfile", "mail_admins"],
+            "handlers": ["console-colored", "logfile"],
             "level": LOG_LEVEL,
         },
         # Syslog for authentication


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Since we received a lot of error messages lately, I suggest to turn off this alert channel...
In the short term, we can have a look at our server log files, in the long term we can think about how we want to monitor for errors on Grafana etc...
