### PR TITLE
Fix fcm endpoint JSON format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 UNRELEASED
 ----------
 
+* [ [#1269](https://github.com/digitalfabrik/integreat-cms/issues/1269) ] Fix fcm endpoint JSON format
+
 
 2022.3.1
 --------

--- a/integreat_cms/api/v3/push_notifications.py
+++ b/integreat_cms/api/v3/push_notifications.py
@@ -48,8 +48,8 @@ def transform_notification(pnt):
     :rtype: dict
     """
     return {
+        "id": str(pnt.pk),
         "title": pnt.title,
-        "text": pnt.text,
-        "channel": pnt.push_notification.channel,
-        "sent_date": pnt.push_notification.sent_date,
+        "message": pnt.text,
+        "timestamp": pnt.push_notification.sent_date.strftime("%Y-%m-%d %H:%M:%S"),
     }

--- a/tests/api/expected-outputs/nurnberg_de_fcm.json
+++ b/tests/api/expected-outputs/nurnberg_de_fcm.json
@@ -1,1 +1,1 @@
-[{"title": "Test DE", "text": "Test DE Inhalt", "channel": "news", "sent_date": "2022-03-05T10:32:33.118Z"}]
+[{"id": "1", "title": "Test DE", "message": "Test DE Inhalt", "timestamp": "2022-03-05 10:32:33"}]

--- a/tests/api/expected-outputs/nurnberg_en_fcm.json
+++ b/tests/api/expected-outputs/nurnberg_en_fcm.json
@@ -1,1 +1,1 @@
-[{"title": "Test EN", "text": "Test EN content", "channel": "news", "sent_date": "2022-03-05T10:32:33.118Z"}]
+[{"id": "2", "title": "Test EN", "message": "Test EN content", "timestamp": "2022-03-05 10:32:33"}]


### PR DESCRIPTION
### Short description
The JSON format of the fcm API endpoint is not in the format the app expects it to be.

### Proposed changes
Each message needs to have the following attributes: `id`, `message`, `timestamp`, `title`.