### PR TITLE
Support legacy PDF API, fixes #1209

### DIFF
--- a/integreat_cms/api/urls.py
+++ b/integreat_cms/api/urls.py
@@ -136,6 +136,11 @@ urlpatterns = [
                     "<slug:language_slug>/wp-json/extensions/v3/",
                     include(content_api_urlpatterns),
                 ),
+                path(
+                    "<slug:language_slug>/wp-json/ig-mpdf/v1/pdf/",
+                    pdf_export,
+                    name="pdf_export",
+                ),
             ]
         ),
     ),


### PR DESCRIPTION
### Short description
Route the PDF creation endpoint to the Integreat APIv3 PDF creation URL.

### Proposed changes
Add a URL pattern that routes the view `pdf_export` to `/REGION/LAN/wp-json/ig-mpdf/v1/pdf`

### Resolved issues
Fixes: #1209
