### PR TITLE
Use transactions for tree manipulations

### DIFF
--- a/integreat_cms/cms/views/language_tree/language_tree_actions.py
+++ b/integreat_cms/cms/views/language_tree/language_tree_actions.py
@@ -8,6 +8,7 @@ from django.contrib import messages
 from django.shortcuts import redirect, get_object_or_404
 from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
+from django.db import transaction
 
 from treebeard.exceptions import InvalidPosition, InvalidMoveToDescendant
 
@@ -20,6 +21,7 @@ logger = logging.getLogger(__name__)
 
 @require_POST
 @permission_required("cms.change_languagetreenode")
+@transaction.atomic
 def move_language_tree_node(
     request, region_slug, language_tree_node_id, target_id, target_position
 ):
@@ -81,6 +83,7 @@ def move_language_tree_node(
 
 @require_POST
 @permission_required("cms.delete_languagetreenode")
+@transaction.atomic
 def delete_language_tree_node(request, region_slug, language_tree_node_id):
     """
     Deletes the language node of distinct region

--- a/integreat_cms/cms/views/language_tree/language_tree_node_form_view.py
+++ b/integreat_cms/cms/views/language_tree/language_tree_node_form_view.py
@@ -5,6 +5,7 @@ from django.shortcuts import render, redirect
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
 from django.views.generic import TemplateView
+from django.db import transaction
 
 from ...decorators import permission_required
 from ...forms import LanguageTreeNodeForm
@@ -65,6 +66,7 @@ class LanguageTreeNodeFormView(TemplateView):
         )
 
     # pylint: disable=unused-argument
+    @transaction.atomic
     def post(self, request, *args, **kwargs):
         r"""
         Save and show form for editing a single language (HTTP POST) in the language tree

--- a/integreat_cms/cms/views/pages/page_actions.py
+++ b/integreat_cms/cms/views/pages/page_actions.py
@@ -14,6 +14,7 @@ from django.http import HttpResponseNotFound, JsonResponse
 from django.shortcuts import render, redirect, get_object_or_404
 from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
+from django.db import transaction
 
 from treebeard.exceptions import InvalidPosition, InvalidMoveToDescendant
 
@@ -183,6 +184,7 @@ def view_page(request, page_id, region_slug, language_slug):
 
 @require_POST
 @permission_required("cms.delete_page")
+@transaction.atomic
 def delete_page(request, page_id, region_slug, language_slug):
     """
     Delete page object
@@ -394,6 +396,7 @@ def upload_xliff(request, region_slug, language_slug):
 
 @require_POST
 @permission_required("cms.change_page")
+@transaction.atomic
 # pylint: disable=too-many-arguments
 def move_page(request, region_slug, language_slug, page_id, target_id, position):
     """

--- a/integreat_cms/cms/views/pages/page_form_view.py
+++ b/integreat_cms/cms/views/pages/page_form_view.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 from django.utils.decorators import method_decorator
 from django.utils.translation import ugettext as _
 from django.views.generic import TemplateView
+from django.db import transaction
 
 from ...constants import status, text_directions
 from ...decorators import permission_required
@@ -176,6 +177,7 @@ class PageFormView(
             },
         )
 
+    @transaction.atomic
     # pylint: disable=too-many-branches,unused-argument
     def post(self, request, *args, **kwargs):
         r"""

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-01 16:03+0000\n"
+"POT-Creation-Date: 2022-04-02 08:41+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -4725,7 +4725,7 @@ msgstr "Seite löschen"
 #: cms/templates/pages/page_form.html:327
 #: cms/templates/pages/page_tree_archived_node.html:115
 #: cms/templates/pages/page_tree_node.html:137
-#: cms/views/pages/page_actions.py:210
+#: cms/views/pages/page_actions.py:212
 msgid "You cannot delete a page which has subpages."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
 
@@ -5903,7 +5903,7 @@ msgstr ""
 
 #: cms/views/events/event_form_view.py:198
 #: cms/views/imprint/imprint_form_view.py:216
-#: cms/views/pages/page_form_view.py:260 cms/views/pois/poi_form_view.py:162
+#: cms/views/pages/page_form_view.py:262 cms/views/pois/poi_form_view.py:162
 msgid "No changes detected, autosave skipped"
 msgstr "Keine Änderungen vorgenommen, automatisches Speichern übersprungen"
 
@@ -5912,7 +5912,7 @@ msgid "Event \"{}\" was successfully created"
 msgstr "Veranstaltung \"{}\" wurde erfolgreich erstellt"
 
 #: cms/views/events/event_form_view.py:229
-#: cms/views/pages/page_form_view.py:291 cms/views/pois/poi_form_view.py:176
+#: cms/views/pages/page_form_view.py:293 cms/views/pois/poi_form_view.py:176
 msgid "No changes detected, but date refreshed"
 msgstr "Keine Änderungen vorgenommen, aber Datum aktualisiert"
 
@@ -5944,7 +5944,7 @@ msgid "Feedback was successfully deleted"
 msgstr "Feedback wurde erfolgreich gelöscht"
 
 #: cms/views/form_views.py:97 cms/views/imprint/imprint_sbs_view.py:207
-#: cms/views/language_tree/language_tree_node_form_view.py:103
+#: cms/views/language_tree/language_tree_node_form_view.py:105
 #: cms/views/pages/page_sbs_view.py:192 cms/views/roles/role_form_view.py:93
 #: cms/views/settings/user_settings_view.py:91
 #: cms/views/settings/user_settings_view.py:108
@@ -5994,7 +5994,7 @@ msgid "Imprint was successfully created"
 msgstr "Impressum wurde erfolgreich erstellt"
 
 #: cms/views/imprint/imprint_form_view.py:288
-#: cms/views/pages/page_form_view.py:363
+#: cms/views/pages/page_form_view.py:365
 #, python-brace-format
 msgid "{source_language} to {target_language}"
 msgstr "{source_language} nach {target_language}"
@@ -6039,15 +6039,15 @@ msgstr ""
 "Sie können die Side-by-Side-Ansicht nicht verwenden, wenn die Quell-"
 "Übersetzung (in diesem Fall {source_language}) nicht existiert."
 
-#: cms/views/language_tree/language_tree_actions.py:56
+#: cms/views/language_tree/language_tree_actions.py:58
 msgid "A region can only have one root language."
 msgstr "Eine Region kann nur eine Standard-Sprache besitzen."
 
-#: cms/views/language_tree/language_tree_actions.py:64
+#: cms/views/language_tree/language_tree_actions.py:66
 msgid "The language tree node \"{}\" was successfully moved."
 msgstr "Der Sprach-Knoten \"{}\" wurde erfolgreich verschoben."
 
-#: cms/views/language_tree/language_tree_actions.py:131
+#: cms/views/language_tree/language_tree_actions.py:134
 msgid ""
 "The language tree node \"{}\" and all corresponding translations were "
 "successfully deleted."
@@ -6067,11 +6067,11 @@ msgstr ""
 "Alle Übersetzungen zu Seiten, Orten, Veranstaltungen und Push-"
 "Benachrichtigungen zu dieser Sprache werden ebenfalls gelöscht."
 
-#: cms/views/language_tree/language_tree_node_form_view.py:111
+#: cms/views/language_tree/language_tree_node_form_view.py:113
 msgid "Language tree node for \"{}\" was successfully saved"
 msgstr "Sprach-Knoten für \"{}\" wurde erfolgreich gespeichert"
 
-#: cms/views/language_tree/language_tree_node_form_view.py:119
+#: cms/views/language_tree/language_tree_node_form_view.py:121
 msgid "Language tree node for \"{}\" was successfully created"
 msgstr "Sprach-Knoten für \"{}\" wurde erfolgreich erstellt"
 
@@ -6268,67 +6268,67 @@ msgstr "Es ist ein Fehler aufgetreten."
 msgid "Please confirm that you really want to delete this {}"
 msgstr "Bitte bestätigen Sie, dass diese {} gelöscht werden soll"
 
-#: cms/views/pages/page_actions.py:65
+#: cms/views/pages/page_actions.py:66
 msgid "Page was successfully archived"
 msgstr "Seite wurde erfolgreich archiviert"
 
-#: cms/views/pages/page_actions.py:118 cms/views/pages/page_actions.py:132
+#: cms/views/pages/page_actions.py:119 cms/views/pages/page_actions.py:133
 msgid "Page was successfully restored."
 msgstr "Seite wurde erfolgreich wiederhergestellt."
 
-#: cms/views/pages/page_actions.py:121
+#: cms/views/pages/page_actions.py:122
 msgid ""
 "However, it is still archived because one of its parent pages is archived."
 msgstr ""
 "Sie ist jedoch immer noch archiviert, weil eine ihrer übergeordneten Seiten "
 "archiviert ist."
 
-#: cms/views/pages/page_actions.py:214
+#: cms/views/pages/page_actions.py:216
 msgid "Page was successfully deleted"
 msgstr "Seite wurde erfolgreich gelöscht"
 
-#: cms/views/pages/page_actions.py:323
+#: cms/views/pages/page_actions.py:325
 msgid "File \"{}\" is neither a ZIP archive nor an XLIFF file."
 msgstr "Die Datei \"{}\" ist weder ein ZIP-Archiv noch eine XLIFF-Datei."
 
-#: cms/views/pages/page_actions.py:350
+#: cms/views/pages/page_actions.py:352
 msgid "The ZIP archive \"{}\" does not contain XLIFF files."
 msgstr "Das ZIP-Archiv \"{}\" enthält keine XLIFF-Dateien"
 
-#: cms/views/pages/page_actions.py:358
+#: cms/views/pages/page_actions.py:360
 msgid "The ZIP archive \"{}\" contains the following invalid files: \"{}\""
 msgstr "Das ZIP-Archiv \"{}\" enthält die folgenden ungültigen Dateien: \"{}\""
 
-#: cms/views/pages/page_actions.py:383
+#: cms/views/pages/page_actions.py:385
 msgid "No XLIFF file was selected for import."
 msgstr "Es wurde keine XLIFF-Datei für den Import ausgewählt."
 
-#: cms/views/pages/page_actions.py:443
+#: cms/views/pages/page_actions.py:446
 #, python-brace-format
 msgid "The page \"{page}\" was successfully moved."
 msgstr "Die Seite \"{page}\" wurde erfolgreich verschoben."
 
-#: cms/views/pages/page_actions.py:523 cms/views/pages/page_actions.py:538
+#: cms/views/pages/page_actions.py:526 cms/views/pages/page_actions.py:541
 #, python-brace-format
 msgid "Information: The user {user} has this permission already."
 msgstr "Information: Der Nutzer {user} hat diese Berechtigung bereits"
 
-#: cms/views/pages/page_actions.py:530
+#: cms/views/pages/page_actions.py:533
 #, python-brace-format
 msgid "Success: The user {user} can now edit this page."
 msgstr "Erfolg: Der Nutzer {user} kann nun diese Seite bearbeiten"
 
-#: cms/views/pages/page_actions.py:546
+#: cms/views/pages/page_actions.py:549
 #, python-brace-format
 msgid "Success: The user {user} can now publish this page."
 msgstr "Erfolg: Der Nutzer {user} kann dieses Seite nun veröffentlichen"
 
-#: cms/views/pages/page_actions.py:555 cms/views/pages/page_actions.py:667
+#: cms/views/pages/page_actions.py:558 cms/views/pages/page_actions.py:670
 msgid "An error has occurred. Please contact an administrator."
 msgstr ""
 "Ein Fehler ist aufgetreten. Bitte kontaktieren Sie einen Administrator."
 
-#: cms/views/pages/page_actions.py:635
+#: cms/views/pages/page_actions.py:638
 #, python-brace-format
 msgid ""
 "Information: The user {user} has been removed from the editors of this page, "
@@ -6338,12 +6338,12 @@ msgstr ""
 "bearbeiten wurde entfernt,aber er kann sie auf Grund seiner anderen "
 "Berechtigungen weiterhin bearbeiten."
 
-#: cms/views/pages/page_actions.py:641
+#: cms/views/pages/page_actions.py:644
 #, python-brace-format
 msgid "Success: The user {user} cannot edit this page anymore."
 msgstr "Erfolg: Der Nutzer {user} kann diese Seite nicht mehr bearbeiten"
 
-#: cms/views/pages/page_actions.py:652
+#: cms/views/pages/page_actions.py:655
 #, python-brace-format
 msgid ""
 "Information: The user {user} has been removed from the publishers of this "
@@ -6353,7 +6353,7 @@ msgstr ""
 "veröffentlichen wurde entfernt,aber er kann sie auf Grund seiner anderen "
 "Berechtigungen weiterhin veröffentlichen."
 
-#: cms/views/pages/page_actions.py:658
+#: cms/views/pages/page_actions.py:661
 #, python-brace-format
 msgid "Success: The user {user} cannot publish this page anymore."
 msgstr "Erfolg: Der Nutzer {user} kann diese Seite nicht mehr veröffentlichen"
@@ -6405,11 +6405,11 @@ msgstr "Bitte bestätigen Sie, dass diese Seite gelöscht werden soll"
 msgid "All translations of this page will also be deleted."
 msgstr "Alle Übersetzungen dieser Seite werden gelöscht."
 
-#: cms/views/pages/page_form_view.py:79
+#: cms/views/pages/page_form_view.py:80
 msgid "You cannot edit this page because it is archived."
 msgstr "Sie können diese Seite nicht bearbeiten, weil sie archiviert ist."
 
-#: cms/views/pages/page_form_view.py:86
+#: cms/views/pages/page_form_view.py:87
 msgid ""
 "You cannot edit this page, because one of its parent pages is archived and "
 "therefore, this page is archived as well."
@@ -6417,7 +6417,7 @@ msgstr ""
 "Sie können diese Seite nicht bearbeiten, weil eine ihrer übergeordneten "
 "Seiten archiviert ist, und sie dadurch ebenfalls archiviert ist."
 
-#: cms/views/pages/page_form_view.py:95
+#: cms/views/pages/page_form_view.py:96
 #, python-format
 msgid ""
 "The latest changes have only been saved as a draft. Currently, <a "
@@ -6428,11 +6428,11 @@ msgstr ""
 "Version <a href='%(revision_url)s' class='underline hover:no-"
 "underline'>Version %(revision)s</a> dieser Seite in der App angezeigt."
 
-#: cms/views/pages/page_form_view.py:116
+#: cms/views/pages/page_form_view.py:117
 msgid "You don't have the permission to edit this page."
 msgstr "Sie haben nicht die nötige Berechtigung, um diese Seite zu bearbeiten."
 
-#: cms/views/pages/page_form_view.py:123
+#: cms/views/pages/page_form_view.py:124
 msgid ""
 "You don't have the permission to publish this page, but you can propose "
 "changes and submit them for review instead."
@@ -6440,7 +6440,7 @@ msgstr ""
 "Sie haben nicht die nötige Berechtigung, um diese Seite zu veröffentlichen, "
 "aber Sie können Änderungen vornehmen und diese zur Überprüfung vorlegen."
 
-#: cms/views/pages/page_form_view.py:284
+#: cms/views/pages/page_form_view.py:286
 msgid "Page \"{}\" was successfully created"
 msgstr "Seite \"{}\" wurde erfolgreich erstellt"
 


### PR DESCRIPTION
Apply changes to MPTT tree structures in SQL tables with transactions to prevent race conditions with other requests.

### Short description
Use the `@transaction.atomic` decorator for all views that update MPTT trees.

Fixes: #1320 (maybe)
