### PR TITLE
Fix feedback cache invalidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ UNRELEASED
 
 * [ [#1301](https://github.com/digitalfabrik/integreat-cms/issues/1301) ] Fix order of push notifications
 * [ [#1296](https://github.com/digitalfabrik/integreat-cms/issues/1296) ] Fix page tree after resetting filters
+* [ [#1282](https://github.com/digitalfabrik/integreat-cms/issues/1282) ] Fix feedback cache invalidation
 
 
 2022.3.4

--- a/integreat_cms/cms/apps.py
+++ b/integreat_cms/cms/apps.py
@@ -23,6 +23,11 @@ class CmsConfig(AppConfig):
 
     name = "integreat_cms.cms"
 
+    # pylint: disable=unused-import,import-outside-toplevel
+    def ready(self):
+        # Implicitly connect a signal handlers decorated with @receiver.
+        from .signals import feedback_signals
+
 
 authlog = logging.getLogger("auth")
 

--- a/integreat_cms/cms/signals/feedback_signals.py
+++ b/integreat_cms/cms/signals/feedback_signals.py
@@ -1,0 +1,59 @@
+from django.db.models.signals import post_delete, post_save
+from django.dispatch import receiver
+
+from cacheops import invalidate_obj
+
+from ..models import (
+    Feedback,
+    EventFeedback,
+    EventListFeedback,
+    PageFeedback,
+    POIFeedback,
+    ImprintPageFeedback,
+    MapFeedback,
+    OfferFeedback,
+    OfferListFeedback,
+    RegionFeedback,
+    SearchResultFeedback,
+)
+
+
+@receiver(post_delete, sender=Feedback)
+# pylint: disable=unused-argument
+def feedback_delete_handler(sender, **kwargs):
+    r"""
+    Invalidate feedback cache after feedback deletion
+
+    :param sender: The class of the feedback that was deleted
+    :type sender: type
+
+    :param \**kwargs: The supplied keyword arguments
+    :type \**kwargs: dict
+    """
+    if kwargs.get("instance"):
+        invalidate_obj(kwargs.get("instance"))
+
+
+@receiver(post_save, sender=PageFeedback)
+@receiver(post_save, sender=EventFeedback)
+@receiver(post_save, sender=EventListFeedback)
+@receiver(post_save, sender=POIFeedback)
+@receiver(post_save, sender=ImprintPageFeedback)
+@receiver(post_save, sender=MapFeedback)
+@receiver(post_save, sender=OfferFeedback)
+@receiver(post_save, sender=OfferListFeedback)
+@receiver(post_save, sender=RegionFeedback)
+@receiver(post_save, sender=SearchResultFeedback)
+# pylint: disable=unused-argument
+def feedback_create_handler(sender, **kwargs):
+    r"""
+    Invalidate feedback cache after feedback creation
+
+    :param sender: The class of the feedback that was deleted
+    :type sender: type
+
+    :param \**kwargs: The supplied keyword arguments
+    :type \**kwargs: dict
+    """
+    if kwargs.get("instance") and hasattr(kwargs.get("instance"), "feedback_ptr"):
+        invalidate_obj(kwargs.get("instance").feedback_ptr)

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-17 10:09+0000\n"
+"POT-Creation-Date: 2022-03-18 08:27+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -5790,18 +5790,18 @@ msgstr ""
 "Sie haben nicht die nötige Berechtigung, um Veranstaltungen zu bearbeiten "
 "oder zu erstellen."
 
-#: cms/views/feedback/admin_feedback_actions.py:36
-#: cms/views/feedback/region_feedback_actions.py:45
+#: cms/views/feedback/admin_feedback_actions.py:41
+#: cms/views/feedback/region_feedback_actions.py:52
 msgid "Feedback was successfully marked as read"
 msgstr "Feedback wurde als gelesen markiert"
 
-#: cms/views/feedback/admin_feedback_actions.py:60
-#: cms/views/feedback/region_feedback_actions.py:78
+#: cms/views/feedback/admin_feedback_actions.py:70
+#: cms/views/feedback/region_feedback_actions.py:90
 msgid "Feedback was successfully marked as unread"
 msgstr "Feedback wurde als ungelesen markiert"
 
-#: cms/views/feedback/admin_feedback_actions.py:82
-#: cms/views/feedback/region_feedback_actions.py:107
+#: cms/views/feedback/admin_feedback_actions.py:92
+#: cms/views/feedback/region_feedback_actions.py:119
 msgid "Feedback was successfully deleted"
 msgstr "Feedback wurde erfolgreich gelöscht"
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fix feedback cache invalidation

### Proposed changes
<!-- Describe this PR in more detail. -->

django-cacheops does not support multi-table inheritance (https://github.com/Suor/django-cacheops/issues/31)
The suggested workaround is to use signal handlers to invalidate the cache manually (https://github.com/Suor/django-cacheops/issues/31#issuecomment-673564324), so signal handlers are used to invalidate the cache on feedback creation and deletion.
But marking feedback as read/unread uses the query set update method and does not trigger a save signal, so in case of feedback updates cache invalidation is performed in the view instead.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1282
