### PR TITLE
Allow events to be monthly recurring on mondays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 UNRELEASED
 ----------
 
+* [ [#1366](https://github.com/digitalfabrik/integreat-cms/issues/1366) ] Fix monthly recurring events on mondays
+
 
 2022.4.1
 --------

--- a/integreat_cms/cms/forms/events/recurrence_rule_form.py
+++ b/integreat_cms/cms/forms/events/recurrence_rule_form.py
@@ -90,7 +90,7 @@ class RecurrenceRuleForm(CustomModelForm):
                 ),
             )
         elif cleaned_data.get("frequency") == frequency.MONTHLY:
-            if not cleaned_data.get("weekday_for_monthly"):
+            if cleaned_data.get("weekday_for_monthly") is None:
                 self.add_error(
                     "weekday_for_monthly",
                     forms.ValidationError(


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Allow events to be monthly recurring on mondays

### Proposed changes
<!-- Describe this PR in more detail. -->
- Check for `None` instead of implicitly casting the value into a boolean (which doesn't work because monday is defined as the integer `0` which evaluates to `False`...

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1366