### PR TITLE
Enable cache in parents endpoint again

### DIFF
--- a/integreat_cms/api/v3/pages.py
+++ b/integreat_cms/api/v3/pages.py
@@ -298,7 +298,7 @@ def get_public_ancestor_translations(current_page, language_slug):
     :rtype: ~django.http.JsonResponse
     """
     result = []
-    for ancestor in current_page.get_ancestors():
+    for ancestor in current_page.get_cached_ancestors():
         public_translation = ancestor.get_public_translation(language_slug)
         if not public_translation or ancestor.explicitly_archived:
             raise Http404("No Page matches the given url or id.")


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
The cache in the parents endpoint was disabled in #1230, but since it seems we solved our caching problems, we can enable it again.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Use `get_cached_ancestors()` instead of `get_ancestors()` in the parents API endpoint

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1234
