### PR TITLE
Flush Cacheops when modifying laguage tree nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ UNRELEASED
 
 * [ [#1227](https://github.com/digitalfabrik/integreat-cms/issues/1227) ] Correct URL and Path field in imprint API
 * [ [#1222](https://github.com/digitalfabrik/integreat-cms/issues/1222) ] Fix missing translations and archived pages in API
+* [ [#1131](https://github.com/digitalfabrik/integreat-cms/issues/1131) ] Flush Cache of related objects when changing a tree
 
 
 2022.2.3

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-02-23 09:11+0000\n"
+"POT-Creation-Date: 2022-02-23 15:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1619,7 +1619,7 @@ msgstr "Von"
 msgid "To"
 msgstr "Bis"
 
-#: cms/forms/language_tree/language_tree_node_form.py:112
+#: cms/forms/language_tree/language_tree_node_form.py:114
 msgid ""
 "This region has already a default language.Please specify a source language "
 "for this language."


### PR DESCRIPTION
### Short description
Flush the Cacheops Cache when modifying the language tree of a region.

I'm not really sure if this actually fixes the issue at hand. This probably needs some thorough testing. If nobody sees a reason why this should not help, then I suggest to deploy to the test server and invest some time into clicking around.

### Proposed changes
When moving a language tree node, flush all related objects in the region from the cache.

### Resolved issues
Fixes: #1131
Fixes: #1236 
