### PR TITLE
Disable pagination on language tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ UNRELEASED
 * [ [#1214](https://github.com/digitalfabrik/integreat-cms/issues/1214) ] Fix API return format of event location
 * [ [#1218](https://github.com/digitalfabrik/integreat-cms/issues/1218) ] Fix saving of first root node
 * [ [#1215](https://github.com/digitalfabrik/integreat-cms/issues/1215) ] Use canonical Enter / Shift+Enter behavior in TinyMCE
+* [ [#1221](https://github.com/digitalfabrik/integreat-cms/issues/1221) ] Disable pagination on language tree
 
 
 2022.2.1

--- a/integreat_cms/cms/views/language_tree/language_tree_view.py
+++ b/integreat_cms/cms/views/language_tree/language_tree_view.py
@@ -18,6 +18,8 @@ class LanguageTreeView(LanguageTreeContextMixin, ModelListView):
     template_name = "language_tree/language_tree.html"
     #: The model of this list view
     model = LanguageTreeNode
+    #: Disable pagination for language tree
+    paginate_by = None
 
     def get_queryset(self):
         """


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Disable pagination on language tree

### Proposed changes
<!-- Describe this PR in more detail. -->

- Set `paginate_by` to `None`

