### PR TITLE
Don't show empty tag if the page has no subpages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ UNRELEASED
 * [ [#1179](https://github.com/digitalfabrik/integreat-cms/issues/1179) ] Disable browser cache of page tree
 * [ [#1190](https://github.com/digitalfabrik/integreat-cms/issues/1190) ] Add possibility to set custom region prefix
 * [ [#1164](https://github.com/digitalfabrik/integreat-cms/issues/1164) ] Fix possibility to cancel translation process
+* [ [#1175](https://github.com/digitalfabrik/integreat-cms/issues/1175) ] Don't show empty tag if the page has subpages
 
 
 2022.2.0-beta

--- a/integreat_cms/cms/models/pages/page_translation.py
+++ b/integreat_cms/cms/models/pages/page_translation.py
@@ -140,7 +140,7 @@ class PageTranslation(AbstractBasePageTranslation):
         This functions returns a list of translated tags which apply to this function.
         Supported tags:
         * Live content: if the page of this translation has live content
-        * Empty: if the page contains no text
+        * Empty: if the page contains no text and has no subpages (TODO: Can also be empty if subpages are archived)
 
         :return: A list of tags which apply to this translation
         :rtype: list [ str ]
@@ -150,7 +150,7 @@ class PageTranslation(AbstractBasePageTranslation):
         if self.page.mirrored_page:
             tags.append(_("Live content"))
 
-        if not self.combined_text.strip():
+        if not self.combined_text.strip() and self.page.is_leaf():
             tags.append(_("Empty"))
 
         return tags

--- a/integreat_cms/static/src/js/tree-drag-and-drop.ts
+++ b/integreat_cms/static/src/js/tree-drag-and-drop.ts
@@ -134,6 +134,6 @@ function drop(event: DragEvent) {
   const target_position = target.getAttribute("data-drop-position");
   // abuse confirmation dialog form to perform action
   let form = document.getElementById("confirmation-dialog").querySelector("form");
-  form.action = window.location.href + node_id + "/move/" + target_id + "/" + target_position;
+  form.action = window.location.href + node_id + "/move/" + target_id + "/" + target_position + "/";
   form.submit();
 }


### PR DESCRIPTION
### Short description
This pr hides the empty for a page if the page has no subpages.
Generally, this tag should be hidden if the page has no publicly visible subpages, however this is not implemented as part of this pr.
This work should be done together with #1158.

Additionally, this pr fixes a crash due to an invalid url when moving a page.

Partially solves: #1175 

### Proposed changes
<!-- Describe this PR in more detail. -->
- Check if the page is a leaf before adding the empty tag

