### PR TITLE
Implement lock for content editing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ UNRELEASED
 * [ [#1319](https://github.com/digitalfabrik/integreat-cms/issues/1319) ] Fix error on Imprint API
 * [ [#1103](https://github.com/digitalfabrik/integreat-cms/issues/1103) ] Add automatic translations via DeepL API
 * [ [#1024](https://github.com/digitalfabrik/integreat-cms/issues/1024) ] Add URL search-replace for linkchecker
+* [ [#1177](https://github.com/digitalfabrik/integreat-cms/issues/1177) ] Add content locking mechanism
 
 
 2022.3.6

--- a/integreat_cms/cms/forms/custom_content_model_form.py
+++ b/integreat_cms/cms/forms/custom_content_model_form.py
@@ -5,7 +5,9 @@ from urllib.parse import urlparse
 from lxml.etree import LxmlError
 from lxml.html import fromstring, tostring
 
+from django import forms
 from django.conf import settings
+from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q
 from django.contrib import messages
 from django.utils.translation import ugettext_lazy as _
@@ -21,6 +23,43 @@ class CustomContentModelForm(CustomModelForm):
     """
     Form for the content model forms for pages, events and POIs.
     """
+
+    def __init__(self, **kwargs):
+        self.changed_by_user = kwargs.pop("changed_by_user", None)
+        self.locked_by_user = kwargs.pop("locked_by_user", None)
+
+        super().__init__(**kwargs)
+
+        if not self.locked_by_user:
+            try:
+                self.locked_by_user = self.instance.foreign_object.get_locking_user()
+            except ObjectDoesNotExist:
+                # If the foreign object does not exist yet, there ist also no lock so nothing must be done
+                pass
+
+    def clean(self):
+        """
+        This method extends the ``clean()``-method to verify that a user can modify this content model
+
+        :return: The cleaned data (see :ref:`overriding-modelform-clean-method`)
+        :rtype: dict
+        """
+        if (
+            self.changed_by_user
+            and self.locked_by_user
+            and self.changed_by_user != self.locked_by_user
+        ):
+            self.add_error(
+                None,
+                forms.ValidationError(
+                    _(
+                        "Could not update because this content because it is already being edited by another user"
+                    ),
+                    code="invalid",
+                ),
+            )
+
+        return super().clean()
 
     def clean_content(self):
         """

--- a/integreat_cms/cms/forms/custom_content_model_form.py
+++ b/integreat_cms/cms/forms/custom_content_model_form.py
@@ -44,8 +44,10 @@ class CustomContentModelForm(CustomModelForm):
         :return: The cleaned data (see :ref:`overriding-modelform-clean-method`)
         :rtype: dict
         """
+        force_update = self.cleaned_data["status"] == status.AUTO_SAVE
         if (
-            self.changed_by_user
+            not force_update
+            and self.changed_by_user
             and self.locked_by_user
             and self.changed_by_user != self.locked_by_user
         ):

--- a/integreat_cms/cms/models/abstract_content_model.py
+++ b/integreat_cms/cms/models/abstract_content_model.py
@@ -6,6 +6,7 @@ from django.utils.translation import get_language, ugettext_lazy as _
 from django.utils import timezone
 
 from ..constants import status, translation_status
+from ..utils.content_edit_lock import get_locking_user
 from .regions.region import Region
 from .abstract_base_model import AbstractBaseModel
 
@@ -306,6 +307,25 @@ class AbstractContentModel(AbstractBaseModel):
             for node in self.region.language_tree
             if node.active
         }
+
+    @property
+    def edit_lock_key(self):
+        """
+        This property returns the key that is used to lock this specific content object
+
+        :return: A tuple of the id of this object and the classname
+        :rtype: tuple
+        """
+        return (self.id, type(self).__name__)
+
+    def get_locking_user(self):
+        """
+        This method returns the user that is currently locking this content object.
+
+        :return: The user
+        :rtype: ~django.contrib.auth.models.User
+        """
+        return get_locking_user(*self.edit_lock_key)
 
     def __str__(self):
         """

--- a/integreat_cms/cms/models/pages/imprint_page.py
+++ b/integreat_cms/cms/models/pages/imprint_page.py
@@ -23,6 +23,17 @@ class ImprintPage(AbstractContentModel):
         """
         return ImprintPageTranslation
 
+    @property
+    def edit_lock_key(self):
+        """
+        This property returns the key that is used to lock this specific content object
+        This overwrites :meth:`~integreat_cms.cms.models.abstract_content_model.AbstractContentModel.edit_lock_key`
+
+        :return: A tuple of the region slug and the classname
+        :rtype: tuple
+        """
+        return (self.region.slug, type(self).__name__)
+
     class Meta:
         #: The verbose name of the model
         verbose_name = _("imprint")

--- a/integreat_cms/cms/templates/_content_edit_lock.html
+++ b/integreat_cms/cms/templates/_content_edit_lock.html
@@ -1,8 +1,14 @@
 {% load text_filters %}
+{% load i18n %}
 
 <div
     id="content-edit-lock-data"
     data-heartbeat-url="{% url 'content_edit_lock_heartbeat' region_slug=request.region.slug %}"
     data-lock-release-url="{% url 'content_edit_lock_release' region_slug=request.region.slug %}"
     data-heartbeat-payload="{{ lock_key|to_json }}"
+    data-cancel-url="{{ back_url }}"
+    data-popup-title-locked="{% trans '{} is already editing this content' %}"
+    data-popup-title-takeover="{% trans 'This content got locked by {}' %}"
+    data-popup-subject="{% trans 'Do you want to take over this site?' %}"
+    data-popup-text="{% trans 'Continuing will prevent the current editor from working on it.' %}"
 ></div>

--- a/integreat_cms/cms/templates/_content_edit_lock.html
+++ b/integreat_cms/cms/templates/_content_edit_lock.html
@@ -1,0 +1,8 @@
+{% load text_filters %}
+
+<div
+    id="content-edit-lock-data"
+    data-heartbeat-url="{% url 'content_edit_lock_heartbeat' region_slug=request.region.slug %}"
+    data-lock-release-url="{% url 'content_edit_lock_release' region_slug=request.region.slug %}"
+    data-heartbeat-payload="{{ lock_key|to_json }}"
+></div>

--- a/integreat_cms/cms/templates/events/event_form.html
+++ b/integreat_cms/cms/templates/events/event_form.html
@@ -355,6 +355,9 @@
         {% include '../_tinymce_config.html' with readonly=1 %}
     {% else %}
         {% include '../_tinymce_config.html' %}
+        {% if event_form.instance.id %}
+            {% include '../_content_edit_lock.html' with lock_key=event_form.instance.edit_lock_key %}
+        {% endif %}
     {% endif %}
     {% if event_form.instance.id %}
         {% include '../generic_confirmation_dialog.html' %}

--- a/integreat_cms/cms/templates/generic_confirmation_dialog.html
+++ b/integreat_cms/cms/templates/generic_confirmation_dialog.html
@@ -13,7 +13,7 @@
         </div>
         <div class="w-full p-4 rounded shadow">
             <h2 id="confirmation-title"></h2>
-            <h3 id="confirmation-subject" class="text-center mt-4 mb-6 break-all"></h3>
+            <h3 id="confirmation-subject" class="text-center mt-4 mb-6 break-words"></h3>
             <p id="confirmation-text" class="mt-4 mb-6">
             </p>
             <form method="post" action="#">

--- a/integreat_cms/cms/templates/imprint/imprint_form.html
+++ b/integreat_cms/cms/templates/imprint/imprint_form.html
@@ -161,6 +161,7 @@
         {% include '../_tinymce_config.html' with readonly=1 %}
     {% else %}
         {% include '../_tinymce_config.html' %}
+        {% include '../_content_edit_lock.html' %}
     {% endif %}
     {% include "../generic_confirmation_dialog.html" %}
 {% endblock content %}

--- a/integreat_cms/cms/templates/pages/page_form.html
+++ b/integreat_cms/cms/templates/pages/page_form.html
@@ -392,6 +392,9 @@
         {% include '../_tinymce_config.html' with readonly=1 %}
     {% else %}
         {% include '../_tinymce_config.html' %}
+        {% if page_form.instance.id %}
+            {% include '../_content_edit_lock.html' with lock_key=page.edit_lock_key %}
+        {% endif %}
     {% endif %}
     {% include "../generic_confirmation_dialog.html" %}
 {% endblock content %}

--- a/integreat_cms/cms/templates/pois/poi_form.html
+++ b/integreat_cms/cms/templates/pois/poi_form.html
@@ -226,6 +226,9 @@
         {% include '../_tinymce_config.html' with readonly=1 %}
     {% else %}
         {% include '../_tinymce_config.html' %}
+        {% if poi_form.instance.id %}
+            {% include '../_content_edit_lock.html' with lock_key=poi_form.instance.edit_lock_key %}
+        {% endif %}
     {% endif %}
     {% if poi_form.instance.id %}
         {% include '../generic_confirmation_dialog.html' %}

--- a/integreat_cms/cms/templates/pois/poi_form.html
+++ b/integreat_cms/cms/templates/pois/poi_form.html
@@ -30,7 +30,7 @@
                     {% trans 'Create new location' %}
                 {% endif %}
             </h1>
-            {% if not poi_form.instance.archived and perms.cms.change_imprintpage %}
+            {% if not poi_form.instance.archived and perms.cms.change_poi %}
                 <div class="flex flex-wrap gap-4">
                     <button name="submit_draft" class="btn btn-gray">{% trans 'Save as draft' %}</button>
                     <button name="submit_public" class="btn">{% trans 'Publish' %}</button>

--- a/integreat_cms/cms/templatetags/text_filters.py
+++ b/integreat_cms/cms/templatetags/text_filters.py
@@ -44,7 +44,7 @@ def linkcheck_status_filter(status_message):
 @register.filter(name="to_json")
 def to_json(obj):
     """
-    Converts the given obj to a json string
+    Converts the given object to a json string
 
     :param obj: The input object
     :type obj: object

--- a/integreat_cms/cms/templatetags/text_filters.py
+++ b/integreat_cms/cms/templatetags/text_filters.py
@@ -1,6 +1,8 @@
 """
 This is a collection of tags and filters for strings.
 """
+import json
+
 from django import template
 from django.utils.translation import ugettext as _
 
@@ -37,3 +39,17 @@ def linkcheck_status_filter(status_message):
     if status_message.startswith("Other Error:"):
         return _("Error")
     return status_message
+
+
+@register.filter(name="to_json")
+def to_json(obj):
+    """
+    Converts the given obj to a json string
+
+    :param obj: The input object
+    :type obj: object
+
+    :return: object as json string
+    :rtype: str
+    """
+    return json.dumps(obj)

--- a/integreat_cms/cms/urls/protected.py
+++ b/integreat_cms/cms/urls/protected.py
@@ -540,6 +540,23 @@ urlpatterns = [
                                 name="cancel_translation_process_ajax",
                             ),
                             path(
+                                "content-edit-lock/",
+                                include(
+                                    [
+                                        path(
+                                            "heartbeat/",
+                                            utils.content_edit_lock_heartbeat,
+                                            name="content_edit_lock_heartbeat",
+                                        ),
+                                        path(
+                                            "release/",
+                                            utils.content_edit_lock_release,
+                                            name="content_edit_lock_release",
+                                        ),
+                                    ]
+                                ),
+                            ),
+                            path(
                                 "search-poi/",
                                 events.search_poi_ajax,
                                 name="search_poi_ajax",

--- a/integreat_cms/cms/utils/content_edit_lock.py
+++ b/integreat_cms/cms/utils/content_edit_lock.py
@@ -1,0 +1,119 @@
+"""
+This file contains a mechanism to lock a content editor for other people while a person is using it.
+"""
+import logging
+
+from django.core.cache import cache
+
+logger = logging.getLogger(__name__)
+
+
+LOCKED_PAGE_PREFIX = "cms_content_edit_lock"
+LOCK_TIMEOUT_SECONDS = 90
+
+
+def get_locking_user(id_, type_):
+    """
+    This function returns the user that locks a specific object
+
+    :param id_: The id of the content object or None
+    :type id_: object
+
+    :param type_: The type of the content object
+    :type type_: str
+
+    :return: The user that holds the lock for this content object or None
+    :rtype: ~django.contrib.auth.models.User
+    """
+    if id_ is None:
+        return None
+
+    cache_key = get_cache_key(id_, type_)
+    return cache.get(cache_key)
+
+
+def lock_content(id_, type_, user):
+    """
+    This function tries to lock a content object for a user.
+    If it is already locked by someone else, nothing will happen.
+    If it is already locked by the same user, the timeout gets reset.
+
+    :param id_: The id of the content object or None
+    :type id_: int
+
+    :param type_: The type of the content object
+    :type type_: str
+
+    :param user: The user that should get unique access to this content object
+    :type user: ~django.contrib.auth.models.User
+
+    :return: Whether the content object could be locked
+    :rtype: bool
+    """
+    if id_ is None:
+        return False
+
+    cache_key = get_cache_key(id_, type_)
+
+    locking_user = get_locking_user(id_, type_)
+    if locking_user is not None and locking_user != user:
+        return False
+
+    cache.set(cache_key, user, timeout=LOCK_TIMEOUT_SECONDS)
+
+    if locking_user is None:
+        logger.debug("Locked %s with id %s by %r", type_, id_, user)
+    else:
+        logger.debug("Extended lock for %s with id %s by %r", type_, id_, user)
+
+    return True
+
+
+def unlock_content(id_, type_, user):
+    """
+    This function tries to unlock a content object for a user.
+    If it is not locked by the passed user, nothing will happen.
+
+    :param id_: The id of the content object or None
+    :type id_: int
+
+    :param type_: The type of the content object
+    :type type_: str
+
+    :param user: The user that wants to release the lock
+    :type user: ~django.contrib.auth.models.User
+
+    :return: Whether the content object could be unlocked
+    :rtype: bool
+    """
+    if id_ is None:
+        return False
+
+    cache_key = get_cache_key(id_, type_)
+
+    locking_user = get_locking_user(id_, type_)
+    if locking_user is None or locking_user != user:
+        return False
+
+    cache.delete(cache_key)
+
+    logger.debug("Explicitly unlocked %s with id %s by %r", type_, id_, user)
+
+    return True
+
+
+def get_cache_key(id_, type_):
+    """
+    This function returns the key that is used to lock a content object in the cache.
+    It should not be used outside of this module.
+
+    :param id_: The id of the content object
+    :type id_: int
+
+    :param type_: The type of the content object
+    :type type_: str
+
+    :return: The key to use
+    :rtype: str
+    """
+    return f"{LOCKED_PAGE_PREFIX}_{type_}_{id_}"

--- a/integreat_cms/cms/views/events/event_form_view.py
+++ b/integreat_cms/cms/views/events/event_form_view.py
@@ -167,6 +167,7 @@ class EventFormView(TemplateView, EventContextMixin, MediaContextMixin):
                 "language": language,
                 "event": event_form.instance,
             },
+            changed_by_user=request.user,
         )
 
         if (

--- a/integreat_cms/cms/views/events/event_form_view.py
+++ b/integreat_cms/cms/views/events/event_form_view.py
@@ -15,6 +15,7 @@ from ...forms import EventForm, EventTranslationForm, RecurrenceRuleForm
 from ...models import Language, Event, EventTranslation, RecurrenceRule, POI
 from .event_context_mixin import EventContextMixin
 from ..media.media_context_mixin import MediaContextMixin
+from ..mixins import ContentEditLockMixin
 
 
 logger = logging.getLogger(__name__)
@@ -22,7 +23,9 @@ logger = logging.getLogger(__name__)
 
 @method_decorator(permission_required("cms.view_event"), name="dispatch")
 @method_decorator(permission_required("cms.change_event"), name="post")
-class EventFormView(TemplateView, EventContextMixin, MediaContextMixin):
+class EventFormView(
+    TemplateView, EventContextMixin, MediaContextMixin, ContentEditLockMixin
+):
     """
     Class for rendering the events form
     """
@@ -34,6 +37,8 @@ class EventFormView(TemplateView, EventContextMixin, MediaContextMixin):
         "current_menu_item": "events_form",
         "translation_status": translation_status,
     }
+    #: The url name of the view to show if the user decides to go back (see :class:`~integreat_cms.cms.views.mixins.ContentEditLockMixin`
+    back_url_name = "events"
 
     # pylint: disable=too-many-locals
     def get(self, request, *args, **kwargs):

--- a/integreat_cms/cms/views/imprint/imprint_form_view.py
+++ b/integreat_cms/cms/views/imprint/imprint_form_view.py
@@ -130,7 +130,7 @@ class ImprintFormView(TemplateView, MediaContextMixin):
             region, language, imprint
         )
 
-        # If the imprint does not exist yet, use a dummy key to lock it
+        # If the imprint does not exist yet, create the key manually
         edit_lock_key = (
             imprint.edit_lock_key if imprint else (region.slug, ImprintPage.__name__)
         )
@@ -140,6 +140,7 @@ class ImprintFormView(TemplateView, MediaContextMixin):
             self.template_name,
             {
                 **self.get_context_data(**kwargs),
+                "back_url": reverse("dashboard", kwargs={"region_slug": region.slug}),
                 "imprint_translation_form": imprint_translation_form,
                 "imprint": imprint,
                 "language": language,
@@ -188,8 +189,8 @@ class ImprintFormView(TemplateView, MediaContextMixin):
 
         # Since imprints have a special rule for the lock key, compute it here and just pass it to the form
         lock_key = (
-            imprint_translation_instance.page.edit_lock_key
-            if imprint_translation_instance
+            imprint_instance.edit_lock_key
+            if imprint_instance
             else (region.slug, ImprintPage.__name__)
         )
         locked_by_user = get_locking_user(*lock_key)
@@ -239,6 +240,7 @@ class ImprintFormView(TemplateView, MediaContextMixin):
             self.template_name,
             {
                 **self.get_context_data(**kwargs),
+                "back_url": reverse("dashboard", kwargs={"region_slug": region.slug}),
                 "imprint_translation_form": imprint_translation_form,
                 "imprint": imprint_instance,
                 "language": language,

--- a/integreat_cms/cms/views/imprint/imprint_form_view.py
+++ b/integreat_cms/cms/views/imprint/imprint_form_view.py
@@ -129,6 +129,11 @@ class ImprintFormView(TemplateView, MediaContextMixin):
             region, language, imprint
         )
 
+        # If the imprint does not exist yet, use a dummy key to lock it
+        edit_lock_key = (
+            imprint.edit_lock_key if imprint else (region.slug, ImprintPage.__name__)
+        )
+
         return render(
             request,
             self.template_name,
@@ -141,6 +146,7 @@ class ImprintFormView(TemplateView, MediaContextMixin):
                 "languages": region.active_languages if imprint else [language],
                 "side_by_side_language_options": side_by_side_language_options,
                 "translation_states": imprint.translation_states if imprint else [],
+                "lock_key": edit_lock_key,
             },
         )
 

--- a/integreat_cms/cms/views/mixins.py
+++ b/integreat_cms/cms/views/mixins.py
@@ -4,11 +4,12 @@ This module contains mixins for our views
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.views.generic.base import ContextMixin, TemplateResponseMixin
 from django.utils.translation import ugettext as _
+from django.urls import reverse
 
 
 class RegionPermissionRequiredMixing(UserPassesTestMixin):
     """
-    A mixin that can be used for class-based views that require that the user is has access to thhe current region of this request
+    A mixin that can be used for class-based views that require that the user is has access to the current region of this request
     """
 
     def test_func(self):
@@ -67,6 +68,40 @@ class ModelConfirmationContextMixin(ContextMixin):
                     "Please confirm that you really want to delete this {}"
                 ).format(self.model._meta.verbose_name),
                 "delete_dialog_text": _("This cannot be reversed."),
+            }
+        )
+        return context
+
+
+class ContentEditLockMixin(ContextMixin):
+    """
+    A mixin that provides some variables required for the content edit lock
+    """
+
+    #: The reverse name of the url of the associated list view
+    back_url_name = None
+
+    def get_context_data(self, **kwargs):
+        r"""
+        Returns a dictionary representing the template context
+        (see :meth:`~django.views.generic.base.ContextMixin.get_context_data`).
+
+        :param \**kwargs: The given keyword arguments
+        :type \**kwargs: dict
+
+        :return: The template context
+        :rtype: dict
+        """
+        context = super().get_context_data(**kwargs)
+        context.update(
+            {
+                "back_url": reverse(
+                    self.back_url_name,
+                    kwargs={
+                        "region_slug": kwargs["region_slug"],
+                        "language_slug": kwargs["language_slug"],
+                    },
+                )
             }
         )
         return context

--- a/integreat_cms/cms/views/pages/page_form_view.py
+++ b/integreat_cms/cms/views/pages/page_form_view.py
@@ -232,6 +232,7 @@ class PageFormView(TemplateView, PageContextMixin, MediaContextMixin):
                 "language": language,
                 "page": page_form.instance,
             },
+            changed_by_user=request.user,
         )
 
         if not page_form.is_valid() or not page_translation_form.is_valid():

--- a/integreat_cms/cms/views/pages/page_form_view.py
+++ b/integreat_cms/cms/views/pages/page_form_view.py
@@ -14,12 +14,15 @@ from ...forms import PageForm, PageTranslationForm
 from ...models import PageTranslation
 from .page_context_mixin import PageContextMixin
 from ..media.media_context_mixin import MediaContextMixin
+from ..mixins import ContentEditLockMixin
 
 logger = logging.getLogger(__name__)
 
 
 @method_decorator(permission_required("cms.view_page"), name="dispatch")
-class PageFormView(TemplateView, PageContextMixin, MediaContextMixin):
+class PageFormView(
+    TemplateView, PageContextMixin, MediaContextMixin, ContentEditLockMixin
+):
     """
     View for the page form and page translation form
     """
@@ -30,6 +33,8 @@ class PageFormView(TemplateView, PageContextMixin, MediaContextMixin):
     extra_context = {
         "current_menu_item": "new_page",
     }
+    #: The url name of the view to show if the user decides to go back (see :class:`~integreat_cms.cms.views.mixins.ContentEditLockMixin`)
+    back_url_name = "pages"
 
     # pylint: disable=too-many-locals
     def get(self, request, *args, **kwargs):

--- a/integreat_cms/cms/views/pois/poi_form_view.py
+++ b/integreat_cms/cms/views/pois/poi_form_view.py
@@ -15,6 +15,7 @@ from ...forms import POIForm, POITranslationForm
 from ...models import POI, POITranslation, Language
 from .poi_context_mixin import POIContextMixin
 from ..media.media_context_mixin import MediaContextMixin
+from ..mixins import ContentEditLockMixin
 from ...constants import status
 
 logger = logging.getLogger(__name__)
@@ -22,7 +23,9 @@ logger = logging.getLogger(__name__)
 
 @method_decorator(permission_required("cms.view_poi"), name="dispatch")
 @method_decorator(permission_required("cms.change_poi"), name="post")
-class POIFormView(TemplateView, POIContextMixin, MediaContextMixin):
+class POIFormView(
+    TemplateView, POIContextMixin, MediaContextMixin, ContentEditLockMixin
+):
     """
     View for editing POIs
     """
@@ -31,6 +34,8 @@ class POIFormView(TemplateView, POIContextMixin, MediaContextMixin):
     template_name = "pois/poi_form.html"
     #: The context dict passed to the template (see :class:`~django.views.generic.base.ContextMixin`)
     extra_context = {"current_menu_item": "pois_form"}
+    #: The url name of the view to show if the user decides to go back (see :class:`~integreat_cms.cms.views.mixins.ContentEditLockMixin`)
+    back_url_name = "pois"
 
     def get(self, request, *args, **kwargs):
         r"""

--- a/integreat_cms/cms/views/pois/poi_form_view.py
+++ b/integreat_cms/cms/views/pois/poi_form_view.py
@@ -142,6 +142,7 @@ class POIFormView(TemplateView, POIContextMixin, MediaContextMixin):
                 "language": language,
                 "poi": poi_form.instance,
             },
+            changed_by_user=request.user,
         )
 
         if not poi_form.is_valid() or not poi_translation_form.is_valid():

--- a/integreat_cms/cms/views/utils/__init__.py
+++ b/integreat_cms/cms/views/utils/__init__.py
@@ -1,2 +1,3 @@
 from .slugify_ajax import slugify_ajax
 from .search_content_ajax import search_content_ajax
+from .content_edit_lock import content_edit_lock_heartbeat, content_edit_lock_release

--- a/integreat_cms/cms/views/utils/content_edit_lock.py
+++ b/integreat_cms/cms/views/utils/content_edit_lock.py
@@ -1,0 +1,55 @@
+import json
+import logging
+
+from django.http import JsonResponse
+from django.views.decorators.http import require_POST
+
+from ...utils.content_edit_lock import lock_content, unlock_content
+
+logger = logging.getLogger(__name__)
+
+
+@require_POST
+# pylint: disable=unused-argument
+def content_edit_lock_heartbeat(request, region_slug=None):
+    """
+    This function handles heartbeat requests.
+    When a heartbeat is received, this function tries to extend the lock for a user
+    who is editing some content.
+
+    :param request: The current request
+    :type request: ~django.http.HttpResponse
+
+    :param region_slug: The slug of the current region, unused
+    :type region_slug: str
+
+    :return: Json object containing `success: true` if the lock could be acquired
+    :rtype: ~django.http.JsonResponse
+    """
+    body = json.loads(request.body.decode("utf-8"))
+    id_, type_ = body
+
+    success = lock_content(id_, type_, request.user)
+    return JsonResponse({"success": success})
+
+
+@require_POST
+# pylint: disable=unused-argument
+def content_edit_lock_release(request, region_slug=None):
+    """
+    This function handles unlock requests
+
+    :param request: The current request
+    :type request: ~django.http.HttpResponse
+
+    :param region_slug: The slug of the current region, unused
+    :type region_slug: str
+
+    :return: Json object containing `success: true` if the content object could be unlocked
+    :rtype: ~django.http.JsonResponse
+    """
+    body = json.loads(request.body.decode("utf-8"))
+    id_, type_ = body
+
+    success = unlock_content(id_, type_, request.user)
+    return JsonResponse({"success": success})

--- a/integreat_cms/cms/views/utils/content_edit_lock.py
+++ b/integreat_cms/cms/views/utils/content_edit_lock.py
@@ -4,7 +4,7 @@ import logging
 from django.http import JsonResponse
 from django.views.decorators.http import require_POST
 
-from ...utils.content_edit_lock import lock_content, unlock_content
+from ...utils.content_edit_lock import lock_content, unlock_content, get_locking_user
 
 logger = logging.getLogger(__name__)
 
@@ -27,10 +27,30 @@ def content_edit_lock_heartbeat(request, region_slug=None):
     :rtype: ~django.http.JsonResponse
     """
     body = json.loads(request.body.decode("utf-8"))
-    id_, type_ = body
+    id_, type_ = json.loads(body["key"])
+    force_take_over = body["force"]
+
+    if force_take_over:
+        locking_user = get_locking_user(id_, type_)
+        if locking_user:
+            logger.debug(
+                "User %r took control over %s with id %s from %r",
+                request.user,
+                type_,
+                id_,
+                locking_user,
+            )
+            unlock_content(id_, type_, locking_user)
 
     success = lock_content(id_, type_, request.user)
-    return JsonResponse({"success": success})
+    if not success:
+        # If another user has locked the content before and a takeover was not forced, return the new locking user
+        locking_user = get_locking_user(id_, type_)
+    else:
+        locking_user = request.user
+    return JsonResponse(
+        {"success": success, "lockingUser": locking_user.full_user_name}
+    )
 
 
 @require_POST

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-23 14:12+0000\n"
+"POT-Creation-Date: 2022-03-24 11:46+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1839,7 +1839,7 @@ msgstr "Sie haben Ihr bisheriges Passwort falsch eingegeben."
 msgid "The new passwords do not match."
 msgstr "Die Passwörter stimmen nicht überein."
 
-#: cms/models/abstract_content_model.py:96 cms/models/abstract_tree_node.py:35
+#: cms/models/abstract_content_model.py:97 cms/models/abstract_tree_node.py:35
 #: cms/models/feedback/feedback.py:60 cms/models/media/directory.py:24
 #: cms/models/media/media_file.py:138
 #: cms/models/push_notifications/push_notification.py:21
@@ -1847,7 +1847,7 @@ msgstr "Die Passwörter stimmen nicht überein."
 msgid "region"
 msgstr "Region"
 
-#: cms/models/abstract_content_model.py:99 cms/models/feedback/feedback.py:96
+#: cms/models/abstract_content_model.py:100 cms/models/feedback/feedback.py:96
 #: cms/models/languages/language.py:85
 #: cms/models/languages/language_tree_node.py:37
 #: cms/models/media/directory.py:36 cms/models/offers/offer_template.py:56
@@ -3571,7 +3571,7 @@ msgid "Select region"
 msgstr "Region auswählen"
 
 #: cms/templates/error_handler/http_error.html:10
-#: cms/templatetags/text_filters.py:38
+#: cms/templatetags/text_filters.py:40
 msgid "Error"
 msgstr "Fehler"
 
@@ -5582,7 +5582,7 @@ msgstr ""
 "verändern soll und keine Aktualisierung der Übersetzungen in anderen "
 "Sprachen erfordert."
 
-#: cms/templatetags/text_filters.py:36
+#: cms/templatetags/text_filters.py:38
 msgid "Unknown"
 msgstr "Unbekannt"
 
@@ -5827,7 +5827,7 @@ msgstr ""
 "Überprüfung vorlegen."
 
 #: cms/views/events/event_form_view.py:192
-#: cms/views/imprint/imprint_form_view.py:198
+#: cms/views/imprint/imprint_form_view.py:204
 #: cms/views/pages/page_form_view.py:254 cms/views/pois/poi_form_view.py:156
 msgid "No changes detected, autosave skipped"
 msgstr "Keine Änderungen vorgenommen, automatisches Speichern übersprungen"
@@ -5914,11 +5914,11 @@ msgid "You don't have the permission to edit the imprint."
 msgstr ""
 "Sie haben nicht die nötige Berechtigung, um das Impressum zu bearbeiten."
 
-#: cms/views/imprint/imprint_form_view.py:208
+#: cms/views/imprint/imprint_form_view.py:214
 msgid "Imprint was successfully created"
 msgstr "Impressum wurde erfolgreich erstellt"
 
-#: cms/views/imprint/imprint_form_view.py:268
+#: cms/views/imprint/imprint_form_view.py:274
 #: cms/views/pages/page_form_view.py:357
 #, python-brace-format
 msgid "{source_language} to {target_language}"
@@ -6701,6 +6701,13 @@ msgstr ""
 
 #~ msgid "URL could not be replaced"
 #~ msgstr "URL konnte nicht ersetzt werden"
+
+#~ msgid ""
+#~ "You cannot edit this page because it is already being edited by someone "
+#~ "else."
+#~ msgstr ""
+#~ "Sie können diese Seite nicht bearbeiten, weil sie bereits von jemand "
+#~ "anderem bearbeitet wird."
 
 #~ msgid "Settings for all translations"
 #~ msgstr "Einstellungen für alle Übersetzungen"

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-24 11:46+0000\n"
+"POT-Creation-Date: 2022-03-24 11:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1459,15 +1459,23 @@ msgstr "Dritte Woche"
 msgid "Fourth week"
 msgstr "Vierte Woche"
 
-#: cms/forms/custom_content_model_form.py:90
+#: cms/forms/custom_content_model_form.py:56
+msgid ""
+"Could not update because this content because it is already being edited by "
+"another user"
+msgstr ""
+"Sie können diese Seite nicht aktualisieren, weil sie bereits von jemand "
+"anderem bearbeitet wird."
+
+#: cms/forms/custom_content_model_form.py:129
 msgid "{} \"{}\" was successfully saved as draft"
 msgstr "{} \"{}\" wurde erfolgreich als Entwurf gespeichert"
 
-#: cms/forms/custom_content_model_form.py:97
+#: cms/forms/custom_content_model_form.py:136
 msgid "{} \"{}\" was successfully updated"
 msgstr "{} \"{}\" wurde erfolgreich aktualisiert"
 
-#: cms/forms/custom_content_model_form.py:104
+#: cms/forms/custom_content_model_form.py:143
 msgid "{} \"{}\" was successfully published"
 msgstr "{} \"{}\" wurde erfolgreich veröffentlicht"
 
@@ -5826,18 +5834,18 @@ msgstr ""
 "veröffentlichen, aber Sie können Änderungen vornehmen und diese zur "
 "Überprüfung vorlegen."
 
-#: cms/views/events/event_form_view.py:192
-#: cms/views/imprint/imprint_form_view.py:204
-#: cms/views/pages/page_form_view.py:254 cms/views/pois/poi_form_view.py:156
+#: cms/views/events/event_form_view.py:193
+#: cms/views/imprint/imprint_form_view.py:215
+#: cms/views/pages/page_form_view.py:255 cms/views/pois/poi_form_view.py:157
 msgid "No changes detected, autosave skipped"
 msgstr "Keine Änderungen vorgenommen, automatisches Speichern übersprungen"
 
-#: cms/views/events/event_form_view.py:214
+#: cms/views/events/event_form_view.py:215
 msgid "Event \"{}\" was successfully created"
 msgstr "Veranstaltung \"{}\" wurde erfolgreich erstellt"
 
-#: cms/views/events/event_form_view.py:223
-#: cms/views/pages/page_form_view.py:285 cms/views/pois/poi_form_view.py:170
+#: cms/views/events/event_form_view.py:224
+#: cms/views/pages/page_form_view.py:286 cms/views/pois/poi_form_view.py:171
 msgid "No changes detected, but date refreshed"
 msgstr "Keine Änderungen vorgenommen, aber Datum aktualisiert"
 
@@ -5890,14 +5898,14 @@ msgstr "{} \"{}\" wurde erfolgreich erstellt"
 msgid "Imprint was successfully deleted"
 msgstr "Impressum wurde erfolgreich gelöscht"
 
-#: cms/views/imprint/imprint_form_view.py:73
+#: cms/views/imprint/imprint_form_view.py:74
 #: cms/views/pages/page_tree_view.py:77
 msgid "Please create at least one language node before creating pages."
 msgstr ""
 "Bitte erstellen Sie mindestens einen Sprach-Knoten, bevor Sie Seiten "
 "verwalten."
 
-#: cms/views/imprint/imprint_form_view.py:101
+#: cms/views/imprint/imprint_form_view.py:102
 #, python-format
 msgid ""
 "This is <b>not</b> the most recent public revision of this translation. "
@@ -5908,18 +5916,18 @@ msgstr ""
 "Stattdessen wird die <a href='%(revision_url)s' class='underline hover:no-"
 "underline'>Revision %(revision)s</a> in den Apps angezeigt."
 
-#: cms/views/imprint/imprint_form_view.py:120
+#: cms/views/imprint/imprint_form_view.py:121
 #: cms/views/imprint/imprint_sbs_view.py:65
 msgid "You don't have the permission to edit the imprint."
 msgstr ""
 "Sie haben nicht die nötige Berechtigung, um das Impressum zu bearbeiten."
 
-#: cms/views/imprint/imprint_form_view.py:214
+#: cms/views/imprint/imprint_form_view.py:225
 msgid "Imprint was successfully created"
 msgstr "Impressum wurde erfolgreich erstellt"
 
-#: cms/views/imprint/imprint_form_view.py:274
-#: cms/views/pages/page_form_view.py:357
+#: cms/views/imprint/imprint_form_view.py:286
+#: cms/views/pages/page_form_view.py:358
 #, python-brace-format
 msgid "{source_language} to {target_language}"
 msgstr "{source_language} nach {target_language}"
@@ -6365,7 +6373,7 @@ msgstr ""
 "Sie haben nicht die nötige Berechtigung, um diese Seite zu veröffentlichen, "
 "aber Sie können Änderungen vornehmen und diese zur Überprüfung vorlegen."
 
-#: cms/views/pages/page_form_view.py:278
+#: cms/views/pages/page_form_view.py:279
 msgid "Page \"{}\" was successfully created"
 msgstr "Seite \"{}\" wurde erfolgreich erstellt"
 
@@ -6430,7 +6438,7 @@ msgstr "Alle Übersetzungen dieses Ortes werden gelöscht."
 msgid "You cannot edit this location because it is archived."
 msgstr "Sie können diesen Ort nicht bearbeiten, da er archiviert ist."
 
-#: cms/views/pois/poi_form_view.py:165
+#: cms/views/pois/poi_form_view.py:166
 msgid "Location \"{}\" was successfully created"
 msgstr "Ort \"{}\" wurde erfolgreich erstellt"
 

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -1459,7 +1459,7 @@ msgstr "Dritte Woche"
 msgid "Fourth week"
 msgstr "Vierte Woche"
 
-#: cms/forms/custom_content_model_form.py:56
+#: cms/forms/custom_content_model_form.py:58
 msgid ""
 "Could not update because this content because it is already being edited by "
 "another user"
@@ -1467,15 +1467,15 @@ msgstr ""
 "Sie können diese Seite nicht aktualisieren, weil sie bereits von jemand "
 "anderem bearbeitet wird."
 
-#: cms/forms/custom_content_model_form.py:129
+#: cms/forms/custom_content_model_form.py:131
 msgid "{} \"{}\" was successfully saved as draft"
 msgstr "{} \"{}\" wurde erfolgreich als Entwurf gespeichert"
 
-#: cms/forms/custom_content_model_form.py:136
+#: cms/forms/custom_content_model_form.py:138
 msgid "{} \"{}\" was successfully updated"
 msgstr "{} \"{}\" wurde erfolgreich aktualisiert"
 
-#: cms/forms/custom_content_model_form.py:143
+#: cms/forms/custom_content_model_form.py:145
 msgid "{} \"{}\" was successfully published"
 msgstr "{} \"{}\" wurde erfolgreich veröffentlicht"
 
@@ -2510,12 +2510,12 @@ msgstr "mit dem Titel auf"
 msgid "page translations"
 msgstr "Seiten-Übersetzungen"
 
-#: cms/models/pages/imprint_page.py:28
+#: cms/models/pages/imprint_page.py:39
 #: cms/models/pages/imprint_page_translation.py:24
 msgid "imprint"
 msgstr "Impressum"
 
-#: cms/models/pages/imprint_page.py:30
+#: cms/models/pages/imprint_page.py:41
 msgid "imprints"
 msgstr "Impressen"
 
@@ -3184,6 +3184,24 @@ msgstr "Angebots-Vorlagen"
 #: cms/templates/pages/page_sbs.html:118 cms/templates/pois/poi_form.html:52
 msgid "Version"
 msgstr "Version"
+
+#: cms/templates/_content_edit_lock.html:10
+msgid "{} is already editing this content"
+msgstr "Dieser Inhalt wird bereits von {} bearbeitet"
+
+#: cms/templates/_content_edit_lock.html:11
+msgid "This content got locked by {}"
+msgstr "{} hat die Bearbeitung von diesem Inhalt übernommen"
+
+#: cms/templates/_content_edit_lock.html:12
+msgid "Do you want to take over this site?"
+msgstr "Wollen Sie die Bearbeitung von diesem Inhalt übernehmen?"
+
+#: cms/templates/_content_edit_lock.html:13
+msgid "Continuing will prevent the current editor from working on it."
+msgstr ""
+"Wenn Sie fortfahren, werden andere Benutzer an der gleichzeitigen "
+"Bearbeitung gehindert."
 
 #: cms/templates/_form_language_tabs.html:61
 msgid "Other Languages"
@@ -5416,7 +5434,7 @@ msgid "Please confirm that you really want to delete this user"
 msgstr "Bitte bestätigen Sie, dass dieser Benutzer gelöscht werden soll"
 
 #: cms/templates/users/region_user_form.html:107
-#: cms/templates/users/user_form.html:131 cms/views/mixins.py:69
+#: cms/templates/users/user_form.html:131 cms/views/mixins.py:70
 msgid "This cannot be reversed."
 msgstr "Dies kann nicht rückgängig gemacht werden."
 
@@ -5815,17 +5833,17 @@ msgstr "Bitte bestätigen Sie, dass dieses Event gelöscht werden soll"
 msgid "All translations of this event will also be deleted."
 msgstr "Alle Übersetzungen dieses Events werden gelöscht."
 
-#: cms/views/events/event_form_view.py:77
+#: cms/views/events/event_form_view.py:82
 msgid "You cannot edit this event because it is archived."
 msgstr ""
 "Sie können diese Veranstaltung nicht bearbeiten, weil sie archiviert ist."
 
-#: cms/views/events/event_form_view.py:82
+#: cms/views/events/event_form_view.py:87
 msgid "You don't have the permission to edit events."
 msgstr ""
 "Sie haben nicht die nötige Berechtigung, um Veranstaltungen zu bearbeiten."
 
-#: cms/views/events/event_form_view.py:91
+#: cms/views/events/event_form_view.py:96
 msgid ""
 "You don't have the permission to publish events, but you can propose changes "
 "and submit them for review instead."
@@ -5834,18 +5852,18 @@ msgstr ""
 "veröffentlichen, aber Sie können Änderungen vornehmen und diese zur "
 "Überprüfung vorlegen."
 
-#: cms/views/events/event_form_view.py:193
-#: cms/views/imprint/imprint_form_view.py:215
-#: cms/views/pages/page_form_view.py:255 cms/views/pois/poi_form_view.py:157
+#: cms/views/events/event_form_view.py:198
+#: cms/views/imprint/imprint_form_view.py:216
+#: cms/views/pages/page_form_view.py:260 cms/views/pois/poi_form_view.py:162
 msgid "No changes detected, autosave skipped"
 msgstr "Keine Änderungen vorgenommen, automatisches Speichern übersprungen"
 
-#: cms/views/events/event_form_view.py:215
+#: cms/views/events/event_form_view.py:220
 msgid "Event \"{}\" was successfully created"
 msgstr "Veranstaltung \"{}\" wurde erfolgreich erstellt"
 
-#: cms/views/events/event_form_view.py:224
-#: cms/views/pages/page_form_view.py:286 cms/views/pois/poi_form_view.py:171
+#: cms/views/events/event_form_view.py:229
+#: cms/views/pages/page_form_view.py:291 cms/views/pois/poi_form_view.py:176
 msgid "No changes detected, but date refreshed"
 msgstr "Keine Änderungen vorgenommen, aber Datum aktualisiert"
 
@@ -5922,12 +5940,12 @@ msgid "You don't have the permission to edit the imprint."
 msgstr ""
 "Sie haben nicht die nötige Berechtigung, um das Impressum zu bearbeiten."
 
-#: cms/views/imprint/imprint_form_view.py:225
+#: cms/views/imprint/imprint_form_view.py:226
 msgid "Imprint was successfully created"
 msgstr "Impressum wurde erfolgreich erstellt"
 
-#: cms/views/imprint/imprint_form_view.py:286
-#: cms/views/pages/page_form_view.py:358
+#: cms/views/imprint/imprint_form_view.py:288
+#: cms/views/pages/page_form_view.py:363
 #, python-brace-format
 msgid "{source_language} to {target_language}"
 msgstr "{source_language} nach {target_language}"
@@ -6197,7 +6215,7 @@ msgstr "Bitte bestätigen Sie, dass dieses Verzeichnis gelöscht werden soll"
 msgid "An error has occurred."
 msgstr "Es ist ein Fehler aufgetreten."
 
-#: cms/views/mixins.py:67
+#: cms/views/mixins.py:68
 msgid "Please confirm that you really want to delete this {}"
 msgstr "Bitte bestätigen Sie, dass diese {} gelöscht werden soll"
 
@@ -6338,11 +6356,11 @@ msgstr "Bitte bestätigen Sie, dass diese Seite gelöscht werden soll"
 msgid "All translations of this page will also be deleted."
 msgstr "Alle Übersetzungen dieser Seite werden gelöscht."
 
-#: cms/views/pages/page_form_view.py:74
+#: cms/views/pages/page_form_view.py:79
 msgid "You cannot edit this page because it is archived."
 msgstr "Sie können diese Seite nicht bearbeiten, weil sie archiviert ist."
 
-#: cms/views/pages/page_form_view.py:81
+#: cms/views/pages/page_form_view.py:86
 msgid ""
 "You cannot edit this page, because one of its parent pages is archived and "
 "therefore, this page is archived as well."
@@ -6350,7 +6368,7 @@ msgstr ""
 "Sie können diese Seite nicht bearbeiten, weil eine ihrer übergeordneten "
 "Seiten archiviert ist, und sie dadurch ebenfalls archiviert ist."
 
-#: cms/views/pages/page_form_view.py:90
+#: cms/views/pages/page_form_view.py:95
 #, python-format
 msgid ""
 "The latest changes have only been saved as a draft. Currently, <a "
@@ -6361,11 +6379,11 @@ msgstr ""
 "Version <a href='%(revision_url)s' class='underline hover:no-"
 "underline'>Version %(revision)s</a> dieser Seite in der App angezeigt."
 
-#: cms/views/pages/page_form_view.py:111
+#: cms/views/pages/page_form_view.py:116
 msgid "You don't have the permission to edit this page."
 msgstr "Sie haben nicht die nötige Berechtigung, um diese Seite zu bearbeiten."
 
-#: cms/views/pages/page_form_view.py:118
+#: cms/views/pages/page_form_view.py:123
 msgid ""
 "You don't have the permission to publish this page, but you can propose "
 "changes and submit them for review instead."
@@ -6373,7 +6391,7 @@ msgstr ""
 "Sie haben nicht die nötige Berechtigung, um diese Seite zu veröffentlichen, "
 "aber Sie können Änderungen vornehmen und diese zur Überprüfung vorlegen."
 
-#: cms/views/pages/page_form_view.py:279
+#: cms/views/pages/page_form_view.py:284
 msgid "Page \"{}\" was successfully created"
 msgstr "Seite \"{}\" wurde erfolgreich erstellt"
 
@@ -6434,11 +6452,11 @@ msgstr "Bitte bestätigen Sie, dass dieser Ort gelöscht werden soll"
 msgid "All translations of this location will also be deleted."
 msgstr "Alle Übersetzungen dieses Ortes werden gelöscht."
 
-#: cms/views/pois/poi_form_view.py:65
+#: cms/views/pois/poi_form_view.py:70
 msgid "You cannot edit this location because it is archived."
 msgstr "Sie können diesen Ort nicht bearbeiten, da er archiviert ist."
 
-#: cms/views/pois/poi_form_view.py:166
+#: cms/views/pois/poi_form_view.py:171
 msgid "Location \"{}\" was successfully created"
 msgstr "Ort \"{}\" wurde erfolgreich erstellt"
 

--- a/integreat_cms/static/src/index.ts
+++ b/integreat_cms/static/src/index.ts
@@ -16,6 +16,7 @@ import "./js/filter-form.ts";
 import "./js/copy-clipboard.ts";
 import "./js/bulk-actions.ts";
 import "./js/confirmation-popups.ts";
+import "./js/content-edit-lock.ts";
 import "./js/revisions.ts";
 import "./js/search-query.ts";
 

--- a/integreat_cms/static/src/js/confirmation-popups.ts
+++ b/integreat_cms/static/src/js/confirmation-popups.ts
@@ -76,7 +76,7 @@ function handleSubmit(event: Event, button: HTMLButtonElement) {
   // Trigger the custom "action-confirmed" event of the source button
   button.dispatchEvent(new Event("action-confirmed"));
   // Close conformation popup
-  closeConfirmationPopupAjax(event);
+  closeConfirmationPopup(event);
 }
 
 function closeConfirmationPopup(event: Event) {
@@ -85,13 +85,7 @@ function closeConfirmationPopup(event: Event) {
   document.getElementById("popup-overlay").classList.add("hidden");
   const confirmationPopup = document.getElementById("confirmation-dialog");
   confirmationPopup.classList.add("hidden");
-}
 
-function closeConfirmationPopupAjax(event: Event) {
-  closeConfirmationPopup(event);
-  // If ajax mode is enabled, remove custom event handler which was inserted in the showConfirmationPopup() function
-  // Handle form submission differently
-  const confirmationPopup = document.getElementById("confirmation-dialog");
   if (handlers.has(confirmationPopup)) {
     confirmationPopup
       .querySelector("form")

--- a/integreat_cms/static/src/js/content-edit-lock.ts
+++ b/integreat_cms/static/src/js/content-edit-lock.ts
@@ -1,0 +1,38 @@
+/**
+ * This file periodically sends a request to the server if the user is editing some content
+ */
+import { getCsrfToken } from "./utils/csrf-token";
+
+window.addEventListener("load", () => setup_heartbeat());
+
+function setup_heartbeat() {
+    const heartbeat_data = document.getElementById("content-edit-lock-data");
+    if (heartbeat_data == null) {
+        return;
+    }
+
+    const heartbeat_url = heartbeat_data.getAttribute("data-heartbeat-url");
+    const lock_release_url = heartbeat_data.getAttribute("data-lock-release-url");
+    const heartbeat_payload = heartbeat_data.getAttribute("data-heartbeat-payload");
+    setInterval(() => send_message(heartbeat_url, heartbeat_payload), 10_000);
+    // Immediately send a heartbeat to get unique edit access
+    send_message(heartbeat_url, heartbeat_payload);
+
+    // On unload release the lock so the page is faster accessible again
+    window.addEventListener("unload", () => send_message(lock_release_url, heartbeat_payload));
+}
+
+async function send_message(url: string, payload: string) {
+    const response = await fetch(url, {
+        method: "POST",
+        headers: {
+            "X-CSRFToken": getCsrfToken(),
+        },
+        body: payload,
+    });
+
+    const json = await response.json();
+    if (!json.success) {
+        console.warn("Failed heartbeat with payload " + payload);
+    }
+}

--- a/integreat_cms/static/src/js/content-edit-lock.ts
+++ b/integreat_cms/static/src/js/content-edit-lock.ts
@@ -1,9 +1,17 @@
 /**
- * This file periodically sends a request to the server if the user is editing some content
+ * If the content-edit-lock-data div exists, this file provides some functionality to periodically send heartbeats to the 
+ * server to acquire and keep the content editing look.
+ * This file also registers an unload handler to quickly release the lock when not required anymore.
  */
+import { showConfirmationPopupWithData } from "./confirmation-popups";
+import { storeDraft } from "./forms/tinymce-init";
 import { getCsrfToken } from "./utils/csrf-token";
 
-window.addEventListener("load", () => setup_heartbeat());
+window.addEventListener("load", setup_heartbeat);
+
+let heartbeat_interval: NodeJS.Timer | null = null;
+let unload_event_listener: (this: Window, ev: Event) => any | null = null;
+let num_heartbeats = 0;
 
 function setup_heartbeat() {
     const heartbeat_data = document.getElementById("content-edit-lock-data");
@@ -11,18 +19,62 @@ function setup_heartbeat() {
         return;
     }
 
-    const heartbeat_url = heartbeat_data.getAttribute("data-heartbeat-url");
-    const lock_release_url = heartbeat_data.getAttribute("data-lock-release-url");
-    const heartbeat_payload = heartbeat_data.getAttribute("data-heartbeat-payload");
-    setInterval(() => send_message(heartbeat_url, heartbeat_payload), 10_000);
     // Immediately send a heartbeat to get unique edit access
-    send_message(heartbeat_url, heartbeat_payload);
+    send_heartbeat(heartbeat_data);
 
     // On unload release the lock so the page is faster accessible again
-    window.addEventListener("unload", () => send_message(lock_release_url, heartbeat_payload));
+    const lock_release_url = heartbeat_data.getAttribute("data-lock-release-url");
+    const heartbeat_payload = heartbeat_data.getAttribute("data-heartbeat-payload");
+    unload_event_listener = () => send_message(lock_release_url, heartbeat_payload);
+    window.addEventListener("unload", unload_event_listener);
 }
 
-async function send_message(url: string, payload: string) {
+async function send_heartbeat(heartbeat_data: HTMLElement) {
+    clearInterval(heartbeat_interval);
+
+    const url = heartbeat_data.getAttribute("data-heartbeat-url");
+    const payload = heartbeat_data.getAttribute("data-heartbeat-payload");
+    const cancel_url = heartbeat_data.getAttribute("data-cancel-url");
+    const result = await send_message(url, JSON.stringify({ key: payload, force: false }));
+    if (!result.success) {
+        // autosave changes if another user took control
+        if (num_heartbeats != 0) {
+            storeDraft();
+        }
+
+        const popup_title_locked = heartbeat_data
+            .getAttribute("data-popup-title-locked")
+            .replace("{}", result.lockingUser);
+        const popup_title_takeover = heartbeat_data
+            .getAttribute("data-popup-title-takeover")
+            .replace("{}", result.lockingUser);
+        const popup_subject = heartbeat_data.getAttribute("data-popup-subject");
+        const popup_text = heartbeat_data.getAttribute("data-popup-text");
+
+        showConfirmationPopupWithData(
+            popup_subject,
+            num_heartbeats == 0 ? popup_title_locked : popup_title_takeover,
+            popup_text,
+            (_) => send_take_over_message(url, payload).then(() => {
+                window.removeEventListener("unload", unload_event_listener);
+                // window.location.reload() does not correctly work if the view is rendered after a post request, because then
+                // the browser tries to re-send the post request
+                window.location.href = window.location.href
+            }),
+            (_) => window.location.href = cancel_url,
+        )
+    } else {
+        // Sends a heartbeat every 10 seconds
+        heartbeat_interval = setInterval(() => send_heartbeat(heartbeat_data), 10_000);
+    }
+    num_heartbeats += 1;
+}
+
+async function send_take_over_message(url: string, payload: string) {
+    await send_message(url, JSON.stringify({ key: payload, force: true }))
+}
+
+async function send_message(url: string, payload: string): Promise<any> {
     const response = await fetch(url, {
         method: "POST",
         headers: {
@@ -31,8 +83,5 @@ async function send_message(url: string, payload: string) {
         body: payload,
     });
 
-    const json = await response.json();
-    if (!json.success) {
-        console.warn("Failed heartbeat with payload " + payload);
-    }
+    return await response.json();
 }

--- a/integreat_cms/static/src/js/forms/autosave.ts
+++ b/integreat_cms/static/src/js/forms/autosave.ts
@@ -1,5 +1,6 @@
 import { getCsrfToken } from "../utils/csrf-token";
 import tinymce from "tinymce";
+import { markContentSaved } from "../unsaved-warning";
 
 export async function autosaveEditor() {
   const form = document.getElementById("content_form") as HTMLFormElement;
@@ -15,4 +16,5 @@ export async function autosaveEditor() {
   });
   // Set the form action to the url of the server response to make sure new pages aren't created multiple times
   form.action = data.url;
+  markContentSaved();
 }

--- a/integreat_cms/static/src/js/forms/tinymce-init.ts
+++ b/integreat_cms/static/src/js/forms/tinymce-init.ts
@@ -22,6 +22,10 @@ import { Editor } from "tinymce";
 
 import { autosaveEditor } from "./autosave";
 
+export function storeDraft() {
+  tinymce.activeEditor.plugins.autosave.storeDraft();
+}
+
 function parseSvg(svgUrl: string): string {
   return atob(svgUrl.replace("data:image/svg+xml;base64,", ""));
 }

--- a/integreat_cms/static/src/js/unsaved-warning.ts
+++ b/integreat_cms/static/src/js/unsaved-warning.ts
@@ -28,3 +28,10 @@ window.addEventListener("load", () => {
     console.debug("form submitted, disabled beforeunload warning");
   });
 });
+
+/**
+ * This function marks the form as submitted, so no unsaved warning will be shown
+ */
+export function markContentSaved() {
+  confirmed = true;
+}


### PR DESCRIPTION
### Short description
This pr implements support for locking a content object so it can be edited by only a single user.
When a user tries to edit some content that is already being edited by another user, a popup will show up and ask the user to go back or to take over.


### Proposed changes
- Track which objects are locked using django's caching system
- Don't allow edits for content forms if the editor does not have the exlusive lock on the content
- Send a "heartbeat" every few seconds to extend the lock and check if the page is still locked for the user
- Create an auto-save if editing permission is lost (version history is not implemented right now for pois and events though)
- Show a popup notification if the user does not have editing permission

### Resolved issues
Fixes: #1177 
