### PR TITLE
Modify broken link checker to list links in not-default languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ UNRELEASED
 
 * [ [#1354](https://github.com/digitalfabrik/integreat-cms/issues/1354) ] Fix order of root pages
 * [ [#1353](https://github.com/digitalfabrik/integreat-cms/issues/1353) ] Add tunews setting to region model
+* [ [#1328](https://github.com/digitalfabrik/integreat-cms/issues/1328) ] Fix missing entries in broken link checker
 
 
 2022.4.0

--- a/integreat_cms/cms/utils/filter_links.py
+++ b/integreat_cms/cms/utils/filter_links.py
@@ -18,19 +18,19 @@ def filter_links(region_slug, link_filter=None):
     # Get all translation objects of this region and prefetch its links
     page_translations = list(
         PageTranslation.objects.filter(page__region__slug=region_slug)
-        .distinct("page")
+        .distinct("page", "language")
         .select_related("language")
         .prefetch_related("links__url")
     )
     event_translations = list(
         EventTranslation.objects.filter(event__region__slug=region_slug)
-        .distinct("event")
+        .distinct("event", "language")
         .select_related("language")
         .prefetch_related("links__url")
     )
     poi_translations = list(
         POITranslation.objects.filter(poi__region__slug=region_slug)
-        .distinct("poi")
+        .distinct("poi", "language")
         .select_related("language")
         .prefetch_related("links__url")
     )


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR is to make the broken link checker list not only links in the default language of the region but also links in the other languages.

### Proposed changes
<!-- Describe this PR in more detail. -->
- as suggested, `.distinct("page")` is replaced with `.distinct("page", "language")`.
- the same change is applied for POI and event.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1328 
