### PR TITLE
Add browser warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ UNRELEASED
 * [ [#1190](https://github.com/digitalfabrik/integreat-cms/issues/1190) ] Add possibility to set custom region prefix
 * [ [#1164](https://github.com/digitalfabrik/integreat-cms/issues/1164) ] Fix possibility to cancel translation process
 * [ [#1175](https://github.com/digitalfabrik/integreat-cms/issues/1175) ] Don't show empty tag if the page has subpages
+* [ [#988](https://github.com/digitalfabrik/integreat-cms/issues/988) ] Add browser warning when leaving unsaved forms
 
 
 2022.2.0-beta

--- a/integreat_cms/cms/templates/events/event_form.html
+++ b/integreat_cms/cms/templates/events/event_form.html
@@ -10,6 +10,7 @@
     <form id="content_form"
           method="post"
           enctype="multipart/form-data"
+          data-unsaved-warning
           {% if event_form.disabled %}data-disable-poi-query{% endif %}>
         {% csrf_token %}
         {% get_current_language as LANGUAGE_CODE %}

--- a/integreat_cms/cms/templates/imprint/imprint_form.html
+++ b/integreat_cms/cms/templates/imprint/imprint_form.html
@@ -7,7 +7,7 @@
 {% load rules %}
 {% load render_bundle from webpack_loader %}
 {% block content %}
-    <form method="post" id="content_form">
+    <form method="post" id="content_form" data-unsaved-warning>
         {% csrf_token %}
         <div class="w-full flex flex-wrap justify-between gap-4 mb-4">
             <h1 class="heading">

--- a/integreat_cms/cms/templates/imprint/imprint_sbs.html
+++ b/integreat_cms/cms/templates/imprint/imprint_sbs.html
@@ -5,7 +5,7 @@
 {% load rules %}
 {% load render_bundle from webpack_loader %}
 {% block content %}
-    <form method="post" id="content_form">
+    <form method="post" id="content_form" data-unsaved-warning>
         <div>
             <div class="flex flex-wrap mb-4">
                 <div class="w-3/5 flex flex-wrap flex-col justify-center mb-6">

--- a/integreat_cms/cms/templates/language_tree/language_tree_node_form.html
+++ b/integreat_cms/cms/templates/language_tree/language_tree_node_form.html
@@ -6,7 +6,7 @@
 {% load widget_tweaks %}
 
 {% block content %}
-<form method="post">
+<form method="post" data-unsaved-warning>
     {% csrf_token %}
     <div class="flex flex-wrap mb-4">
         <div class="w-2/5 flex flex-wrap flex-col justify-center">

--- a/integreat_cms/cms/templates/languages/language_form.html
+++ b/integreat_cms/cms/templates/languages/language_form.html
@@ -3,7 +3,7 @@
 {% block content %}
 {% load static %}
 {% load widget_tweaks %}
-<form method="post">
+<form method="post" data-unsaved-warning>
     {% csrf_token %}
     <div class="flex flex-wrap mb-4 justify-between">
         <h1 class="heading">

--- a/integreat_cms/cms/templates/offertemplates/offertemplate_form.html
+++ b/integreat_cms/cms/templates/offertemplates/offertemplate_form.html
@@ -3,7 +3,7 @@
 {% block content %}
 {% load static %}
 {% load widget_tweaks %}
-<form method="post">
+<form method="post" data-unsaved-warning>
     {% csrf_token %}
     <div class="flex justify-between mb-4">
 		<h1 class="heading">

--- a/integreat_cms/cms/templates/organizations/organization_form.html
+++ b/integreat_cms/cms/templates/organizations/organization_form.html
@@ -3,7 +3,7 @@
 {% block content %}
 {% load static %}
 {% load widget_tweaks %}
-<form method="post" enctype="multipart/form-data">
+<form method="post" enctype="multipart/form-data" data-unsaved-warning>
     {% csrf_token %}
     <div class="flex justify-between mb-4">
 		<h1 class="heading">

--- a/integreat_cms/cms/templates/pages/page_form.html
+++ b/integreat_cms/cms/templates/pages/page_form.html
@@ -10,7 +10,7 @@
 {% block content %}
     {% get_current_language as LANGUAGE_CODE %}
     {% has_perm 'cms.change_page_object' request.user page as can_edit_page %}
-    <form enctype="multipart/form-data" method="post" id="content_form">
+    <form enctype="multipart/form-data" method="post" id="content_form" data-unsaved-warning>
         {% csrf_token %}
         <div class="w-full flex flex-wrap justify-between mb-6">
             <h1 class="heading">

--- a/integreat_cms/cms/templates/pages/page_sbs.html
+++ b/integreat_cms/cms/templates/pages/page_sbs.html
@@ -5,7 +5,7 @@
 {% load rules %}
 {% load render_bundle from webpack_loader %}
 {% block content %}
-    <form method="post" id="content_form">
+    <form method="post" id="content_form" data-unsaved-warning>
         <div>
             <div class="flex flex-wrap mb-4">
                 <div class="w-3/5 flex flex-wrap flex-col justify-center mb-6">

--- a/integreat_cms/cms/templates/pois/poi_form.html
+++ b/integreat_cms/cms/templates/pois/poi_form.html
@@ -7,7 +7,7 @@
 {% load poi_filters %}
 {% load render_bundle from webpack_loader %}
 {% block content %}
-    <form id="content_form" method="post" enctype="multipart/form-data">
+    <form id="content_form" method="post" enctype="multipart/form-data" data-unsaved-warning>
         {% csrf_token %}
         <div class="w-full flex flex-wrap justify-between mb-4">
             <h1 class="heading">

--- a/integreat_cms/cms/templates/push_notifications/push_notification_form.html
+++ b/integreat_cms/cms/templates/push_notifications/push_notification_form.html
@@ -6,7 +6,7 @@
 {% load page_filters %}
 {% load rules %}
 {% block content %}
-    <form method="post">
+    <form method="post" data-unsaved-warning>
         {% csrf_token %}
         <div class="flex flex-wrap">
             <div class="w-full flex flex-wrap justify-between gap-4 mb-6">

--- a/integreat_cms/cms/templates/regions/region_form.html
+++ b/integreat_cms/cms/templates/regions/region_form.html
@@ -5,7 +5,7 @@
 {% load widget_tweaks %}
 
 {% block content %}
-<form enctype="multipart/form-data" method="post">
+<form enctype="multipart/form-data" method="post" data-unsaved-warning>
     {% csrf_token %}
     <div class="flex flex-wrap justify-between mb-4">
         <h1 class="heading">

--- a/integreat_cms/cms/templates/roles/role_form.html
+++ b/integreat_cms/cms/templates/roles/role_form.html
@@ -3,7 +3,7 @@
 {% block content %}
 {% load static %}
 {% load widget_tweaks %}
-<form method="post">
+<form method="post" data-unsaved-warning>
     {% csrf_token %}
     <div class="flex flex-wrap mb-4">
         <div class="w-2/5 flex flex-wrap flex-col justify-center">

--- a/integreat_cms/cms/templates/users/region_user_form.html
+++ b/integreat_cms/cms/templates/users/region_user_form.html
@@ -6,7 +6,7 @@
 {% load user_filters %}
 
 {% block content %}
-<form method="post">
+<form method="post" data-unsaved-warning>
     {% csrf_token %}
     <div class="flex justify-between mb-4">
         <h1 class="heading">

--- a/integreat_cms/cms/templates/users/user_form.html
+++ b/integreat_cms/cms/templates/users/user_form.html
@@ -3,7 +3,7 @@
 {% block content %}
 {% load static %}
 {% load widget_tweaks %}
-<form method="post">
+<form method="post" data-unsaved-warning>
     {% csrf_token %}
     <div class="flex justify-between mb-4">
         <h1 class="heading">

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-02-21 15:12+0000\n"
+"POT-Creation-Date: 2022-02-21 15:29+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1298,7 +1298,7 @@ msgid "Hidden"
 msgstr "Versteckt"
 
 #: cms/constants/region_status.py:18 cms/models/pages/page.py:284
-#: cms/models/regions/region.py:597 cms/templates/events/event_form.html:69
+#: cms/models/regions/region.py:597 cms/templates/events/event_form.html:70
 #: cms/templates/pages/page_form.html:88
 #: cms/templates/pages/page_tree_archived_node.html:78
 #: cms/templates/pois/poi_form.html:57
@@ -1578,7 +1578,7 @@ msgid "Category"
 msgstr "Kategorie"
 
 #: cms/forms/feedback/region_feedback_filter_form.py:30
-#: cms/templates/events/event_form.html:66
+#: cms/templates/events/event_form.html:67
 #: cms/templates/events/event_list.html:69
 #: cms/templates/events/event_list_archived.html:46
 #: cms/templates/imprint/imprint_form.html:49
@@ -2453,7 +2453,7 @@ msgid "Whether or not the page is explicitly archived"
 msgstr "Ob die Seite explizit archiviert ist oder nicht"
 
 #: cms/models/pages/abstract_base_page_translation.py:71
-#: cms/templates/events/event_form.html:26
+#: cms/templates/events/event_form.html:27
 #: cms/templates/events/event_list.html:52
 #: cms/templates/events/event_list.html:56
 #: cms/templates/events/event_list_archived.html:29
@@ -3131,7 +3131,7 @@ msgstr "Organisationen"
 msgid "Offer Templates"
 msgstr "Angebots-Vorlagen"
 
-#: cms/templates/_base.html:280 cms/templates/events/event_form.html:61
+#: cms/templates/_base.html:280 cms/templates/events/event_form.html:62
 #: cms/templates/imprint/imprint_form.html:43
 #: cms/templates/imprint/imprint_revisions.html:20
 #: cms/templates/imprint/imprint_sbs.html:48
@@ -3588,20 +3588,20 @@ msgstr "Bestehenden Ort auswählen"
 msgid "Create location \"%(poi_query)s\""
 msgstr "Ort \"%(poi_query)s\" erstellen"
 
-#: cms/templates/events/event_form.html:22
+#: cms/templates/events/event_form.html:23
 #, python-format
 msgid "Edit event \"%(event_title)s\""
 msgstr "Event \"%(event_title)s\" bearbeiten"
 
-#: cms/templates/events/event_form.html:30
+#: cms/templates/events/event_form.html:31
 msgid "Create new event translation"
 msgstr "Neue Event-Übersetzung erstellen"
 
-#: cms/templates/events/event_form.html:33
+#: cms/templates/events/event_form.html:34
 msgid "Create new event"
 msgstr "Veranstaltung erstellen"
 
-#: cms/templates/events/event_form.html:39
+#: cms/templates/events/event_form.html:40
 #: cms/templates/imprint/imprint_form.html:26
 #: cms/templates/imprint/imprint_sbs.html:24
 #: cms/templates/pages/page_form.html:37 cms/templates/pages/page_sbs.html:26
@@ -3609,7 +3609,7 @@ msgstr "Veranstaltung erstellen"
 msgid "Save as draft"
 msgstr "Als Entwurf speichern"
 
-#: cms/templates/events/event_form.html:41
+#: cms/templates/events/event_form.html:42
 #: cms/templates/imprint/imprint_form.html:27
 #: cms/templates/imprint/imprint_sbs.html:25
 #: cms/templates/pages/page_form.html:45 cms/templates/pages/page_sbs.html:30
@@ -3617,17 +3617,17 @@ msgstr "Als Entwurf speichern"
 msgid "Publish"
 msgstr "Veröffentlichen"
 
-#: cms/templates/events/event_form.html:43
+#: cms/templates/events/event_form.html:44
 #: cms/templates/pages/page_form.html:49 cms/templates/pages/page_sbs.html:32
 msgid "Submit for review"
 msgstr "Zur Überprüfung vorlegen"
 
-#: cms/templates/events/event_form.html:85
+#: cms/templates/events/event_form.html:86
 #: cms/templates/pages/page_form.html:123 cms/templates/pois/poi_form.html:72
 msgid "Edit"
 msgstr "Bearbeiten"
 
-#: cms/templates/events/event_form.html:89
+#: cms/templates/events/event_form.html:90
 #: cms/templates/imprint/imprint_form.html:64
 #: cms/templates/imprint/imprint_form.html:78
 #: cms/templates/imprint/imprint_sbs.html:61
@@ -3637,39 +3637,39 @@ msgstr "Bearbeiten"
 msgid "Copy to clipboard"
 msgstr "In die Zwischenablage kopieren"
 
-#: cms/templates/events/event_form.html:113
+#: cms/templates/events/event_form.html:114
 msgid "Date and time"
 msgstr "Datum und Uhrzeit"
 
-#: cms/templates/events/event_form.html:216
+#: cms/templates/events/event_form.html:217
 msgid "Venue"
 msgstr "Veranstaltungsort"
 
-#: cms/templates/events/event_form.html:228
+#: cms/templates/events/event_form.html:229
 msgid "Name of event location"
 msgstr "Name des Veranstaltungsortes"
 
-#: cms/templates/events/event_form.html:241
+#: cms/templates/events/event_form.html:242
 msgid "Remove location from event"
 msgstr "Veranstaltungsort von Veranstaltung entfernen"
 
-#: cms/templates/events/event_form.html:248
+#: cms/templates/events/event_form.html:249
 msgid ""
 "Create an event location or start typing the name of an existing location"
 msgstr ""
 "Erstellen Sie einen Veranstaltungsort oder beginnen Sie den Namen eines "
 "bestehenden Veranstaltungsortes einzutippen"
 
-#: cms/templates/events/event_form.html:255
+#: cms/templates/events/event_form.html:256
 #: cms/templates/pois/poi_form.html:113
 msgid "Address"
 msgstr "Adresse"
 
-#: cms/templates/events/event_form.html:275
+#: cms/templates/events/event_form.html:276
 msgid "Open on Google Maps"
 msgstr "Auf Google Maps öffnen"
 
-#: cms/templates/events/event_form.html:300
+#: cms/templates/events/event_form.html:301
 #: cms/templates/imprint/imprint_form.html:112
 #: cms/templates/pages/page_form.html:234 cms/templates/pois/poi_form.html:158
 #: cms/templates/regions/region_list.html:25
@@ -3677,31 +3677,31 @@ msgstr "Auf Google Maps öffnen"
 msgid "Actions"
 msgstr "Aktionen"
 
-#: cms/templates/events/event_form.html:307
+#: cms/templates/events/event_form.html:308
 #: cms/templates/events/event_list_archived_row.html:84
 msgid "Restore event"
 msgstr "Veranstaltung wiederherstellen"
 
-#: cms/templates/events/event_form.html:315
+#: cms/templates/events/event_form.html:316
 msgid "Restore this event"
 msgstr "Diese Veranstaltung wiederherstellen"
 
-#: cms/templates/events/event_form.html:319
+#: cms/templates/events/event_form.html:320
 #: cms/templates/events/event_list_row.html:108
 msgid "Archive event"
 msgstr "Veranstaltung archivieren"
 
-#: cms/templates/events/event_form.html:327
+#: cms/templates/events/event_form.html:328
 msgid "Archive this event"
 msgstr "Diese Veranstaltung archivieren"
 
-#: cms/templates/events/event_form.html:334
+#: cms/templates/events/event_form.html:335
 #: cms/templates/events/event_list_archived_row.html:93
 #: cms/templates/events/event_list_row.html:117
 msgid "Delete event"
 msgstr "Veranstaltung löschen"
 
-#: cms/templates/events/event_form.html:342
+#: cms/templates/events/event_form.html:343
 msgid "Delete this event"
 msgstr "Diese Veranstaltung löschen"
 

--- a/integreat_cms/static/src/index.ts
+++ b/integreat_cms/static/src/index.ts
@@ -65,6 +65,8 @@ import "./js/pagination/pagination.ts";
 
 import "./js/tutorial-overlay.ts";
 
+import "./js/unsaved-warning";
+
 window.addEventListener('load',() => {
     feather.replace({ class: 'inline-block' });
 })

--- a/integreat_cms/static/src/js/unsaved-warning.ts
+++ b/integreat_cms/static/src/js/unsaved-warning.ts
@@ -1,0 +1,30 @@
+/**
+ * This file contains a function to warn the user when they leave a content without saving
+ */
+
+let confirmed = false;
+let edited = false;
+
+
+window.addEventListener("beforeunload", (event) => {
+  // trigger only when something is edited and no submit/save button clicked
+  if (edited && !confirmed) {
+    event.preventDefault();
+    event.returnValue = "This content is not saved. Would you leave the page?";
+  }
+});
+
+
+window.addEventListener("load", () => {
+  const form = document.querySelector("[data-unsaved-warning]");
+  // checks whether the user typed something in the content
+  form?.addEventListener("input", () => {
+    edited = true;
+    console.debug("editing detected, enabled beforeunload warning");
+  }, { once: true });
+  // checks whether the user has saved or submitted the content
+  form?.addEventListener("submit", () => {
+    confirmed = true;
+    console.debug("form submitted, disabled beforeunload warning");
+  });
+});


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Browser warning is added so users will be warned when they are leaving a content editing page wihout saving or publishing.
### Proposed changes
<!-- Describe this PR in more detail. -->
- Input and click on the form section will be detected.
- If the user leaves the edit page clicking on "save as Draft", "Save as review" or "Publish"/"Update", nothing new happens. A warning will be shown before leaving otherwise. 

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #988 
