### PR TITLE
Track API requests with Matomo

### DIFF
--- a/integreat_cms/api/decorators.py
+++ b/integreat_cms/api/decorators.py
@@ -2,14 +2,23 @@
 This module includes functions that are used as decorators in the API endpoints.
 """
 import json
+import threading
+import logging
+import random
+import re
 
 from functools import wraps
 
+from urllib import request, parse, error
+
 from django.http import JsonResponse, Http404
 from django.views.decorators.csrf import csrf_exempt
+from django.conf import settings
 
 from ..cms.models import Region, Language
 from ..cms.constants import feedback_ratings
+
+logger = logging.getLogger(__name__)
 
 
 def feedback_handler(func):
@@ -115,5 +124,81 @@ def json_response(function):
             return function(request, *args, **kwargs)
         except Http404 as e:
             return JsonResponse({"error": str(e) or "Not found."}, status=404)
+
+    return wrap
+
+
+def matomo_tracking(func):
+    """
+    This decorator is supposed to be applied to API content endpoints. It will track
+    the request in Matomo. The request to the Matomo API is executed asynchronously in its
+    own thread to not block the Integreat CMS API request.
+
+    Only the URL and the User Agent will be sent to Matomo.
+
+    :param func: decorated function
+    :type func: ~collections.abc.Callable
+
+    :return: The decorated feedback view function
+    :rtype: ~collections.abc.Callable
+    """
+
+    @wraps(func)
+    def wrap(request, *args, **kwargs):
+        r"""
+        The inner function for this decorator.
+
+        :param request: Django request
+        :type request: ~django.http.HttpRequest
+
+        :param \*args: The supplied arguments
+        :type \*args: list
+
+        :param \**kwargs: The supplied kwargs
+        :type \**kwargs: dict
+
+        :return: The response of the given function or an 404 :class:`~django.http.JsonResponse`
+        :rtype: ~django.http.JsonResponse
+        """
+        if not request.region.matomo_id or not request.region.matomo_token:
+            return func(request, *args, **kwargs)
+        data = {
+            "idsite": request.region.matomo_id,
+            "token_auth": request.region.matomo_token,
+            "rec": 1,
+            "url": request.build_absolute_uri(),
+            "urlref": settings.BASE_URL,
+            "ua": request.META.get("HTTP_USER_AGENT", "unknown user agent"),
+            "cip": f"{random.randint(0, 255)}.{random.randint(0, 255)}.{random.randint(0, 255)}.{random.randint(0, 255)}",
+        }
+
+        t = threading.Thread(target=matomo_request, args=(settings.MATOMO_URL, data))
+        t.setDaemon(True)
+        t.start()
+        return func(request, *args, **kwargs)
+
+    def matomo_request(host, data):
+        """
+        Wrap HTTP request to Matomo in threaded function.
+
+        :param host: Hostname + protocol of Matomo installation
+        :type host:
+
+        :param data: Data to send to Matomo API
+        :type data: dict
+        """
+        data = parse.urlencode(data)
+        url = f"{host}/matomo.php?{data}"
+        req = request.Request(url)
+        try:
+            with request.urlopen(req):
+                pass
+        except error.HTTPError as e:
+            logger.error(
+                "Matomo Tracking API request to %r failed with: %s",
+                # Mask auth token in log
+                re.sub(r"&token_auth=[^&]+", "&token_auth=********", url),
+                e,
+            )
 
     return wrap

--- a/integreat_cms/api/v3/pages.py
+++ b/integreat_cms/api/v3/pages.py
@@ -6,7 +6,7 @@ from django.http import JsonResponse, Http404
 from django.shortcuts import get_object_or_404
 
 from ...cms.models import Page
-from ..decorators import json_response
+from ..decorators import json_response, matomo_tracking
 
 
 def transform_page(page_translation):
@@ -54,6 +54,7 @@ def transform_page(page_translation):
     }
 
 
+@matomo_tracking
 @json_response
 # pylint: disable=unused-argument
 def pages(request, region_slug, language_slug):
@@ -129,6 +130,7 @@ def get_single_page(request, language_slug):
     return page
 
 
+@matomo_tracking
 @json_response
 # pylint: disable=unused-argument
 def single_page(request, region_slug, language_slug):
@@ -162,6 +164,7 @@ def single_page(request, region_slug, language_slug):
     raise Http404("No Page matches the given url or id.")
 
 
+@matomo_tracking
 @json_response
 # pylint: disable=unused-argument
 def children(request, region_slug, language_slug):


### PR DESCRIPTION
### Short description
Track single page and pages API endpoint requests with Matomo.

### Proposed changes
Add a decorator to allow tracking API endpoints. The decorator spawns a thread which executes the HTTP request to Matomo. This improves the performance of the CMS API, as the request does not have to wait for the response from Matomo.

### Resolved issues
Fixes: #1196 


This mostly works, however the `cip` parameter (https://developer.matomo.org/api-reference/tracking-api) breaks the request.