### PR TITLE
Fix creating language tree nodes

### DIFF
--- a/integreat_cms/api/v3/events.py
+++ b/integreat_cms/api/v3/events.py
@@ -49,7 +49,7 @@ def transform_event_translation(event_translation):
     if event.location:
         location_translation = (
             event.location.get_public_translation(event_translation.language.slug)
-            or event.location.default_translation
+            or event.location.best_translation
         )
     else:
         location_translation = None

--- a/integreat_cms/api/v3/pages.py
+++ b/integreat_cms/api/v3/pages.py
@@ -96,7 +96,7 @@ def pages(request, region_slug, language_slug):
     # requested from the database
     for page in region.pages.filter(explicitly_archived=False).cache_tree(
         archived=False, language_slug=language_slug
-    )[0]:
+    ):
         page_translation = page.get_public_translation(language_slug)
         if page_translation:
             result.append(transform_page(page_translation))
@@ -234,8 +234,7 @@ def children(request, region_slug, language_slug):
         # like in wordpress depth = 0 will return no results in this case
         depth = depth - 1
     result = []
-    # pylint: disable=unused-variable
-    public_region_pages, skipped_pages = request.region.pages.filter(
+    public_region_pages = request.region.pages.filter(
         explicitly_archived=False, tree_id__in=[page.tree_id for page in root_pages]
     ).cache_tree(archived=False, language_slug=language_slug)
     for root in root_pages:

--- a/integreat_cms/cms/fixtures/test_data.json
+++ b/integreat_cms/cms/fixtures/test_data.json
@@ -311,6 +311,21 @@
     }
   },
   {
+    "model": "cms.language",
+    "pk": 5,
+    "fields": {
+      "slug": "es",
+      "bcp47_tag": "es-es",
+      "english_name": "Spanish",
+      "native_name": "Español",
+      "text_direction": "RIGHT_TO_LEFT",
+      "primary_country_code": "es",
+      "table_of_contents": "Índice de contenidos",
+      "created_date": "2019-08-12T07:52:21.399Z",
+      "last_updated": "2019-08-12T07:52:21.400Z"
+    }
+  },
+  {
     "model": "cms.languagetreenode",
     "pk": 1,
     "fields": {

--- a/integreat_cms/cms/forms/custom_tree_node_form.py
+++ b/integreat_cms/cms/forms/custom_tree_node_form.py
@@ -25,7 +25,6 @@ class CustomTreeNodeForm(MoveNodeForm):
 
         # Hide tree node inputs
         self.fields["_ref_node_id"].widget = forms.HiddenInput()
-        self.fields["_ref_node_id"]._coerce = int
         self.fields["_position"].widget = forms.HiddenInput()
 
     def _clean_cleaned_data(self):
@@ -64,14 +63,16 @@ class CustomTreeNodeForm(MoveNodeForm):
                 logger.debug(
                     "Node %r is now referenced left to node %r", instance, next_sibling
                 )
-                return {"_ref_node_id": next_sibling.id, "_position": "left"}
+                return {"_ref_node_id": str(next_sibling.id), "_position": "left"}
             # If the page is the only root page of this region, do not reference other nodes
             logger.debug(
                 "Node %r is the only root node of its region and now referenced to no other node",
                 instance,
             )
             return {"_ref_node_id": "", "_position": "first-child"}
-        return super()._get_position_ref_node(instance)
+        # Convert initial data to string to fix the change detection
+        initial_data = super()._get_position_ref_node(instance)
+        return {key: str(value) for key, value in initial_data.items()}
 
     @classmethod
     def mk_dropdown_tree(cls, model, for_node=None):

--- a/integreat_cms/cms/forms/pages/page_form.py
+++ b/integreat_cms/cms/forms/pages/page_form.py
@@ -133,14 +133,14 @@ class PageForm(CustomModelForm, CustomTreeNodeForm):
         # Set choices of mirrored_page field manually to make use of cache_tree()
         logger.debug("Set choices for mirrored page field:")
         self.fields["mirrored_page"].choices = [
-            (page.id, str(page)) for page in mirrored_page_queryset.cache_tree()[0]
+            (page.id, str(page)) for page in mirrored_page_queryset.cache_tree()
         ]
 
         # Set choices of parent and _ref_node_id fields manually to make use of cache_tree()
         logger.debug("Set choices for parent field:")
         cached_parent_choices = [("", "---------")]
         cached_parent_choices.extend(
-            [(page.id, str(page)) for page in parent_queryset.cache_tree()[0]]
+            [(page.id, str(page)) for page in parent_queryset.cache_tree()]
         )
         self.fields["parent"].choices = cached_parent_choices
         self.fields["_ref_node_id"].choices = cached_parent_choices

--- a/integreat_cms/cms/forms/pages/page_form.py
+++ b/integreat_cms/cms/forms/pages/page_form.py
@@ -3,7 +3,6 @@ import logging
 from django import forms
 from django.contrib.auth import get_user_model
 from django.db.models import Q
-from django.utils.text import capfirst
 from django.utils.translation import ugettext_lazy as _
 
 from ...constants import mirrored_page_first, position
@@ -21,12 +20,6 @@ class PageForm(CustomModelForm, CustomTreeNodeForm):
     Form for creating and modifying page objects
     """
 
-    parent = forms.ModelChoiceField(
-        queryset=Page.objects.all(),
-        required=False,
-        widget=ParentFieldWidget(),
-        label=capfirst(Page._meta.get_field("parent").verbose_name),
-    )
     editors = forms.ModelChoiceField(
         queryset=get_user_model().objects.all(),
         required=False,
@@ -56,11 +49,18 @@ class PageForm(CustomModelForm, CustomTreeNodeForm):
         #: The model of this :class:`django.forms.ModelForm`
         model = Page
         #: The fields of the model which should be handled by this form
-        fields = ["icon", "mirrored_page", "mirrored_page_first", "organization"]
+        fields = [
+            "icon",
+            "mirrored_page",
+            "mirrored_page_first",
+            "organization",
+            "parent",
+        ]
         #: The widgets for the fields if they differ from the standard widgets
         widgets = {
             "mirrored_page_first": forms.Select(choices=mirrored_page_first.CHOICES),
             "icon": IconWidget(),
+            "parent": ParentFieldWidget(),
         }
 
     def __init__(self, **kwargs):
@@ -71,7 +71,7 @@ class PageForm(CustomModelForm, CustomTreeNodeForm):
         :type \**kwargs: dict
         """
 
-        # Instantiate CustomModelForm
+        # Instantiate CustomModelForm and CustomTreeNodeForm
         super().__init__(**kwargs)
 
         # Pass form object to ParentFieldWidget
@@ -117,8 +117,6 @@ class PageForm(CustomModelForm, CustomTreeNodeForm):
                 tree_id=self.instance.tree_id,
                 lft__range=(self.instance.lft, self.instance.rgt - 1),
             )
-            # Set initial value for parent field
-            self.fields["parent"].initial = self.instance.parent_id
             # Exclude the current page from the possible options for mirrored pages
             mirrored_page_queryset = mirrored_page_queryset.exclude(id=self.instance.id)
         else:
@@ -128,7 +126,7 @@ class PageForm(CustomModelForm, CustomTreeNodeForm):
                 self.fields["_ref_node_id"].initial = last_root_page.id
                 self.fields["_position"].initial = position.RIGHT
             else:
-                # If no page exists, treebeard expects the value "0" as reference node id
+                # If no page exists, treebeard expects the value "" as reference node id
                 self.fields["_ref_node_id"].initial = ""
                 self.fields["_position"].initial = position.FIRST_CHILD
 

--- a/integreat_cms/cms/models/abstract_content_model.py
+++ b/integreat_cms/cms/models/abstract_content_model.py
@@ -255,7 +255,8 @@ class AbstractContentModel(AbstractBaseModel):
         """
         This function returns the translation of this content object in the region's default language.
         Since a content object can only be created by creating a translation in the default language, this is guaranteed
-        to return a object translation.
+        to return a object translation (Exception: When the default language tree node is changed to another language
+        after the page has been created, the default translation might not exist).
 
         :return: The default translation of a content object
         :rtype: ~integreat_cms.cms.models.abstract_content_translation.AbstractContentTranslation
@@ -271,7 +272,11 @@ class AbstractContentModel(AbstractBaseModel):
         :return: The "best" translation of a content object for displaying in the backend
         :rtype: ~integreat_cms.cms.models.abstract_content_translation.AbstractContentTranslation
         """
-        return self.backend_translation or self.default_translation
+        return (
+            self.backend_translation
+            or self.default_translation
+            or self.translations.first()
+        )
 
     def get_translation_state(self, language_slug):
         """

--- a/integreat_cms/cms/models/abstract_tree_node.py
+++ b/integreat_cms/cms/models/abstract_tree_node.py
@@ -35,21 +35,6 @@ class AbstractTreeNode(NS_Node, AbstractBaseModel):
         verbose_name=_("region"),
     )
 
-    def save(self, *args, **kwargs):
-        r"""
-        Update the parent field and save the model instance
-
-        :param \*args: The supplied arguments
-        :type \*args: list
-
-        :param \**kwargs: The supplied keyword arguments
-        :type \**kwargs: dict
-        """
-        # Update parent to fix inconsistencies between tree fields
-        if self.id:
-            self.parent = self.get_parent()
-        super().save(*args, **kwargs)
-
     @classmethod
     def get_region_root_nodes(cls, region_slug):
         """
@@ -275,6 +260,7 @@ class AbstractTreeNode(NS_Node, AbstractBaseModel):
 
         :raises ~treebeard.exceptions.InvalidPosition: If the node is moved to another region
         """
+        logger.debug("Moving %r to position %r of %r", self, pos, target)
         # Do not allow to move a node outside its region
         if self.region != target.region:
             # Allow moving as siblings of root nodes (because it's a separate tree)
@@ -298,6 +284,14 @@ class AbstractTreeNode(NS_Node, AbstractBaseModel):
         invalidate_model(self.__class__)
         super().move(target=target, pos=pos)
         invalidate_model(self.__class__)
+
+        # Reload 'self' because lft/rgt may have changed
+        self.refresh_from_db()
+        # Update parent to fix inconsistencies between tree fields
+        new_parent = self.get_parent(update=True)
+        logger.debug("Updating parent field from %r to %r", self.parent, new_parent)
+        self.parent = new_parent
+        self.save()
 
     @classmethod
     def find_problems(cls):

--- a/integreat_cms/cms/models/pages/page.py
+++ b/integreat_cms/cms/models/pages/page.py
@@ -102,7 +102,7 @@ class PageQuerySet(NS_NodeQuerySet, ContentQuerySet):
                 skipped_pages.append(page)
         logger.debug("Cached result: %r", result)
         logger.debug("Skipped pages: %r", skipped_pages)
-        return list(result.values()), skipped_pages
+        return list(result.values())
 
 
 # pylint: disable=too-few-public-methods

--- a/integreat_cms/cms/models/pages/page_translation.py
+++ b/integreat_cms/cms/models/pages/page_translation.py
@@ -48,7 +48,7 @@ class PageTranslation(AbstractBasePageTranslation):
             if translation:
                 slugs.append(translation.slug)
                 continue
-            slugs.append(ancestor.default_translation.slug)
+            slugs.append(ancestor.best_translation.slug)
         return "/".join(slugs)
 
     @cached_property

--- a/integreat_cms/cms/models/push_notifications/push_notification.py
+++ b/integreat_cms/cms/models/push_notifications/push_notification.py
@@ -98,7 +98,11 @@ class PushNotification(AbstractBaseModel):
         :return: The "best" translation of a push notification for displaying in the backend
         :rtype: ~integreat_cms.cms.models.push_notifications.push_notification_translation.PushNotificationTranslation
         """
-        return self.backend_translation or self.default_translation
+        return (
+            self.backend_translation
+            or self.default_translation
+            or self.translations.first()
+        )
 
     def __str__(self):
         """

--- a/integreat_cms/cms/templates/language_tree/language_tree_node_form.html
+++ b/integreat_cms/cms/templates/language_tree/language_tree_node_form.html
@@ -41,12 +41,12 @@
                 {% render_field language_tree_node_form.parent|add_error_class:"border-red-500" %}
             </div>
             <div>
-                {% render_field language_tree_node_form.visible|add_error_class:"border-red-500" id="visible" %}
+                {% render_field language_tree_node_form.visible|add_error_class:"border-red-500" %}
                 <label for="{{ language_tree_node_form.visible.id_for_label }}">{{ language_tree_node_form.visible.label }}</label>
                 <div class="help-text">{{ language_tree_node_form.visible.help_text }}</div>
             </div>
             <div>
-                {% render_field language_tree_node_form.active|add_error_class:"border-red-500" id="active" %}
+                {% render_field language_tree_node_form.active|add_error_class:"border-red-500" %}
                 <label for="{{ language_tree_node_form.active.id_for_label }}">{{ language_tree_node_form.active.label }}</label>
                 <div class="help-text">{{ language_tree_node_form.active.help_text }}</div>
             </div>

--- a/integreat_cms/cms/views/analytics/translation_coverage_view.py
+++ b/integreat_cms/cms/views/analytics/translation_coverage_view.py
@@ -36,7 +36,7 @@ class TranslationCoverageView(TemplateView):
         pages = (
             region.pages.filter(explicitly_archived=False)
             .prefetch_major_public_translations()
-            .cache_tree(archived=False)[0]
+            .cache_tree(archived=False)
         )
         for language in region.active_languages:
             language_coverage_data = Counter()

--- a/integreat_cms/cms/views/pages/page_tree_view.py
+++ b/integreat_cms/cms/views/pages/page_tree_view.py
@@ -9,7 +9,6 @@ from django.views.generic import TemplateView
 from ...constants import translation_status
 from ...decorators import permission_required
 from ...forms import PageFilterForm
-from ...models import Language
 from .page_context_mixin import PageContextMixin
 
 logger = logging.getLogger(__name__)
@@ -58,18 +57,17 @@ class PageTreeView(TemplateView, PageContextMixin):
         """
 
         # current region
-        region_slug = kwargs.get("region_slug")
         region = request.region
 
         # current language
         language_slug = kwargs.get("language_slug")
         if language_slug:
-            language = Language.objects.get(slug=language_slug)
+            language = region.get_language_or_404(language_slug, only_active=True)
         elif region.default_language:
             return redirect(
                 "pages",
                 **{
-                    "region_slug": region_slug,
+                    "region_slug": region.slug,
                     "language_slug": region.default_language.slug,
                 }
             )
@@ -81,7 +79,7 @@ class PageTreeView(TemplateView, PageContextMixin):
             return redirect(
                 "language_tree",
                 **{
-                    "region_slug": region_slug,
+                    "region_slug": region.slug,
                 }
             )
 

--- a/integreat_cms/cms/views/pages/page_tree_view.py
+++ b/integreat_cms/cms/views/pages/page_tree_view.py
@@ -97,7 +97,7 @@ class PageTreeView(TemplateView, PageContextMixin):
             page_queryset = region.pages.filter(lft=1)
         pages = page_queryset.prefetch_major_public_translations().cache_tree(
             archived=self.archived
-        )[0]
+        )
 
         if filter_data:
             # Set data for filter form rendering

--- a/integreat_cms/cms/views/pages/partial_page_tree_view.py
+++ b/integreat_cms/cms/views/pages/partial_page_tree_view.py
@@ -51,7 +51,7 @@ class PartialPageTreeView(TemplateView, PageContextMixin):
                 | Q(tree_id=tree_id, lft__lt=lft, rgt__gt=rgt)
             )
             .prefetch_major_public_translations()
-            .cache_tree(False)[0]
+            .cache_tree(False)
         )
         # If the depth is 1, the first element must be the direct parent, etc.
         parent = pages[depth - 1]

--- a/integreat_cms/cms/views/pois/poi_list_view.py
+++ b/integreat_cms/cms/views/pois/poi_list_view.py
@@ -10,7 +10,7 @@ from django.views.generic import TemplateView
 
 from ...constants import status
 from ...decorators import permission_required
-from ...models import Language, POITranslation
+from ...models import POITranslation
 from ...forms import ObjectSearchForm
 from .poi_context_mixin import POIContextMixin
 
@@ -67,18 +67,17 @@ class POIListView(TemplateView, POIContextMixin):
         """
 
         # current region
-        region_slug = kwargs.get("region_slug")
         region = request.region
 
         # current language
         language_slug = kwargs.get("language_slug")
         if language_slug:
-            language = Language.objects.get(slug=language_slug)
+            language = region.get_language_or_404(language_slug, only_active=True)
         elif region.default_language:
             return redirect(
                 "pois",
                 **{
-                    "region_slug": region_slug,
+                    "region_slug": region.slug,
                     "language_slug": region.default_language.slug,
                 }
             )
@@ -92,7 +91,7 @@ class POIListView(TemplateView, POIContextMixin):
             return redirect(
                 "language_tree",
                 **{
-                    "region_slug": region_slug,
+                    "region_slug": region.slug,
                 }
             )
 

--- a/integreat_cms/cms/views/push_notifications/push_notification_list_view.py
+++ b/integreat_cms/cms/views/push_notifications/push_notification_list_view.py
@@ -10,7 +10,7 @@ from django.views.generic import TemplateView
 
 from ...forms import ObjectSearchForm
 from ...decorators import permission_required
-from ...models import Language, PushNotificationTranslation
+from ...models import PushNotificationTranslation
 
 logger = logging.getLogger(__name__)
 
@@ -50,7 +50,7 @@ class PushNotificationListView(TemplateView):
         # current language
         language_slug = kwargs.get("language_slug")
         if language_slug:
-            language = Language.objects.get(slug=language_slug)
+            language = region.get_language_or_404(language_slug, only_active=True)
         elif region.default_language:
             return redirect(
                 "push_notifications",

--- a/integreat_cms/cms/views/utils/search_content_ajax.py
+++ b/integreat_cms/cms/views/utils/search_content_ajax.py
@@ -99,7 +99,7 @@ def search_content_ajax(request, region_slug=None, language_slug=None):
 
     if user.has_perm("cms.view_page") and "page" in object_types:
         object_types.remove("page")
-        pages = region.pages.all().cache_tree(archived=archived_flag)[0]
+        pages = region.pages.all().cache_tree(archived=archived_flag)
         for page in pages:
             page_translation = page.get_translation(language_slug)
             if page_translation and (

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-05 11:16+0000\n"
+"POT-Creation-Date: 2022-03-06 11:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1619,7 +1619,7 @@ msgstr "Von"
 msgid "To"
 msgstr "Bis"
 
-#: cms/forms/language_tree/language_tree_node_form.py:114
+#: cms/forms/language_tree/language_tree_node_form.py:108
 msgid ""
 "This region has already a default language.Please specify a source language "
 "for this language."
@@ -1662,24 +1662,24 @@ msgstr ""
 msgid "Translation status"
 msgstr "Übersetzungsstatus"
 
-#: cms/forms/pages/page_form.py:33
+#: cms/forms/pages/page_form.py:26
 msgid "Editors"
 msgstr "Bearbeiter"
 
-#: cms/forms/pages/page_form.py:35
+#: cms/forms/pages/page_form.py:28
 msgid "These users can edit this page, but are not allowed to publish it."
 msgstr ""
 "Diese Benutzer können die Seite bearbeiten, aber nicht veröffentlichen."
 
-#: cms/forms/pages/page_form.py:41
+#: cms/forms/pages/page_form.py:34
 msgid "Publishers"
 msgstr "Veröffentlicher"
 
-#: cms/forms/pages/page_form.py:42
+#: cms/forms/pages/page_form.py:35
 msgid "These users can edit and publish this page."
 msgstr "Diese Benutzer können die Seite bearbeiten und veröffentlichen"
 
-#: cms/forms/pages/page_form.py:47
+#: cms/forms/pages/page_form.py:40
 msgid "Source region for live content"
 msgstr "Quell-Region für Live-Inhalte"
 
@@ -1934,7 +1934,7 @@ msgstr "Ersteller"
 msgid "parent"
 msgstr "übergeordneter Knoten"
 
-#: cms/models/abstract_tree_node.py:292
+#: cms/models/abstract_tree_node.py:278
 msgid "The node \"{}\" in region \"{}\" cannot be moved to \"{}\"."
 msgstr ""
 "Der Knoten \"{}\" in Region \"{}\" kann nicht nach \"{}\" verschoben werden."

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -2691,12 +2691,12 @@ msgstr ""
 "Legt das Verhalten für den Umgang mit nicht vorhandenen Übersetzungen von "
 "Push-Benachrichtigungen fest"
 
-#: cms/models/push_notifications/push_notification.py:125
+#: cms/models/push_notifications/push_notification.py:129
 #: cms/models/push_notifications/push_notification_translation.py:34
 msgid "push notification"
 msgstr "Push-Benachrichtigung"
 
-#: cms/models/push_notifications/push_notification.py:127
+#: cms/models/push_notifications/push_notification.py:131
 msgid "push notifications"
 msgstr "Push-Benachrichtigungen"
 
@@ -5768,7 +5768,7 @@ msgid "Imprint was successfully deleted"
 msgstr "Impressum wurde erfolgreich gelöscht"
 
 #: cms/views/imprint/imprint_form_view.py:73
-#: cms/views/pages/page_tree_view.py:79
+#: cms/views/pages/page_tree_view.py:77
 msgid "Please create at least one language node before creating pages."
 msgstr ""
 "Bitte erstellen Sie mindestens einen Sprach-Knoten, bevor Sie Seiten "
@@ -6254,7 +6254,7 @@ msgid "You cannot restore revisions of this page because it is archived."
 msgstr ""
 "Sie können Revisionen dieser Seite nicht bearbeiten, weil sie archiviert ist."
 
-#: cms/views/pages/page_tree_view.py:90
+#: cms/views/pages/page_tree_view.py:88
 msgid "You don't have the permission to edit or create pages."
 msgstr ""
 "Sie haben nicht die nötige Berechtigung, um Seiten zu bearbeiten oder zu "
@@ -6308,12 +6308,12 @@ msgstr "Sie können diesen Ort nicht bearbeiten, da er archiviert ist."
 msgid "Location \"{}\" was successfully created"
 msgstr "Ort \"{}\" wurde erfolgreich erstellt"
 
-#: cms/views/pois/poi_list_view.py:89
+#: cms/views/pois/poi_list_view.py:88
 msgid "Please create at least one language node before creating locations."
 msgstr ""
 "Bitte erstellen Sie mindestens einen Sprach-Knoten, bevor Sie Orte verwalten."
 
-#: cms/views/pois/poi_list_view.py:103
+#: cms/views/pois/poi_list_view.py:102
 #, python-format
 msgid "You can only create locations in the default language (%(language)s)."
 msgstr "Sie können Orte nur in der Standard-Sprache (%(language)s) anlegen"

--- a/tests/cms/views/view_config.py
+++ b/tests/cms/views/view_config.py
@@ -62,6 +62,18 @@ VIEWS = [
             ("mediacenter_directory_path", ROLES),
             ("mediacenter_get_directory_content", ROLES),
             ("new_language_tree_node", STAFF_ROLES),
+            (
+                "new_language_tree_node",
+                PRIV_STAFF_ROLES,
+                {
+                    "language": 5,
+                    "parent": 1,
+                    "_ref_node_id": 1,
+                    "_position": "first-child",
+                    "visible": True,
+                    "active": True,
+                },
+            ),
             ("new_region_user", STAFF_ROLES + [MANAGEMENT]),
             (
                 "new_region_user",
@@ -87,6 +99,18 @@ VIEWS = [
             ("mediacenter_directory_path", STAFF_ROLES),
             ("mediacenter_get_directory_content", STAFF_ROLES),
             ("new_language_tree_node", STAFF_ROLES),
+            (
+                "new_language_tree_node",
+                PRIV_STAFF_ROLES,
+                {
+                    "language": 5,
+                    "parent": 5,
+                    "_ref_node_id": 5,
+                    "_position": "first-child",
+                    "visible": True,
+                    "active": True,
+                },
+            ),
             ("new_region_user", STAFF_ROLES),
             (
                 "new_region_user",
@@ -704,7 +728,16 @@ VIEWS = [
     (
         [
             ("edit_language_tree_node", STAFF_ROLES),
-            ("edit_language_tree_node", PRIV_STAFF_ROLES, {"language": 3, "parent": 2}),
+            (
+                "edit_language_tree_node",
+                PRIV_STAFF_ROLES,
+                {
+                    "language": 3,
+                    "parent": 2,
+                    "_ref_node_id": 2,
+                    "_position": "first-child",
+                },
+            ),
         ],
         # The kwargs for these views
         {"region_slug": "augsburg", "language_tree_node_id": 3},


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
The fix in bbe3e55e2a57179ce6c31de5efa44ecdb7b5e68a did not work correctly, so a few more substantial changes were required.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add test for creating language tree nodes
- Fix creating language tree nodes
    - coerce ref_node field to int was not possible because the reference to no node cannot be expressed by an integer
    - Use strings for values of ref_node fields where possible
    - Fix parent field after `move()` and not before `save()` because it caused problems for language tree nodes
- Provide fallback translation if default translation doesn't exist
    - Under normal circumstances, this should not happen. But when the default language is changed into a language that does not have a translation for each page, this might lead to problems.
- Show content list views only for active languages
- Do not return skipped nodes in `cache_tree()` method

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1257
