### PR TITLE
Disable browser cache of page tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ UNRELEASED
 * [ [#1172](https://github.com/digitalfabrik/integreat-cms/issues/1172) ] Fix filtering for locations in event list
 * [ [#1185](https://github.com/digitalfabrik/integreat-cms/issues/1185) ] Fix feedback API
 * [ [#1188](https://github.com/digitalfabrik/integreat-cms/issues/1188) ] Fix error in broken link checker
+* [ [#1179](https://github.com/digitalfabrik/integreat-cms/issues/1179) ] Disable browser cache of page tree
 
 
 2022.2.0-beta

--- a/integreat_cms/cms/views/pages/page_tree_view.py
+++ b/integreat_cms/cms/views/pages/page_tree_view.py
@@ -107,7 +107,7 @@ class PageTreeView(TemplateView, PageContextMixin):
             filter_form = PageFilterForm()
             filter_form.changed_data.clear()
 
-        return render(
+        response = render(
             request,
             self.template_name,
             {
@@ -118,6 +118,9 @@ class PageTreeView(TemplateView, PageContextMixin):
                 "filter_form": filter_form,
             },
         )
+        # Disable browser cache of page tree to prevent subpages from being expanded after using "back"-button
+        response["Cache-Control"] = "no-store, must-revalidate"
+        return response
 
     def post(self, request, *args, **kwargs):
         r"""


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Disable browser cache of page tree

### Proposed changes
<!-- Describe this PR in more detail. -->
- Set HTTP header `Cache-Control: no-store, must-revalidate`

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1179
