### PR TITLE
Reduce queries for translation coverage to a constant amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ UNRELEASED
 * Add database migrations
 * Add bulk actions for events and POIs
 * Improve performance of content forms
+* Improve performance of translation coverage view
 
 
 2021.12.0-beta

--- a/integreat_cms/cms/constants/translation_status.py
+++ b/integreat_cms/cms/constants/translation_status.py
@@ -1,11 +1,18 @@
+"""
+This module contains the states a translation can have
+"""
 from django.utils.translation import ugettext_lazy as _
 
-
+#: Up to date
 UP_TO_DATE = "UP_TO_DATE"
+#: In translation
 IN_TRANSLATION = "IN_TRANSLATION"
+#: Outdated
 OUTDATED = "OUTDATED"
+#: Missing
 MISSING = "MISSING"
 
+#: Choices to use these constants in a database field
 CHOICES = (
     (UP_TO_DATE, _("Translation up-to-date")),
     (IN_TRANSLATION, _("Currently in translation")),
@@ -13,6 +20,7 @@ CHOICES = (
     (MISSING, _("Translation missing")),
 )
 
+#: Maps from the translation state to the color used to render this state in the translation coverage view
 COLORS = {
     UP_TO_DATE: "#4ade80",
     IN_TRANSLATION: "#60a5fa",

--- a/integreat_cms/cms/models/abstract_content_model.py
+++ b/integreat_cms/cms/models/abstract_content_model.py
@@ -212,15 +212,13 @@ class AbstractContentModel(models.Model):
 
     def get_translation_state(self, language):
         """
-        This function uses the reverse foreign key ``self.translations`` to get all translations of ``self``
-        and filters them to the requested :class:`~integreat_cms.cms.models.languages.language.Language` slug.
+        This function returns the current state of a translation in the given language.
 
         :param language: The desired :class:`~integreat_cms.cms.models.languages.language.Language`
         :type language: ~integreat_cms.cms.models.languages.language.Language
 
-        :return: The object translation in the requested :class:`~integreat_cms.cms.models.languages.language.Language` or
-                 :obj:`None` if no translation exists
-        :rtype: ~integreat_cms.cms.models.abstract_content_translation.AbstractContentTranslation
+        :return: A string describing the state of the translation, one of :data:`~integreat_cms.cms.constants.translation_status.CHOICES`
+        :rtype: str
         """
         translation = self.get_translation(language.slug)
         if not translation:
@@ -240,11 +238,10 @@ class AbstractContentModel(models.Model):
     @cached_property
     def translation_states(self):
         """
-        This function calculates all translations states of the object
+        This property calculates all translations states of the object
 
-        :return: The translation in the requested :class:`~integreat_cms.cms.models.languages.language.Language` or :obj:`None`
-                 if no translation exists
-        :rtype: ~integreat_cms.cms.models.abstract_content_translation.AbstractContentTranslation
+        :return: A dictionary containing each language as key and the given translation state as value
+        :rtype: dict
         """
         return {
             node.slug: (node.language, self.get_translation_state(node))

--- a/integreat_cms/cms/models/regions/region.py
+++ b/integreat_cms/cms/models/regions/region.py
@@ -507,7 +507,7 @@ class Region(models.Model):
                                              (default: ``False``)
         :type prefetch_public_translations: bool
 
-        :param annotate_language_tree: Whether the pages should be anotated with the region's language tree
+        :param annotate_language_tree: Whether the pages should be annotated with the region's language tree
                                        (default: ``False``)
         :type annotate_language_tree: bool
 

--- a/integreat_cms/cms/views/analytics/translation_coverage_view.py
+++ b/integreat_cms/cms/views/analytics/translation_coverage_view.py
@@ -1,4 +1,5 @@
 import logging
+from collections import Counter
 
 from django.contrib.auth.decorators import login_required
 from django.utils.decorators import method_decorator
@@ -6,7 +7,6 @@ from django.views.generic import TemplateView
 from django.shortcuts import render
 
 from ...constants import translation_status
-from ...models import PageTranslation
 from ...decorators import region_permission_required
 
 
@@ -44,67 +44,45 @@ class TranslationCoverageView(TemplateView):
 
         region = request.region
 
-        total_number_pages = region.pages.count()
+        translation_coverage_data = {}
+        outdated_word_count = Counter()
 
-        translation_coverage_data = []
-        outdated_word_count = {}
-
+        pages = (
+            region.pages.filter(explicitly_archived=False)
+            .prefetch_translations()
+            .cache_tree()
+        )
         for language in region.active_languages:
-            # Get all page translation of this region and language
-            page_translations = PageTranslation.get_translations(region, language)
+            language_coverage_data = Counter()
+            for page in pages:
+                translation_state = page.get_translation_state(language)
+                language_coverage_data[translation_state] += 1
 
-            # Get the QuerySet of translations which are currently not in translation (so either up-to-date or outdated)
-            currently_not_in_translation = page_translations.filter(
-                currently_in_translation=False
-            )
-            # Get a list of translations which are outdated
-            outdated_page_translations = [
-                translation
-                for translation in currently_not_in_translation
-                if translation.is_outdated
-            ]
-            # Count the words in the outdated translations
-            outdated_word_count[language] = sum(
-                len(translation.content.split())
-                for translation in outdated_page_translations
-            )
-            # Count the outdated translations
-            outdated_count = len(outdated_page_translations)
-            # Append the translation coverage data for this language
-            translation_coverage_data.append(
-                {
-                    # The number of pages which do not have a translation in this language
-                    translation_status.MISSING: (
-                        total_number_pages - page_translations.count()
-                    ),
-                    # The number of translations which are outdated
-                    translation_status.OUTDATED: outdated_count,
-                    # The number of translations which are currently being translated
-                    translation_status.IN_TRANSLATION: (
-                        page_translations.count() - currently_not_in_translation.count()
-                    ),
-                    # The number of up-to-date translations (neither missing, nor currently in translation, nor outdated)
-                    translation_status.UP_TO_DATE: (
-                        currently_not_in_translation.count() - outdated_count
-                    ),
-                }
-            )
+                if translation_state == translation_status.OUTDATED:
+                    translation = page.get_translation(language.slug)
+                    outdated_word_count[language] += len(translation.content.split())
+            translation_coverage_data[language] = language_coverage_data
+
+        for (language, data) in translation_coverage_data.items():
             logger.debug(
-                "Coverage data for %r: %r", language, translation_coverage_data[-1]
+                "Coverage data for %r: %r",
+                language,
+                data,
             )
-
         logger.debug("Outdated word count: %r", outdated_word_count)
 
         # Assemble the ChartData in the format expected by ChartJS (one dataset for each translation status)
         chart_data = {
             "labels": [
-                language.translated_name for language in region.active_languages
+                language.translated_name for language in translation_coverage_data
             ],
             "datasets": [
                 {
                     "label": label,
                     "backgroundColor": translation_status.COLORS[status],
-                    "data": [data[status] for data in translation_coverage_data],
+                    "data": [
+                        data[status] for data in translation_coverage_data.values()
+                    ],
                 }
                 for status, label in translation_status.CHOICES
             ],
@@ -116,7 +94,7 @@ class TranslationCoverageView(TemplateView):
             {
                 **self.base_context,
                 "coverage_data": chart_data,
-                "outdated_word_count": outdated_word_count,
+                "outdated_word_count": dict(outdated_word_count),
                 "total_outdated_words": sum(outdated_word_count.values()),
             },
         )

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-01-28 09:06+0000\n"
+"POT-Creation-Date: 2022-01-28 18:48+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1355,7 +1355,7 @@ msgstr "Links nach Rechts"
 msgid "Right to left"
 msgstr "Rechts nach Links"
 
-#: cms/constants/translation_status.py:10
+#: cms/constants/translation_status.py:17
 #: cms/templates/_form_language_tabs.html:26
 #: cms/templates/_form_language_tabs.html:68
 #: cms/templates/events/event_list_archived_row.html:44
@@ -1369,7 +1369,7 @@ msgstr "Rechts nach Links"
 msgid "Translation up-to-date"
 msgstr "Übersetzung ist aktuell"
 
-#: cms/constants/translation_status.py:11
+#: cms/constants/translation_status.py:18
 #: cms/templates/_form_language_tabs.html:18
 #: cms/templates/_form_language_tabs.html:60
 #: cms/templates/events/event_list_archived_row.html:36
@@ -1386,7 +1386,7 @@ msgstr "Übersetzung ist aktuell"
 msgid "Currently in translation"
 msgstr "Wird derzeit übersetzt"
 
-#: cms/constants/translation_status.py:12
+#: cms/constants/translation_status.py:19
 #: cms/templates/_form_language_tabs.html:22
 #: cms/templates/_form_language_tabs.html:64
 #: cms/templates/events/event_list_archived_row.html:40
@@ -1400,7 +1400,7 @@ msgstr "Wird derzeit übersetzt"
 msgid "Translation outdated"
 msgstr "Übersetzung ist veraltet"
 
-#: cms/constants/translation_status.py:13
+#: cms/constants/translation_status.py:20
 #: cms/templates/_form_language_tabs.html:30
 #: cms/templates/_form_language_tabs.html:72
 #: cms/templates/events/event_list_archived_row.html:49


### PR DESCRIPTION
### Short description
This pr reduces the amount of database queries required to load the translation coverage view to a constant number.
Related issue: #943 


### Proposed changes
<!-- Describe this PR in more detail. -->
- Use the new page query api
- Don't show languages in the outdated translation word count table if no translation for that language is outdated