### PR TITLE
Publish dev package on branches matching pattern

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -453,7 +453,9 @@ workflows:
       - bump-dev-version:
           filters:
             branches:
-              only: develop
+              only:
+                - develop
+                - /.*-publish-dev-package/
           requires:
             - pipenv-install
       - build-package:
@@ -467,7 +469,9 @@ workflows:
           context: pypi-test
           filters:
             branches:
-              only: develop
+              only:
+                - develop
+                - /.*-publish-dev-package/
           requires:
             - build-dev-package
       - black:

--- a/sphinx/continuous-integration.rst
+++ b/sphinx/continuous-integration.rst
@@ -54,12 +54,26 @@ black
 
 This job executes ``pipenv run black --check .``, which checks whether the code matches the :ref:`black-code-style` code style.
 
+check-migrations
+----------------
+
+This job checks whether there are any changes to the models that need a database migration
+
+setup-test-reporter
+-------------------
+
+This job sets up the test coverage reporter for CodeClimate.
+
 tests
 -----
 
-This job runs the unit tests. It sets up a temporary postgres database and runs the migrations before testing.
-It uses the command ``pipenv run integreat-cms-cli test cms --set=COVERAGE`` and
-passes the coverage in the ``htmlcov`` directory to the build artifacts.
+This job runs the tests in 16 parallel containers. It sets up a temporary postgres database and runs the migrations
+before testing. It runs pytest and passes the coverage in the ``test-results`` directory to the build artifacts.
+
+upload-test-coverage
+--------------------
+
+This job joins all separate coverage data files generated from the previous steps and uploads it to CodeClimate.
 
 check-translations
 ------------------
@@ -80,6 +94,7 @@ bump-dev-version
 This job modifies the ``bumpver`` config to make sure the changes are only temporary and not committed, then it bumps
 the version to the next alpha version which is not yet published on
 `TestPyPI <https://test.pypi.org/project/integreat-cms/#history>`__.
+This is only executed on develop (usually after PRs have been merged) or on branches that end with ``-publish-dev-package``.
 
 .. _circleci-build-package:
 
@@ -95,6 +110,7 @@ publish-package
 ---------------
 
 This job publishes the built package to `TestPyPI <https://test.pypi.org/project/integreat-cms/>`__ via :doc:`twine:index`.
+This is only executed on develop (usually after PRs have been merged) or on branches that end with ``-publish-dev-package``.
 
 build-documentation
 -------------------
@@ -167,7 +183,7 @@ See :ref:`circleci-build-package`.
 publish-package
 ---------------
 
-See :ref:`circleci-build-package`. The only difference is that PyPI is used as repository instead of TestPyPI.
+See :ref:`circleci-publish-package`. The only difference is that PyPI is used as repository instead of TestPyPI.
 
 create-release
 --------------


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
In some cases, we want to build specific branches as dev packages before merging the PR into develop. For this use case, we can now just append `-publish-dev-package` to the branch name and push the changes, which triggers the dev release workflow.
Since all push events trigger the CircleCI build, It is not required to open a separate PR for the new branch.
After the dev package has been published, it can be installed on the test system to check how the changes affect a production-like environment.

Since the resulting packages might not be in the correct order, this needs a bit of care when database migrations are involved. In this case, make sure to only use migrations that can be reversed and reverse them before you install another package version which might not contain the migration file of the feature branch.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Publish dev packages on every branch ending with `-publish-dev-package` 
- Update documentation
