### PR TITLE
Fix matomo API token check

### DIFF
--- a/integreat_cms/cms/utils/matomo_api_manager.py
+++ b/integreat_cms/cms/utils/matomo_api_manager.py
@@ -133,7 +133,8 @@ class MatomoApiManager:
         # Execute async request to Matomo API
         response = loop.run_until_complete(
             self.get_matomo_id_async(
-                token_auth=token_auth, method="SitesManager.getSitesIdWithAdminAccess"
+                token_auth=token_auth,
+                method="SitesManager.getSitesIdWithAtLeastViewAccess",
             )
         )
 

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-24 14:24+0000\n"
+"POT-Creation-Date: 2022-01-25 15:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1559,7 +1559,7 @@ msgid "Language"
 msgstr "Sprache"
 
 #: cms/forms/feedback/region_feedback_filter_form.py:17
-#: cms/utils/matomo_api_manager.py:211 cms/utils/matomo_api_manager.py:341
+#: cms/utils/matomo_api_manager.py:212 cms/utils/matomo_api_manager.py:342
 msgid "All languages"
 msgstr "Alle Sprachen"
 
@@ -5350,7 +5350,7 @@ msgstr ""
 msgid "Your username is:"
 msgstr "Ihr Benutzername lautet:"
 
-#: cms/utils/matomo_api_manager.py:390 cms/utils/matomo_api_manager.py:395
+#: cms/utils/matomo_api_manager.py:391 cms/utils/matomo_api_manager.py:396
 msgid "CW"
 msgstr "KW"
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
For legacy reasons, our API tokens don't have consistent permissions levels.
Thus, we can just check for 'at least view access' to determine the correct matomo id.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Use `getSitesIdWithAtLeastViewAccess` instead of `getSitesIdWithAdminAccess` for Matomo id check
