### PR TITLE
Fix order of root pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 UNRELEASED
 ----------
 
+* [ [#1354](https://github.com/digitalfabrik/integreat-cms/issues/1354) ] Fix order of root pages
+
 
 2022.4.0
 --------

--- a/integreat_cms/api/v3/pages.py
+++ b/integreat_cms/api/v3/pages.py
@@ -46,6 +46,8 @@ def transform_page(page_translation):
                 "url": settings.BASE_URL + parent_absolute_url,
                 "path": parent_absolute_url,
             }
+            # use left edge indicator of mptt model for ordering of child pages
+            order = page_translation.page.lft
         else:
             logger.info(
                 "The parent %r of %r does not have a public translation in %r",
@@ -56,6 +58,8 @@ def transform_page(page_translation):
             raise Http404("No Page matches the given url or id.")
     else:
         parent = fallback_parent
+        # use tree id of mptt model for ordering of root pages
+        order = page_translation.page.tree_id
 
     absolute_url = page_translation.get_absolute_url()
     return {
@@ -67,7 +71,7 @@ def transform_page(page_translation):
         "excerpt": page_translation.content,
         "content": page_translation.combined_text,
         "parent": parent,
-        "order": page_translation.page.lft,  # use left edge indicator of mptt model for order
+        "order": order,
         "available_languages": page_translation.available_languages,
         "thumbnail": page_translation.page.icon.url
         if page_translation.page.icon

--- a/tests/api/expected-outputs/api_augsburg_de_children_depth_2.json
+++ b/tests/api/expected-outputs/api_augsburg_de_children_depth_2.json
@@ -12,7 +12,7 @@
             "url": null,
             "path": null
         },
-        "order": 1,
+        "order": 2,
         "available_languages": {
             "en": {
                 "id": 7,
@@ -180,7 +180,7 @@
             "url": null,
             "path": null
         },
-        "order": 1,
+        "order": 3,
         "available_languages": {
             "en": {
                 "id": 44,
@@ -248,7 +248,7 @@
             "url": null,
             "path": null
         },
-        "order": 1,
+        "order": 4,
         "available_languages": {
             "en": {
                 "id": 51,
@@ -408,7 +408,7 @@
             "url": null,
             "path": null
         },
-        "order": 1,
+        "order": 5,
         "available_languages": {
             "en": {
                 "id": 63,

--- a/tests/api/expected-outputs/augsburg_de_children.json
+++ b/tests/api/expected-outputs/augsburg_de_children.json
@@ -12,7 +12,7 @@
             "url": null,
             "path": null
         },
-        "order": 1,
+        "order": 2,
         "available_languages": {
             "en": {
                 "id": 7,
@@ -46,7 +46,7 @@
             "url": null,
             "path": null
         },
-        "order": 1,
+        "order": 3,
         "available_languages": {
             "en": {
                 "id": 44,
@@ -80,7 +80,7 @@
             "url": null,
             "path": null
         },
-        "order": 1,
+        "order": 4,
         "available_languages": {
             "en": {
                 "id": 51,
@@ -114,7 +114,7 @@
             "url": null,
             "path": null
         },
-        "order": 1,
+        "order": 5,
         "available_languages": {
             "en": {
                 "id": 63,

--- a/tests/api/expected-outputs/augsburg_de_page_1.json
+++ b/tests/api/expected-outputs/augsburg_de_page_1.json
@@ -11,7 +11,7 @@
         "url": null,
         "path": null
     },
-    "order": 1,
+    "order": 2,
     "available_languages": {
         "ar": {
             "id": 13,

--- a/tests/api/expected-outputs/augsburg_de_pages.json
+++ b/tests/api/expected-outputs/augsburg_de_pages.json
@@ -12,7 +12,7 @@
             "url": null,
             "path": null
         },
-        "order": 1,
+        "order": 2,
         "available_languages": {
             "en": {
                 "id": 7,
@@ -180,7 +180,7 @@
             "url": null,
             "path": null
         },
-        "order": 1,
+        "order": 3,
         "available_languages": {
             "en": {
                 "id": 44,
@@ -316,7 +316,7 @@
             "url": null,
             "path": null
         },
-        "order": 1,
+        "order": 4,
         "available_languages": {
             "en": {
                 "id": 51,
@@ -476,7 +476,7 @@
             "url": null,
             "path": null
         },
-        "order": 1,
+        "order": 5,
         "available_languages": {
             "en": {
                 "id": 63,


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fix order of root pages

### Proposed changes
<!-- Describe this PR in more detail. -->
- Order root pages by the `tree_id` instead of the `lft` field

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1354
