### PR TITLE
Fix push notifications attribute name in API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 UNRELEASED
 ----------
 
+* [ [#1267](https://github.com/digitalfabrik/integreat-cms/issues/1267) ] Fix push notifications attribute name in API
+
 
 2022.3.0
 --------

--- a/integreat_cms/api/v3/regions.py
+++ b/integreat_cms/api/v3/regions.py
@@ -28,7 +28,7 @@ def transform_region(region):
         "plz": region.postal_code,
         "extras": region.offers.exists(),
         "events": region.events_enabled,
-        "push-notifications": region.push_notifications_enabled,
+        "push_notifications": region.push_notifications_enabled,
         "longitude": region.longitude,
         "latitude": region.latitude,
         "aliases": region.aliases,

--- a/tests/api/expected-outputs/regions.json
+++ b/tests/api/expected-outputs/regions.json
@@ -9,7 +9,7 @@
         "plz": "86150",
         "extras": true,
         "events": true,
-        "push-notifications": true,
+        "push_notifications": true,
         "longitude": 10.8958715,
         "latitude": 48.36882,
         "aliases": "[\"Haunstetten\",\"Friedberg\"]"
@@ -24,7 +24,7 @@
         "plz": "90403",
         "extras": true,
         "events": true,
-        "push-notifications": true,
+        "push_notifications": true,
         "longitude": 11.0766198,
         "latitude": 49.455288,
         "aliases": "[\"Schwabach\",\"Lauf an der Pegnitz\"]"

--- a/tests/api/expected-outputs/regions_live.json
+++ b/tests/api/expected-outputs/regions_live.json
@@ -8,7 +8,7 @@
         "plz": "86150",
         "extras": true,
         "events": true,
-        "push-notifications": true,
+        "push_notifications": true,
         "longitude": 10.8958715,
         "latitude": 48.36882,
         "aliases": "[\"Haunstetten\",\"Friedberg\"]"
@@ -22,7 +22,7 @@
         "plz": "90403",
         "extras": true,
         "events": true,
-        "push-notifications": true,
+        "push_notifications": true,
         "longitude": 11.0766198,
         "latitude": 49.455288,
         "aliases": "[\"Schwabach\",\"Lauf an der Pegnitz\"]"


### PR DESCRIPTION
### Short description
The attribute that indicates activated push notifications in the regions/sites endpoint should be `push_notifications`.


### Proposed changes
Change the attribute name `push-notifications` to `push_notifications` in the regions API endpoint.