### PR TITLE
Do not send a push notification twice, fixes #1281

### DIFF
--- a/integreat_cms/cms/templates/push_notifications/push_notification_form.html
+++ b/integreat_cms/cms/templates/push_notifications/push_notification_form.html
@@ -23,7 +23,7 @@
                     {% if perms.cms.change_pushnotification %}
                         <button name="submit_save" class="btn btn-gray">{% trans 'Save' %}</button>
                     {% endif %}
-                    {% if perms.cms.send_push_notification %}
+                    {% if perms.cms.send_push_notification and not push_notification_form.instance.sent_date %}
                         <button name="submit_send" class="btn">{% trans 'Save & Send' %}</button>
                     {% endif %}
                 </div>

--- a/integreat_cms/cms/views/push_notifications/push_notification_form_view.py
+++ b/integreat_cms/cms/views/push_notifications/push_notification_form_view.py
@@ -192,7 +192,7 @@ class PushNotificationFormView(TemplateView):
                     ),
                 )
 
-            if "submit_send" in request.POST:
+            if "submit_send" in request.POST and not pn_form.instance.sent_date:
                 if not request.user.has_perm("cms.send_push_notification"):
                     logger.warning(
                         "%r does not have the permission to send %r",


### PR DESCRIPTION
### Short description
Prevent sending push notifications (again) that have a `sent_date`.


### Proposed changes
- Hide the Send button if a sent_date exists
- When submitting the form do not send the news if a sent_date exists

### Resolved issues
Fixes: #1281
