### PR TITLE
Fix page filters

### DIFF
--- a/integreat_cms/api/v3/pages.py
+++ b/integreat_cms/api/v3/pages.py
@@ -72,9 +72,11 @@ def pages(request, region_slug, language_slug):
     """
     region = request.region
     result = []
-    for page in region.get_pages(
-        prefetch_translations=True, prefetch_public_translations=True
-    ).cache_tree():
+    # The preliminary filter for explicitly_archived=False is not strictly required, but reduces the number of entries
+    # requested from the database
+    for page in region.pages.filter(explicitly_archived=False).cache_tree(
+        archived=False
+    )[0]:
         page_translation = page.get_public_translation(language_slug)
         if page_translation:
             result.append(transform_page(page_translation))

--- a/integreat_cms/cms/forms/pages/page_form.py
+++ b/integreat_cms/cms/forms/pages/page_form.py
@@ -88,11 +88,7 @@ class PageForm(CustomModelForm, MoveNodeForm):
         )
 
         # Limit possible parents to pages of current region
-        parent_queryset = (
-            self.instance.region.pages.all()
-            .prefetch_translations()
-            .prefetch_public_translations()
-        )
+        parent_queryset = self.instance.region.pages.all()
 
         # Set the initial value for the mirrored page region
         if self.instance.mirrored_page:
@@ -149,16 +145,13 @@ class PageForm(CustomModelForm, MoveNodeForm):
         # Set choices of mirrored_page field manually to make use of cache_tree()
         logger.debug("Set choices for mirrored page field:")
         self.fields["mirrored_page"].choices = [
-            (page.id, str(page))
-            for page in mirrored_page_queryset.prefetch_translations()
-            .prefetch_public_translations()
-            .cache_tree()
+            (page.id, str(page)) for page in mirrored_page_queryset.cache_tree()[0]
         ]
 
         # Set choices of parent and _ref_node_id fields manually to make use of cache_tree()
         logger.debug("Set choices for parent field:")
         cached_parent_choices = [
-            (page.id, str(page)) for page in parent_queryset.cache_tree()
+            (page.id, str(page)) for page in parent_queryset.cache_tree()[0]
         ]
         self.fields["parent"].choices = cached_parent_choices
         self.fields["_ref_node_id"].choices = cached_parent_choices

--- a/integreat_cms/cms/templates/_search_input.html
+++ b/integreat_cms/cms/templates/_search_input.html
@@ -19,6 +19,15 @@
         <div id="table-search-suggestions" class="absolute hidden shadow rounded-b top-full bg-graz-200 w-full z-10 max-h-60 overflow-y-auto cursor-pointer">
         </div>
     </div>
+    {% if search_query %}
+        <button
+            id="search-reset-btn"
+            title="{% trans 'Reset search' %}"
+            class="bg-gray-200 hover:bg-gray-300 text-gray-800 py-2 px-3"
+        >
+            <i data-feather="x" class="w-5"></i>
+        </button>
+    {% endif %}
     <button
         id="search-submit-btn"
         title="{% trans 'Search' %}" {% if related_form %}form={{ related_form }}{% endif %}

--- a/integreat_cms/cms/templates/language_tree/language_tree_node.html
+++ b/integreat_cms/cms/templates/language_tree/language_tree_node.html
@@ -4,34 +4,34 @@
 {% if node.depth != 1 %}
 <tr data-drop-id="{{ node.id }}" data-drop-position="left" class="drop drop-between h-3 -m-3 hidden level-{{node.depth}}"><td colspan="9"><div><span></span></div></td></tr>
 {% endif %}
-<tr data-drop-id="{{ node.id }}" data-drop-position="last-child" class="drop drop-on border-t border-b border-solid border-gray-200 hover:bg-gray-100{% if node.depth > 1 %} child level-{{node.depth}}{% endif %}">
+<tr data-drop-id="{{ node.id }}" data-drop-position="last-child" class="drop drop-on border-t border-b border-solid border-gray-200 hover:bg-gray-100{% if node.depth > 1 %} level-{{node.depth}}{% endif %}">
     <td class="hierarchy single_icon">
-		<span data-drag-id="{{ node.id }}" data-node-descendants="{{ node|get_descendant_ids }}" class="drag text-gray-800 block py-3 pl-4 pr-2 cursor-move" draggable="true">
+		<span data-drag-id="{{ node.id }}" data-node-descendants="{{ node|get_descendant_ids }}" class="drag text-gray-800 block py-1.5 pl-4 pr-2 cursor-move" draggable="true">
             <i data-feather="move" class="text-gray-800"></i>
         </span>
     </td>
 	<td>
-		<a href="{% url 'edit_language_tree_node' language_tree_node_id=node.id region_slug=request.region.slug %}" class="block py-3 px-2 text-gray-800">
+		<a href="{% url 'edit_language_tree_node' language_tree_node_id=node.id region_slug=request.region.slug %}" class="block py-1.5 px-2 text-gray-800">
 			{{ node.translated_name }}
 		</a>
 	</td>
 	<td>
-		<a href="{% url 'edit_language_tree_node' language_tree_node_id=node.id region_slug=request.region.slug %}" class="block py-3 px-2 text-gray-800">
+		<a href="{% url 'edit_language_tree_node' language_tree_node_id=node.id region_slug=request.region.slug %}" class="block py-1.5 px-2 text-gray-800">
 			{{ node.slug }}
 		</a>
 	</td>
 	<td>
-		<a href="{% url 'edit_language_tree_node' language_tree_node_id=node.id region_slug=request.region.slug %}" class="block py-3 px-2 text-gray-800">
+		<a href="{% url 'edit_language_tree_node' language_tree_node_id=node.id region_slug=request.region.slug %}" class="block py-1.5 px-2 text-gray-800">
 			{{ node.language.bcp47_tag }}
 		</a>
 	</td>
 	<td>
-		<a href="{% url 'edit_language_tree_node' language_tree_node_id=node.id region_slug=request.region.slug %}" class="block py-3 px-2 text-gray-800">
+		<a href="{% url 'edit_language_tree_node' language_tree_node_id=node.id region_slug=request.region.slug %}" class="block py-1.5 px-2 text-gray-800">
 			{{ node.language.get_text_direction_display }}
 		</a>
 	</td>
 	<td>
-		<a href="{% url 'edit_language_tree_node' language_tree_node_id=node.id region_slug=request.region.slug %}" class="block py-3 px-2 text-gray-800">
+		<a href="{% url 'edit_language_tree_node' language_tree_node_id=node.id region_slug=request.region.slug %}" class="block py-1.5 px-2 text-gray-800">
 			<span class="fp fp-{{ node.language.primary_country_code }} fp-rounded " title="{{ node.language.get_primary_country_code_display }}"></span>
 			<span class="fp fp-{{ node.language.secondary_country_code }} fp-rounded " title="{{ node.language.get_secondary_country_code_display }}"></span>
 		</a>

--- a/integreat_cms/cms/templates/pages/page_form.html
+++ b/integreat_cms/cms/templates/pages/page_form.html
@@ -233,7 +233,7 @@
                             <label>{% trans 'Restore page' %}</label>
                             <div class="bg-orange-100 border-l-4 border-orange-500 text-orange-500 px-4 py-3 mb-5" role="alert">
                                 <p>
-                                    {% blocktrans count counter=page.explicitly_archived_ancestors.count trimmed %}
+                                    {% blocktrans count counter=page.explicitly_archived_ancestors|length trimmed %}
                                         To restore this page, you have to restore its parent page:
                                     {% plural %}
                                         To restore this page, you have to restore all its archived parent pages:

--- a/integreat_cms/cms/templates/pages/page_tree.html
+++ b/integreat_cms/cms/templates/pages/page_tree.html
@@ -21,7 +21,7 @@
     <div class="flex flex-wrap justify-between gap-4">
         <div class="flex flex-wrap gap-4">
             {% include "generic_language_switcher.html" with target='pages' %}
-            {% include "_search_input.html" with object_type="page" related_form='page-filter-form' %}
+            {% include "_search_input.html" with object_type="page" related_form='page-filter-form' search_query=filter_form.cleaned_data.query %}
         </div>
         <div class="flex flex-wrap gap-4">
             {% if request.user.expert_mode %}
@@ -57,7 +57,9 @@
             <thead>
                 <tr class="border-b border-solid border-gray-200">
                     <th class="text-sm text-left uppercase py-3 pl-4 pr-2 min"><input type="checkbox" id="bulk-select-all"></th>
-                    <th class="text-sm text-left uppercase py-3 pl-2 pr-2 min">{% trans 'Hierarchy' %}</th>
+                    {% if not filter_form.has_changed %}
+                        <th class="text-sm text-left uppercase py-3 pl-2 pr-2 min">{% trans 'Hierarchy' %}</th>
+                    {% endif %}
                     <th class="text-sm text-left uppercase py-3 pl-2 pr-2">{% trans 'Title in' %} {{ language.translated_name }}</th>
                     {% get_current_language as LANGUAGE_CODE %}
                     {% get_language LANGUAGE_CODE as backend_language %}

--- a/integreat_cms/cms/templates/pages/page_tree.html
+++ b/integreat_cms/cms/templates/pages/page_tree.html
@@ -12,9 +12,9 @@
     <div class="flex flex-wrap justify-between gap-4">
         <h1 class="heading">{% trans 'Page Tree' %} <button data-show-tutorial="page_tree_tutorial_seen" class="hover:text-blue-500"><i data-feather="help-circle" class="align-baseline"></i></button></h1>
         <a href="{% url 'archived_pages' region_slug=request.region.slug language_slug=language.slug %}" class="font-bold text-sm text-gray-800 flex items-center gap-1 mb-2 hover:underline">
-            <span>{% trans 'Archived pages' %}</span>
+            <span><i data-feather="archive" class="align-top h-5"></i> {% trans 'Archived pages' %}</span>
             <span class="inline-block rounded-full bg-integreat-500 text-gray-800 px-2 py-1 text-xs font-bold">
-                {{ archived_count }}
+                {{ skipped_count }}
             </span>
         </a>
     </div>

--- a/integreat_cms/cms/templates/pages/page_tree_archived.html
+++ b/integreat_cms/cms/templates/pages/page_tree_archived.html
@@ -1,4 +1,5 @@
 {% extends "_base.html" %}
+
 {% load i18n %}
 {% load static %}
 {% load content_filters %}
@@ -8,7 +9,15 @@
 {% block content %}
 {% with filter_form.filters_visible as filters_visible %}
 <div class="table-header">
-    <h1 class="heading">{% trans 'Archived Pages' %}</h1>
+    <div class="flex flex-wrap justify-between gap-4">
+        <h1 class="heading">{% trans 'Archived Pages' %}</h1>
+        <a href="{% url 'pages' region_slug=request.region.slug language_slug=language.slug %}" class="font-bold text-sm text-gray-800 flex items-center gap-1 mb-2 hover:underline">
+            <span><i data-feather="layout" class="align-top h-5"></i> {% trans 'Page Tree' %}</span>
+            <span class="inline-block rounded-full bg-integreat-500 text-gray-800 px-2 py-1 text-xs font-bold">
+                {{ skipped_count }}
+            </span>
+        </a>
+    </div>
     <div class="flex flex-wrap justify-between gap-4">
         <div class="flex flex-wrap gap-4">
             {% include "generic_language_switcher.html" with target='archived_pages' %}

--- a/integreat_cms/cms/templates/pages/page_tree_archived.html
+++ b/integreat_cms/cms/templates/pages/page_tree_archived.html
@@ -32,7 +32,9 @@
         <table data-activate-tree-drag-drop class="w-full mt-4 rounded border-2 border-solid border-gray-200 shadow bg-white table-auto">
             <thead>
                 <tr class="border-b border-solid border-gray-200">
-                    <th class="text-sm text-left uppercase py-3 pl-4 pr-2 min">{% trans 'Hierarchy' %}</th>
+                    {% if not filter_form.has_changed %}
+                        <th class="text-sm text-left uppercase py-3 pl-4 pr-2 min">{% trans 'Hierarchy' %}</th>
+                    {% endif %}
                     <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {{ language.translated_name }}</th>
                     {% get_current_language as LANGUAGE_CODE %}
                     {% get_language LANGUAGE_CODE as backend_language %}
@@ -51,7 +53,8 @@
                         </div>
                     </th>
                     <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Status' %}</th>
-                    <th class="text-sm text-right uppercase py-3 pl-2 pr-4">{% trans 'Options' %}</th>
+                    <th class="text-sm text-left uppercase py-3 pl-2">{% trans 'Last updated' %}</th>
+                    <th class="text-sm text-right uppercase py-3 pl-2 pr-4 min">{% trans 'Options' %}</th>
                 </tr>
             </thead>
             <tbody>
@@ -61,7 +64,11 @@
                 {% empty %}
                     <tr>
                         <td colspan="7" class="px-4 py-3">
-                            {% trans 'No pages archived yet.' %}
+                            {% if filter_form.has_changed %}
+                                {% trans 'No archived pages found with these filters.' %}
+                            {% else %}
+                                {% trans 'No pages archived yet.' %}
+                            {% endif %}
                         </td>
                     </tr>
                 {% endfor %}

--- a/integreat_cms/cms/templates/pages/page_tree_archived_node.html
+++ b/integreat_cms/cms/templates/pages/page_tree_archived_node.html
@@ -1,12 +1,25 @@
 {% load i18n %}
 {% load content_filters %}
 {% load page_filters %}
-<tr class="border-t border-b border-solid border-gray-200 hover:bg-gray-100{% if page.depth > 1 %} child level-{{page.depth}}{% endif %}">
-    <td class="hierarchy single_icon">
-        <span class="text-gray-800 block py-3 pl-4 pr-2" title="{% trans 'Drag & drop is disabled for archived pages.' %}">
-            <i data-feather="move"></i>
-        </span>
-    </td>
+{% load tree_filters %}
+
+<tr id="page-{{ page.id }}" class="border-t border-b border-solid border-gray-200 hover:bg-gray-100 {% if page.relative_depth > 1 %} level-{{page.relative_depth}} {% if not filter_form.has_changed and page.parent.archived %} hidden {% endif %} {% endif %}">
+    {% if not filter_form.has_changed %}
+        <td class="hierarchy single_icon whitespace-nowrap">
+            <span class="cursor-move text-gray-800 inline-block pl-4 align-middle" title="{% trans 'Drag & drop is disabled for archived pages.' %}">
+                <i data-feather="move"></i>
+            </span>
+            {% if not page.is_leaf %}
+                <span class="collapse-subpages cursor-pointer inline-block align-middle"
+                  title="{% trans 'Expand all subpages' %}"
+                  data-alt-title="{% trans 'Collapse all subpages' %}"
+                  data-page-id="{{ page.id }}"
+                  data-page-children="{{ page|get_children_ids }}">
+                    <i data-feather="chevron-right"></i>
+                </span>
+            {% endif %}
+        </td>
+    {% endif %}
     <td>
         <a href="{% url 'edit_page' page_id=page.id region_slug=request.region.slug language_slug=language.slug %}" class="block py-3 px-2 overflow-hidden max-w-xs whitespace-nowrap text-ellipsis text-gray-800" title="{% if page_translation %} {{ page_translation.title }} {% endif %}">
             {% if page_translation %}
@@ -70,7 +83,12 @@
             </div>
         {% endif %}
     </td>
-    <td class="pl-2 pr-4 py-3 flex flex-nowrap justify-end gap-2">
+    <td>
+        <div class="block py-2 px-2 whitespace-nowrap text-gray-800">
+            {{ page_translation.last_updated|date:"d.m.Y, H:i" }}
+        </div>
+    </td>
+    <td class="pl-2 pr-4 py-2 flex flex-nowrap justify-end gap-2">
         <!-- TODO: add link to view page in web app -->
         <a href="{% url 'view_page' page_id=page.id region_slug=request.region.slug language_slug=language.slug %}"
            target="_blank" rel="noopener noreferrer" title="{% trans 'View page' %}" class="icon">

--- a/integreat_cms/cms/templates/pages/page_tree_archived_node.html
+++ b/integreat_cms/cms/templates/pages/page_tree_archived_node.html
@@ -21,7 +21,7 @@
         </td>
     {% endif %}
     <td>
-        <a href="{% url 'edit_page' page_id=page.id region_slug=request.region.slug language_slug=language.slug %}" class="block py-3 px-2 overflow-hidden max-w-xs whitespace-nowrap text-ellipsis text-gray-800" title="{% if page_translation %} {{ page_translation.title }} {% endif %}">
+        <a href="{% url 'edit_page' page_id=page.id region_slug=request.region.slug language_slug=language.slug %}" class="block py-2 px-2 overflow-hidden max-w-xs whitespace-nowrap text-ellipsis text-gray-800" title="{% if page_translation %} {{ page_translation.title }} {% endif %}">
             {% if page_translation %}
                 {{ page_translation.title }}
             {% else %}
@@ -31,7 +31,7 @@
     </td>
     {% if backend_language and backend_language != language %}
         <td>
-            <a href="{% url 'edit_page' page_id=page.id region_slug=request.region.slug language_slug=LANGUAGE_CODE %}" class="block py-3 px-2 overflow-hidden max-w-xs whitespace-nowrap text-ellipsis text-gray-800" title="{% if page.backend_translation %} {{ page.backend_translation.title }} {% endif %}">
+            <a href="{% url 'edit_page' page_id=page.id region_slug=request.region.slug language_slug=LANGUAGE_CODE %}" class="block py-2 px-2 overflow-hidden max-w-xs whitespace-nowrap text-ellipsis text-gray-800" title="{% if page.backend_translation %} {{ page.backend_translation.title }} {% endif %}">
                 {% if page.backend_translation %}
                     {{ page.backend_translation.title }}
                 {% else %}
@@ -41,7 +41,7 @@
         </td>
     {% endif %}
     <td class="whitespace-nowrap">
-        <div class="block py-3 pl-2 text-gray-800">
+        <div class="block py-2 pl-2 text-gray-800">
             <div class="lang-grid">
                 {% spaceless %}
                     {% for other_language in languages %}
@@ -74,11 +74,11 @@
     </td>
     <td>
         {% if page.explicitly_archived %}
-            <div  title="{% trans 'This page is archived.' %}" href="{% url 'edit_page' page_id=page.id region_slug=request.region.slug language_slug=language.slug %}" class="block py-3 pl-2 text-gray-800">
+            <div  title="{% trans 'This page is archived.' %}" href="{% url 'edit_page' page_id=page.id region_slug=request.region.slug language_slug=language.slug %}" class="block py-2 pl-2 text-gray-800">
                 {% trans 'Archived' %}
             </div>
         {% else %}
-            <div  title="{% trans 'This page is archived, because at least one of its parent pages is archived.' %}" href="{% url 'edit_page' page_id=page.id region_slug=request.region.slug language_slug=language.slug %}" class="block py-3 pl-2 text-gray-800">
+            <div  title="{% trans 'This page is archived, because at least one of its parent pages is archived.' %}" href="{% url 'edit_page' page_id=page.id region_slug=request.region.slug language_slug=language.slug %}" class="block py-2 pl-2 text-gray-800">
                 {% trans 'Archived, because a parent page is archived' %}
             </div>
         {% endif %}

--- a/integreat_cms/cms/templates/pages/page_tree_node.html
+++ b/integreat_cms/cms/templates/pages/page_tree_node.html
@@ -5,31 +5,30 @@
 
 {% get_translation page language.slug as page_translation %}
 <tr id="page-{{ page.id }}-drop-left" data-drop-id="{{ page.id }}" data-drop-position="left" class="drop {% if page.depth == 1 %} drop-between {% endif %} h-3 -m-3 hidden level-{{page.depth}}"><td colspan="9"><div><span></span></div></td></tr>
-<tr id="page-{{ page.id }}" data-drop-id="{{ page.id }}" data-drop-position="last-child" class="drop drop-on border-t border-b border-solid border-gray-200 hover:bg-gray-100 child {% if page.depth > 1 %} hidden level-{{page.depth}}{% endif %}">
+<tr id="page-{{ page.id }}" data-drop-id="{{ page.id }}" data-drop-position="last-child" class="drop drop-on border-t border-b border-solid border-gray-200 hover:bg-gray-100 child {% if page.depth > 1 %} level-{{page.depth}} {% if not filter_form.has_changed %} hidden {% endif %} {% endif %}">
     <td class="pl-4">
         <input type="checkbox" name="selected_ids[]" value="{{ page.id }}" class="bulk-select-item">
     </td>
-    <td class="hierarchy single_icon whitespace-nowrap">
-        <span data-drag-id="{{ page.id }}"
-              data-node-descendants="{{ page|get_descendant_ids }}"
-              class="{% if enable_drag_and_drop %}drag cursor-move{% else %}cursor-not-allowed{% endif %} text-gray-800 inline-block pl-4 align-middle"
-              {% if enable_drag_and_drop %}
-              draggable="true"
-              title="{% trans 'Change the order and position of the pages with drag & drop.' %}"
-              {% else %}
-              title="{% trans 'Drag & drop is disabled when filters are applied.' %}"
-              {% endif %}>
-            <i data-feather="move"></i>
-        </span>
-        {% if not page.is_leaf %}
-        <span class="collapse-subpages cursor-pointer inline-block align-middle"
-              title="{% trans 'Collapse all subpages' %}"
-              data-page-id="{{ page.id }}"
-              data-page-children="{{ page|get_children_ids }}">
-                <i data-feather="chevron-right"></i>
+    {% if not filter_form.has_changed %}
+        <td class="hierarchy single_icon whitespace-nowrap">
+            <span data-drag-id="{{ page.id }}"
+                  data-node-descendants="{{ page|get_descendant_ids }}"
+                  class="drag cursor-move text-gray-800 inline-block pl-4 align-middle"
+                  draggable="true"
+                  title="{% trans 'Change the order and position of the pages with drag & drop.' %}">
+                <i data-feather="move"></i>
             </span>
-        {% endif %}
-    </td>
+            {% if page.cached_children|length > 0 %}
+                <span class="collapse-subpages cursor-pointer inline-block align-middle"
+                      title="{% trans 'Expand all subpages' %}"
+                      data-alt-title="{% trans 'Collapse all subpages' %}"
+                      data-page-id="{{ page.id }}"
+                      data-page-children="{{ page|get_children_ids }}">
+                    <i data-feather="chevron-right"></i>
+                </span>
+            {% endif %}
+        </td>
+    {% endif %}
     <td>
         <a href="{% url 'edit_page' page_id=page.id region_slug=request.region.slug language_slug=language.slug %}" class="block py-3 px-2 overflow-hidden max-w-xs whitespace-nowrap text-ellipsis text-gray-800" title="{% if page_translation %} {{ page_translation.title }} {% endif %}">
             {% if page_translation %}

--- a/integreat_cms/cms/templates/pages/page_tree_node.html
+++ b/integreat_cms/cms/templates/pages/page_tree_node.html
@@ -30,7 +30,7 @@
         </td>
     {% endif %}
     <td>
-        <a href="{% url 'edit_page' page_id=page.id region_slug=request.region.slug language_slug=language.slug %}" class="block py-3 px-2 overflow-hidden max-w-xs whitespace-nowrap text-ellipsis text-gray-800" title="{% if page_translation %} {{ page_translation.title }} {% endif %}">
+        <a href="{% url 'edit_page' page_id=page.id region_slug=request.region.slug language_slug=language.slug %}" class="block py-1.5 px-2 overflow-hidden max-w-xs whitespace-nowrap text-ellipsis text-gray-800" title="{% if page_translation %} {{ page_translation.title }} {% endif %}">
             {% if page_translation %}
                 {{ page_translation.title }}
             {% else %}
@@ -40,7 +40,7 @@
     </td>
     {% if backend_language and backend_language != language %}
         <td>
-            <a href="{% url 'edit_page' page_id=page.id region_slug=request.region.slug language_slug=LANGUAGE_CODE %}" class="block py-3 px-2 overflow-hidden max-w-xs whitespace-nowrap text-ellipsis text-gray-800" title="{% if page.backend_translation %} {{ page.backend_translation.title }} {% endif %}">
+            <a href="{% url 'edit_page' page_id=page.id region_slug=request.region.slug language_slug=LANGUAGE_CODE %}" class="block py-1.5 px-2 overflow-hidden max-w-xs whitespace-nowrap text-ellipsis text-gray-800" title="{% if page.backend_translation %} {{ page.backend_translation.title }} {% endif %}">
                 <div class="translation-title">
                     {% if page.backend_translation %}
                         {{ page.backend_translation.title }}
@@ -52,14 +52,14 @@
         </td>
     {% endif %}
     <td class="whitespace-nowrap">
-        <div class="block py-3 px-2 text-gray-800">
+        <div class="block py-1.5 px-2 text-gray-800">
             {% for tag in page_translation.tags %}
                 <span class="bg-orange-400 text-white rounded px-2 py-1">{{ tag }}</span>
             {% endfor %}
         </div>
     </td>
     <td class="whitespace-nowrap">
-        <div class="block py-3 px-2 text-gray-800">
+        <div class="block py-1.5 px-2 text-gray-800">
             <div class="lang-grid">
                 {% spaceless %}
                     {% for other_language, other_status in page.translation_states.values %}
@@ -96,16 +96,16 @@
         </div>
     </td>
     <td>
-        <div class="block py-3 px-2 text-gray-800">
+        <div class="block py-1.5 px-2 text-gray-800">
             {{ page_translation.get_status_display }}
         </div>
     </td>
     <td>
-        <div class="block py-3 px-2 whitespace-nowrap text-gray-800">
+        <div class="block py-1.5 px-2 whitespace-nowrap text-gray-800">
             {{ page_translation.last_updated|date:"d.m.Y, H:i" }}
         </div>
     </td>
-    <td class="pl-2 pr-4 py-3 text-right flex flex-nowrap gap-2">
+    <td class="pl-2 pr-4 py-1.5 text-right flex flex-nowrap gap-2">
         <a href="{% url 'view_page' page_id=page.id region_slug=request.region.slug language_slug=language.slug %}"
            target="_blank" rel="noopener noreferrer" title="{% trans 'View page as preview' %}" class="btn-icon">
             <i data-feather="eye"></i>

--- a/integreat_cms/cms/templates/pages/page_tree_node.html
+++ b/integreat_cms/cms/templates/pages/page_tree_node.html
@@ -4,8 +4,8 @@
 {% load tree_filters %}
 
 {% get_translation page language.slug as page_translation %}
-<tr id="page-{{ page.id }}-drop-left" data-drop-id="{{ page.id }}" data-drop-position="left" class="drop {% if page.depth == 1 %} drop-between {% endif %} h-3 -m-3 hidden level-{{page.depth}}"><td colspan="9"><div><span></span></div></td></tr>
-<tr id="page-{{ page.id }}" data-drop-id="{{ page.id }}" data-drop-position="last-child" class="drop drop-on border-t border-b border-solid border-gray-200 hover:bg-gray-100 child {% if page.depth > 1 %} level-{{page.depth}} {% if not filter_form.has_changed %} hidden {% endif %} {% endif %}">
+<tr id="page-{{ page.id }}-drop-left" data-drop-id="{{ page.id }}" data-drop-position="left" class="drop {% if page.relative_depth == 1 %} drop-between {% endif %} h-3 -m-3 hidden level-{{page.relative_depth}}"><td colspan="9"><div><span></span></div></td></tr>
+<tr id="page-{{ page.id }}" data-drop-id="{{ page.id }}" data-drop-position="last-child" class="drop drop-on border-t border-b border-solid border-gray-200 hover:bg-gray-100 {% if page.relative_depth > 1 %} level-{{page.relative_depth}} {% if not filter_form.has_changed %} hidden {% endif %} {% endif %}">
     <td class="pl-4">
         <input type="checkbox" name="selected_ids[]" value="{{ page.id }}" class="bulk-select-item">
     </td>

--- a/integreat_cms/cms/views/analytics/translation_coverage_view.py
+++ b/integreat_cms/cms/views/analytics/translation_coverage_view.py
@@ -47,11 +47,9 @@ class TranslationCoverageView(TemplateView):
         translation_coverage_data = {}
         outdated_word_count = Counter()
 
-        pages = (
-            region.pages.filter(explicitly_archived=False)
-            .prefetch_translations()
-            .cache_tree()
-        )
+        pages = region.pages.filter(explicitly_archived=False).cache_tree(
+            archived=False
+        )[0]
         for language in region.active_languages:
             language_coverage_data = Counter()
             for page in pages:

--- a/integreat_cms/cms/views/pages/page_tree_view.py
+++ b/integreat_cms/cms/views/pages/page_tree_view.py
@@ -95,12 +95,8 @@ class PageTreeView(TemplateView, PageContextMixin):
             )
         context = self.get_context_data(**kwargs)
 
-        pages = (
-            region.pages.filter(explicitly_archived=False)
-            .prefetch_translations()
-            .prefetch_public_translations()
-            .cache_tree()
-        )
+        page_queryset = region.pages.all()
+        pages, skipped_pages = page_queryset.cache_tree(archived=self.archived)
         # Filter pages according to given filters, if any
         filter_data = kwargs.get("filter_data")
         if filter_data:
@@ -118,7 +114,7 @@ class PageTreeView(TemplateView, PageContextMixin):
                 **context,
                 "current_menu_item": "pages",
                 "pages": pages,
-                "archived_count": region.get_pages(archived=True).count(),
+                "skipped_count": len(skipped_pages),
                 "language": language,
                 "languages": region.active_languages,
                 "filter_form": filter_form,

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-02-02 00:26+0000\n"
+"POT-Creation-Date: 2022-02-02 00:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -3094,11 +3094,15 @@ msgstr "Weitere Sprachen"
 msgid "Integreat Editorial System"
 msgstr "Integreat Redaktionssystem"
 
-#: cms/templates/_search_input.html:13 cms/templates/_search_input.html:24
+#: cms/templates/_search_input.html:13 cms/templates/_search_input.html:33
 #: cms/templates/events/_event_filter_form.html:34
 #: cms/views/media/media_context_mixin.py:55
 msgid "Search"
 msgstr "Suchen"
+
+#: cms/templates/_search_input.html:25
+msgid "Reset search"
+msgstr "Suche zurücksetzen"
 
 #: cms/templates/_tinymce_config.html:23
 msgid "Do not translate the selected text."

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-28 18:48+0000\n"
+"POT-Creation-Date: 2022-02-02 00:26+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1299,7 +1299,7 @@ msgstr "Versteckt"
 
 #: cms/constants/region_status.py:18 cms/models/pages/page.py:204
 #: cms/models/regions/region.py:583 cms/templates/pages/page_form.html:78
-#: cms/templates/pages/page_tree_archived_node.html:65
+#: cms/templates/pages/page_tree_archived_node.html:78
 msgid "Archived"
 msgstr "Archiviert"
 
@@ -1363,8 +1363,8 @@ msgstr "Rechts nach Links"
 #: cms/templates/imprint/imprint_sbs.html:47
 #: cms/templates/imprint/imprint_sbs.html:97
 #: cms/templates/pages/page_sbs.html:54 cms/templates/pages/page_sbs.html:104
-#: cms/templates/pages/page_tree_archived_node.html:47
-#: cms/templates/pages/page_tree_node.html:79
+#: cms/templates/pages/page_tree_archived_node.html:60
+#: cms/templates/pages/page_tree_node.html:78
 #: cms/templates/pois/poi_list_row.html:44
 msgid "Translation up-to-date"
 msgstr "Übersetzung ist aktuell"
@@ -1378,9 +1378,9 @@ msgstr "Übersetzung ist aktuell"
 #: cms/templates/imprint/imprint_sbs.html:43
 #: cms/templates/imprint/imprint_sbs.html:93
 #: cms/templates/pages/page_sbs.html:50 cms/templates/pages/page_sbs.html:100
-#: cms/templates/pages/page_tree_archived_node.html:39
-#: cms/templates/pages/page_tree_node.html:71
-#: cms/templates/pages/page_tree_node.html:89
+#: cms/templates/pages/page_tree_archived_node.html:52
+#: cms/templates/pages/page_tree_node.html:70
+#: cms/templates/pages/page_tree_node.html:88
 #: cms/templates/pois/poi_list_row.html:36
 #: cms/templates/pois/poi_list_row.html:54
 msgid "Currently in translation"
@@ -1394,8 +1394,8 @@ msgstr "Wird derzeit übersetzt"
 #: cms/templates/imprint/imprint_sbs.html:39
 #: cms/templates/imprint/imprint_sbs.html:89
 #: cms/templates/pages/page_sbs.html:46 cms/templates/pages/page_sbs.html:96
-#: cms/templates/pages/page_tree_archived_node.html:43
-#: cms/templates/pages/page_tree_node.html:75
+#: cms/templates/pages/page_tree_archived_node.html:56
+#: cms/templates/pages/page_tree_node.html:74
 #: cms/templates/pois/poi_list_row.html:40
 msgid "Translation outdated"
 msgstr "Übersetzung ist veraltet"
@@ -1405,8 +1405,8 @@ msgstr "Übersetzung ist veraltet"
 #: cms/templates/_form_language_tabs.html:72
 #: cms/templates/events/event_list_archived_row.html:49
 #: cms/templates/events/event_list_row.html:51
-#: cms/templates/pages/page_tree_archived_node.html:52
-#: cms/templates/pages/page_tree_node.html:83
+#: cms/templates/pages/page_tree_archived_node.html:65
+#: cms/templates/pages/page_tree_node.html:82
 #: cms/templates/pois/poi_list_row.html:48
 msgid "Translation missing"
 msgstr "Übersetzung fehlt"
@@ -1586,8 +1586,8 @@ msgstr "Kategorie"
 #: cms/templates/pages/page_form.html:75
 #: cms/templates/pages/page_revisions.html:50
 #: cms/templates/pages/page_sbs.html:66 cms/templates/pages/page_sbs.html:123
-#: cms/templates/pages/page_sbs.html:128 cms/templates/pages/page_tree.html:79
-#: cms/templates/pages/page_tree_archived.html:53
+#: cms/templates/pages/page_sbs.html:128 cms/templates/pages/page_tree.html:81
+#: cms/templates/pages/page_tree_archived.html:55
 #: cms/templates/pois/poi_form.html:47 cms/templates/pois/poi_list.html:59
 #: cms/templates/pois/poi_list_archived.html:23
 #: cms/templates/regions/region_list.html:24
@@ -2421,10 +2421,10 @@ msgstr "Ob die Seite explizit archiviert ist oder nicht"
 #: cms/templates/events/event_list.html:56
 #: cms/templates/events/event_list_archived.html:29
 #: cms/templates/events/event_list_archived.html:33
-#: cms/templates/pages/page_form.html:28 cms/templates/pages/page_tree.html:61
-#: cms/templates/pages/page_tree.html:65
-#: cms/templates/pages/page_tree_archived.html:36
-#: cms/templates/pages/page_tree_archived.html:40
+#: cms/templates/pages/page_form.html:28 cms/templates/pages/page_tree.html:63
+#: cms/templates/pages/page_tree.html:67
+#: cms/templates/pages/page_tree_archived.html:38
+#: cms/templates/pages/page_tree_archived.html:42
 #: cms/templates/pois/poi_form.html:27 cms/templates/pois/poi_list.html:44
 #: cms/templates/pois/poi_list.html:46
 #: cms/templates/pois/poi_list_archived.html:24
@@ -3664,8 +3664,8 @@ msgstr "Wiederholung"
 #: cms/templates/languages/language_list.html:29
 #: cms/templates/offertemplates/offertemplate_list.html:25
 #: cms/templates/organizations/organization_list.html:23
-#: cms/templates/pages/page_tree.html:81
-#: cms/templates/pages/page_tree_archived.html:54
+#: cms/templates/pages/page_tree.html:83
+#: cms/templates/pages/page_tree_archived.html:57
 #: cms/templates/pois/poi_list.html:64
 #: cms/templates/pois/poi_list_archived.html:32
 #: cms/templates/roles/role_list.html:20
@@ -3684,7 +3684,7 @@ msgstr "Keine zukünftigen Veranstaltungen vorhanden."
 #: cms/templates/feedback/admin_feedback_list.html:128
 #: cms/templates/feedback/region_feedback_list.html:121
 #: cms/templates/linkcheck/links_by_filter.html:72
-#: cms/templates/pages/page_tree.html:107 cms/templates/pois/poi_list.html:87
+#: cms/templates/pages/page_tree.html:109 cms/templates/pois/poi_list.html:87
 msgid "Select bulk action"
 msgstr "Mehrfachaktion auswählen"
 
@@ -3696,7 +3696,7 @@ msgstr "Fehlende übersetzungen automatisch erstellen"
 #: cms/templates/feedback/admin_feedback_list.html:135
 #: cms/templates/feedback/region_feedback_list.html:128
 #: cms/templates/linkcheck/links_by_filter.html:80
-#: cms/templates/pages/page_tree.html:126 cms/templates/pois/poi_list.html:90
+#: cms/templates/pages/page_tree.html:128 cms/templates/pois/poi_list.html:90
 msgid "Execute"
 msgstr "Ausführen"
 
@@ -3712,10 +3712,10 @@ msgstr "Keine zukünftigen Veranstaltungen archiviert."
 #: cms/templates/events/event_list_archived_row.html:24
 #: cms/templates/events/event_list_row.html:15
 #: cms/templates/events/event_list_row.html:27
-#: cms/templates/pages/page_tree_archived_node.html:15
-#: cms/templates/pages/page_tree_archived_node.html:25
-#: cms/templates/pages/page_tree_node.html:38
-#: cms/templates/pages/page_tree_node.html:49
+#: cms/templates/pages/page_tree_archived_node.html:28
+#: cms/templates/pages/page_tree_archived_node.html:38
+#: cms/templates/pages/page_tree_node.html:37
+#: cms/templates/pages/page_tree_node.html:48
 #: cms/templates/pois/poi_list_archived_row.html:16
 #: cms/templates/pois/poi_list_archived_row.html:26
 #: cms/templates/pois/poi_list_row.html:14
@@ -4096,8 +4096,8 @@ msgid "Create language tree node"
 msgstr "Sprach-Knoten hinzufügen"
 
 #: cms/templates/language_tree/language_tree.html:21
-#: cms/templates/pages/page_tree.html:60
-#: cms/templates/pages/page_tree_archived.html:35
+#: cms/templates/pages/page_tree.html:61
+#: cms/templates/pages/page_tree_archived.html:36
 msgid "Hierarchy"
 msgstr "Hierarchie"
 
@@ -4219,7 +4219,8 @@ msgstr "Erstellt"
 #: cms/templates/languages/language_list.html:28
 #: cms/templates/offertemplates/offertemplate_list.html:23
 #: cms/templates/pages/_page_xliff_import_diff.html:36
-#: cms/templates/pages/page_tree.html:80
+#: cms/templates/pages/page_tree.html:82
+#: cms/templates/pages/page_tree_archived.html:56
 #: cms/templates/regions/region_list.html:23
 msgid "Last updated"
 msgstr "Zuletzt aktualisiert"
@@ -4410,7 +4411,7 @@ msgid "Show"
 msgstr "Anzeigen"
 
 #: cms/templates/pages/page_form.html:80
-#: cms/templates/pages/page_tree_archived_node.html:69
+#: cms/templates/pages/page_tree_archived_node.html:82
 msgid "Archived, because a parent page is archived"
 msgstr "Archiviert, weil eine übergeordnete Seite archiviert ist"
 
@@ -4457,7 +4458,7 @@ msgstr ""
 #: cms/templates/pages/page_form.html:224
 #: cms/templates/pages/page_form.html:225
 #: cms/templates/pages/page_form.html:233
-#: cms/templates/pages/page_tree_archived_node.html:80
+#: cms/templates/pages/page_tree_archived_node.html:98
 msgid "Restore page"
 msgstr "Seite wiederherstellen"
 
@@ -4478,7 +4479,7 @@ msgstr[1] ""
 
 #: cms/templates/pages/page_form.html:249
 #: cms/templates/pages/page_form.html:250
-#: cms/templates/pages/page_tree_node.html:128
+#: cms/templates/pages/page_tree_node.html:127
 msgid "Archive page"
 msgstr "Seite archivieren"
 
@@ -4488,14 +4489,14 @@ msgstr "Diese Seite archivieren"
 
 #: cms/templates/pages/page_form.html:260
 #: cms/templates/pages/page_form.html:280
-#: cms/templates/pages/page_tree_archived_node.html:98
-#: cms/templates/pages/page_tree_node.html:141
+#: cms/templates/pages/page_tree_archived_node.html:116
+#: cms/templates/pages/page_tree_node.html:140
 msgid "Delete page"
 msgstr "Seite löschen"
 
 #: cms/templates/pages/page_form.html:265
-#: cms/templates/pages/page_tree_archived_node.html:94
-#: cms/templates/pages/page_tree_node.html:137
+#: cms/templates/pages/page_tree_archived_node.html:112
+#: cms/templates/pages/page_tree_node.html:136
 #: cms/views/pages/page_actions.py:223
 msgid "You cannot delete a page which has subpages."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
@@ -4568,51 +4569,51 @@ msgstr "Seite erstellen"
 msgid "You can only create pages in the default language"
 msgstr "Sie können Seiten nur in der Standard-Sprache anlegen"
 
-#: cms/templates/pages/page_tree.html:67
+#: cms/templates/pages/page_tree.html:69
 msgid "Tags"
 msgstr "Tags"
 
-#: cms/templates/pages/page_tree.html:95
+#: cms/templates/pages/page_tree.html:97
 msgid "No pages found with these filters."
 msgstr "Keine Seiten mit diesen Filtern gefunden."
 
-#: cms/templates/pages/page_tree.html:97
+#: cms/templates/pages/page_tree.html:99
 msgid "No pages available yet."
 msgstr "Noch keine Seiten vorhanden."
 
-#: cms/templates/pages/page_tree.html:108
+#: cms/templates/pages/page_tree.html:110
 msgid "Archive pages"
 msgstr "Seiten archivieren"
 
-#: cms/templates/pages/page_tree.html:113
+#: cms/templates/pages/page_tree.html:115
 msgid "Export published pages as PDF"
 msgstr "Veröffentlichte Seiten als PDF exportieren"
 
-#: cms/templates/pages/page_tree.html:120
+#: cms/templates/pages/page_tree.html:122
 msgid "You cannot export XLIFF files for the default language"
 msgstr "Sie können keine XLIFF-Dateien für die Standard-Sprache exportieren"
 
-#: cms/templates/pages/page_tree.html:123
+#: cms/templates/pages/page_tree.html:125
 msgid "Export XLIFF for translation to"
 msgstr "Exportiere XLIFF für Übersetzung nach"
 
-#: cms/templates/pages/page_tree.html:131
+#: cms/templates/pages/page_tree.html:133
 msgid "Import XLIFF files"
 msgstr "XLIFF-Dateien importieren"
 
-#: cms/templates/pages/page_tree.html:132
+#: cms/templates/pages/page_tree.html:134
 msgid "Supported file extensions"
 msgstr "Unterstützte Dateiendungen"
 
-#: cms/templates/pages/page_tree.html:137
+#: cms/templates/pages/page_tree.html:139
 msgid "Select files"
 msgstr "Dateien auswählen"
 
-#: cms/templates/pages/page_tree.html:139
+#: cms/templates/pages/page_tree.html:141
 msgid "and {} other files"
 msgstr "und {} weitere Dateien"
 
-#: cms/templates/pages/page_tree.html:142
+#: cms/templates/pages/page_tree.html:144
 msgid "Import"
 msgstr "Importieren"
 
@@ -4620,36 +4621,50 @@ msgstr "Importieren"
 msgid "Archived Pages"
 msgstr "Archivierte Seiten"
 
-#: cms/templates/pages/page_tree_archived.html:64
+#: cms/templates/pages/page_tree_archived.html:68
+msgid "No archived pages found with these filters."
+msgstr "Keine archivierten Seiten mit diesen Filtern gefunden."
+
+#: cms/templates/pages/page_tree_archived.html:70
 msgid "No pages archived yet."
 msgstr "Noch keine Seiten archiviert."
 
-#: cms/templates/pages/page_tree_archived_node.html:6
+#: cms/templates/pages/page_tree_archived_node.html:9
 msgid "Drag & drop is disabled for archived pages."
 msgstr "Drag & drop ist für archivierte Seiten nicht möglich."
 
-#: cms/templates/pages/page_tree_archived_node.html:64
+#: cms/templates/pages/page_tree_archived_node.html:14
+#: cms/templates/pages/page_tree_node.html:23
+msgid "Expand all subpages"
+msgstr "Alle Unterseiten ausklappen"
+
+#: cms/templates/pages/page_tree_archived_node.html:15
+#: cms/templates/pages/page_tree_node.html:24
+msgid "Collapse all subpages"
+msgstr "Alle Unterseiten einklappen"
+
+#: cms/templates/pages/page_tree_archived_node.html:77
 msgid "This page is archived."
 msgstr "Diese Seite ist archiviert."
 
-#: cms/templates/pages/page_tree_archived_node.html:68
+#: cms/templates/pages/page_tree_archived_node.html:81
 msgid ""
 "This page is archived, because at least one of its parent pages is archived."
 msgstr ""
 "Diese Seite ist archiviert, weil eine ihrer übergeordneten Seiten archiviert "
 "ist."
 
-#: cms/templates/pages/page_tree_archived_node.html:76
+#: cms/templates/pages/page_tree_archived_node.html:94
 msgid "View page"
 msgstr "Seite ansehen"
 
-#: cms/templates/pages/page_tree_archived_node.html:88
+#: cms/templates/pages/page_tree_archived_node.html:106
 msgid "To restore this page, you have to restore its archived parent page."
 msgstr ""
 "Um diese Seite wiederherzustellen, müssen Sie ihre archivierte übergeordnete "
 "Seite wiederherstellen."
 
-#: cms/templates/pages/page_tree_archived_node.html:94
+#: cms/templates/pages/page_tree_archived_node.html:112
 msgid "This also involves non-archived subpages."
 msgstr "Dies betrifft auch nicht-archivierte Unterseiten."
 
@@ -4657,41 +4672,33 @@ msgstr "Dies betrifft auch nicht-archivierte Unterseiten."
 msgid "Change the order and position of the pages with drag & drop."
 msgstr "Ändern Sie die Reihenfolge und Position der Seiten mit Drag & Drop."
 
-#: cms/templates/pages/page_tree_node.html:20
-msgid "Drag & drop is disabled when filters are applied."
-msgstr "Drag & drop nicht möglich, wenn Filter aktiv sind"
-
-#: cms/templates/pages/page_tree_node.html:26
-msgid "Collapse all subpages"
-msgstr "Alle Unterseiten einklappen"
-
-#: cms/templates/pages/page_tree_node.html:111
+#: cms/templates/pages/page_tree_node.html:110
 msgid "View page as preview"
 msgstr "Seite als Vorschau ansehen"
 
-#: cms/templates/pages/page_tree_node.html:116
+#: cms/templates/pages/page_tree_node.html:115
 msgid "Open page in web app"
 msgstr "Seite in der Web-App öffnen"
 
-#: cms/templates/pages/page_tree_node.html:120
+#: cms/templates/pages/page_tree_node.html:119
 msgid "This page cannot be opened in the web app, because it is not public."
 msgstr ""
 "Diese Seite kann nicht in der Web-App geöffnet werden, weil sie nicht "
 "veröffentlicht ist."
 
-#: cms/templates/pages/page_tree_node.html:124
+#: cms/templates/pages/page_tree_node.html:123
 msgid "Edit page"
 msgstr "Seite bearbeiten"
 
-#: cms/templates/pages/page_tree_node.html:137
+#: cms/templates/pages/page_tree_node.html:136
 msgid "This also involves archived subpages."
 msgstr "Dies betrifft auch archivierte Unterseiten."
 
-#: cms/templates/pages/page_tree_node.html:152
+#: cms/templates/pages/page_tree_node.html:151
 msgid "Copy short link"
 msgstr "Kurz-URL kopieren"
 
-#: cms/templates/pages/page_tree_node.html:156
+#: cms/templates/pages/page_tree_node.html:155
 msgid "You cannot copy a short link of a page which has no translation."
 msgstr "Sie können keine Kurz-URL zu einer fehlenden Übersetzung kopieren."
 
@@ -5645,7 +5652,7 @@ msgid "Imprint was successfully deleted"
 msgstr "Impressum wurde erfolgreich gelöscht"
 
 #: cms/views/imprint/imprint_form_view.py:73
-#: cms/views/pages/page_tree_view.py:84
+#: cms/views/pages/page_tree_view.py:83
 msgid "Please create at least one language node before creating pages."
 msgstr ""
 "Bitte erstellen Sie mindestens einen Sprach-Knoten, bevor Sie das Impressum "
@@ -6155,7 +6162,7 @@ msgid "You cannot restore revisions of this page because it is archived."
 msgstr ""
 "Sie können Revisionen dieser Seite nicht bearbeiten, weil sie archiviert ist."
 
-#: cms/views/pages/page_tree_view.py:95
+#: cms/views/pages/page_tree_view.py:94
 msgid "You don't have the permission to edit or create pages."
 msgstr ""
 "Sie haben nicht die nötige Berechtigung, um Seiten zu bearbeiten oder zu "
@@ -6404,6 +6411,12 @@ msgid "This page belongs to another region ({})."
 msgstr ""
 "Diese Seite konnte nicht importiert werden, da sie zu einer anderen Region "
 "gehört ({})."
+
+#~ msgid "Drag & drop is disabled when filters are applied."
+#~ msgstr "Drag & drop ist nicht möglich, wenn Filter aktiv sind."
+
+#~ msgid "Collapsing subpages is disabled when filters are applied."
+#~ msgstr "Unterseiten einklappen ist nicht möglich, wenn Filter aktiv sind."
 
 #~ msgid "Language \"{}\" was successfully created"
 #~ msgstr "Sprache \"{}\" wurde erfolgreich erstellt"

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -1297,7 +1297,7 @@ msgstr "Aktiv"
 msgid "Hidden"
 msgstr "Versteckt"
 
-#: cms/constants/region_status.py:18 cms/models/pages/page.py:204
+#: cms/constants/region_status.py:18 cms/models/pages/page.py:284
 #: cms/models/regions/region.py:583 cms/templates/pages/page_form.html:78
 #: cms/templates/pages/page_tree_archived_node.html:78
 msgid "Archived"
@@ -1587,7 +1587,7 @@ msgstr "Kategorie"
 #: cms/templates/pages/page_revisions.html:50
 #: cms/templates/pages/page_sbs.html:66 cms/templates/pages/page_sbs.html:123
 #: cms/templates/pages/page_sbs.html:128 cms/templates/pages/page_tree.html:81
-#: cms/templates/pages/page_tree_archived.html:55
+#: cms/templates/pages/page_tree_archived.html:64
 #: cms/templates/pois/poi_form.html:47 cms/templates/pois/poi_list.html:59
 #: cms/templates/pois/poi_list_archived.html:23
 #: cms/templates/regions/region_list.html:24
@@ -1801,7 +1801,7 @@ msgstr "Sie haben Ihr bisheriges Passwort falsch eingegeben."
 msgid "The new passwords do not match."
 msgstr "Die Passwörter stimmen nicht überein."
 
-#: cms/models/abstract_content_model.py:72 cms/models/abstract_tree_node.py:93
+#: cms/models/abstract_content_model.py:72 cms/models/abstract_tree_node.py:34
 #: cms/models/feedback/feedback.py:25 cms/models/media/directory.py:23
 #: cms/models/media/media_file.py:135
 #: cms/models/push_notifications/push_notification.py:19
@@ -1902,11 +1902,11 @@ msgstr "Änderungsdatum"
 msgid "creator"
 msgstr "Ersteller"
 
-#: cms/models/abstract_tree_node.py:88
+#: cms/models/abstract_tree_node.py:29
 msgid "parent"
 msgstr "übergeordneter Knoten"
 
-#: cms/models/abstract_tree_node.py:344
+#: cms/models/abstract_tree_node.py:282
 msgid "The node \"{}\" in region \"{}\" cannot be moved to \"{}\"."
 msgstr ""
 "Der Knoten \"{}\" in Region \"{}\" kann nicht nach \"{}\" verschoben werden."
@@ -1953,7 +1953,7 @@ msgstr "End-Uhrzeit"
 msgid "recurrence rule"
 msgstr "Wiederholungs-Regel"
 
-#: cms/models/events/event.py:101 cms/models/pages/page.py:51
+#: cms/models/events/event.py:101 cms/models/pages/page.py:118
 #: cms/models/pois/poi.py:34
 msgid "icon"
 msgstr "Icon"
@@ -2423,8 +2423,8 @@ msgstr "Ob die Seite explizit archiviert ist oder nicht"
 #: cms/templates/events/event_list_archived.html:33
 #: cms/templates/pages/page_form.html:28 cms/templates/pages/page_tree.html:63
 #: cms/templates/pages/page_tree.html:67
-#: cms/templates/pages/page_tree_archived.html:38
-#: cms/templates/pages/page_tree_archived.html:42
+#: cms/templates/pages/page_tree_archived.html:47
+#: cms/templates/pages/page_tree_archived.html:51
 #: cms/templates/pois/poi_form.html:27 cms/templates/pois/poi_list.html:44
 #: cms/templates/pois/poi_list.html:46
 #: cms/templates/pois/poi_list_archived.html:24
@@ -2458,26 +2458,26 @@ msgstr "Impressums-Übersetzung"
 msgid "imprint translations"
 msgstr "Impressums-Übersetzungen"
 
-#: cms/models/pages/page.py:43
+#: cms/models/pages/page.py:110
 msgid "parent page"
 msgstr "übergeordnete Seite"
 
-#: cms/models/pages/page.py:62
+#: cms/models/pages/page.py:129
 msgid "mirrored page"
 msgstr "eingebettete Seite"
 
-#: cms/models/pages/page.py:64
+#: cms/models/pages/page.py:131
 msgid ""
 "If the page embeds live content from another page, it is referenced here."
 msgstr ""
 "Wenn die Seite Live-Inhalte von einer anderen Seite einbettet, wird hier auf "
 "sie verwiesen."
 
-#: cms/models/pages/page.py:71
+#: cms/models/pages/page.py:138
 msgid "Position of mirrored page"
 msgstr "Position der gespiegelten Seite"
 
-#: cms/models/pages/page.py:73
+#: cms/models/pages/page.py:140
 msgid ""
 "If a mirrored page is set, this field determines whether the live content is "
 "embedded before the content of this page or after."
@@ -2485,17 +2485,17 @@ msgstr ""
 "Wenn eine gespiegelte Seite eingestellt ist, bestimmt dieses Feld, ob der "
 "Live-Inhalt vor oder nach dem Inhalt dieser Seite eingebettet wird."
 
-#: cms/models/pages/page.py:80
+#: cms/models/pages/page.py:147
 msgid "editors"
 msgstr "Bearbeiter"
 
-#: cms/models/pages/page.py:82
+#: cms/models/pages/page.py:149
 msgid "A list of users who have the permission to edit this specific page."
 msgstr ""
 "Eine Liste von Benutzern, die die Berechtigung haben, diese bestimmte Seite "
 "zu editieren."
 
-#: cms/models/pages/page.py:84
+#: cms/models/pages/page.py:151
 msgid ""
 "Only has effect if these users do not have the permission to edit pages "
 "anyway."
@@ -2503,17 +2503,17 @@ msgstr ""
 "Dies betrifft nur Benutzer, die nicht ohnehin die Berechtigung haben, "
 "beliebige Seiten zu ändern."
 
-#: cms/models/pages/page.py:92
+#: cms/models/pages/page.py:159
 msgid "publishers"
 msgstr "Veröffentlicher"
 
-#: cms/models/pages/page.py:94
+#: cms/models/pages/page.py:161
 msgid "A list of users who have the permission to publish this specific page."
 msgstr ""
 "Eine Liste von Benutzern, die die Berechtigung haben, diese bestimmte Seite "
 "zu veröffentlichen."
 
-#: cms/models/pages/page.py:96
+#: cms/models/pages/page.py:163
 msgid ""
 "Only has effect if these users do not have the permission to publish pages "
 "anyway."
@@ -2521,22 +2521,22 @@ msgstr ""
 "Dies betrifft nur Benutzer, die nicht ohnehin die Berechtigung haben, "
 "beliebige Seiten zu veröffentlichen."
 
-#: cms/models/pages/page.py:105
+#: cms/models/pages/page.py:172
 msgid "responsible organization"
 msgstr "zuständige Organisation"
 
-#: cms/models/pages/page.py:107
+#: cms/models/pages/page.py:174
 msgid ""
 "This allows all members of the organization to edit and publish this page."
 msgstr ""
 "Dies erlaubt allen Mitgliedern der Organisation diese Seite zu bearbeiten "
 "und veröffentlichen"
 
-#: cms/models/pages/page.py:210 cms/models/pages/page_translation.py:30
+#: cms/models/pages/page.py:290 cms/models/pages/page_translation.py:30
 msgid "page"
 msgstr "Seite"
 
-#: cms/models/pages/page.py:212
+#: cms/models/pages/page.py:292
 msgid "pages"
 msgstr "Seiten"
 
@@ -3627,7 +3627,7 @@ msgstr "Archivierte Veranstaltungen"
 #: cms/templates/feedback/admin_feedback_list.html:15
 #: cms/templates/feedback/region_feedback_list.html:15
 #: cms/templates/pages/page_tree.html:29
-#: cms/templates/pages/page_tree_archived.html:19
+#: cms/templates/pages/page_tree_archived.html:28
 msgid "Show filters"
 msgstr "Filter einblenden"
 
@@ -3636,7 +3636,7 @@ msgstr "Filter einblenden"
 #: cms/templates/feedback/admin_feedback_list.html:16
 #: cms/templates/feedback/region_feedback_list.html:16
 #: cms/templates/pages/page_tree.html:30
-#: cms/templates/pages/page_tree_archived.html:20
+#: cms/templates/pages/page_tree_archived.html:29
 msgid "Hide filters"
 msgstr "Filter ausblenden"
 
@@ -3665,7 +3665,7 @@ msgstr "Wiederholung"
 #: cms/templates/offertemplates/offertemplate_list.html:25
 #: cms/templates/organizations/organization_list.html:23
 #: cms/templates/pages/page_tree.html:83
-#: cms/templates/pages/page_tree_archived.html:57
+#: cms/templates/pages/page_tree_archived.html:66
 #: cms/templates/pois/poi_list.html:64
 #: cms/templates/pois/poi_list_archived.html:32
 #: cms/templates/roles/role_list.html:20
@@ -4097,7 +4097,7 @@ msgstr "Sprach-Knoten hinzufügen"
 
 #: cms/templates/language_tree/language_tree.html:21
 #: cms/templates/pages/page_tree.html:61
-#: cms/templates/pages/page_tree_archived.html:36
+#: cms/templates/pages/page_tree_archived.html:45
 msgid "Hierarchy"
 msgstr "Hierarchie"
 
@@ -4220,7 +4220,7 @@ msgstr "Erstellt"
 #: cms/templates/offertemplates/offertemplate_list.html:23
 #: cms/templates/pages/_page_xliff_import_diff.html:36
 #: cms/templates/pages/page_tree.html:82
-#: cms/templates/pages/page_tree_archived.html:56
+#: cms/templates/pages/page_tree_archived.html:65
 #: cms/templates/regions/region_list.html:23
 msgid "Last updated"
 msgstr "Zuletzt aktualisiert"
@@ -4554,6 +4554,7 @@ msgstr ""
 "generieren"
 
 #: cms/templates/pages/page_tree.html:13
+#: cms/templates/pages/page_tree_archived.html:15
 msgid "Page Tree"
 msgstr "Seiten-Baum"
 
@@ -4617,15 +4618,15 @@ msgstr "und {} weitere Dateien"
 msgid "Import"
 msgstr "Importieren"
 
-#: cms/templates/pages/page_tree_archived.html:11
+#: cms/templates/pages/page_tree_archived.html:13
 msgid "Archived Pages"
 msgstr "Archivierte Seiten"
 
-#: cms/templates/pages/page_tree_archived.html:68
+#: cms/templates/pages/page_tree_archived.html:77
 msgid "No archived pages found with these filters."
 msgstr "Keine archivierten Seiten mit diesen Filtern gefunden."
 
-#: cms/templates/pages/page_tree_archived.html:70
+#: cms/templates/pages/page_tree_archived.html:79
 msgid "No pages archived yet."
 msgstr "Noch keine Seiten archiviert."
 

--- a/integreat_cms/static/src/css/style.scss
+++ b/integreat_cms/static/src/css/style.scss
@@ -217,12 +217,6 @@ label:not([for]) {
     width: inherit !important;
 
     tr {
-      &.child {
-        .py-3 {
-          padding-top: 0.35rem;
-          padding-bottom: 0.35rem;
-        }
-      }
 
       &.level-2 {
         > td.hierarchy {

--- a/integreat_cms/static/src/js/pages/collapse-subpages.ts
+++ b/integreat_cms/static/src/js/pages/collapse-subpages.ts
@@ -27,6 +27,10 @@ function toggleSubpages(event: Event) {
   } else {
     collapseSpan.innerHTML = '<i data-feather="chevron-down"></i>';
   }
+  // Toggle title
+  const titleBuffer = collapseSpan.title;
+  collapseSpan.title = collapseSpan.getAttribute("data-alt-title");
+  collapseSpan.setAttribute("data-alt-title", titleBuffer);
   // Trigger icon replacement
   feather.replace({ class: 'inline-block' });
 }
@@ -51,7 +55,7 @@ function toggleSubpagesRecursive(collapseSpan: HTMLElement) {
     // Remove the left sibling from possible drop targets while it is collapsed
     document
       .getElementById("page-" + childId + "-drop-left")
-      .classList.toggle("drop-between");
+      ?.classList.toggle("drop-between");
     // Find out whether this page has children itself
     const collapseSpan = child.querySelector(
       ".collapse-subpages"

--- a/integreat_cms/static/src/js/search-query.ts
+++ b/integreat_cms/static/src/js/search-query.ts
@@ -113,4 +113,12 @@ export function setSearchQueryEventListeners() {
         // Submit the search
         document.getElementById("search-submit-btn").click();
     })
+
+    // Reset the search
+    document.getElementById("search-reset-btn").addEventListener("click", (event) => {
+        // Empty the search value
+        table_search_input.value = "";
+        // Submit the search
+        document.getElementById("search-submit-btn").click();
+    });
 }


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fixes the handling of page filters (by search query and by status filter)

### Proposed changes
<!-- Describe this PR in more detail. -->
- Make the page filters work with the cached tree structure

Caveats:
I'm still not sure how the hierarchy should be handled when filtering the tree. At the moment, I just disabled expanding/collapsing subpages, because it would require quite some computation to get all subpages that are in the same filtered set...
Do you think it would make more sense to completely hide the "hierarchy" column when filters are applied? Since it's not a real tree structure in this case anyway...

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1128
