### PR TITLE
Ignore minor edits in target language translations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ UNRELEASED
 * [ [#1222](https://github.com/digitalfabrik/integreat-cms/issues/1222) ] Fix missing translations and archived pages in API
 * [ [#1131](https://github.com/digitalfabrik/integreat-cms/issues/1131) ] Flush Cache of related objects when changing a tree
 * [ [#1242](https://github.com/digitalfabrik/integreat-cms/issues/1242) ] Add setting to activate Matomo tracking
+* [ [#1197](https://github.com/digitalfabrik/integreat-cms/issues/1197) ] Fix calculation of translation status
 
 
 2022.2.3

--- a/integreat_cms/cms/templates/imprint/imprint_form.html
+++ b/integreat_cms/cms/templates/imprint/imprint_form.html
@@ -94,14 +94,14 @@
                                 {% trans "Minor edit" %}
                             </h3>
                         </div>
-                        <div class="w-full p-4 rounded shadow bg-white">
+                        <div class="w-full px-4 pb-4 rounded shadow bg-white">
                             <label>{% trans 'Implications on other translations' %}</label>
                             {% render_field imprint_translation_form.minor_edit %}
                             <label for="{{ imprint_translation_form.minor_edit.id_for_label }}"
                                    class="secondary">
                                 {{ imprint_translation_form.minor_edit.label }}
                             </label>
-                            <div class="help-text">{{ imprint_translation_form.minor_edit.help_text }}</div>
+                            <div class="help-text">{% minor_edit_help_text request.region language imprint_translation_form %}</div>
                         </div>
                     </div>
                     {% if perms.cms.delete_imprintpage %}

--- a/integreat_cms/cms/templates/pages/page_form.html
+++ b/integreat_cms/cms/templates/pages/page_form.html
@@ -1,4 +1,5 @@
 {% extends "_base.html" %}
+
 {% load i18n %}
 {% load static %}
 {% load widget_tweaks %}
@@ -7,6 +8,7 @@
 {% load page_filters %}
 {% load rules %}
 {% load render_bundle from webpack_loader %}
+
 {% block content %}
     {% get_current_language as LANGUAGE_CODE %}
     {% has_perm 'cms.change_page_object' request.user page as can_edit_page %}
@@ -163,7 +165,7 @@
                                    class="secondary">
                                 {{ page_translation_form.minor_edit.label }}
                             </label>
-                            <div class="help-text">{{ page_translation_form.minor_edit.help_text }}</div>
+                            <div class="help-text">{% minor_edit_help_text request.region language page_translation_form %}</div>
                         </div>
                     </div>
                 {% endif %}

--- a/integreat_cms/cms/templates/pages/page_revisions.html
+++ b/integreat_cms/cms/templates/pages/page_revisions.html
@@ -54,6 +54,9 @@
         {% elif forloop.first %}
             ({% trans 'This is <b>not</b> the version shown in the apps.' %})
         {% endif %}
+        {% if page_translation.minor_edit %}
+            - <i>{% trans 'Minor edit' %}</i>
+        {% endif %}
         <span class="float-right">
             <label class="inline-block">{% trans 'Author' %}:</label>
             {% firstof page_translation.creator deleted_user_text %}

--- a/integreat_cms/cms/templatetags/content_filters.py
+++ b/integreat_cms/cms/templatetags/content_filters.py
@@ -7,6 +7,7 @@ import logging
 from django.urls import reverse
 
 from django import template
+from django.utils.translation import gettext as _
 
 from ..constants import translation_status
 from ..models import Language, PageTranslation, EventTranslation, POITranslation
@@ -80,6 +81,33 @@ def get_language(language_slug):
     :rtype: ~integreat_cms.cms.models.languages.language.Language
     """
     return Language.objects.filter(slug=language_slug).first()
+
+
+@register.simple_tag
+def minor_edit_help_text(region, language, translation_form):
+    """
+    This tag returns the help text of the minor edit field of the given form
+
+    :param region: current region
+    :type region: ~integreat_cms.cms.models.regions.region.Region
+
+    :param language: The current language
+    :type language: ~integreat_cms.cms.models.languages.language.Language
+
+    :param translation_form: The given model form
+    :type translation_form: ~integreat_cms.cms.forms.custom_model_form.CustomModelForm
+
+    :return: The minor edit help text
+    :rtype: str
+    """
+    language_node = region.language_node_by_slug[language.slug]
+    if language_node.is_leaf():
+        return _("Tick if this edit should not change the status of this translation.")
+    if language_node.is_root():
+        return translation_form["minor_edit"].help_text
+    return _(
+        "Tick if this edit should not change the status of this translation and does not require an update of translations in other languages."
+    )
 
 
 @register.simple_tag

--- a/integreat_cms/cms/views/analytics/translation_coverage_view.py
+++ b/integreat_cms/cms/views/analytics/translation_coverage_view.py
@@ -33,9 +33,11 @@ class TranslationCoverageView(TemplateView):
         translation_coverage_data = {}
         outdated_word_count = Counter()
 
-        pages = region.pages.filter(explicitly_archived=False).cache_tree(
-            archived=False
-        )[0]
+        pages = (
+            region.pages.filter(explicitly_archived=False)
+            .prefetch_major_public_translations()
+            .cache_tree(archived=False)[0]
+        )
         for language in region.active_languages:
             language_coverage_data = Counter()
             for page in pages:

--- a/integreat_cms/cms/views/imprint/imprint_actions.py
+++ b/integreat_cms/cms/views/imprint/imprint_actions.py
@@ -71,7 +71,7 @@ def expand_imprint_translation_id(request, imprint_translation_id):
 
     imprint_translation = ImprintPageTranslation.objects.get(
         id=imprint_translation_id
-    ).latest_public_revision
+    ).public_version
 
     if imprint_translation and not imprint_translation.page.archived:
         return redirect(settings.WEBAPP_URL + imprint_translation.get_absolute_url())

--- a/integreat_cms/cms/views/pages/page_actions.py
+++ b/integreat_cms/cms/views/pages/page_actions.py
@@ -277,9 +277,7 @@ def expand_page_translation_id(request, short_url_id):
     :rtype: ~django.http.HttpResponseRedirect
     """
 
-    page_translation = PageTranslation.objects.get(
-        id=short_url_id
-    ).latest_public_revision
+    page_translation = PageTranslation.objects.get(id=short_url_id).public_version
 
     if page_translation and not page_translation.page.archived:
         return redirect(settings.WEBAPP_URL + page_translation.get_absolute_url())

--- a/integreat_cms/cms/views/pages/page_tree_view.py
+++ b/integreat_cms/cms/views/pages/page_tree_view.py
@@ -97,7 +97,9 @@ class PageTreeView(TemplateView, PageContextMixin):
             page_queryset = region.pages.all()
         else:
             page_queryset = region.pages.filter(lft=1)
-        pages = page_queryset.cache_tree(archived=self.archived)[0]
+        pages = page_queryset.prefetch_major_public_translations().cache_tree(
+            archived=self.archived
+        )[0]
 
         if filter_data:
             # Set data for filter form rendering

--- a/integreat_cms/cms/views/pages/partial_page_tree_view.py
+++ b/integreat_cms/cms/views/pages/partial_page_tree_view.py
@@ -43,12 +43,16 @@ class PartialPageTreeView(TemplateView, PageContextMixin):
             kwargs.get("language_slug"), only_active=True
         )
         # List of all ancestors, the requested parent and all direct children
-        pages = region.pages.filter(
-            # This condition queries the parent and all direct children
-            Q(tree_id=tree_id, lft__range=(lft, rgt - 1), depth__lte=depth + 1)
-            # This condition queries all ancestors
-            | Q(tree_id=tree_id, lft__lt=lft, rgt__gt=rgt)
-        ).cache_tree(False)[0]
+        pages = (
+            region.pages.filter(
+                # This condition queries the parent and all direct children
+                Q(tree_id=tree_id, lft__range=(lft, rgt - 1), depth__lte=depth + 1)
+                # This condition queries all ancestors
+                | Q(tree_id=tree_id, lft__lt=lft, rgt__gt=rgt)
+            )
+            .prefetch_major_public_translations()
+            .cache_tree(False)[0]
+        )
         # If the depth is 1, the first element must be the direct parent, etc.
         parent = pages[depth - 1]
         # The remaining pages are the direct children

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-02-23 15:52+0000\n"
+"POT-Creation-Date: 2022-02-23 22:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1299,7 +1299,7 @@ msgstr "Versteckt"
 
 #: cms/constants/region_status.py:18 cms/models/pages/page.py:298
 #: cms/models/regions/region.py:597 cms/templates/events/event_form.html:70
-#: cms/templates/pages/page_form.html:91
+#: cms/templates/pages/page_form.html:93
 #: cms/templates/pages/page_tree_archived_node.html:78
 #: cms/templates/pois/poi_form.html:57
 msgid "Archived"
@@ -1587,7 +1587,7 @@ msgstr "Kategorie"
 #: cms/templates/imprint/imprint_sbs.html:115
 #: cms/templates/imprint/imprint_sbs.html:134
 #: cms/templates/linkcheck/links_by_filter.html:52
-#: cms/templates/pages/page_form.html:88
+#: cms/templates/pages/page_form.html:90
 #: cms/templates/pages/page_revisions.html:50
 #: cms/templates/pages/page_sbs.html:59 cms/templates/pages/page_sbs.html:115
 #: cms/templates/pages/page_sbs.html:121 cms/templates/pages/page_tree.html:81
@@ -1829,7 +1829,7 @@ msgstr "Sie haben Ihr bisheriges Passwort falsch eingegeben."
 msgid "The new passwords do not match."
 msgstr "Die Passwörter stimmen nicht überein."
 
-#: cms/models/abstract_content_model.py:72 cms/models/abstract_tree_node.py:35
+#: cms/models/abstract_content_model.py:96 cms/models/abstract_tree_node.py:35
 #: cms/models/feedback/feedback.py:26 cms/models/media/directory.py:24
 #: cms/models/media/media_file.py:136
 #: cms/models/push_notifications/push_notification.py:21
@@ -1837,7 +1837,7 @@ msgstr "Die Passwörter stimmen nicht überein."
 msgid "region"
 msgstr "Region"
 
-#: cms/models/abstract_content_model.py:75 cms/models/feedback/feedback.py:62
+#: cms/models/abstract_content_model.py:99 cms/models/feedback/feedback.py:62
 #: cms/models/languages/language.py:85
 #: cms/models/languages/language_tree_node.py:37
 #: cms/models/media/directory.py:36 cms/models/offers/offer_template.py:56
@@ -2458,7 +2458,7 @@ msgstr "Ob die Seite explizit archiviert ist oder nicht"
 #: cms/templates/events/event_list.html:56
 #: cms/templates/events/event_list_archived.html:29
 #: cms/templates/events/event_list_archived.html:33
-#: cms/templates/pages/page_form.html:27 cms/templates/pages/page_tree.html:63
+#: cms/templates/pages/page_form.html:29 cms/templates/pages/page_tree.html:63
 #: cms/templates/pages/page_tree.html:67
 #: cms/templates/pages/page_tree_archived.html:44
 #: cms/templates/pages/page_tree_archived.html:48
@@ -3137,7 +3137,7 @@ msgstr "Angebots-Vorlagen"
 #: cms/templates/imprint/imprint_sbs.html:48
 #: cms/templates/imprint/imprint_sbs.html:112
 #: cms/templates/imprint/imprint_sbs.html:131
-#: cms/templates/pages/page_form.html:82
+#: cms/templates/pages/page_form.html:84
 #: cms/templates/pages/page_revisions.html:24
 #: cms/templates/pages/page_sbs.html:56 cms/templates/pages/page_sbs.html:112
 #: cms/templates/pages/page_sbs.html:118 cms/templates/pois/poi_form.html:49
@@ -3195,7 +3195,7 @@ msgstr "Öffnungszeiten"
 msgid "Hint"
 msgstr "Tipp"
 
-#: cms/templates/_tinymce_config.html:37 cms/templates/pages/page_form.html:46
+#: cms/templates/_tinymce_config.html:37 cms/templates/pages/page_form.html:48
 msgid "Update"
 msgstr "Aktualisieren"
 
@@ -3604,7 +3604,7 @@ msgstr "Veranstaltung erstellen"
 #: cms/templates/events/event_form.html:40
 #: cms/templates/imprint/imprint_form.html:26
 #: cms/templates/imprint/imprint_sbs.html:24
-#: cms/templates/pages/page_form.html:40 cms/templates/pages/page_sbs.html:26
+#: cms/templates/pages/page_form.html:42 cms/templates/pages/page_sbs.html:26
 #: cms/templates/pois/poi_form.html:32
 msgid "Save as draft"
 msgstr "Als Entwurf speichern"
@@ -3612,18 +3612,18 @@ msgstr "Als Entwurf speichern"
 #: cms/templates/events/event_form.html:42
 #: cms/templates/imprint/imprint_form.html:27
 #: cms/templates/imprint/imprint_sbs.html:25
-#: cms/templates/pages/page_form.html:48 cms/templates/pages/page_sbs.html:30
+#: cms/templates/pages/page_form.html:50 cms/templates/pages/page_sbs.html:30
 #: cms/templates/pois/poi_form.html:33
 msgid "Publish"
 msgstr "Veröffentlichen"
 
 #: cms/templates/events/event_form.html:44
-#: cms/templates/pages/page_form.html:52 cms/templates/pages/page_sbs.html:32
+#: cms/templates/pages/page_form.html:54 cms/templates/pages/page_sbs.html:32
 msgid "Submit for review"
 msgstr "Zur Überprüfung vorlegen"
 
 #: cms/templates/events/event_form.html:86
-#: cms/templates/pages/page_form.html:126 cms/templates/pois/poi_form.html:72
+#: cms/templates/pages/page_form.html:128 cms/templates/pois/poi_form.html:72
 msgid "Edit"
 msgstr "Bearbeiten"
 
@@ -3632,8 +3632,8 @@ msgstr "Bearbeiten"
 #: cms/templates/imprint/imprint_form.html:78
 #: cms/templates/imprint/imprint_sbs.html:61
 #: cms/templates/imprint/imprint_sbs.html:125
-#: cms/templates/pages/page_form.html:111
-#: cms/templates/pages/page_form.html:130 cms/templates/pois/poi_form.html:76
+#: cms/templates/pages/page_form.html:113
+#: cms/templates/pages/page_form.html:132 cms/templates/pois/poi_form.html:76
 msgid "Copy to clipboard"
 msgstr "In die Zwischenablage kopieren"
 
@@ -3671,7 +3671,7 @@ msgstr "Auf Google Maps öffnen"
 
 #: cms/templates/events/event_form.html:301
 #: cms/templates/imprint/imprint_form.html:112
-#: cms/templates/pages/page_form.html:238 cms/templates/pois/poi_form.html:158
+#: cms/templates/pages/page_form.html:240 cms/templates/pois/poi_form.html:158
 #: cms/templates/regions/region_list.html:25
 #: cms/templates/settings/user_settings.html:93
 msgid "Actions"
@@ -3923,7 +3923,7 @@ msgid "No feedback available yet."
 msgstr "Noch kein Feedback vorhanden."
 
 #: cms/templates/generic_confirmation_dialog.html:12
-#: cms/templates/pages/page_form.html:65
+#: cms/templates/pages/page_form.html:67
 msgid "Warning"
 msgstr "Warnung"
 
@@ -3973,12 +3973,12 @@ msgid "Create imprint"
 msgstr "Impressum erstellen"
 
 #: cms/templates/imprint/imprint_form.html:47
-#: cms/templates/pages/page_form.html:86
+#: cms/templates/pages/page_form.html:88
 msgid "Show"
 msgstr "Anzeigen"
 
 #: cms/templates/imprint/imprint_form.html:57
-#: cms/templates/pages/page_form.html:104
+#: cms/templates/pages/page_form.html:106
 msgid "Short URL"
 msgstr "Kurz-URL"
 
@@ -3990,13 +3990,14 @@ msgid "Link to the imprint"
 msgstr "Link zum Impressum"
 
 #: cms/templates/imprint/imprint_form.html:94
-#: cms/templates/pages/page_form.html:156
+#: cms/templates/pages/page_form.html:158
+#: cms/templates/pages/page_revisions.html:58
 msgid "Minor edit"
 msgstr "Geringfügige Änderung"
 
 #: cms/templates/imprint/imprint_form.html:98
 #: cms/templates/imprint/imprint_sbs.html:145
-#: cms/templates/pages/page_form.html:160 cms/templates/pages/page_sbs.html:134
+#: cms/templates/pages/page_form.html:162 cms/templates/pages/page_sbs.html:134
 msgid "Implications on other translations"
 msgstr "Auswirkungen auf andere Übersetzungen"
 
@@ -4022,7 +4023,7 @@ msgid "Side-by-Side view"
 msgstr "Side-by-Side-Ansicht"
 
 #: cms/templates/imprint/imprint_form.html:137
-#: cms/templates/pages/page_form.html:337
+#: cms/templates/pages/page_form.html:339
 msgid "Direction of translation"
 msgstr "Übersetzungsrichtung"
 
@@ -4042,7 +4043,7 @@ msgstr "Zurück zum Impressums-Editor"
 #: cms/templates/imprint/imprint_revisions.html:21
 #: cms/templates/imprint/imprint_revisions.html:54
 #: cms/templates/pages/page_revisions.html:25
-#: cms/templates/pages/page_revisions.html:58
+#: cms/templates/pages/page_revisions.html:61
 msgid "Author"
 msgstr "Autor"
 
@@ -4064,16 +4065,16 @@ msgstr "Diese Version wird <b>nicht</b> in den Apps angezeigt."
 
 #: cms/templates/imprint/imprint_revisions.html:58
 #: cms/templates/imprint/imprint_revisions.html:72
-#: cms/templates/pages/page_revisions.html:62
-#: cms/templates/pages/page_revisions.html:76
+#: cms/templates/pages/page_revisions.html:65
+#: cms/templates/pages/page_revisions.html:79
 msgid "Permalink"
 msgstr "Permalink"
 
 #: cms/templates/imprint/imprint_revisions.html:60
 #: cms/templates/imprint/imprint_revisions.html:73
 #: cms/templates/pages/_page_xliff_import_diff.html:81
-#: cms/templates/pages/page_revisions.html:64
-#: cms/templates/pages/page_revisions.html:77
+#: cms/templates/pages/page_revisions.html:67
+#: cms/templates/pages/page_revisions.html:80
 #: cms/templates/push_notifications/push_notification_list.html:27
 msgid "Title"
 msgstr "Titel"
@@ -4081,18 +4082,18 @@ msgstr "Titel"
 #: cms/templates/imprint/imprint_revisions.html:62
 #: cms/templates/imprint/imprint_revisions.html:74
 #: cms/templates/pages/_page_xliff_import_diff.html:83
-#: cms/templates/pages/page_revisions.html:66
-#: cms/templates/pages/page_revisions.html:78
+#: cms/templates/pages/page_revisions.html:69
+#: cms/templates/pages/page_revisions.html:81
 msgid "Content"
 msgstr "Inhalt"
 
 #: cms/templates/imprint/imprint_revisions.html:78
-#: cms/templates/pages/page_revisions.html:85
+#: cms/templates/pages/page_revisions.html:88
 msgid "Restore this version as draft"
 msgstr "Diese Version als Entwurf wiederherstellen"
 
 #: cms/templates/imprint/imprint_revisions.html:79
-#: cms/templates/pages/page_revisions.html:88
+#: cms/templates/pages/page_revisions.html:91
 msgid "Restore and publish this version"
 msgstr "Diese Version wiederherstellen und veröffentlichen"
 
@@ -4482,53 +4483,53 @@ msgstr "Quellcode"
 msgid "No changes detected."
 msgstr "Keine Änderungen vorgenommen."
 
-#: cms/templates/pages/page_form.html:23
+#: cms/templates/pages/page_form.html:25
 #, python-format
 msgid "Edit page \"%(page_title)s\""
 msgstr "Seite \"%(page_title)s\" bearbeiten"
 
-#: cms/templates/pages/page_form.html:31
+#: cms/templates/pages/page_form.html:33
 msgid "Create new translation"
 msgstr "Neue Übersetzung erstellen"
 
-#: cms/templates/pages/page_form.html:34
+#: cms/templates/pages/page_form.html:36
 msgid "Create new page"
 msgstr "Neue Seite erstellen"
 
-#: cms/templates/pages/page_form.html:66
+#: cms/templates/pages/page_form.html:68
 msgid "Translation in progress"
 msgstr "Übersetzung wird durchgeführt"
 
-#: cms/templates/pages/page_form.html:71
+#: cms/templates/pages/page_form.html:73
 msgid "Cancel translation process"
 msgstr "Übersetzungsprozess abbrechen"
 
-#: cms/templates/pages/page_form.html:93
+#: cms/templates/pages/page_form.html:95
 #: cms/templates/pages/page_tree_archived_node.html:82
 msgid "Archived, because a parent page is archived"
 msgstr "Archiviert, weil eine übergeordnete Seite archiviert ist"
 
-#: cms/templates/pages/page_form.html:174
+#: cms/templates/pages/page_form.html:176
 msgid "Settings of the page"
 msgstr "Einstellungen der Seite"
 
-#: cms/templates/pages/page_form.html:183
+#: cms/templates/pages/page_form.html:185
 msgid "Positioning"
 msgstr "Anordnung"
 
-#: cms/templates/pages/page_form.html:188
+#: cms/templates/pages/page_form.html:190
 msgid "Order"
 msgstr "Reihenfolge"
 
-#: cms/templates/pages/page_form.html:192
+#: cms/templates/pages/page_form.html:194
 msgid "Embed live content"
 msgstr "Live-Inhalte einbinden"
 
-#: cms/templates/pages/page_form.html:207
+#: cms/templates/pages/page_form.html:209
 msgid "Additional permissions for this page"
 msgstr "Zusätzliche Berechtigungen für diese Seite"
 
-#: cms/templates/pages/page_form.html:209
+#: cms/templates/pages/page_form.html:211
 msgid ""
 "This affects only users, who don't have the permission to change arbitrary "
 "pages anyway."
@@ -4536,18 +4537,18 @@ msgstr ""
 "Dies betrifft nur Benutzer, die nicht ohnehin die Berechtigung haben, "
 "beliebige Seiten zu ändern."
 
-#: cms/templates/pages/page_form.html:244
 #: cms/templates/pages/page_form.html:246
-#: cms/templates/pages/page_form.html:256
+#: cms/templates/pages/page_form.html:248
+#: cms/templates/pages/page_form.html:258
 #: cms/templates/pages/page_tree_archived_node.html:98
 msgid "Restore page"
 msgstr "Seite wiederherstellen"
 
-#: cms/templates/pages/page_form.html:252
+#: cms/templates/pages/page_form.html:254
 msgid "Restore this page"
 msgstr "Diese Seite wiederherstellen"
 
-#: cms/templates/pages/page_form.html:261
+#: cms/templates/pages/page_form.html:263
 msgid "To restore this page, you have to restore its parent page:"
 msgid_plural ""
 "To restore this page, you have to restore all its archived parent pages:"
@@ -4558,31 +4559,31 @@ msgstr[1] ""
 "Um diese Seite wiederherzustellen, müssen Sie alle ihre archivierten "
 "übergeordneten Seiten wiederherstellen:"
 
-#: cms/templates/pages/page_form.html:276
 #: cms/templates/pages/page_form.html:278
+#: cms/templates/pages/page_form.html:280
 #: cms/templates/pages/page_tree_node.html:129
 msgid "Archive page"
 msgstr "Seite archivieren"
 
-#: cms/templates/pages/page_form.html:285
+#: cms/templates/pages/page_form.html:287
 msgid "Archive this page"
 msgstr "Diese Seite archivieren"
 
-#: cms/templates/pages/page_form.html:290
-#: cms/templates/pages/page_form.html:314
+#: cms/templates/pages/page_form.html:292
+#: cms/templates/pages/page_form.html:316
 #: cms/templates/pages/page_tree_archived_node.html:116
 #: cms/templates/pages/page_tree_node.html:142
 msgid "Delete page"
 msgstr "Seite löschen"
 
-#: cms/templates/pages/page_form.html:297
+#: cms/templates/pages/page_form.html:299
 #: cms/templates/pages/page_tree_archived_node.html:112
 #: cms/templates/pages/page_tree_node.html:138
 #: cms/views/pages/page_actions.py:215
 msgid "You cannot delete a page which has subpages."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
 
-#: cms/templates/pages/page_form.html:299
+#: cms/templates/pages/page_form.html:301
 msgid "To delete this page, you have to delete or move its subpage first:"
 msgid_plural ""
 "To delete this page, you have to delete or move its subpages first:"
@@ -4593,15 +4594,15 @@ msgstr[1] ""
 "Um diese Seite zu löschen, müssen Sie zuerst ihre Unterseiten löschen oder "
 "verschieben:"
 
-#: cms/templates/pages/page_form.html:321
+#: cms/templates/pages/page_form.html:323
 msgid "Delete this page"
 msgstr "Diese Seite löschen"
 
-#: cms/templates/pages/page_form.html:332
+#: cms/templates/pages/page_form.html:334
 msgid "Translator view"
 msgstr "Übersetzeransicht"
 
-#: cms/templates/pages/page_form.html:352
+#: cms/templates/pages/page_form.html:354
 msgid "Show translator view"
 msgstr "Übersetzeransicht anzeigen"
 
@@ -4615,7 +4616,7 @@ msgstr "Versionen der Seite \"%(page_title)s\""
 msgid "Go Back to Page Editor"
 msgstr "Zurück zum Seiten-Editor"
 
-#: cms/templates/pages/page_revisions.html:90
+#: cms/templates/pages/page_revisions.html:93
 msgid "Restore this version and submit for review"
 msgstr "Diese Revision wiederherstellen und zum Review vorlegen"
 
@@ -5453,6 +5454,21 @@ msgstr ""
 msgid "Your username is:"
 msgstr "Ihr Benutzername lautet:"
 
+#: cms/templatetags/content_filters.py:105
+msgid "Tick if this edit should not change the status of this translation."
+msgstr ""
+"Kreuzen Sie an, wenn diese Änderung den Status dieser Übersetzung nicht "
+"ändern soll."
+
+#: cms/templatetags/content_filters.py:109
+msgid ""
+"Tick if this edit should not change the status of this translation and does "
+"not require an update of translations in other languages."
+msgstr ""
+"Kreuzen Sie an, wenn diese Änderung den Status dieser Übersetzung nicht "
+"verändern soll und keine Aktualisierung der Übersetzungen in anderen "
+"Sprachen erfordert."
+
 #: cms/templatetags/text_filters.py:36
 msgid "Unknown"
 msgstr "Unbekannt"
@@ -6065,62 +6081,62 @@ msgstr ""
 msgid "Page was successfully deleted"
 msgstr "Seite wurde erfolgreich gelöscht"
 
-#: cms/views/pages/page_actions.py:313
+#: cms/views/pages/page_actions.py:311
 msgid "No pages selected for XLIFF export."
 msgstr ""
 "Es wurden keine gültigen Seiten zur Erzeugung der XLIFF-Datei ausgewählt."
 
-#: cms/views/pages/page_actions.py:338
+#: cms/views/pages/page_actions.py:336
 msgid "XLIFF file for translation to {} successfully created."
 msgstr "XLIFF Datei für die Übersetzung nach {} wurde erfolgreich erstellt."
 
-#: cms/views/pages/page_actions.py:342
+#: cms/views/pages/page_actions.py:340
 msgid "If the download does not start automatically, please click {}here{}."
 msgstr ""
 "Wenn der Download nicht automatisch startet, klicken Sie bitte {}hier{}."
 
-#: cms/views/pages/page_actions.py:436
+#: cms/views/pages/page_actions.py:434
 msgid "File \"{}\" is neither a ZIP archive nor an XLIFF file."
 msgstr "Die Datei \"{}\" ist weder ein ZIP-Archiv noch eine XLIFF-Datei."
 
-#: cms/views/pages/page_actions.py:463
+#: cms/views/pages/page_actions.py:461
 msgid "The ZIP archive \"{}\" does not contain XLIFF files."
 msgstr "Das ZIP-Archiv \"{}\" enthält keine XLIFF-Dateien"
 
-#: cms/views/pages/page_actions.py:471
+#: cms/views/pages/page_actions.py:469
 msgid "The ZIP archive \"{}\" contains the following invalid files: \"{}\""
 msgstr "Das ZIP-Archiv \"{}\" enthält die folgenden ungültigen Dateien: \"{}\""
 
-#: cms/views/pages/page_actions.py:496
+#: cms/views/pages/page_actions.py:494
 msgid "No XLIFF file was selected for import."
 msgstr "Es wurde keine XLIFF-Datei für den Import ausgewählt."
 
-#: cms/views/pages/page_actions.py:556
+#: cms/views/pages/page_actions.py:554
 #, python-brace-format
 msgid "The page \"{page}\" was successfully moved."
 msgstr "Die Seite \"{page}\" wurde erfolgreich verschoben."
 
-#: cms/views/pages/page_actions.py:636 cms/views/pages/page_actions.py:651
+#: cms/views/pages/page_actions.py:634 cms/views/pages/page_actions.py:649
 #, python-brace-format
 msgid "Information: The user {user} has this permission already."
 msgstr "Information: Der Nutzer {user} hat diese Berechtigung bereits"
 
-#: cms/views/pages/page_actions.py:643
+#: cms/views/pages/page_actions.py:641
 #, python-brace-format
 msgid "Success: The user {user} can now edit this page."
 msgstr "Erfolg: Der Nutzer {user} kann nun diese Seite bearbeiten"
 
-#: cms/views/pages/page_actions.py:659
+#: cms/views/pages/page_actions.py:657
 #, python-brace-format
 msgid "Success: The user {user} can now publish this page."
 msgstr "Erfolg: Der Nutzer {user} kann dieses Seite nun veröffentlichen"
 
-#: cms/views/pages/page_actions.py:668 cms/views/pages/page_actions.py:780
+#: cms/views/pages/page_actions.py:666 cms/views/pages/page_actions.py:778
 msgid "An error has occurred. Please contact an administrator."
 msgstr ""
 "Ein Fehler ist aufgetreten. Bitte kontaktieren Sie einen Administrator."
 
-#: cms/views/pages/page_actions.py:748
+#: cms/views/pages/page_actions.py:746
 #, python-brace-format
 msgid ""
 "Information: The user {user} has been removed from the editors of this page, "
@@ -6130,12 +6146,12 @@ msgstr ""
 "bearbeiten wurde entfernt,aber er kann sie auf Grund seiner anderen "
 "Berechtigungen weiterhin bearbeiten."
 
-#: cms/views/pages/page_actions.py:754
+#: cms/views/pages/page_actions.py:752
 #, python-brace-format
 msgid "Success: The user {user} cannot edit this page anymore."
 msgstr "Erfolg: Der Nutzer {user} kann diese Seite nicht mehr bearbeiten"
 
-#: cms/views/pages/page_actions.py:765
+#: cms/views/pages/page_actions.py:763
 #, python-brace-format
 msgid ""
 "Information: The user {user} has been removed from the publishers of this "
@@ -6145,7 +6161,7 @@ msgstr ""
 "veröffentlichen wurde entfernt,aber er kann sie auf Grund seiner anderen "
 "Berechtigungen weiterhin veröffentlichen."
 
-#: cms/views/pages/page_actions.py:771
+#: cms/views/pages/page_actions.py:769
 #, python-brace-format
 msgid "Success: The user {user} cannot publish this page anymore."
 msgstr "Erfolg: Der Nutzer {user} kann diese Seite nicht mehr veröffentlichen"

--- a/integreat_cms/xliff/utils.py
+++ b/integreat_cms/xliff/utils.py
@@ -271,7 +271,7 @@ def get_xliff_import_diff(request, xliff_dir):
     for xliff_file, deserialized_objects in xliffs_to_pages(request, xliff_dir).items():
         for deserialized in deserialized_objects:
             page_translation = deserialized.object
-            existing_translation = page_translation.latest_revision or PageTranslation(
+            existing_translation = page_translation.latest_version or PageTranslation(
                 page=page_translation.page,
                 language=page_translation.language,
             )
@@ -403,7 +403,7 @@ def get_xliff_import_errors(request, page_translation):
         )
     # Retrieve existing page translation in the target language
     # (using model instances in forms may change them, so we need to copy it in order to not change the cached property)
-    existing_translation = deepcopy(page_translation.latest_revision)
+    existing_translation = deepcopy(page_translation.latest_version)
     # Validate page translation
     page_translation_form = PageTranslationForm(
         data=model_to_dict(page_translation),


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Ignore minor edits in target language translations

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add helper methods to prefetch the most recent public versions that are not minor edits
- Refactor calculation of translation status
- Update minor edit help text in forms

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1197
