### PR TITLE
Add option to activate Matomo tracking, fixes #1242

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ UNRELEASED
 * [ [#1227](https://github.com/digitalfabrik/integreat-cms/issues/1227) ] Correct URL and Path field in imprint API
 * [ [#1222](https://github.com/digitalfabrik/integreat-cms/issues/1222) ] Fix missing translations and archived pages in API
 * [ [#1131](https://github.com/digitalfabrik/integreat-cms/issues/1131) ] Flush Cache of related objects when changing a tree
+* [ [#1242](https://github.com/digitalfabrik/integreat-cms/issues/1242) ] Add setting to activate Matomo tracking
 
 
 2022.2.3

--- a/example-configs/integreat-cms.ini
+++ b/example-configs/integreat-cms.ini
@@ -36,6 +36,8 @@ BASE_URL = https://cms.integreat-app.de
 WEBAPP_URL = https://integreat.app
 # The url to the statistics server [optional, defaults to "https://statistics.integreat-app.de"]
 MATOMO_URL = https://statistics.integreat-app.de
+# Enable or disable tracking of API requests with Matomo, defaults to False
+MATOMO_TRACKING = False
 # The url to the blog website [optional, defaults to "https://integreat-app.de"]
 WEBSITE_URL = https://integreat-app.de
 # The url to the wiki [optional, defaults to "https://wiki.integreat-app.de"]

--- a/integreat_cms/api/decorators.py
+++ b/integreat_cms/api/decorators.py
@@ -160,7 +160,11 @@ def matomo_tracking(func):
         :return: The response of the given function or an 404 :class:`~django.http.JsonResponse`
         :rtype: ~django.http.JsonResponse
         """
-        if not request.region.matomo_id or not request.region.matomo_token:
+        if (
+            not settings.MATOMO_TRACKING
+            or not request.region.matomo_id
+            or not request.region.matomo_token
+        ):
             return func(request, *args, **kwargs)
         data = {
             "idsite": request.region.matomo_id,

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -31,6 +31,11 @@ MATOMO_URL = os.environ.get(
     "INTEGREAT_CMS_MATOMO_URL", "https://statistics.integreat-app.de"
 )
 
+#: Enable tracking of API requests in Matomo
+MATOMO_TRACKING = bool(
+    strtobool(os.environ.get("INTEGREAT_CMS_MATOMO_TRACKING", "False"))
+)
+
 #: The slug for the legal notice (see e.g. :class:`~integreat_cms.cms.models.pages.imprint_page_translation.ImprintPageTranslation`)
 IMPRINT_SLUG = "imprint"
 


### PR DESCRIPTION
### Short description
Add an option to disable tracking of API requests. This is necessary when we want to connect to a Matomo instance in general but do not want to track API requests.


### Proposed changes
Add a `MATOMO_TRACKING` setting.

### Resolved issues
Fixes: #1242
