### PR TITLE
Improve performance of content searches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ UNRELEASED
 * Improve performance of content forms
 * Improve performance of translation coverage view
 * Support legacy XLIFF export for MemoQ WPML filter
+* Improve performance of content searches
 
 
 2021.12.0-beta

--- a/integreat_cms/cms/models/abstract_content_translation.py
+++ b/integreat_cms/cms/models/abstract_content_translation.py
@@ -388,12 +388,12 @@ class AbstractContentTranslation(models.Model):
     @classmethod
     def search(cls, region, language_slug, query):
         """
-        Searches for all poi translations which match the given `query` in their title or slug.
+        Searches for all content translations which match the given `query` in their title or slug.
         :param region: The current region
         :type region: ~integreat_cms.cms.models.regions.region.Region
         :param language_slug: The language slug
         :type language_slug: str
-        :param query: The query string used for filtering the pois
+        :param query: The query string used for filtering the content translations
         :type query: str
         :return: A query for all matching objects
         :rtype: ~django.db.models.QuerySet


### PR DESCRIPTION
### Short description
This pr improves the performance when performing a content search.
In general, the search was fairly optimized and the biggest changes could be made to pages.
Related issue: #943

### Proposed changes
- Prefetch some attributes for pages, events and pois
- Make use of cached data when searching pages
