### PR TITLE
Fix cache invalidation after page tree move

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ UNRELEASED
 * [ [#1198](https://github.com/digitalfabrik/integreat-cms/issues/1198) ] Check availability for DeepL bulk actions
 * [ [#1293](https://github.com/digitalfabrik/integreat-cms/issues/1293) ] Enable login via email address
 * [ [#1327](https://github.com/digitalfabrik/integreat-cms/issues/1327) ] Fix page PDF export
+* [ [#1226](https://github.com/digitalfabrik/integreat-cms/issues/1226) ] Fix page tree fields cache invalidation
 
 
 2022.3.6

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-04 06:44+0000\n"
+"POT-Creation-Date: 2022-04-05 15:23+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1297,7 +1297,7 @@ msgstr "Aktiv"
 msgid "Hidden"
 msgstr "Versteckt"
 
-#: cms/constants/region_status.py:18 cms/models/pages/page.py:304
+#: cms/constants/region_status.py:18 cms/models/pages/page.py:323
 #: cms/models/regions/region.py:597 cms/templates/events/event_form.html:70
 #: cms/templates/pages/page_form.html:93
 #: cms/templates/pages/page_tree_archived_node.html:81
@@ -1999,7 +1999,7 @@ msgstr "End-Uhrzeit"
 msgid "recurrence rule"
 msgstr "Wiederholungs-Regel"
 
-#: cms/models/events/event.py:101 cms/models/pages/page.py:132
+#: cms/models/events/event.py:101 cms/models/pages/page.py:134
 #: cms/models/pois/poi.py:34
 msgid "icon"
 msgstr "Icon"
@@ -2559,26 +2559,26 @@ msgstr "Impressums-Übersetzung"
 msgid "imprint translations"
 msgstr "Impressums-Übersetzungen"
 
-#: cms/models/pages/page.py:124
+#: cms/models/pages/page.py:126
 msgid "parent page"
 msgstr "übergeordnete Seite"
 
-#: cms/models/pages/page.py:143
+#: cms/models/pages/page.py:145
 msgid "mirrored page"
 msgstr "eingebettete Seite"
 
-#: cms/models/pages/page.py:145
+#: cms/models/pages/page.py:147
 msgid ""
 "If the page embeds live content from another page, it is referenced here."
 msgstr ""
 "Wenn die Seite Live-Inhalte von einer anderen Seite einbettet, wird hier auf "
 "sie verwiesen."
 
-#: cms/models/pages/page.py:152
+#: cms/models/pages/page.py:154
 msgid "Position of mirrored page"
 msgstr "Position der gespiegelten Seite"
 
-#: cms/models/pages/page.py:154
+#: cms/models/pages/page.py:156
 msgid ""
 "If a mirrored page is set, this field determines whether the live content is "
 "embedded before the content of this page or after."
@@ -2586,17 +2586,17 @@ msgstr ""
 "Wenn eine gespiegelte Seite eingestellt ist, bestimmt dieses Feld, ob der "
 "Live-Inhalt vor oder nach dem Inhalt dieser Seite eingebettet wird."
 
-#: cms/models/pages/page.py:161
+#: cms/models/pages/page.py:163
 msgid "editors"
 msgstr "Bearbeiter"
 
-#: cms/models/pages/page.py:163
+#: cms/models/pages/page.py:165
 msgid "A list of users who have the permission to edit this specific page."
 msgstr ""
 "Eine Liste von Benutzern, die die Berechtigung haben, diese bestimmte Seite "
 "zu editieren."
 
-#: cms/models/pages/page.py:165
+#: cms/models/pages/page.py:167
 msgid ""
 "Only has effect if these users do not have the permission to edit pages "
 "anyway."
@@ -2604,17 +2604,17 @@ msgstr ""
 "Dies betrifft nur Benutzer, die nicht ohnehin die Berechtigung haben, "
 "beliebige Seiten zu ändern."
 
-#: cms/models/pages/page.py:173
+#: cms/models/pages/page.py:175
 msgid "publishers"
 msgstr "Veröffentlicher"
 
-#: cms/models/pages/page.py:175
+#: cms/models/pages/page.py:177
 msgid "A list of users who have the permission to publish this specific page."
 msgstr ""
 "Eine Liste von Benutzern, die die Berechtigung haben, diese bestimmte Seite "
 "zu veröffentlichen."
 
-#: cms/models/pages/page.py:177
+#: cms/models/pages/page.py:179
 msgid ""
 "Only has effect if these users do not have the permission to publish pages "
 "anyway."
@@ -2622,30 +2622,30 @@ msgstr ""
 "Dies betrifft nur Benutzer, die nicht ohnehin die Berechtigung haben, "
 "beliebige Seiten zu veröffentlichen."
 
-#: cms/models/pages/page.py:186
+#: cms/models/pages/page.py:188
 msgid "responsible organization"
 msgstr "zuständige Organisation"
 
-#: cms/models/pages/page.py:188
+#: cms/models/pages/page.py:190
 msgid ""
 "This allows all members of the organization to edit and publish this page."
 msgstr ""
 "Dies erlaubt allen Mitgliedern der Organisation diese Seite zu bearbeiten "
 "und veröffentlichen"
 
-#: cms/models/pages/page.py:194
+#: cms/models/pages/page.py:196
 msgid "API access token"
 msgstr "API Zugangs-Token"
 
-#: cms/models/pages/page.py:195
+#: cms/models/pages/page.py:197
 msgid "API token to allow writing content to translations."
 msgstr "Token um das Überschreiben der Übersetzungen via API zu erlauben."
 
-#: cms/models/pages/page.py:325 cms/models/pages/page_translation.py:30
+#: cms/models/pages/page.py:344 cms/models/pages/page_translation.py:30
 msgid "page"
 msgstr "Seite"
 
-#: cms/models/pages/page.py:327
+#: cms/models/pages/page.py:346
 msgid "pages"
 msgstr "Seiten"
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fix cache invalidation in children endpoint

### Proposed changes
<!-- Describe this PR in more detail. -->

When a complete page tree is moved, it's tree_id is changed, so it is necessary to clear the cache for the page translation - page relation.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1226
