### PR TITLE
Add bulk actions for archiving/restoring pages, events and locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ UNRELEASED
 * [ [#1195](https://github.com/digitalfabrik/integreat-cms/issues/1195) ] Insert full images into content instead of thumbnails
 * [ [#1181](https://github.com/digitalfabrik/integreat-cms/issues/1181) ] Scroll media library and sidebar independently of each other
 * [ [#1279](https://github.com/digitalfabrik/integreat-cms/issues/1279) ] Fix error in news form when submitted without data
+* [ [#1055](https://github.com/digitalfabrik/integreat-cms/issues/1055) ] Add bulk actions for archiving/restoring pages, events and locations
 
 
 2022.3.4

--- a/integreat_cms/cms/models/abstract_base_model.py
+++ b/integreat_cms/cms/models/abstract_base_model.py
@@ -2,6 +2,8 @@ import logging
 
 from django.db import models
 
+from debug_toolbar.panels.sql.tracking import SQLQueryTriggered
+
 
 logger = logging.getLogger(__name__)
 
@@ -34,13 +36,14 @@ class AbstractBaseModel(models.Model):
         # pylint: disable=broad-except
         except Exception as e:
             fallback_repr = f"<{type(self).__name__} (id: {self.id})>"
-            logger.debug(
-                "repr() for object %s failed because of %s: %s",
-                fallback_repr,
-                type(e),
-                e,
-                exc_info=e,
-            )
+            if not isinstance(e, SQLQueryTriggered):
+                logger.debug(
+                    "repr() for object %s failed because of %s: %s",
+                    fallback_repr,
+                    type(e),
+                    e,
+                    exc_info=e,
+                )
             return fallback_repr
 
     class Meta:

--- a/integreat_cms/cms/templates/events/event_list.html
+++ b/integreat_cms/cms/templates/events/event_list.html
@@ -103,6 +103,9 @@
         <div class="flex flex-wrap gap-2 mt-4">
             <select id="bulk-action" class="w-auto max-w-full">
                 <option>{% trans 'Select bulk action' %}</option>
+                <option data-bulk-action="{% url 'bulk_archive_events' region_slug=request.region.slug language_slug=language.slug %}">
+                    {% trans 'Archive events' %}
+                </option>
                 {% if DEEPL_ENABLED %}
                     <option data-bulk-action="{% url 'automatic_translation_events' region_slug=request.region.slug language_slug=language.slug %}">{% trans 'Create missing translations automatically' %}</option>
                 {% endif %}

--- a/integreat_cms/cms/templates/events/event_list_archived.html
+++ b/integreat_cms/cms/templates/events/event_list_archived.html
@@ -23,10 +23,16 @@
     </div>
     {% endwith %}
     <div class="table-listing">
+        <form id="bulk-action-form" method="post">
+            {% csrf_token %}
+        </form>
         <table id="event-list" class="w-full mt-4 rounded border border-solid border-gray-200 shadow bg-white">
             <thead>
             <tr class="border-b border-solid border-gray-200">
-                <th class="text-sm text-left uppercase py-3 pl-4 pr-2">{% trans 'Title in' %} {{ language.translated_name }}</th>
+                <th class="py-3 pl-4 pr-2 min">
+                    <input form="bulk-action-form" type="checkbox" id="bulk-select-all">
+                </th>
+                <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Title in' %} {{ language.translated_name }}</th>
                 {% get_current_language as LANGUAGE_CODE %}
                 {% get_language LANGUAGE_CODE as backend_language %}
                 {% if backend_language and backend_language != language %}
@@ -70,6 +76,15 @@
             {% endif %}
             </tbody>
         </table>
+        <div class="flex flex-wrap gap-2 mt-4">
+            <select id="bulk-action" class="w-auto max-w-full">
+                <option>{% trans 'Select bulk action' %}</option>
+                <option data-bulk-action="{% url 'bulk_restore_events' region_slug=request.region.slug language_slug=language.slug %}">
+                    {% trans 'Restore events' %}
+                </option>
+            </select>
+            <button form="bulk-action-form" id="bulk-action-execute" class="btn" disabled>{% trans 'Execute' %}</button>
+        </div>
     </div>
     {% include "../generic_confirmation_dialog.html" %}
     {% url "events" as url %}

--- a/integreat_cms/cms/templates/events/event_list_archived_row.html
+++ b/integreat_cms/cms/templates/events/event_list_archived_row.html
@@ -4,8 +4,11 @@
 {% load poi_filters %}
 
 <tr class="border-t border-solid border-gray-200 hover:bg-gray-100 text-gray-800">
+    <td class="py-3 pl-4 pr-2">
+        <input type="checkbox" name="selected_ids[]" value="{{ event.id }}" form="bulk-action-form" class="bulk-select-item">
+    </td>
     <td>
-        <a href="{% url 'edit_event' event_id=event.id region_slug=request.region.slug language_slug=language.slug%}" class="py-3 pl-4 pr-2 text-gray-800">
+        <a href="{% url 'edit_event' event_id=event.id region_slug=request.region.slug language_slug=language.slug%}" class="py-3 pr-2 text-gray-800">
             {% if event_translation %}
                 {{ event_translation.title }}
             {% else %}

--- a/integreat_cms/cms/templates/pages/page_tree.html
+++ b/integreat_cms/cms/templates/pages/page_tree.html
@@ -121,7 +121,9 @@
     <div class="flex flex-wrap gap-2 mt-2">
         <select id="bulk-action" class="w-auto max-w-full">
             <option>{% trans 'Select bulk action' %}</option>
-            <!-- TODO: <option data-bulk-action="">{% trans 'Archive pages' %}</option> -->
+            <option data-bulk-action="{% url 'bulk_archive_pages' region_slug=request.region.slug language_slug=language.slug %}">
+                {% trans 'Archive pages' %}
+            </option>
             <option
                 id="pdf-export-option"
                 data-bulk-action="{% url 'export_pdf' region_slug=request.region.slug language_slug=language.slug %}"

--- a/integreat_cms/cms/templates/pages/page_tree_archived.html
+++ b/integreat_cms/cms/templates/pages/page_tree_archived.html
@@ -35,11 +35,17 @@
 
 <div class="table-listing">
     <div class="overflow-x-auto">
+        <form id="bulk-action-form" method="post">
+            {% csrf_token %}
+        </form>
         <table data-activate-tree-drag-drop class="w-full mt-4 rounded border-2 border-solid border-gray-200 shadow bg-white table-auto">
             <thead>
                 <tr class="border-b border-solid border-gray-200">
+                    <th class="text-sm text-left uppercase py-3 pl-4 pr-2 min">
+                        <input form="bulk-action-form" type="checkbox" id="bulk-select-all">
+                    </th>
                     {% if not filter_form.is_enabled %}
-                        <th class="text-sm text-left uppercase py-3 pl-4 pr-2 min">{% trans 'Hierarchy' %}</th>
+                        <th class="text-sm text-left uppercase py-3 pr-2 min">{% trans 'Hierarchy' %}</th>
                     {% endif %}
                     <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {{ language.translated_name }}</th>
                     {% get_current_language as LANGUAGE_CODE %}
@@ -80,6 +86,17 @@
                 {% endfor %}
             </tbody>
         </table>
+        <div class="flex flex-wrap gap-2 mt-4">
+            <select id="bulk-action" class="w-auto max-w-full">
+                <option>
+                    {% trans 'Select bulk action' %}
+                </option>
+                <option data-bulk-action="{% url 'bulk_restore_pages' region_slug=request.region.slug language_slug=language.slug %}">
+                    {% trans 'Restore pages' %}
+                </option>
+            </select>
+            <button form="bulk-action-form" id="bulk-action-execute" class="btn" disabled>{% trans 'Execute' %}</button>
+        </div>
     </div>
 </div>
 {% include "../generic_confirmation_dialog.html" %}

--- a/integreat_cms/cms/templates/pages/page_tree_archived_node.html
+++ b/integreat_cms/cms/templates/pages/page_tree_archived_node.html
@@ -4,9 +4,12 @@
 {% load tree_filters %}
 
 <tr id="page-{{ page.id }}" class="border-t border-b border-solid border-gray-200 hover:bg-gray-100 {% if page.relative_depth > 1 %} level-{{page.relative_depth}} {% if not filter_form.is_enabled and page.parent.archived %} hidden {% endif %} {% endif %}">
+    <td class="pl-4">
+        <input form="bulk-action-form" type="checkbox" name="selected_ids[]" value="{{ page.id }}" class="bulk-select-item">
+    </td>
     {% if not filter_form.is_enabled %}
         <td class="hierarchy single_icon whitespace-nowrap">
-            <span class="cursor-move text-gray-800 inline-block pl-4 align-middle" title="{% trans 'Drag & drop is disabled for archived pages.' %}">
+            <span class="cursor-move text-gray-800 inline-block align-middle" title="{% trans 'Drag & drop is disabled for archived pages.' %}">
                 <i data-feather="move"></i>
             </span>
             {% if page.cached_children|length > 0 %}

--- a/integreat_cms/cms/templates/pois/poi_list.html
+++ b/integreat_cms/cms/templates/pois/poi_list.html
@@ -44,10 +44,10 @@
         <table class="w-full mt-4 rounded border border-gray-200 shadow bg-white table-fixed">
             <thead>
                 <tr class="border-b border-gray-200">
-                    <th class="py-3 pl-4 min">
+                    <th class="py-3 pl-4 pr-2 min">
                         <input form="bulk-action-form" type="checkbox" id="bulk-select-all"/>
                     </th>
-                    <th class="text-sm text-left uppercase py-3 pl-2 pr-2">{% trans 'Title in' %} {{ language.translated_name }}</th>
+                    <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Title in' %} {{ language.translated_name }}</th>
                     {% if backend_language and backend_language != language %}
                         <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Title in' %} {{ backend_language.translated_name }}</th>
                     {% endif %}
@@ -92,6 +92,9 @@
             <select id="bulk-action" class="w-auto max-w-full">
                 <option>
                     {% trans 'Select bulk action' %}
+                </option>
+                <option data-bulk-action="{% url 'bulk_archive_pois' region_slug=request.region.slug language_slug=language.slug %}">
+                    {% trans 'Archive locations' %}
                 </option>
                 {% if DEEPL_ENABLED %}
                     <option data-bulk-action="{% url 'automatic_translation_pois' region_slug=request.region.slug language_slug=language.slug %}">

--- a/integreat_cms/cms/templates/pois/poi_list_archived.html
+++ b/integreat_cms/cms/templates/pois/poi_list_archived.html
@@ -17,14 +17,20 @@
 </div>
 
 <div class="table-listing">
+    <form id="bulk-action-form" method="post">
+        {% csrf_token %}
+    </form>
     <table class="w-full mt-4 rounded border border-gray-200 shadow bg-white table-fixed">
         <thead>
             <tr class="border-b border-gray-200">
-                <th class="text-sm text-left uppercase py-3 pl-4 pr-2">{% trans 'Status' %}</th>
+                <th class="py-3 pl-4 pr-2 min">
+                    <input form="bulk-action-form" type="checkbox" id="bulk-select-all">
+                </th>
                 <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Title in' %} {{ language.translated_name }}</th>
                 {% if backend_language and backend_language != language %}
                     <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Title in' %} {{ backend_language.translated_name }}</th>
                 {% endif %}
+                <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Status' %}</th>
                 <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Street' %}</th>
                 <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Postal Code' %}</th>
 	            <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'City' %}</th>
@@ -45,6 +51,15 @@
         {% endfor %}
         </tbody>
     </table>
+    <div class="flex flex-wrap gap-2 mt-4">
+        <select id="bulk-action" class="w-auto max-w-full">
+            <option>{% trans 'Select bulk action' %}</option>
+            <option data-bulk-action="{% url 'bulk_restore_pois' region_slug=request.region.slug language_slug=language.slug %}">
+                {% trans 'Restore locations' %}
+            </option>
+        </select>
+        <button form="bulk-action-form" id="bulk-action-execute" class="btn" disabled>{% trans 'Execute' %}</button>
+    </div>
 </div>
 {% include "../generic_confirmation_dialog.html" %}
 {% url "pois" as url %}

--- a/integreat_cms/cms/templates/pois/poi_list_archived_row.html
+++ b/integreat_cms/cms/templates/pois/poi_list_archived_row.html
@@ -4,9 +4,7 @@
 
 <tr class="border-t border-gray-200 hover:bg-gray-100 text-gray-800">
     <td class="py-3 pl-4 pr-2">
-        <a href="{% url 'edit_poi' poi_id=poi.id region_slug=request.region.slug language_slug=language.slug %}" class="block">
-            {{ poi_translation.get_status_display }}
-        </a>
+        <input type="checkbox" name="selected_ids[]" value="{{ poi.id }}" form="bulk-action-form" class="bulk-select-item">
     </td>
 	<td class="pr-2">
 		<a href="{% url 'edit_poi' poi_id=poi.id region_slug=request.region.slug language_slug=language.slug %}" class="block">
@@ -28,6 +26,11 @@
             </a>
         </td>
     {% endif %}
+    <td class="pr-2">
+        <a href="{% url 'edit_poi' poi_id=poi.id region_slug=request.region.slug language_slug=language.slug %}" class="block">
+            {{ poi_translation.get_status_display }}
+        </a>
+    </td>
 	<td class="pr-2">
         <a href="{% url 'edit_poi' poi_id=poi.id region_slug=request.region.slug language_slug=language.slug %}" class="block">
             {{ poi.address }}

--- a/integreat_cms/cms/templates/pois/poi_list_row.html
+++ b/integreat_cms/cms/templates/pois/poi_list_row.html
@@ -3,10 +3,10 @@
 {% load content_filters %}
 
 <tr class="border-t border-gray-200 hover:bg-gray-100 text-gray-800">
-    <td class="py-3 pl-4">
+    <td class="py-3 pl-4 pr-2">
         <input type="checkbox" name="selected_ids[]" value="{{ poi.id }}" form="bulk-action-form" class="bulk-select-item">
     </td>
-    <td class="pr-2 pl-2">
+    <td class="pr-2">
         <a href="{% url 'edit_poi' poi_id=poi.id region_slug=request.region.slug language_slug=language.slug %}" class="block">
             {%  if poi_translation %}
                 {{ poi_translation.title }}

--- a/integreat_cms/cms/urls/protected.py
+++ b/integreat_cms/cms/urls/protected.py
@@ -6,10 +6,11 @@ Views which should not have login protection go into :mod:`~integreat_cms.cms.ur
 from django.urls import include, path
 
 from ..forms import LanguageForm, OfferTemplateForm, OrganizationForm, RegionForm
-from ..models import Language, OfferTemplate, Organization, Role
+from ..models import Event, Language, OfferTemplate, Organization, POI, Role
 
 from ..views import (
     analytics,
+    bulk_action_views,
     chat,
     dashboard,
     delete_views,
@@ -628,13 +629,17 @@ urlpatterns = [
                                                 [
                                                     path(
                                                         "download/",
-                                                        pages.download_xliff,
+                                                        pages.ExportXliffView.as_view(
+                                                            prefetch_translations=True
+                                                        ),
                                                         name="download_xliff",
                                                     ),
                                                     path(
                                                         "only-public/",
-                                                        pages.download_xliff,
-                                                        {"only_public": True},
+                                                        pages.ExportXliffView.as_view(
+                                                            only_public=True,
+                                                            prefetch_public_translations=True,
+                                                        ),
                                                         name="download_xliff_only_public",
                                                     ),
                                                     path(
@@ -652,7 +657,7 @@ urlpatterns = [
                                         ),
                                         path(
                                             "export/",
-                                            pages.export_pdf,
+                                            pages.GeneratePdfView.as_view(),
                                             name="export_pdf",
                                         ),
                                         path(
@@ -813,7 +818,9 @@ urlpatterns = [
                                         ),
                                         path(
                                             "auto-translate/",
-                                            events.automatic_translation,
+                                            bulk_action_views.BulkAutoTranslateView.as_view(
+                                                model=Event
+                                            ),
                                             name="automatic_translation_events",
                                         ),
                                         path(
@@ -880,7 +887,9 @@ urlpatterns = [
                                         ),
                                         path(
                                             "auto-translate/",
-                                            pois.automatic_translation,
+                                            bulk_action_views.BulkAutoTranslateView.as_view(
+                                                model=POI
+                                            ),
                                             name="automatic_translation_pois",
                                         ),
                                         path(

--- a/integreat_cms/cms/urls/protected.py
+++ b/integreat_cms/cms/urls/protected.py
@@ -6,7 +6,7 @@ Views which should not have login protection go into :mod:`~integreat_cms.cms.ur
 from django.urls import include, path
 
 from ..forms import LanguageForm, OfferTemplateForm, OrganizationForm, RegionForm
-from ..models import Event, Language, OfferTemplate, Organization, POI, Role
+from ..models import Event, Language, OfferTemplate, Organization, Page, POI, Role
 
 from ..views import (
     analytics,
@@ -661,6 +661,22 @@ urlpatterns = [
                                             name="export_pdf",
                                         ),
                                         path(
+                                            "bulk-archive/",
+                                            bulk_action_views.BulkArchiveView.as_view(
+                                                model=Page,
+                                                archived_field="explicitly_archived",
+                                            ),
+                                            name="bulk_archive_pages",
+                                        ),
+                                        path(
+                                            "bulk-restore/",
+                                            bulk_action_views.BulkRestoreView.as_view(
+                                                model=Page,
+                                                archived_field="explicitly_archived",
+                                            ),
+                                            name="bulk_restore_pages",
+                                        ),
+                                        path(
                                             "<int:page_id>/",
                                             include(
                                                 [
@@ -824,6 +840,20 @@ urlpatterns = [
                                             name="automatic_translation_events",
                                         ),
                                         path(
+                                            "bulk-archive/",
+                                            bulk_action_views.BulkArchiveView.as_view(
+                                                model=Event
+                                            ),
+                                            name="bulk_archive_events",
+                                        ),
+                                        path(
+                                            "bulk-restore/",
+                                            bulk_action_views.BulkRestoreView.as_view(
+                                                model=Event
+                                            ),
+                                            name="bulk_restore_events",
+                                        ),
+                                        path(
                                             "<int:event_id>/",
                                             include(
                                                 [
@@ -891,6 +921,20 @@ urlpatterns = [
                                                 model=POI
                                             ),
                                             name="automatic_translation_pois",
+                                        ),
+                                        path(
+                                            "bulk-archive/",
+                                            bulk_action_views.BulkArchiveView.as_view(
+                                                model=POI
+                                            ),
+                                            name="bulk_archive_pois",
+                                        ),
+                                        path(
+                                            "bulk-restore/",
+                                            bulk_action_views.BulkRestoreView.as_view(
+                                                model=POI
+                                            ),
+                                            name="bulk_restore_pois",
                                         ),
                                         path(
                                             "<int:poi_id>/",

--- a/integreat_cms/cms/views/bulk_action_views.py
+++ b/integreat_cms/cms/views/bulk_action_views.py
@@ -1,0 +1,127 @@
+"""
+This module contains the base view for bulk actions
+"""
+import logging
+
+from django.conf import settings
+from django.contrib import messages
+from django.contrib.auth.mixins import PermissionRequiredMixin
+from django.http import Http404
+from django.urls import reverse
+from django.utils.translation import ugettext as _
+from django.views.generic import RedirectView
+from django.views.generic.list import MultipleObjectMixin
+
+logger = logging.getLogger(__name__)
+
+
+class BulkActionView(PermissionRequiredMixin, MultipleObjectMixin, RedirectView):
+    """
+    View for executing a bulk action and redirect to a given location
+    """
+
+    #: The list of HTTP method names that this view will accept.
+    #: The bulk action form uses only POST as submission method.
+    http_method_names = ["post"]
+    #: Whether the view requires change permissions
+    require_change_permission = True
+    #: Whether the translation objects should be prefetched
+    prefetch_translations = False
+    #: Whether the public translation objects should be prefetched
+    prefetch_public_translations = False
+
+    def get_permission_required(self):
+        """
+        Override this method to override the permission_required attribute.
+
+        :return: The permissions that are required for views inheriting from this Mixin
+        :rtype: ~collections.abc.Iterable
+        """
+        # If the bulk action performs changes to the database, require the change permission
+        if self.require_change_permission:
+            return (f"cms.change_{self.model._meta.model_name}",)
+        # If the bulk action is just a read-view (e.g. export), require the view permission
+        return (f"cms.view_{self.model._meta.model_name}",)
+
+    def get_redirect_url(self, *args, **kwargs):
+        r"""
+        Retrieve url for redirection
+
+        :param \*args: The supplied arguments
+        :type \*args: list
+
+        :param \**kwargs: The supplied keyword arguments
+        :type \**kwargs: dict
+
+        :return: url to redirect to
+        :rtype: str
+        """
+        return reverse(
+            f"{self.model._meta.model_name}s",
+            kwargs={
+                "region_slug": self.request.region.slug,
+                "language_slug": kwargs.get("language_slug"),
+            },
+        )
+
+    def get_queryset(self):
+        """
+        Get the queryset of selected items for this bulk action
+
+        :raises ~django.http.Http404: HTTP status 404 if no objects with the given ids exist
+
+        :return: The QuerySet of the filtered links
+        :rtype: ~django.db.models.query.QuerySet
+        """
+        queryset = (
+            super()
+            .get_queryset()
+            .filter(
+                region=self.request.region,
+                id__in=self.request.POST.getlist("selected_ids[]"),
+            )
+        )
+        if not queryset:
+            raise Http404(f"No {self.model._meta.object_name} matches the given query.")
+        if self.prefetch_translations:
+            queryset = queryset.prefetch_translations()
+        if self.prefetch_public_translations:
+            queryset = queryset.prefetch_public_translations()
+        return queryset
+
+
+class BulkAutoTranslateView(BulkActionView):
+    """
+    Bulk action for automatically translating multiple objects
+    """
+
+    #: Whether the public translation objects should be prefetched
+    prefetch_translations = True
+
+    def post(self, request, *args, **kwargs):
+        r"""
+        Translate multiple objects automatically
+
+        :param request: The current request
+        :type request: ~django.http.HttpResponse
+
+        :param \*args: The supplied arguments
+        :type \*args: list
+
+        :param \**kwargs: The supplied keyword arguments
+        :type \**kwargs: dict
+
+        :return: The redirect
+        :rtype: ~django.http.HttpResponseRedirect
+        """
+        logger.debug("Automatic translation for: %r", self.get_queryset())
+
+        if settings.DEEPL_ENABLED:
+            messages.warning(
+                request, _("Automatic translations are not fully implemented yet")
+            )
+        else:
+            messages.error(request, _("Automatic translations are disabled"))
+
+        # Let the base view handle the redirect
+        return super().post(request, *args, **kwargs)

--- a/integreat_cms/cms/views/events/__init__.py
+++ b/integreat_cms/cms/views/events/__init__.py
@@ -9,5 +9,4 @@ from .event_actions import (
     delete,
     search_poi_ajax,
     duplicate,
-    automatic_translation,
 )

--- a/integreat_cms/cms/views/events/event_actions.py
+++ b/integreat_cms/cms/views/events/event_actions.py
@@ -4,7 +4,6 @@ This module contains action methods for events (archive, restore, ...)
 import json
 import logging
 
-from django.conf import settings
 from django.contrib import messages
 from django.db.models import Subquery, OuterRef
 from django.shortcuts import render, redirect, get_object_or_404
@@ -222,46 +221,4 @@ def search_poi_ajax(request, region_slug):
             "create_poi_option": create_poi_option,
             "region": region,
         },
-    )
-
-
-@require_POST
-@permission_required("cms.change_event")
-def automatic_translation(request, region_slug, language_slug):
-    """
-    Automatic translation for events
-
-    :param request: Object representing the user call
-    :type request: ~django.http.HttpRequest
-
-    :param region_slug: slug of the region which the event belongs to
-    :type region_slug: str
-
-    :param language_slug: current GUI language slug
-    :type language_slug: str
-
-    :return: The rendered template response
-    :rtype: ~django.template.response.TemplateResponse
-    """
-    # Get current region
-    region = request.region
-    # Retrieve the selected event ids
-    event_ids = request.POST.getlist("selected_ids[]")
-    # Collect the corresponding event objects
-    events = region.events.filter(id__in=event_ids).prefetch_translations()
-    logger.debug("Automatic translation for events: %r", events)
-
-    if settings.DEEPL_ENABLED:
-        messages.warning(
-            request, _("Automatic translations are not fully implemented yet")
-        )
-    else:
-        messages.error(request, _("Automatic translations are disabled"))
-
-    return redirect(
-        "events",
-        **{
-            "region_slug": region_slug,
-            "language_slug": language_slug,
-        }
     )

--- a/integreat_cms/cms/views/pages/__init__.py
+++ b/integreat_cms/cms/views/pages/__init__.py
@@ -17,7 +17,10 @@ from .page_actions import (
     render_mirrored_page_field,
     cancel_translation_process_ajax,
 )
-from .page_bulk_actions import GeneratePdfView, ExportXliffView
+from .page_bulk_actions import (
+    GeneratePdfView,
+    ExportXliffView,
+)
 from .page_sbs_view import PageSideBySideView
 from .page_revision_view import PageRevisionView
 from .page_xliff_import_view import PageXliffImportView

--- a/integreat_cms/cms/views/pages/__init__.py
+++ b/integreat_cms/cms/views/pages/__init__.py
@@ -9,8 +9,6 @@ from .page_actions import (
     view_page,
     delete_page,
     expand_page_translation_id,
-    export_pdf,
-    download_xliff,
     upload_xliff,
     move_page,
     grant_page_permission_ajax,
@@ -19,6 +17,7 @@ from .page_actions import (
     render_mirrored_page_field,
     cancel_translation_process_ajax,
 )
+from .page_bulk_actions import GeneratePdfView, ExportXliffView
 from .page_sbs_view import PageSideBySideView
 from .page_revision_view import PageRevisionView
 from .page_xliff_import_view import PageXliffImportView

--- a/integreat_cms/cms/views/pages/page_bulk_actions.py
+++ b/integreat_cms/cms/views/pages/page_bulk_actions.py
@@ -1,0 +1,122 @@
+import logging
+
+from django.contrib import messages
+from django.shortcuts import get_object_or_404
+from django.utils.translation import ugettext as _
+from django.views.generic.list import MultipleObjectMixin
+
+from ....xliff.utils import pages_to_xliff_file
+from ...models import Page
+from ...utils.pdf_utils import generate_pdf
+from ...utils.translation_utils import ugettext_many_lazy as __
+from ..bulk_action_views import BulkActionView
+
+logger = logging.getLogger(__name__)
+
+
+class PageBulkActionMixin(MultipleObjectMixin):
+    """
+    Mixin for page bulk actions
+    """
+
+    #: The model of this :class:`~integreat_cms.cms.views.bulk_action_views.BulkActionView`
+    model = Page
+
+
+# pylint: disable=too-many-ancestors
+class GeneratePdfView(PageBulkActionMixin, BulkActionView):
+    """
+    Bulk action for generating a PDF document of the content
+    """
+
+    #: Whether the view requires change permissions
+    require_change_permission = False
+    #: Whether the public translation objects should be prefetched
+    prefetch_public_translations = True
+
+    def post(self, request, *args, **kwargs):
+        r"""
+        Apply the bulk action on every item in the queryset and redirect
+
+        :param request: The current request
+        :type request: ~django.http.HttpResponse
+
+        :param \*args: The supplied arguments
+        :type \*args: list
+
+        :param \**kwargs: The supplied keyword arguments
+        :type \**kwargs: dict
+
+        :return: The redirect
+        :rtype: ~django.http.HttpResponseRedirect
+        """
+        # Generate PDF document wrapped in a HtmlResponse object
+        response = generate_pdf(
+            request.region,
+            kwargs.get("language_slug"),
+            self.get_queryset(),
+        )
+        if response.status_code == 200:
+            # Offer PDF document for download
+            response["Content-Disposition"] = (
+                response["Content-Disposition"] + "; attachment"
+            )
+        return response
+
+
+# pylint: disable=too-many-ancestors
+class ExportXliffView(PageBulkActionMixin, BulkActionView):
+    """
+    Bulk action for generating XLIFF files for translations
+    """
+
+    #: Whether only public translation should be exported
+    only_public = False
+    #: Whether the view requires change permissions
+    require_change_permission = False
+
+    def post(self, request, *args, **kwargs):
+        r"""
+        Function for handling a pdf export request for pages.
+        The pages get extracted from request.GET attribute and the request is forwarded to :func:`~integreat_cms.cms.utils.pdf_utils.generate_pdf`
+
+        :param request: The current request
+        :type request: ~django.http.HttpResponse
+
+        :param \*args: The supplied arguments
+        :type \*args: list
+
+        :param \**kwargs: The supplied keyword arguments
+        :type \**kwargs: dict
+
+        :return: The redirect
+        :rtype: ~django.http.HttpResponseRedirect
+        """
+        target_language = get_object_or_404(
+            self.request.region.language_tree_nodes,
+            language__slug=kwargs.get("language_slug"),
+            parent__isnull=False,
+        ).language
+
+        xliff_file_url = pages_to_xliff_file(
+            request, self.get_queryset(), target_language, only_public=self.only_public
+        )
+        if xliff_file_url:
+            # Insert link with automatic download into success message
+            messages.success(
+                request,
+                __(
+                    _("XLIFF file for translation to {} successfully created.").format(
+                        target_language
+                    ),
+                    _(
+                        "If the download does not start automatically, please click {}here{}."
+                    ).format(
+                        f"<a data-auto-download href='{xliff_file_url}' class='font-bold underline hover:no-underline' download>",
+                        "</a>",
+                    ),
+                ),
+            )
+
+        # Let the base view handle the redirect
+        return super().post(request, *args, **kwargs)

--- a/integreat_cms/cms/views/pois/__init__.py
+++ b/integreat_cms/cms/views/pois/__init__.py
@@ -7,6 +7,5 @@ from .poi_actions import (
     archive_poi,
     restore_poi,
     delete_poi,
-    automatic_translation,
 )
 from .poi_list_view import POIListView

--- a/integreat_cms/cms/views/pois/poi_actions.py
+++ b/integreat_cms/cms/views/pois/poi_actions.py
@@ -3,7 +3,6 @@ This module contains view actions for objects related to POIs.
 """
 import logging
 
-from django.conf import settings
 from django.contrib import messages
 from django.http import Http404
 from django.shortcuts import render, redirect
@@ -161,45 +160,3 @@ def view_poi(request, poi_id, region_slug, language_slug):
         raise Http404
 
     return render(request, template_name, {"poi_translation": poi_translation})
-
-
-@require_POST
-@permission_required("cms.change_poi")
-def automatic_translation(request, region_slug, language_slug):
-    """
-    Automatic translation for POIs
-
-    :param request: Object representing the user call
-    :type request: ~django.http.HttpRequest
-
-    :param region_slug: slug of the region which the event belongs to
-    :type region_slug: str
-
-    :param language_slug: current GUI language slug
-    :type language_slug: str
-
-    :return: The rendered template response
-    :rtype: ~django.template.response.TemplateResponse
-    """
-    # Get current region
-    region = request.region
-    # Retrieve the selected POI ids
-    poi_ids = request.POST.getlist("selected_ids[]")
-    # Collect the corresponding POI objects
-    pois = region.pois.filter(id__in=poi_ids).prefetch_translations()
-    logger.debug("Automatic translation for POIs: %r", pois)
-
-    if settings.DEEPL_ENABLED:
-        messages.warning(
-            request, _("Automatic translations are not fully implemented yet")
-        )
-    else:
-        messages.error(request, _("Automatic translations are disabled"))
-
-    return redirect(
-        "pois",
-        **{
-            "region_slug": region_slug,
-            "language_slug": language_slug,
-        }
-    )

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-20 18:38+0000\n"
+"POT-Creation-Date: 2022-03-20 18:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -4628,7 +4628,7 @@ msgstr "Seite löschen"
 #: cms/templates/pages/page_form.html:327
 #: cms/templates/pages/page_tree_archived_node.html:112
 #: cms/templates/pages/page_tree_node.html:137
-#: cms/views/pages/page_actions.py:215
+#: cms/views/pages/page_actions.py:212
 msgid "You cannot delete a page which has subpages."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
 
@@ -5670,6 +5670,14 @@ msgstr ""
 "Adresse eingegeben haben, mit der Sie sich registriert haben, und überprüfen "
 "Sie Ihren Spam-Ordner."
 
+#: cms/views/bulk_action_views.py:121
+msgid "Automatic translations are not fully implemented yet"
+msgstr "Automatische Übersetzungen sind noch nicht vollständig implementiert"
+
+#: cms/views/bulk_action_views.py:124
+msgid "Automatic translations are disabled"
+msgstr "Automatische Übersetzungen sind deaktiviert"
+
 #: cms/views/delete_views.py:80
 msgid "{} \"{}\" was successfully deleted"
 msgstr "{} \"{}\" wurde erfolgreich gelöscht"
@@ -5714,29 +5722,21 @@ msgstr "CSRF Fehler"
 msgid "Please try to reload the page."
 msgstr "Bitte versuchen Sie, die Seite neu zu laden."
 
-#: cms/views/events/event_actions.py:49
+#: cms/views/events/event_actions.py:48
 msgid "Event was successfully archived"
 msgstr "Veranstaltung wurde erfolgreich archiviert"
 
-#: cms/views/events/event_actions.py:87
+#: cms/views/events/event_actions.py:86
 msgid "Event was successfully duplicated"
 msgstr "Veranstaltung wurde erfolgreich dupliziert"
 
-#: cms/views/events/event_actions.py:122
+#: cms/views/events/event_actions.py:121
 msgid "Event was successfully restored"
 msgstr "Veranstaltung wurde erfolgreich wiederhergestellt"
 
-#: cms/views/events/event_actions.py:162
+#: cms/views/events/event_actions.py:161
 msgid "Event was successfully deleted"
 msgstr "Veranstaltung wurde erfolgreich gelöscht"
-
-#: cms/views/events/event_actions.py:256 cms/views/pois/poi_actions.py:194
-msgid "Automatic translations are not fully implemented yet"
-msgstr "Automatische Übersetzungen sind noch nicht vollständig implementiert"
-
-#: cms/views/events/event_actions.py:259 cms/views/pois/poi_actions.py:197
-msgid "Automatic translations are disabled"
-msgstr "Automatische Übersetzungen sind deaktiviert"
 
 #: cms/views/events/event_context_mixin.py:30
 msgid "Please confirm that you really want to archive this event"
@@ -6145,81 +6145,67 @@ msgstr "Es ist ein Fehler aufgetreten."
 msgid "Please confirm that you really want to delete this {}"
 msgstr "Bitte bestätigen Sie, dass diese {} gelöscht werden soll"
 
-#: cms/views/pages/page_actions.py:68
+#: cms/views/pages/page_actions.py:65
 msgid "Page was successfully archived"
 msgstr "Seite wurde erfolgreich archiviert"
 
-#: cms/views/pages/page_actions.py:121 cms/views/pages/page_actions.py:135
+#: cms/views/pages/page_actions.py:118 cms/views/pages/page_actions.py:132
 msgid "Page was successfully restored."
 msgstr "Seite wurde erfolgreich wiederhergestellt."
 
-#: cms/views/pages/page_actions.py:124
+#: cms/views/pages/page_actions.py:121
 msgid ""
 "However, it is still archived because one of its parent pages is archived."
 msgstr ""
 "Sie ist jedoch immer noch archiviert, weil eine ihrer übergeordneten Seiten "
 "archiviert ist."
 
-#: cms/views/pages/page_actions.py:219
+#: cms/views/pages/page_actions.py:216
 msgid "Page was successfully deleted"
 msgstr "Seite wurde erfolgreich gelöscht"
 
-#: cms/views/pages/page_actions.py:314
-msgid "No pages selected for XLIFF export."
-msgstr ""
-"Es wurden keine gültigen Seiten zur Erzeugung der XLIFF-Datei ausgewählt."
-
-#: cms/views/pages/page_actions.py:341
-msgid "XLIFF file for translation to {} successfully created."
-msgstr "XLIFF Datei für die Übersetzung nach {} wurde erfolgreich erstellt."
-
-#: cms/views/pages/page_actions.py:345
-msgid "If the download does not start automatically, please click {}here{}."
-msgstr ""
-"Wenn der Download nicht automatisch startet, klicken Sie bitte {}hier{}."
-
-#: cms/views/pages/page_actions.py:439
+#: cms/views/pages/page_actions.py:325
 msgid "File \"{}\" is neither a ZIP archive nor an XLIFF file."
 msgstr "Die Datei \"{}\" ist weder ein ZIP-Archiv noch eine XLIFF-Datei."
 
-#: cms/views/pages/page_actions.py:466
+#: cms/views/pages/page_actions.py:352
 msgid "The ZIP archive \"{}\" does not contain XLIFF files."
 msgstr "Das ZIP-Archiv \"{}\" enthält keine XLIFF-Dateien"
 
-#: cms/views/pages/page_actions.py:474
+#: cms/views/pages/page_actions.py:360
 msgid "The ZIP archive \"{}\" contains the following invalid files: \"{}\""
 msgstr "Das ZIP-Archiv \"{}\" enthält die folgenden ungültigen Dateien: \"{}\""
 
-#: cms/views/pages/page_actions.py:499
+#: cms/views/pages/page_actions.py:385
 msgid "No XLIFF file was selected for import."
 msgstr "Es wurde keine XLIFF-Datei für den Import ausgewählt."
 
-#: cms/views/pages/page_actions.py:559
+#: cms/views/pages/page_actions.py:445
 #, python-brace-format
 msgid "The page \"{page}\" was successfully moved."
 msgstr "Die Seite \"{page}\" wurde erfolgreich verschoben."
 
-#: cms/views/pages/page_actions.py:639 cms/views/pages/page_actions.py:654
+#: cms/views/pages/page_actions.py:525 cms/views/pages/page_actions.py:540
 #, python-brace-format
 msgid "Information: The user {user} has this permission already."
 msgstr "Information: Der Nutzer {user} hat diese Berechtigung bereits"
 
-#: cms/views/pages/page_actions.py:646
+#: cms/views/pages/page_actions.py:532
 #, python-brace-format
 msgid "Success: The user {user} can now edit this page."
 msgstr "Erfolg: Der Nutzer {user} kann nun diese Seite bearbeiten"
 
-#: cms/views/pages/page_actions.py:662
+#: cms/views/pages/page_actions.py:548
 #, python-brace-format
 msgid "Success: The user {user} can now publish this page."
 msgstr "Erfolg: Der Nutzer {user} kann dieses Seite nun veröffentlichen"
 
-#: cms/views/pages/page_actions.py:671 cms/views/pages/page_actions.py:783
+#: cms/views/pages/page_actions.py:557 cms/views/pages/page_actions.py:669
 msgid "An error has occurred. Please contact an administrator."
 msgstr ""
 "Ein Fehler ist aufgetreten. Bitte kontaktieren Sie einen Administrator."
 
-#: cms/views/pages/page_actions.py:751
+#: cms/views/pages/page_actions.py:637
 #, python-brace-format
 msgid ""
 "Information: The user {user} has been removed from the editors of this page, "
@@ -6229,12 +6215,12 @@ msgstr ""
 "bearbeiten wurde entfernt,aber er kann sie auf Grund seiner anderen "
 "Berechtigungen weiterhin bearbeiten."
 
-#: cms/views/pages/page_actions.py:757
+#: cms/views/pages/page_actions.py:643
 #, python-brace-format
 msgid "Success: The user {user} cannot edit this page anymore."
 msgstr "Erfolg: Der Nutzer {user} kann diese Seite nicht mehr bearbeiten"
 
-#: cms/views/pages/page_actions.py:768
+#: cms/views/pages/page_actions.py:654
 #, python-brace-format
 msgid ""
 "Information: The user {user} has been removed from the publishers of this "
@@ -6244,10 +6230,19 @@ msgstr ""
 "veröffentlichen wurde entfernt,aber er kann sie auf Grund seiner anderen "
 "Berechtigungen weiterhin veröffentlichen."
 
-#: cms/views/pages/page_actions.py:774
+#: cms/views/pages/page_actions.py:660
 #, python-brace-format
 msgid "Success: The user {user} cannot publish this page anymore."
 msgstr "Erfolg: Der Nutzer {user} kann diese Seite nicht mehr veröffentlichen"
+
+#: cms/views/pages/page_bulk_actions.py:109
+msgid "XLIFF file for translation to {} successfully created."
+msgstr "XLIFF Datei für die Übersetzung nach {} wurde erfolgreich erstellt."
+
+#: cms/views/pages/page_bulk_actions.py:113
+msgid "If the download does not start automatically, please click {}here{}."
+msgstr ""
+"Wenn der Download nicht automatisch startet, klicken Sie bitte {}hier{}."
 
 #: cms/views/pages/page_context_mixin.py:38
 msgid "Please confirm that you really want to archive this page"
@@ -6347,15 +6342,15 @@ msgstr ""
 msgid "This XLIFF import is no longer available."
 msgstr "Dieser XLIFF Import ist nicht länger verfügbar."
 
-#: cms/views/pois/poi_actions.py:46
+#: cms/views/pois/poi_actions.py:45
 msgid "Location was successfully archived"
 msgstr "Ort wurde erfolgreich archiviert"
 
-#: cms/views/pois/poi_actions.py:84
+#: cms/views/pois/poi_actions.py:83
 msgid "Location was successfully restored"
 msgstr "Ort wurde erfolgreich wiederhergestellt"
 
-#: cms/views/pois/poi_actions.py:120
+#: cms/views/pois/poi_actions.py:119
 msgid "Location was successfully deleted"
 msgstr "Ort wurde erfolgreich gelöscht"
 
@@ -6620,6 +6615,10 @@ msgstr ""
 
 #~ msgid "Filetype:"
 #~ msgstr "Dateityp:"
+
+#~ msgid "No pages selected for XLIFF export."
+#~ msgstr ""
+#~ "Es wurden keine gültigen Seiten zur Erzeugung der XLIFF-Datei ausgewählt."
 
 #~ msgid "All subpages of this page are archived"
 #~ msgstr "Alle Unterseiten dieser Seite sind archiviert"

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-20 18:52+0000\n"
+"POT-Creation-Date: 2022-03-20 18:58+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -20,7 +20,7 @@ msgstr ""
 
 #: cms/constants/administrative_division.py:38
 #: cms/templates/pois/poi_list.html:69
-#: cms/templates/pois/poi_list_archived.html:30
+#: cms/templates/pois/poi_list_archived.html:36
 msgid "City"
 msgstr "Stadt"
 
@@ -1300,7 +1300,7 @@ msgstr "Versteckt"
 #: cms/constants/region_status.py:18 cms/models/pages/page.py:304
 #: cms/models/regions/region.py:597 cms/templates/events/event_form.html:70
 #: cms/templates/pages/page_form.html:93
-#: cms/templates/pages/page_tree_archived_node.html:78
+#: cms/templates/pages/page_tree_archived_node.html:81
 #: cms/templates/pois/poi_form.html:60
 msgid "Archived"
 msgstr "Archiviert"
@@ -1361,12 +1361,12 @@ msgstr "Rechts nach Links"
 #: cms/templates/_form_language_tabs.html:26
 #: cms/templates/_form_language_tabs.html:35
 #: cms/templates/_form_language_tabs.html:77
-#: cms/templates/events/event_list_archived_row.html:44
+#: cms/templates/events/event_list_archived_row.html:47
 #: cms/templates/events/event_list_row.html:47
 #: cms/templates/imprint/imprint_sbs.html:41
 #: cms/templates/imprint/imprint_sbs.html:98
 #: cms/templates/pages/page_sbs.html:49 cms/templates/pages/page_sbs.html:98
-#: cms/templates/pages/page_tree_archived_node.html:60
+#: cms/templates/pages/page_tree_archived_node.html:63
 #: cms/templates/pages/page_tree_node.html:79
 #: cms/templates/pois/poi_list_row.html:44
 msgid "Translation up-to-date"
@@ -1375,13 +1375,13 @@ msgstr "Übersetzung ist aktuell"
 #: cms/constants/translation_status.py:18
 #: cms/templates/_form_language_tabs.html:18
 #: cms/templates/_form_language_tabs.html:69
-#: cms/templates/events/event_list_archived_row.html:36
+#: cms/templates/events/event_list_archived_row.html:39
 #: cms/templates/events/event_list_row.html:39
 #: cms/templates/events/event_list_row.html:57
 #: cms/templates/imprint/imprint_sbs.html:37
 #: cms/templates/imprint/imprint_sbs.html:94
 #: cms/templates/pages/page_sbs.html:45 cms/templates/pages/page_sbs.html:94
-#: cms/templates/pages/page_tree_archived_node.html:52
+#: cms/templates/pages/page_tree_archived_node.html:55
 #: cms/templates/pages/page_tree_node.html:71
 #: cms/templates/pages/page_tree_node.html:89
 #: cms/templates/pois/poi_list_row.html:36
@@ -1393,12 +1393,12 @@ msgstr "Wird derzeit übersetzt"
 #: cms/templates/_form_language_tabs.html:23
 #: cms/templates/_form_language_tabs.html:31
 #: cms/templates/_form_language_tabs.html:73
-#: cms/templates/events/event_list_archived_row.html:40
+#: cms/templates/events/event_list_archived_row.html:43
 #: cms/templates/events/event_list_row.html:43
 #: cms/templates/imprint/imprint_sbs.html:33
 #: cms/templates/imprint/imprint_sbs.html:90
 #: cms/templates/pages/page_sbs.html:41 cms/templates/pages/page_sbs.html:90
-#: cms/templates/pages/page_tree_archived_node.html:56
+#: cms/templates/pages/page_tree_archived_node.html:59
 #: cms/templates/pages/page_tree_node.html:75
 #: cms/templates/pois/poi_list_row.html:40
 msgid "Translation outdated"
@@ -1407,9 +1407,9 @@ msgstr "Übersetzung ist veraltet"
 #: cms/constants/translation_status.py:20
 #: cms/templates/_form_language_tabs.html:39
 #: cms/templates/_form_language_tabs.html:81
-#: cms/templates/events/event_list_archived_row.html:49
+#: cms/templates/events/event_list_archived_row.html:52
 #: cms/templates/events/event_list_row.html:51
-#: cms/templates/pages/page_tree_archived_node.html:65
+#: cms/templates/pages/page_tree_archived_node.html:68
 #: cms/templates/pages/page_tree_node.html:83
 #: cms/templates/pois/poi_list_row.html:48
 msgid "Translation missing"
@@ -1580,7 +1580,7 @@ msgstr "Kategorie"
 #: cms/forms/feedback/region_feedback_filter_form.py:30
 #: cms/templates/events/event_form.html:67
 #: cms/templates/events/event_list.html:76
-#: cms/templates/events/event_list_archived.html:46
+#: cms/templates/events/event_list_archived.html:52
 #: cms/templates/imprint/imprint_form.html:49
 #: cms/templates/imprint/imprint_revisions.html:46
 #: cms/templates/imprint/imprint_sbs.html:51
@@ -1591,9 +1591,9 @@ msgstr "Kategorie"
 #: cms/templates/pages/page_revisions.html:50
 #: cms/templates/pages/page_sbs.html:59 cms/templates/pages/page_sbs.html:115
 #: cms/templates/pages/page_sbs.html:121 cms/templates/pages/page_tree.html:81
-#: cms/templates/pages/page_tree_archived.html:61
+#: cms/templates/pages/page_tree_archived.html:67
 #: cms/templates/pois/poi_form.html:57 cms/templates/pois/poi_list.html:66
-#: cms/templates/pois/poi_list_archived.html:23
+#: cms/templates/pois/poi_list_archived.html:33
 #: cms/templates/push_notifications/push_notification_form.html:110
 #: cms/templates/regions/region_list.html:24
 msgid "Status"
@@ -2480,16 +2480,16 @@ msgstr "Ob die Seite explizit archiviert ist oder nicht"
 #: cms/templates/events/event_form.html:27
 #: cms/templates/events/event_list.html:59
 #: cms/templates/events/event_list.html:63
-#: cms/templates/events/event_list_archived.html:29
-#: cms/templates/events/event_list_archived.html:33
+#: cms/templates/events/event_list_archived.html:35
+#: cms/templates/events/event_list_archived.html:39
 #: cms/templates/pages/page_form.html:29 cms/templates/pages/page_tree.html:63
 #: cms/templates/pages/page_tree.html:67
-#: cms/templates/pages/page_tree_archived.html:44
-#: cms/templates/pages/page_tree_archived.html:48
+#: cms/templates/pages/page_tree_archived.html:50
+#: cms/templates/pages/page_tree_archived.html:54
 #: cms/templates/pois/poi_form.html:27 cms/templates/pois/poi_list.html:50
 #: cms/templates/pois/poi_list.html:52
-#: cms/templates/pois/poi_list_archived.html:24
-#: cms/templates/pois/poi_list_archived.html:26
+#: cms/templates/pois/poi_list_archived.html:29
+#: cms/templates/pois/poi_list_archived.html:31
 msgid "Title in"
 msgstr "Titel auf"
 
@@ -3587,7 +3587,7 @@ msgstr "Zeitraum"
 
 #: cms/templates/events/_event_filter_form.html:32
 #: cms/templates/events/event_list.html:77
-#: cms/templates/events/event_list_archived.html:47
+#: cms/templates/events/event_list_archived.html:53
 msgid "Event location"
 msgstr "Veranstaltungsort"
 
@@ -3713,7 +3713,7 @@ msgid "Actions"
 msgstr "Aktionen"
 
 #: cms/templates/events/event_form.html:308
-#: cms/templates/events/event_list_archived_row.html:84
+#: cms/templates/events/event_list_archived_row.html:87
 msgid "Restore event"
 msgstr "Veranstaltung wiederherstellen"
 
@@ -3731,7 +3731,7 @@ msgid "Archive this event"
 msgstr "Diese Veranstaltung archivieren"
 
 #: cms/templates/events/event_form.html:335
-#: cms/templates/events/event_list_archived_row.html:93
+#: cms/templates/events/event_list_archived_row.html:96
 #: cms/templates/events/event_list_row.html:117
 msgid "Delete event"
 msgstr "Veranstaltung löschen"
@@ -3777,29 +3777,29 @@ msgstr ""
 "(%(default_language)s) anlegen."
 
 #: cms/templates/events/event_list.html:78
-#: cms/templates/events/event_list_archived.html:48
+#: cms/templates/events/event_list_archived.html:54
 msgid "Start"
 msgstr "Beginn"
 
 #: cms/templates/events/event_list.html:79
-#: cms/templates/events/event_list_archived.html:49
+#: cms/templates/events/event_list_archived.html:55
 msgid "End"
 msgstr "Ende"
 
 #: cms/templates/events/event_list.html:80
-#: cms/templates/events/event_list_archived.html:50
+#: cms/templates/events/event_list_archived.html:56
 msgid "Recurrence"
 msgstr "Wiederholung"
 
 #: cms/templates/events/event_list.html:81
-#: cms/templates/events/event_list_archived.html:51
+#: cms/templates/events/event_list_archived.html:57
 #: cms/templates/languages/language_list.html:30
 #: cms/templates/offertemplates/offertemplate_list.html:26
 #: cms/templates/organizations/organization_list.html:23
 #: cms/templates/pages/page_tree.html:83
-#: cms/templates/pages/page_tree_archived.html:63
+#: cms/templates/pages/page_tree_archived.html:69
 #: cms/templates/pois/poi_list.html:71
-#: cms/templates/pois/poi_list_archived.html:32
+#: cms/templates/pois/poi_list_archived.html:38
 #: cms/templates/roles/role_list.html:20
 msgid "Options"
 msgstr "Optionen"
@@ -3813,54 +3813,71 @@ msgid "No upcoming events available."
 msgstr "Keine zukünftigen Veranstaltungen vorhanden."
 
 #: cms/templates/events/event_list.html:105
+#: cms/templates/events/event_list_archived.html:81
 #: cms/templates/feedback/admin_feedback_list.html:128
 #: cms/templates/feedback/region_feedback_list.html:123
 #: cms/templates/linkcheck/links_by_filter.html:72
-#: cms/templates/pages/page_tree.html:123 cms/templates/pois/poi_list.html:94
+#: cms/templates/pages/page_tree.html:123
+#: cms/templates/pages/page_tree_archived.html:92
+#: cms/templates/pois/poi_list.html:94
+#: cms/templates/pois/poi_list_archived.html:56
 msgid "Select bulk action"
 msgstr "Mehrfachaktion auswählen"
 
-#: cms/templates/events/event_list.html:107 cms/templates/pois/poi_list.html:98
+#: cms/templates/events/event_list.html:107
+msgid "Archive events"
+msgstr "Veranstaltungen archivieren"
+
+#: cms/templates/events/event_list.html:110
+#: cms/templates/pois/poi_list.html:101
 msgid "Create missing translations automatically"
 msgstr "Fehlende Übersetzungen automatisch erstellen"
 
-#: cms/templates/events/event_list.html:110
+#: cms/templates/events/event_list.html:113
+#: cms/templates/events/event_list_archived.html:86
 #: cms/templates/feedback/admin_feedback_list.html:135
 #: cms/templates/feedback/region_feedback_list.html:137
 #: cms/templates/linkcheck/links_by_filter.html:80
-#: cms/templates/pages/page_tree.html:150 cms/templates/pois/poi_list.html:102
+#: cms/templates/pages/page_tree.html:152
+#: cms/templates/pages/page_tree_archived.html:98
+#: cms/templates/pois/poi_list.html:105
+#: cms/templates/pois/poi_list_archived.html:61
 msgid "Execute"
 msgstr "Ausführen"
 
-#: cms/templates/events/event_list_archived.html:64
+#: cms/templates/events/event_list_archived.html:70
 msgid "No archived events found with these filters."
 msgstr "Keine archivierten Veranstaltungen mit diesen Filtern gefunden."
 
-#: cms/templates/events/event_list_archived.html:66
+#: cms/templates/events/event_list_archived.html:72
 msgid "No upcoming events archived."
 msgstr "Keine zukünftigen Veranstaltungen archiviert."
 
-#: cms/templates/events/event_list_archived_row.html:12
-#: cms/templates/events/event_list_archived_row.html:24
+#: cms/templates/events/event_list_archived.html:83
+msgid "Restore events"
+msgstr "Veranstaltungen wiederherstellen"
+
+#: cms/templates/events/event_list_archived_row.html:15
+#: cms/templates/events/event_list_archived_row.html:27
 #: cms/templates/events/event_list_row.html:15
 #: cms/templates/events/event_list_row.html:27
-#: cms/templates/pages/page_tree_archived_node.html:28
-#: cms/templates/pages/page_tree_archived_node.html:38
+#: cms/templates/pages/page_tree_archived_node.html:31
+#: cms/templates/pages/page_tree_archived_node.html:41
 #: cms/templates/pages/page_tree_node.html:38
 #: cms/templates/pages/page_tree_node.html:49
-#: cms/templates/pois/poi_list_archived_row.html:16
-#: cms/templates/pois/poi_list_archived_row.html:26
+#: cms/templates/pois/poi_list_archived_row.html:14
+#: cms/templates/pois/poi_list_archived_row.html:24
 #: cms/templates/pois/poi_list_row.html:14
 #: cms/templates/pois/poi_list_row.html:24
 msgid "Translation not available"
 msgstr "Übersetzung nicht verfügbar"
 
-#: cms/templates/events/event_list_archived_row.html:65
+#: cms/templates/events/event_list_archived_row.html:68
 #: cms/templates/events/event_list_row.html:73
 msgid "Not specified"
 msgstr "Nicht festgelegt"
 
-#: cms/templates/events/event_list_archived_row.html:78
+#: cms/templates/events/event_list_archived_row.html:81
 #: cms/templates/events/event_list_row.html:86
 msgid "One-time"
 msgstr "Einmalig"
@@ -4186,7 +4203,7 @@ msgstr "Sprach-Knoten hinzufügen"
 
 #: cms/templates/language_tree/language_tree.html:21
 #: cms/templates/pages/page_tree.html:61
-#: cms/templates/pages/page_tree_archived.html:42
+#: cms/templates/pages/page_tree_archived.html:48
 msgid "Hierarchy"
 msgstr "Hierarchie"
 
@@ -4327,7 +4344,7 @@ msgstr "Erstellt"
 #: cms/templates/offertemplates/offertemplate_list.html:23
 #: cms/templates/pages/_page_xliff_import_diff.html:36
 #: cms/templates/pages/page_tree.html:82
-#: cms/templates/pages/page_tree_archived.html:62
+#: cms/templates/pages/page_tree_archived.html:68
 #: cms/templates/push_notifications/push_notification_list.html:44
 #: cms/templates/regions/region_list.html:23
 msgid "Last updated"
@@ -4550,7 +4567,7 @@ msgid "Cancel translation process"
 msgstr "Übersetzungsprozess abbrechen"
 
 #: cms/templates/pages/page_form.html:95
-#: cms/templates/pages/page_tree_archived_node.html:82
+#: cms/templates/pages/page_tree_archived_node.html:85
 msgid "Archived, because a parent page is archived"
 msgstr "Archiviert, weil eine übergeordnete Seite archiviert ist"
 
@@ -4589,7 +4606,7 @@ msgstr ""
 #: cms/templates/pages/page_form.html:274
 #: cms/templates/pages/page_form.html:276
 #: cms/templates/pages/page_form.html:286
-#: cms/templates/pages/page_tree_archived_node.html:98
+#: cms/templates/pages/page_tree_archived_node.html:101
 msgid "Restore page"
 msgstr "Seite wiederherstellen"
 
@@ -4620,13 +4637,13 @@ msgstr "Diese Seite archivieren"
 
 #: cms/templates/pages/page_form.html:320
 #: cms/templates/pages/page_form.html:344
-#: cms/templates/pages/page_tree_archived_node.html:116
+#: cms/templates/pages/page_tree_archived_node.html:119
 #: cms/templates/pages/page_tree_node.html:141
 msgid "Delete page"
 msgstr "Seite löschen"
 
 #: cms/templates/pages/page_form.html:327
-#: cms/templates/pages/page_tree_archived_node.html:112
+#: cms/templates/pages/page_tree_archived_node.html:115
 #: cms/templates/pages/page_tree_node.html:137
 #: cms/views/pages/page_actions.py:212
 msgid "You cannot delete a page which has subpages."
@@ -4724,21 +4741,21 @@ msgstr "Alle ausklappen"
 msgid "Collapse all"
 msgstr "Alle einklappen"
 
-#: cms/templates/pages/page_tree.html:124
+#: cms/templates/pages/page_tree.html:125
 msgid "Archive pages"
 msgstr "Seiten archivieren"
 
-#: cms/templates/pages/page_tree.html:129
+#: cms/templates/pages/page_tree.html:131
 msgid "Export published pages as PDF"
 msgstr "Veröffentlichte Seiten als PDF exportieren"
 
-#: cms/templates/pages/page_tree.html:133
+#: cms/templates/pages/page_tree.html:135
 #, python-format
 msgid "Export all pages for %(language_translated_name)s translation"
 msgstr ""
 "Alle Seiten für die %(language_translated_name)s-Übersetzung exportieren"
 
-#: cms/templates/pages/page_tree.html:134
+#: cms/templates/pages/page_tree.html:136
 #, python-format
 msgid ""
 "Export only published pages for %(language_translated_name)s translation"
@@ -4746,27 +4763,27 @@ msgstr ""
 "Nur veröffentlichte Seiten für die %(language_translated_name)s-Übersetzung "
 "exportieren"
 
-#: cms/templates/pages/page_tree.html:136
+#: cms/templates/pages/page_tree.html:138
 msgid "You cannot export XLIFF files for the default language"
 msgstr "Sie können keine XLIFF-Dateien für die Standard-Sprache exportieren"
 
-#: cms/templates/pages/page_tree.html:155
+#: cms/templates/pages/page_tree.html:157
 msgid "Import XLIFF files"
 msgstr "XLIFF-Dateien importieren"
 
-#: cms/templates/pages/page_tree.html:156
+#: cms/templates/pages/page_tree.html:158
 msgid "Supported file extensions"
 msgstr "Unterstützte Dateiendungen"
 
-#: cms/templates/pages/page_tree.html:161
+#: cms/templates/pages/page_tree.html:163
 msgid "Select files"
 msgstr "Dateien auswählen"
 
-#: cms/templates/pages/page_tree.html:163
+#: cms/templates/pages/page_tree.html:165
 msgid "and {} other files"
 msgstr "und {} weitere Dateien"
 
-#: cms/templates/pages/page_tree.html:166
+#: cms/templates/pages/page_tree.html:168
 msgid "Import"
 msgstr "Importieren"
 
@@ -4774,50 +4791,54 @@ msgstr "Importieren"
 msgid "Archived Pages"
 msgstr "Archivierte Seiten"
 
-#: cms/templates/pages/page_tree_archived.html:74
+#: cms/templates/pages/page_tree_archived.html:80
 msgid "No archived pages found with these filters."
 msgstr "Keine archivierten Seiten mit diesen Filtern gefunden."
 
-#: cms/templates/pages/page_tree_archived.html:76
+#: cms/templates/pages/page_tree_archived.html:82
 msgid "No pages archived yet."
 msgstr "Noch keine Seiten archiviert."
 
-#: cms/templates/pages/page_tree_archived_node.html:9
+#: cms/templates/pages/page_tree_archived.html:95
+msgid "Restore pages"
+msgstr "Seiten wiederherstellen"
+
+#: cms/templates/pages/page_tree_archived_node.html:12
 msgid "Drag & drop is disabled for archived pages."
 msgstr "Drag & drop ist für archivierte Seiten nicht möglich."
 
-#: cms/templates/pages/page_tree_archived_node.html:14
+#: cms/templates/pages/page_tree_archived_node.html:17
 #: cms/templates/pages/page_tree_node.html:23
 msgid "Expand all subpages"
 msgstr "Alle Unterseiten ausklappen"
 
-#: cms/templates/pages/page_tree_archived_node.html:15
+#: cms/templates/pages/page_tree_archived_node.html:18
 #: cms/templates/pages/page_tree_node.html:24
 msgid "Collapse all subpages"
 msgstr "Alle Unterseiten einklappen"
 
-#: cms/templates/pages/page_tree_archived_node.html:77
+#: cms/templates/pages/page_tree_archived_node.html:80
 msgid "This page is archived."
 msgstr "Diese Seite ist archiviert."
 
-#: cms/templates/pages/page_tree_archived_node.html:81
+#: cms/templates/pages/page_tree_archived_node.html:84
 msgid ""
 "This page is archived, because at least one of its parent pages is archived."
 msgstr ""
 "Diese Seite ist archiviert, weil eine ihrer übergeordneten Seiten archiviert "
 "ist."
 
-#: cms/templates/pages/page_tree_archived_node.html:94
+#: cms/templates/pages/page_tree_archived_node.html:97
 msgid "View page"
 msgstr "Seite ansehen"
 
-#: cms/templates/pages/page_tree_archived_node.html:106
+#: cms/templates/pages/page_tree_archived_node.html:109
 msgid "To restore this page, you have to restore its archived parent page."
 msgstr ""
 "Um diese Seite wiederherzustellen, müssen Sie ihre archivierte übergeordnete "
 "Seite wiederherstellen."
 
-#: cms/templates/pages/page_tree_archived_node.html:112
+#: cms/templates/pages/page_tree_archived_node.html:115
 msgid "This also involves non-archived subpages."
 msgstr "Dies betrifft auch nicht-archivierte Unterseiten."
 
@@ -4893,7 +4914,7 @@ msgid "Position"
 msgstr "Position"
 
 #: cms/templates/pois/poi_form.html:163 cms/templates/pois/poi_form.html:164
-#: cms/templates/pois/poi_list_archived_row.html:52
+#: cms/templates/pois/poi_list_archived_row.html:55
 msgid "Restore location"
 msgstr "Ort wiederherstellen"
 
@@ -4911,7 +4932,7 @@ msgid "Archive this location"
 msgstr "Diesen Ort archivieren"
 
 #: cms/templates/pois/poi_form.html:186 cms/templates/pois/poi_form.html:207
-#: cms/templates/pois/poi_list_archived_row.html:65
+#: cms/templates/pois/poi_list_archived_row.html:68
 #: cms/templates/pois/poi_list_row.html:111
 msgid "Delete location"
 msgstr "Ort löschen"
@@ -4948,17 +4969,17 @@ msgstr ""
 "Sie können Orte nur in der Standard-Sprache (%(default_language)s) anlegen."
 
 #: cms/templates/pois/poi_list.html:67
-#: cms/templates/pois/poi_list_archived.html:28
+#: cms/templates/pois/poi_list_archived.html:34
 msgid "Street"
 msgstr "Straße"
 
 #: cms/templates/pois/poi_list.html:68
-#: cms/templates/pois/poi_list_archived.html:29
+#: cms/templates/pois/poi_list_archived.html:35
 msgid "Postal Code"
 msgstr "Postleitzahl"
 
 #: cms/templates/pois/poi_list.html:70
-#: cms/templates/pois/poi_list_archived.html:31
+#: cms/templates/pois/poi_list_archived.html:37
 msgid "Country"
 msgstr "Land"
 
@@ -4970,18 +4991,26 @@ msgstr "Keine Orte mit diesen Filtern gefunden."
 msgid "No locations available yet."
 msgstr "Noch keine Orte vorhanden."
 
-#: cms/templates/pois/poi_list_archived.html:42
+#: cms/templates/pois/poi_list.html:97
+msgid "Archive locations"
+msgstr "Orte archivieren"
+
+#: cms/templates/pois/poi_list_archived.html:48
 msgid "No locations archived yet."
 msgstr "Noch keine Orte archiviert."
 
-#: cms/templates/pois/poi_list_archived_row.html:61
+#: cms/templates/pois/poi_list_archived.html:58
+msgid "Restore locations"
+msgstr "Orte wiederherstellen"
+
+#: cms/templates/pois/poi_list_archived_row.html:64
 #: cms/templates/pois/poi_list_row.html:107
 msgid "You cannot delete a location which is used by an event."
 msgstr ""
 "Der Ort kann nicht gelöscht werden, da er von einer Veranstaltung verwendet "
 "wird."
 
-#: cms/templates/pois/poi_list_archived_row.html:61
+#: cms/templates/pois/poi_list_archived_row.html:64
 #: cms/templates/pois/poi_list_row.html:107
 msgid "This also involves archived events."
 msgstr "Dies betrifft auch archivierte Veranstaltungen."
@@ -5670,13 +5699,21 @@ msgstr ""
 "Adresse eingegeben haben, mit der Sie sich registriert haben, und überprüfen "
 "Sie Ihren Spam-Ordner."
 
-#: cms/views/bulk_action_views.py:121
+#: cms/views/bulk_action_views.py:123
 msgid "Automatic translations are not fully implemented yet"
 msgstr "Automatische Übersetzungen sind noch nicht vollständig implementiert"
 
-#: cms/views/bulk_action_views.py:124
+#: cms/views/bulk_action_views.py:126
 msgid "Automatic translations are disabled"
 msgstr "Automatische Übersetzungen sind deaktiviert"
+
+#: cms/views/bulk_action_views.py:164
+msgid "The selected {} were successfully archived"
+msgstr "Die ausgewählten {} wurden erfolgreich archiviert"
+
+#: cms/views/bulk_action_views.py:203
+msgid "The selected {} were successfully restored"
+msgstr "Die ausgewählten {} wurden erfolgreich wiederhergestellt"
 
 #: cms/views/delete_views.py:80
 msgid "{} \"{}\" was successfully deleted"

--- a/tests/cms/views/view_config.py
+++ b/tests/cms/views/view_config.py
@@ -176,6 +176,36 @@ VIEWS = [
             ),
             ("pages", STAFF_ROLES + [MANAGEMENT, EDITOR]),
             ("pois", ROLES),
+            (
+                "bulk_archive_pages",
+                PRIV_STAFF_ROLES + [MANAGEMENT, EDITOR],
+                {"selected_ids[]": [1, 2, 3]},
+            ),
+            (
+                "bulk_restore_pages",
+                PRIV_STAFF_ROLES + [MANAGEMENT, EDITOR],
+                {"selected_ids[]": [1, 2, 3]},
+            ),
+            (
+                "bulk_archive_events",
+                PRIV_STAFF_ROLES + REGION_ROLES,
+                {"selected_ids[]": [1]},
+            ),
+            (
+                "bulk_restore_events",
+                PRIV_STAFF_ROLES + REGION_ROLES,
+                {"selected_ids[]": [1]},
+            ),
+            (
+                "bulk_archive_pois",
+                PRIV_STAFF_ROLES + REGION_ROLES,
+                {"selected_ids[]": [4]},
+            ),
+            (
+                "bulk_restore_pois",
+                PRIV_STAFF_ROLES + REGION_ROLES,
+                {"selected_ids[]": [4]},
+            ),
         ],
         # The kwargs for these views
         {"region_slug": "augsburg", "language_slug": "de"},
@@ -366,20 +396,12 @@ VIEWS = [
     (
         [("get_page_tree_ajax", STAFF_ROLES + [MANAGEMENT, EDITOR])],
         # The kwargs for these views
-        {
-            "region_slug": "augsburg",
-            "language_slug": "de",
-            "tree_id": 2,
-        },
+        {"region_slug": "augsburg", "language_slug": "de", "tree_id": 2},
     ),
     (
         [("get_page_tree_ajax", STAFF_ROLES)],
         # The kwargs for these views
-        {
-            "region_slug": "nurnberg",
-            "language_slug": "de",
-            "tree_id": 1,
-        },
+        {"region_slug": "nurnberg", "language_slug": "de", "tree_id": 1},
     ),
     (
         [


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Add bulk actions for archiving/restoring pages, events and locations

### Proposed changes
<!-- Describe this PR in more detail. -->

- Generalize bulk action views
    - Provide `BulkActionView` as base for all bulk action views
    - Add `BulkAutoTranslateView` as model-agnostic translation bulk action
    - Convert PDF and XLIFF export of pages to the new class based view
- Add bulk actions for archiving/restoring
    - Add `BulkArchiveView` and `BulkRestoreView` as model-agnostic bulk action views to archive/restore
 multiple objects
    - Add bulk action form to all archived lists
    - Add tests for bulk archive/restore

I also updated the pip dependencies because I got a [weird CircleCI error](https://app.circleci.com/pipelines/github/digitalfabrik/integreat-cms/4017/workflows/ea6b2832-b502-4a8e-aaff-05b21e355487) and I assume an outdated cache is responsible.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1055
