### PR TITLE
Fix deleting polymorphic feedback

### DIFF
--- a/integreat_cms/cms/views/feedback/admin_feedback_actions.py
+++ b/integreat_cms/cms/views/feedback/admin_feedback_actions.py
@@ -1,5 +1,5 @@
 """
-This module contains action methods for feedack items (archive, restore, ...)
+This module contains action methods for feedback items (archive, restore, ...)
 """
 import logging
 

--- a/integreat_cms/cms/views/feedback/region_feedback_actions.py
+++ b/integreat_cms/cms/views/feedback/region_feedback_actions.py
@@ -1,5 +1,5 @@
 """
-This module contains action methods for feedack items (archive, restore, ...)
+This module contains action methods for feedback items (archive, restore, ...)
 """
 import logging
 

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-03-23 12:23+0000\n"
+"POT-Creation-Date: 2022-03-23 14:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1840,14 +1840,14 @@ msgid "The new passwords do not match."
 msgstr "Die Passwörter stimmen nicht überein."
 
 #: cms/models/abstract_content_model.py:96 cms/models/abstract_tree_node.py:35
-#: cms/models/feedback/feedback.py:26 cms/models/media/directory.py:24
+#: cms/models/feedback/feedback.py:60 cms/models/media/directory.py:24
 #: cms/models/media/media_file.py:138
 #: cms/models/push_notifications/push_notification.py:21
 #: cms/models/regions/region.py:613
 msgid "region"
 msgstr "Region"
 
-#: cms/models/abstract_content_model.py:99 cms/models/feedback/feedback.py:62
+#: cms/models/abstract_content_model.py:99 cms/models/feedback/feedback.py:96
 #: cms/models/languages/language.py:85
 #: cms/models/languages/language_tree_node.py:37
 #: cms/models/media/directory.py:36 cms/models/offers/offer_template.py:56
@@ -1894,7 +1894,7 @@ msgid "content"
 msgstr "Inhalt"
 
 #: cms/models/abstract_content_translation.py:44
-#: cms/models/feedback/feedback.py:32 cms/models/languages/language.py:135
+#: cms/models/feedback/feedback.py:66 cms/models/languages/language.py:135
 #: cms/models/languages/language_tree_node.py:23
 #: cms/models/push_notifications/push_notification_translation.py:27
 msgid "language"
@@ -2120,39 +2120,39 @@ msgstr "Veranstaltungen"
 msgid "event list feedback"
 msgstr "Veranstaltungslisten-Feedback"
 
-#: cms/models/feedback/feedback.py:40
+#: cms/models/feedback/feedback.py:74
 msgid "rating"
 msgstr "Bewertung"
 
-#: cms/models/feedback/feedback.py:41
+#: cms/models/feedback/feedback.py:75
 msgid "Whether the feedback is positive or negative"
 msgstr "Ob das Feedback positiv oder negativ ist"
 
-#: cms/models/feedback/feedback.py:43
+#: cms/models/feedback/feedback.py:77
 msgid "comment"
 msgstr "Kommentar"
 
-#: cms/models/feedback/feedback.py:45
+#: cms/models/feedback/feedback.py:79
 msgid "technical"
 msgstr "technisch"
 
-#: cms/models/feedback/feedback.py:46
+#: cms/models/feedback/feedback.py:80
 msgid "Whether or not the feedback is targeted at the developers"
 msgstr "Ob das Feedback an die Entwickler gerichtet ist oder nicht"
 
-#: cms/models/feedback/feedback.py:54
+#: cms/models/feedback/feedback.py:88
 msgid "marked as read by"
 msgstr "als gelesen markiert von"
 
-#: cms/models/feedback/feedback.py:56
+#: cms/models/feedback/feedback.py:90
 msgid "The user who marked this feedback as read."
 msgstr "Der Benutzer, der dieses Feedback als gelesen markiert hat."
 
-#: cms/models/feedback/feedback.py:57
+#: cms/models/feedback/feedback.py:91
 msgid "If the feedback is unread, this field is empty."
 msgstr "Wenn das Feedback ungelesen ist, ist dieses Feld leer."
 
-#: cms/models/feedback/feedback.py:150 cms/models/feedback/feedback.py:152
+#: cms/models/feedback/feedback.py:184 cms/models/feedback/feedback.py:186
 msgid "feedback"
 msgstr "Feedback"
 

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -161,6 +161,8 @@ nitpick_ignore = [
     ("py:attr", "linkcheck.models.Link.event_translations"),
     ("py:attr", "linkcheck.models.Link.page_translations"),
     ("py:attr", "linkcheck.models.Link.poi_translations"),
+    ("py:class", "polymorphic.query.PolymorphicQuerySet"),
+    ("py:class", "PolymorphicQuerySet"),
     ("py:class", "realms.magic.unicorn"),
     ("py:class", "webauthn.WebAuthnUser"),
     ("py:class", "xml.dom.minidom.Element"),


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr implements a fix for deleting multiple feedback items of different types, which does not work because of a bug in django-polymorphic ([229](https://github.com/django-polymorphic/django-polymorphic/issues/229)).

### Proposed changes
<!-- Describe this PR in more detail. -->
The fix implements the recommended workaround for this bug, which is to only retrieve the base class before deletion.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1290
