### PR TITLE
Fix editor content not getting submitted

### DIFF
--- a/integreat_cms/static/src/editor.ts
+++ b/integreat_cms/static/src/editor.ts
@@ -5,3 +5,4 @@
 
 import './js/forms/tinymce-init.ts';
 import './js/pages/sbs-copy-content.ts';
+import "./js/content-edit-lock.ts";

--- a/integreat_cms/static/src/index.ts
+++ b/integreat_cms/static/src/index.ts
@@ -16,7 +16,6 @@ import "./js/filter-form.ts";
 import "./js/copy-clipboard.ts";
 import "./js/bulk-actions.ts";
 import "./js/confirmation-popups.ts";
-import "./js/content-edit-lock.ts";
 import "./js/revisions.ts";
 import "./js/search-query.ts";
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr fixes a bug where the tinymce editor was not working correctly.
Basically, the bug was introduced by 11f5d9a8e824d6397b9d9b0759a96be3fe7334d6. The problem was that we have multiple entry points in the `webpack.config.ts` file, such that the tinymce editor only gets imported when needed. Since this commit the `content-edit-lock.ts` file gets loaded in main, which in turn imports `tinymce-init.ts`, which causes the tinymce editor to be loaded twice: once via `main` and once via `editor`. 

### Proposed changes
<!-- Describe this PR in more detail. -->
The fix is quite simple, just defer loading `content-edit-lock.ts` to the editor entry point

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes #1329, Fixes #1335
