### PR TITLE
Add sub page event listeners for bulk action button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ UNRELEASED
 * [ [#765](https://github.com/digitalfabrik/integreat-cms/issues/765) ] Add extended view tests
 * [ [#765](https://github.com/digitalfabrik/integreat-cms/issues/765) ] Add tests of form submissions
 * [ [#1163](https://github.com/digitalfabrik/integreat-cms/issues/1163) ] Fix error when editor creates new page
+* [ [#1165](https://github.com/digitalfabrik/integreat-cms/issues/1165) ] Fix bulk action button for sub pages
 
 
 2022.2.0-beta

--- a/integreat_cms/static/src/js/bulk-actions.ts
+++ b/integreat_cms/static/src/js/bulk-actions.ts
@@ -34,17 +34,15 @@ function isInputElement(el: Element): el is HTMLInputElement {
 
 window.addEventListener("load", () => {
   const selectAllCheckbox = document.getElementById("bulk-select-all");
-  const bulkAction = document.getElementById("bulk-action") as HTMLSelectElement;
   const bulkActionForm = document.getElementById("bulk-action-form");
   const selectItems = Array.from(document.getElementsByClassName("bulk-select-item"));
-  const bulkActionButton = document.getElementById(
-    "bulk-action-execute"
-  ) as HTMLButtonElement;
+  const bulkAction = document.getElementById("bulk-action") as HTMLSelectElement;
 
   if (selectAllCheckbox && isInputElement(selectAllCheckbox)) {
     selectAllCheckbox.addEventListener("click", () => {
       const value = selectAllCheckbox.checked;
-      selectItems
+      // get all currently rendered page checkboxes
+      Array.from(document.getElementsByClassName("bulk-select-item"))
         .filter(isInputElement)
         .forEach((checkbox) => (checkbox.checked = value));
       toggleBulkActionButton();
@@ -63,23 +61,6 @@ window.addEventListener("load", () => {
     el.addEventListener("change", toggleBulkActionButton);
   });
 
-  function toggleBulkActionButton() {
-    // Only activate button if at least one item and the action is selected
-    // also check if at least one page translation exists for PDF export before activation
-    let selectedAction = bulkAction.options[bulkAction.selectedIndex];
-    if (
-      !selectItems
-        .filter(isInputElement)
-        .some((el) => el.checked) ||
-      bulkAction.selectedIndex === 0 ||
-      (selectedAction.id === "pdf-export-option" && !hasTranslation())
-    ) {
-      bulkActionButton.disabled = true;
-    } else {
-      bulkActionButton.disabled = false;
-    }
-  }
-
   function bulkActionExecute(event: Event) {
     event.preventDefault();
     const form = event.target as HTMLFormElement;
@@ -95,16 +76,39 @@ window.addEventListener("load", () => {
     form.submit();
   }
 
-  function hasTranslation(): boolean {
-    // checks if at least one of the selected pages has a translation for the current language
-    let languageSlug = document.getElementById("pdf-export-option").dataset.languageSlug;
-    return selectItems
-      .filter(isInputElement)
-      .filter(inputElement => inputElement.checked)
-      .some(inputElement => {
-        return inputElement
-          .closest("tr")
-          .querySelector(`.lang-grid .${languageSlug} .no-trans`) === null;
-      });
-  }
 });
+
+export function toggleBulkActionButton() {
+  // Only activate button if at least one item and the action is selected
+  // also check if at least one page translation exists for PDF export before activation
+  const selectItems = Array.from(document.getElementsByClassName("bulk-select-item"));
+  const bulkAction = document.getElementById("bulk-action") as HTMLSelectElement;
+  const bulkActionButton = document.getElementById(
+    "bulk-action-execute"
+  ) as HTMLButtonElement;
+  let selectedAction = bulkAction.options[bulkAction.selectedIndex];
+  if (
+    !selectItems
+      .filter(isInputElement)
+      .some((el) => el.checked) ||
+    bulkAction.selectedIndex === 0 ||
+    (selectedAction.id === "pdf-export-option" && !hasTranslation(selectItems))
+  ) {
+    bulkActionButton.disabled = true;
+  } else {
+    bulkActionButton.disabled = false;
+  }
+}
+
+function hasTranslation(selectItems: Element[]): boolean {
+  // checks if at least one of the selected pages has a translation for the current language
+  let languageSlug = document.getElementById("pdf-export-option").dataset.languageSlug;
+  return selectItems
+    .filter(isInputElement)
+    .filter(inputElement => inputElement.checked)
+    .some(inputElement => {
+      return inputElement
+        .closest("tr")
+        .querySelector(`.lang-grid .${languageSlug} .no-trans`) === null;
+    });
+}

--- a/integreat_cms/static/src/js/pages/collapse-subpages.ts
+++ b/integreat_cms/static/src/js/pages/collapse-subpages.ts
@@ -2,6 +2,7 @@ import feather from "feather-icons";
 
 import { addDragAndDropListeners } from "../tree-drag-and-drop";
 import { addConfirmationDialogListeners } from "../confirmation-popups";
+import { toggleBulkActionButton }from "../bulk-actions";
 
 /*
  * The functionality to toggle subpages
@@ -124,9 +125,14 @@ async function fetchSubpages(collapseSpan: HTMLElement): Promise<number[]> {
   let parentRow = collapseSpan.closest("tr");
   childrenDoc.querySelectorAll("tr").forEach(function(rowToinsert: HTMLTableRowElement) {
     let newCollapseSpan = rowToinsert.querySelector(".collapse-subpages");
+    let newCheckbox = rowToinsert.querySelector(".bulk-select-item");
     if (newCollapseSpan) {
       // add event listener for page expansion if not leaf node
       newCollapseSpan.addEventListener("click", toggleSubpages);
+    }
+    if (newCheckbox) {
+      // add event listener to update bulk action button
+      newCheckbox.addEventListener("change", toggleBulkActionButton);
     }
     if (!rowToinsert.classList.contains("drop-between")) {
       // record children ids to update all ancestors descendants data attribute


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Activate bulk action button on selecting sub pages

### Proposed changes
<!-- Describe this PR in more detail. -->

- After selecting a sub page the bulk action button is enabled
- Clicking on "Select all checkboxes" also toggles sub page checkboxes

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1165
