### PR TITLE
Allow user to embed live content from current region

### DIFF
--- a/integreat_cms/cms/forms/pages/page_form.py
+++ b/integreat_cms/cms/forms/pages/page_form.py
@@ -82,11 +82,6 @@ class PageForm(CustomModelForm, MoveNodeForm):
         # Pass form object to ParentFieldWidget
         self.fields["parent"].widget.form = self
 
-        # Exclude current region from choices for mirrored content
-        self.fields["mirrored_page_region"].queryset = Region.objects.exclude(
-            id=self.instance.region_id
-        )
-
         # Limit possible parents to pages of current region
         parent_queryset = self.instance.region.pages.all()
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR should enable the option to embed live content from a site which belongs to the currently selected region. 


### Proposed changes
<!-- Describe this PR in more detail. -->
- Remove an initial query, that filters the current region from the 'mirrored_page_region' 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1176 
