### PR TITLE
Fix superuser permissions mechanic

### DIFF
--- a/integreat_cms/cms/templates/users/user_form.html
+++ b/integreat_cms/cms/templates/users/user_form.html
@@ -80,7 +80,7 @@
 			</div>
 			<div class="px-4 pb-4 divide-y divide-gray-200 space-y-4">
                 <div class="divide-y divide-gray-200">
-                    <div>
+                    <div class="{% if not request.user.is_superuser %}hidden{% endif %}">
                         {% render_field user_form.is_superuser %}
                         <label for="{{ user_form.is_superuser.id_for_label }}">{{ user_form.is_superuser.label }}</label>
                         <div class="help-text">{{ user_form.is_superuser.help_text }}</div>

--- a/integreat_cms/cms/views/users/user_form_view.py
+++ b/integreat_cms/cms/views/users/user_form_view.py
@@ -100,6 +100,11 @@ class UserFormView(TemplateView):
                     "A user has to be either staff/superuser or needs to be restricted to at least one region."
                 ),
             )
+        elif not request.user.is_superuser and "is_superuser" in user_form.changed_data:
+            messages.error(
+                request,
+                _("Superuser permissions need to be set by another superuser."),
+            )
         elif not user_form.has_changed():
             # Add "no changes" messages
             messages.info(request, _("No changes made"))

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -5620,7 +5620,7 @@ msgstr "Feedback wurde erfolgreich gelöscht"
 #: cms/views/settings/user_settings_view.py:94
 #: cms/views/settings/user_settings_view.py:111
 #: cms/views/users/region_user_form_view.py:98
-#: cms/views/users/user_form_view.py:105
+#: cms/views/users/user_form_view.py:110
 msgid "No changes made"
 msgstr "Keine Änderungen vorgenommen"
 
@@ -6327,17 +6327,17 @@ msgstr "Benutzer {} wurde erfolgreich von dieser Region entfernt."
 
 #: cms/views/users/region_user_form_view.py:56
 #: cms/views/users/region_user_form_view.py:131
-#: cms/views/users/user_form_view.py:54 cms/views/users/user_form_view.py:135
+#: cms/views/users/user_form_view.py:54 cms/views/users/user_form_view.py:140
 msgid "Pending account activation"
 msgstr "Aktivierung des Benutzerkontos noch ausstehend"
 
 #: cms/views/users/region_user_form_view.py:112
-#: cms/views/users/user_form_view.py:117
+#: cms/views/users/user_form_view.py:122
 msgid "User \"{}\" was successfully created"
 msgstr "Benutzer \"{}\" wurde erfolgreich erstellt"
 
 #: cms/views/users/region_user_form_view.py:120
-#: cms/views/users/user_form_view.py:125
+#: cms/views/users/user_form_view.py:130
 msgid "User \"{}\" was successfully saved"
 msgstr "Benutzer \"{}\" wurde erfolgreich gespeichert"
 
@@ -6350,8 +6350,13 @@ msgid ""
 "A user has to be either staff/superuser or needs to be restricted to at "
 "least one region."
 msgstr ""
-"Ein Benutzer muss entweder Mitarbeiter/Super-Administrator sein, oder "
-"mindestens einer Region zugewiesen sein."
+"Ein Benutzer muss entweder Mitarbeiter/Administrator sein, oder mindestens "
+"einer Region zugewiesen sein."
+
+#: cms/views/users/user_form_view.py:106
+msgid "Superuser permissions need to be set by another superuser."
+msgstr ""
+"Administratorrechte müssen von einem anderen Administrator vergeben werden."
 
 #: xliff/utils.py:137
 msgid ""
@@ -6935,7 +6940,7 @@ msgstr ""
 #~ msgstr "E-Mail Adresse"
 
 #~ msgid "Superuser"
-#~ msgstr "Super-Administrator"
+#~ msgstr "Administrator"
 
 #~ msgid "Choose new password"
 #~ msgstr "Neues Passwort festlegen"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR should fix an issue, where a user without superuser permissions was able to change his/her superuser state. 


### Proposed changes
<!-- Describe this PR in more detail. -->
- Change the user form template, so that the superuser option is hidden, when the user isn't a superuser him/herself
- Change the user form view, so that a server-side error message is rendered in the same case
- Change 'superuser' translations from 'Superadmin' to 'Admin'

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes:  #1123
