### PR TITLE
Add traceback spoiler to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -27,3 +27,10 @@ labels: bug
 ### Additional Information
 <!-- Add any other context (e.g. logs, screenshots, etc.) about the problem here. -->
 
+<details>
+  <summary>Traceback</summary>
+
+  ```
+  ```
+
+</details>


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
I find myself typing a lot of spoilers for bug tracebacks, so I'd benefit if it was included in the template.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add GitHub spoiler markdown to issue template

