### PR TITLE
Fix search bar

### DIFF
--- a/integreat_cms/cms/models/pages/page.py
+++ b/integreat_cms/cms/models/pages/page.py
@@ -127,7 +127,7 @@ class Page(AbstractTreeNode, AbstractBasePage):
         This returns all of the page's ancestors which are archived.
 
         :return: The QuerySet of archived ancestors
-        :rtype: ~treebeard.ns_tree.NS_NodeQuerySet [ ~integreat_cms.cms.models.pages.page.Page ]
+        :rtype: list [ ~integreat_cms.cms.models.pages.page.Page ]
         """
         return [
             ancestor
@@ -143,7 +143,7 @@ class Page(AbstractTreeNode, AbstractBasePage):
         :return: Whether or not this page is implicitly archived
         :rtype: bool
         """
-        return self.explicitly_archived_ancestors
+        return bool(self.explicitly_archived_ancestors)
 
     @cached_property
     def archived(self):

--- a/integreat_cms/static/src/js/search-query.ts
+++ b/integreat_cms/static/src/js/search-query.ts
@@ -104,6 +104,10 @@ export function setSearchQueryEventListeners() {
 
     document.getElementById("table-search-suggestions").addEventListener("mousedown", ({ target }) => {
         let table_search_input = document.getElementById("table-search-input") as HTMLInputElement;
+        // Don't submit a value if the user clicked e.g. on the search bar and not a specific list element
+        if (!(target as HTMLElement).matches("li")) {
+            return;
+        }
         // Fill in search field with selected suggestion
         table_search_input.value = (target as HTMLElement).textContent;
         // Submit the search


### PR DESCRIPTION
### Short description
This pr fixes a few problems I noticed with the search input bar.


### Proposed changes
- Fix the `page.implicitly_archived` method returning a list instead of a boolean, causing the search to return no results
- ~When filtering for pages in `page_tree_view` create a query instead of a list so that the later call to `pages.cache_tree()` works~ I just noticed that this is fixed by Timo's previous pr #1136
- Don't treat a click on the scrollbar of the search suggestions as simultaneously clicking all suggestions