### PR TITLE
Use canonical Shift+Enter behavior, fixes #1215

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ UNRELEASED
 
 * [ [#1214](https://github.com/digitalfabrik/integreat-cms/issues/1214) ] Fix API return format of event location
 * [ [#1218](https://github.com/digitalfabrik/integreat-cms/issues/1218) ] Fix saving of first root node
+* [ [#1215](https://github.com/digitalfabrik/integreat-cms/issues/1215) ] Use canonical Enter / Shift+Enter behavior in TinyMCE
 
 
 2022.2.1

--- a/integreat_cms/static/src/js/forms/tinymce-init.ts
+++ b/integreat_cms/static/src/js/forms/tinymce-init.ts
@@ -94,7 +94,7 @@ window.addEventListener("load", () => {
       },
       link_title: false,
       autosave_interval: "120s",
-      forced_root_block: false,
+      forced_root_block: true,
       plugins:
         "code fullscreen autosave preview media image lists directionality wordcount hr charmap",
       external_plugins: {


### PR DESCRIPTION
### Short description
Use the canonical behavior for Enter and Shift+Enter in TinyMCE.


### Proposed changes
Set `forced_root_block` to `true`.

### Resolved issues
Fixes: #1215
