### PR TITLE
Add selection counter to trees and lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ UNRELEASED
 ----------
 
 * [ [#1369](https://github.com/digitalfabrik/integreat-cms/issues/1369) ] Add contenthash to CSS files for correct cache handling
+* [ [#1046](https://github.com/digitalfabrik/integreat-cms/issues/1046) ] Show number of selected items in lists and page tree
 
 
 2022.4.2

--- a/integreat_cms/cms/templates/events/event_list.html
+++ b/integreat_cms/cms/templates/events/event_list.html
@@ -55,7 +55,7 @@
             <thead>
             <tr class="border-b border-solid border-gray-200">
                 <th class="py-3 pl-4 min">
-                    <input form="bulk-action-form" type="checkbox" id="bulk-select-all">
+                    <input form="bulk-action-form" type="checkbox" id="bulk-select-all"/>
                 </th>
                 <th class="text-sm text-left uppercase py-3 pl-2 pr-2">{% trans 'Title in' %} {{ language.translated_name }}</th>
                 {% get_current_language as LANGUAGE_CODE %}
@@ -101,6 +101,13 @@
             {% endif %}
             </tbody>
         </table>
+        {% if events %}
+        <div class="pt-2 px-2">
+            <div class="inline">
+                <span class="text-gray-800 font-bold" data-list-selection-count>0</span> <span class="text-gray-600">{% trans "Events selected" %}</span>
+            </div>
+        </div>
+        {% endif %}
         <div class="flex flex-wrap gap-2 mt-4">
             <select id="bulk-action" class="w-auto max-w-full">
                 <option>{% trans 'Select bulk action' %}</option>

--- a/integreat_cms/cms/templates/events/event_list_row.html
+++ b/integreat_cms/cms/templates/events/event_list_row.html
@@ -5,10 +5,10 @@
 
 <tr class="border-t border-solid border-gray-200 hover:bg-gray-100 text-gray-800">
     <td class="py-3 pl-4">
-        <input type="checkbox" name="selected_ids[]" value="{{ event.id }}" form="bulk-action-form" class="bulk-select-item">
+        <input type="checkbox" name="selected_ids[]" value="{{ event.id }}" form="bulk-action-form" class="bulk-select-item" />
     </td>
     <td>
-        <a href="{% url 'edit_event' event_id=event.id region_slug=request.region.slug language_slug=language.slug%}" class="py-3 pl-2 pr-2 text-gray-800">
+        <a href="{% url 'edit_event' event_id=event.id region_slug=request.region.slug language_slug=language.slug %}" class="py-3 pl-2 pr-2 text-gray-800">
             {% if event_translation %}
                 {{ event_translation.title }}
             {% else %}
@@ -43,11 +43,11 @@
                             <span title="{% trans 'Translation outdated' %}">
                                 <i data-feather="alert-triangle" class="{% if other_language.slug == language.slug %}text-yellow-500{% else %}text-gray-800{% endif %}"></i>
                             </span>
-                        {% elif other_status == translation_status.UP_TO_DATE  %}
+                        {% elif other_status == translation_status.UP_TO_DATE %}
                             <span title="{% trans 'Translation up-to-date' %}">
                                 <i data-feather="check" class="{% if other_language.slug == language.slug %}text-green-500{% else %}text-gray-800{% endif %}"></i>
                             </span>
-                        {% elif other_status == translation_status.MISSING  %}
+                        {% elif other_status == translation_status.MISSING %}
                             <span title="{% trans 'Translation missing' %}" class="no-trans">
                                 <i data-feather="x" class="{% if other_language.slug == language.slug %}text-red-500{% else %}text-gray-800{% endif %}"></i>
                             </span>
@@ -74,10 +74,10 @@
         {% endif %}
     </td>
     <td class="py-3 pr-2">
-        <i data-feather="calendar"></i> {{ event.start_date|date:'d.m.Y'}}{% if not event.is_all_day %} <i data-feather="clock" class="ml-2"></i> {{ event.start_time|time:'H:i' }}{% endif %}
+        <i data-feather="calendar"></i> {{ event.start_date|date:'d.m.Y' }}{% if not event.is_all_day %} <i data-feather="clock" class="ml-2"></i> {{ event.start_time|time:'H:i' }}{% endif %}
     </td>
     <td class="py-3 pr-2">
-        <i data-feather="calendar"></i> {{ event.end_date|date:'d.m.Y'}}{% if not event.is_all_day %} <i data-feather="clock" class="ml-2"></i> {{ event.end_time|time:'H:i' }}{% endif %}
+        <i data-feather="calendar"></i> {{ event.end_date|date:'d.m.Y' }}{% if not event.is_all_day %} <i data-feather="clock" class="ml-2"></i> {{ event.end_time|time:'H:i' }}{% endif %}
     </td>
     <td class="py-3 pr-2">
         {% if event.recurrence_rule %}
@@ -99,7 +99,7 @@
         {% endif %}
         {% has_perm 'cms.change_event' request.user as can_edit_event %}
         {% if can_edit_event %}
-            <form action="{% url 'duplicate_event' event_id=event.id region_slug=request.region.slug language_slug=language.slug %}" method="POST">
+            <form action="{% url 'duplicate_event' event_id=event.id region_slug=request.region.slug language_slug=language.slug %}" method="post">
                 {% csrf_token %}
                 <button class="btn-icon" title="{% trans 'Duplicate event' %}">
                     <i data-feather="copy"></i>

--- a/integreat_cms/cms/templates/feedback/admin_feedback_list.html
+++ b/integreat_cms/cms/templates/feedback/admin_feedback_list.html
@@ -1,114 +1,117 @@
 {% extends "_base.html" %}
-
 {% load i18n %}
 {% load static %}
 {% load widget_tweaks %}
 {% load text_filters %}
-
 {% block content %}
-{% with filter_form.filters_visible as filters_visible %}
-<div class="table-header">
-    <h1 class="heading">{% trans 'Technical Feedback' %}</h1>
-    <div class="flex justify-between">
-        {% include "search_input_form.html" with object_type="feedback" related_form='admin-feedback-filter-form' %}
-        <button id="filter-toggle" class="btn btn-light-blue">
-            <span class="filter-toggle-text {% if filters_visible %}hidden{% endif %}">{% trans 'Show filters' %}</span>
-            <span class="filter-toggle-text {% if not filters_visible %}hidden{% endif %}">{% trans 'Hide filters' %}</span>
-        </button>
-    </div>
-</div>
-<div id="filter-form-container" class="{% if not filters_visible %}hidden{% endif %} w-full mt-4 rounded border border-solid border-gray-200 shadow bg-white">
-    {% include 'feedback/_admin_feedback_filter_form.html' %}
-</div>
-{% endwith %}
-
-<form id="bulk-action-form" method="POST">
-    {% csrf_token %}
-    <table class="w-full mt-4 rounded border border-solid border-gray-200 shadow bg-white" data-enable-row-checkbox-toggle>
-        <tr class="border-b border-solid border-gray-200">
-            <th class="text-sm text-left uppercase py-3 pr-2" style="padding-left: 10px;" title="{% trans 'Select all' %}"><input type="checkbox" id="bulk-select-all"></th>
-            <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Category' %}</th>
-            <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Feedback on' %}</th>
-            <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Language' %}</th>
-            <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Comment' %}</th>
-            <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Rating' %}</th>
-            <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Rating' %} ({% trans 'overall' %})</th>
-            <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Region' %}</th>
-            <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Marked as read by' %}</th>
-            <th class="text-sm text-right uppercase py-3 pr-2">{% trans 'Date' %}</th>
-        </tr>
-
-        {% for feedback in admin_feedback %}
-        <tr class="border-t border-solid border-gray-200 hover:bg-gray-200 {% if not feedback.read %}bg-yellow-100 border-yellow-200 hover:border-gray-200{% endif %}">
-            <td class="py-3 {% if not feedback.read %}border-l-4 border-yellow-400{% endif %}" style="padding-left: {% if feedback.read %}10{% else %}8{% endif %}px;">
-                <input type="checkbox" name="selected_ids[]" value="{{ feedback.id }}" class="bulk-select-item">
-            </td>
-            <td class="pr-2 whitespace-nowrap">
-                {{ feedback.category }}
-            </td>
-            <td class="pr-2">
-                {% if feedback.object_url %}
-                <a href="{{ feedback.object_url }}" class="hover:underline">
-                    {{ feedback.object_name }}
-                </a>
-                {% else %}
-                    {{ feedback.object_name }}
-                {% endif %}
-            </td>
-            <td class="pr-2">{{ feedback.language.translated_name }}</td>
-            <td class="pr-2 feedback-comment">
-                {% if not feedback.comment %}
-                    <i data-feather="minus" class="pr-1"></i>
-                {% elif feedback.comment.splitlines|length > 1 %}
-                    <span>
-                        {{ feedback.comment.splitlines.0|truncatewords:20 }} <i data-feather="chevron-down" class="toggle-feedback-comment transform cursor-pointer hover:scale-125"></i>
+    {% with filter_form.filters_visible as filters_visible %}
+        <div class="table-header">
+            <h1 class="heading">{% trans 'Technical Feedback' %}</h1>
+            <div class="flex justify-between">
+                {% include "search_input_form.html" with object_type="feedback" related_form='admin-feedback-filter-form' %}
+                <button id="filter-toggle" class="btn btn-light-blue">
+                    <span class="filter-toggle-text {% if filters_visible %}hidden{% endif %}">{% trans 'Show filters' %}</span>
+                    <span class="filter-toggle-text {% if not filters_visible %}hidden{% endif %}">{% trans 'Hide filters' %}</span>
+                </button>
+            </div>
+        </div>
+        <div id="filter-form-container"
+             class="{% if not filters_visible %}hidden{% endif %} w-full mt-4 rounded border border-solid border-gray-200 shadow bg-white">
+            {% include 'feedback/_admin_feedback_filter_form.html' %}
+        </div>
+    {% endwith %}
+    <form id="bulk-action-form" method="post">
+        {% csrf_token %}
+        <table class="w-full mt-4 rounded border border-solid border-gray-200 shadow bg-white"
+               data-enable-row-checkbox-toggle>
+            <tr class="border-b border-solid border-gray-200">
+                <th class="text-sm text-left uppercase py-3 pr-2"
+                    style="padding-left: 10px;"
+                    title="{% trans 'Select all' %}">
+                    <input type="checkbox" id="bulk-select-all"/>
+                </th>
+                <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Category' %}</th>
+                <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Feedback on' %}</th>
+                <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Language' %}</th>
+                <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Comment' %}</th>
+                <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Rating' %}</th>
+                <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Rating' %} ({% trans 'overall' %})</th>
+                <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Region' %}</th>
+                <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Marked as read by' %}</th>
+                <th class="text-sm text-right uppercase py-3 pr-2">{% trans 'Date' %}</th>
+            </tr>
+            {% for feedback in admin_feedback %}
+                <tr class="border-t border-solid border-gray-200 hover:bg-gray-200 {% if not feedback.read %}bg-yellow-100 border-yellow-200 hover:border-gray-200{% endif %}">
+                    <td class="py-3 {% if not feedback.read %}border-l-4 border-yellow-400{% endif %}"
+                        style="padding-left: {% if feedback.read %}10{% else %}8{% endif %}px;">
+                        <input type="checkbox"
+                               name="selected_ids[]"
+                               value="{{ feedback.id }}"
+                               class="bulk-select-item"/>
+                    </td>
+                    <td class="pr-2 whitespace-nowrap">{{ feedback.category }}</td>
+                    <td class="pr-2">
+                        {% if feedback.object_url %}
+                            <a href="{{ feedback.object_url }}" class="hover:underline">{{ feedback.object_name }}</a>
+                        {% else %}
+                            {{ feedback.object_name }}
+                        {% endif %}
+                    </td>
+                    <td class="pr-2">{{ feedback.language.translated_name }}</td>
+                    <td class="pr-2 feedback-comment">
+                        {% if not feedback.comment %}
+                            <i data-feather="minus" class="pr-1"></i>
+                        {% elif feedback.comment.splitlines|length > 1 %}
+                            <span>
+                                {{ feedback.comment.splitlines.0|truncatewords:20 }} <i data-feather="chevron-down"
+                                class="toggle-feedback-comment transform cursor-pointer hover:scale-125"></i>
+                            </span>
+                            <span class="hidden whitespace-pre-line">{{ feedback.comment }} <i data-feather="chevron-up"
+                                class="toggle-feedback-comment transform cursor-pointer hover:scale-125"></i></span>
+                        {% elif feedback.comment|words|length > 20 %}
+                            <span>
+                                {{ feedback.comment|truncatewords:20 }} <i data-feather="chevron-down"
+                                class="toggle-feedback-comment transform cursor-pointer hover:scale-125"></i>
+                            </span>
+                            <span class="hidden">
+                                {{ feedback.comment }} <i data-feather="chevron-up"
+                                class="toggle-feedback-comment transform cursor-pointer hover:scale-125"></i>
+                            </span>
+                        {% else %}
+                            {{ feedback.comment }}
+                        {% endif %}
+                    </td>
+                    <td class="pr-2">
+                        {% if feedback.rating == True %}
+                            <i data-feather="thumbs-up" class="pr-1"></i>
+                        {% elif feedback.rating == False %}
+                            <i data-feather="thumbs-down" class="pr-1"></i>
+                        {% elif feedback.rating == None %}
+                            <i data-feather="minus" class="pr-1"></i>
+                        {% endif %}
+                    </td>
+                    <td class="pr-2">
+                        <span class="{% if not feedback.rating_sum_positive %}invisible{% endif %}">
+                            <i data-feather="thumbs-up" class="pr-1"></i> {{ feedback.rating_sum_positive }}
                     </span>
-                    <span class="hidden whitespace-pre-line">{{ feedback.comment }} <i data-feather="chevron-up" class="toggle-feedback-comment transform cursor-pointer hover:scale-125"></i></span>
-                {% elif feedback.comment|words|length > 20 %}
-                    <span>
-                        {{ feedback.comment|truncatewords:20 }} <i data-feather="chevron-down" class="toggle-feedback-comment transform cursor-pointer hover:scale-125"></i>
-                    </span>
-                    <span class="hidden">
-                        {{ feedback.comment }} <i data-feather="chevron-up" class="toggle-feedback-comment transform cursor-pointer hover:scale-125"></i>
-                    </span>
-                {% else %}
-                    {{ feedback.comment }}
-                {% endif %}
-            </td>
-            <td class="pr-2">
-                {% if feedback.rating == True %}
-                    <i data-feather="thumbs-up" class="pr-1"></i>
-                {% elif feedback.rating == False %}
-                    <i data-feather="thumbs-down" class="pr-1"></i>
-                {% elif feedback.rating == None %}
-                    <i data-feather="minus" class="pr-1"></i>
-                {% endif %}
-            </td>
-            <td class="pr-2">
-                <span class="{% if not feedback.rating_sum_positive %}invisible{% endif %}">
-                    <i data-feather="thumbs-up" class="pr-1"></i> {{ feedback.rating_sum_positive }}
+                    <span class="{% if not feedback.rating_sum_negative %}invisible{% endif %}">
+                        <i data-feather="thumbs-down" class="pl-1"></i> {{ feedback.rating_sum_negative }}
                 </span>
-                <span class="{% if not feedback.rating_sum_negative %}invisible{% endif %}">
-                    <i data-feather="thumbs-down" class="pl-1"></i> {{ feedback.rating_sum_negative }}
-                </span>
             </td>
             <td class="pr-2">
-                <a href="{% url 'dashboard' region_slug=feedback.region.slug %}" class="hover:underline">
+                <a href="{% url 'dashboard' region_slug=feedback.region.slug %}"
+                   class="hover:underline">
                     {{ feedback.region.get_administrative_division_display }} {{ feedback.region.name }}
                 </a>
             </td>
             <td class="pr-2">
-                {% if feedback.read_by.email %}
-                    <a href="mailto:{{ feedback.read_by.email }}" class="hover:underline">
-                {% endif %}
+                {% if feedback.read_by.email %}<a href="mailto:{{ feedback.read_by.email }}" class="hover:underline">{% endif %}
                 {{ feedback.read_by.full_user_name }}
-                {% if feedback.read_by.email %}
-                    </a>
-                {% endif %}
+                {% if feedback.read_by.email %}</a>{% endif %}
             </td>
             <td class="pr-2 text-right whitespace-nowrap">{{ feedback.created_date }}</td>
         </tr>
-        {% empty %}
+    {% empty %}
         <tr>
             <td colspan="9" class="px-2 py-3 text-center">
                 {% if filter_form.has_changed %}
@@ -118,22 +121,36 @@
                 {% endif %}
             </td>
         </tr>
-        {% endfor %}
-
-    </table>
-    <div class="flex flex-col">
-        {% include "pagination.html" with url=url chunk=admin_feedback %}
-        <div class="flex self-start gap-2 mt-2">
-            <select id="bulk-action">
-                <option>{% trans 'Select bulk action' %}</option>
-                <option data-bulk-action="{% url 'mark_admin_feedback_as_read' %}">{% trans 'Mark as read' %}</option>
-                <option data-bulk-action="{% url 'mark_admin_feedback_as_unread' %}">{% trans 'Mark as unread' %}</option>
-                {% if perms.cms.delete_feedback %}
-                    <option data-bulk-action="{% url 'delete_admin_feedback' %}">{% trans 'Delete' %}</option>
-                {% endif %}
-            </select>
-            <button id="bulk-action-execute" class="btn" disabled>{% trans 'Execute' %}</button>
+    {% endfor %}
+</table>
+{% if admin_feedback %}
+    <div class="pt-2 px-2">
+        <div class="inline">
+            <span class="text-gray-800 font-bold" data-list-selection-count>0</span> <span class="text-gray-600">{% trans "Feedback entries selected" %}</span>
         </div>
     </div>
+{% endif %}
+<div class="flex flex-col">
+    {% include "pagination.html" with url=url chunk=admin_feedback %}
+    <div class="flex self-start gap-2 mt-2">
+        <select id="bulk-action">
+            <option>
+                {% trans 'Select bulk action' %}
+            </option>
+            <option data-bulk-action="{% url 'mark_admin_feedback_as_read' %}">
+                {% trans 'Mark as read' %}
+            </option>
+            <option data-bulk-action="{% url 'mark_admin_feedback_as_unread' %}">
+                {% trans 'Mark as unread' %}
+            </option>
+            {% if perms.cms.delete_feedback %}
+                <option data-bulk-action="{% url 'delete_admin_feedback' %}">
+                    {% trans 'Delete' %}
+                </option>
+            {% endif %}
+        </select>
+        <button id="bulk-action-execute" class="btn" disabled>{% trans 'Execute' %}</button>
+    </div>
+</div>
 </form>
-{% endblock %}
+{% endblock content %}

--- a/integreat_cms/cms/templates/feedback/region_feedback_list.html
+++ b/integreat_cms/cms/templates/feedback/region_feedback_list.html
@@ -20,7 +20,7 @@
             {% include 'feedback/_region_feedback_filter_form.html' %}
         </div>
     {% endwith %}
-    <form id="bulk-action-form" method="POST">
+    <form id="bulk-action-form" method="post">
         {% csrf_token %}
         <table class="w-full mt-4 rounded border border-solid border-gray-200 shadow bg-white"
                data-enable-row-checkbox-toggle>
@@ -63,18 +63,18 @@
                         {% elif feedback.comment.splitlines|length > 1 %}
                             <span>
                                 {{ feedback.comment.splitlines.0|truncatewords:20 }} <i data-feather="chevron-down"
-    class="toggle-feedback-comment transform cursor-pointer hover:scale-125"></i>
+                                class="toggle-feedback-comment transform cursor-pointer hover:scale-125"></i>
                             </span>
                             <span class="hidden whitespace-pre-line">{{ feedback.comment }} <i data-feather="chevron-up"
-    class="toggle-feedback-comment transform cursor-pointer hover:scale-125"></i></span>
+                                class="toggle-feedback-comment transform cursor-pointer hover:scale-125"></i></span>
                         {% elif feedback.comment|words|length > 20 %}
                             <span>
                                 {{ feedback.comment|truncatewords:20 }} <i data-feather="chevron-down"
-    class="toggle-feedback-comment transform cursor-pointer hover:scale-125"></i>
+                                class="toggle-feedback-comment transform cursor-pointer hover:scale-125"></i>
                             </span>
                             <span class="hidden">
                                 {{ feedback.comment }} <i data-feather="chevron-up"
-    class="toggle-feedback-comment transform cursor-pointer hover:scale-125"></i>
+                                class="toggle-feedback-comment transform cursor-pointer hover:scale-125"></i>
                             </span>
                         {% else %}
                             {{ feedback.comment }}
@@ -92,51 +92,58 @@
                     <td class="pr-2">
                         <span class="{% if not feedback.rating_sum_positive %}invisible{% endif %}">
                             <i data-feather="thumbs-up" class="pr-1"></i> {{ feedback.rating_sum_positive }}
-                        </span>
-                        <span class="{% if not feedback.rating_sum_negative %}invisible{% endif %}">
-                            <i data-feather="thumbs-down" class="pl-1"></i> {{ feedback.rating_sum_negative }}
-                        </span>
-                    </td>
-                    <td class="pr-2">
-                        {% if feedback.read_by.email %}<a href="mailto:{{ feedback.read_by.email }}" class="hover:underline">{% endif %}
-                        {{ feedback.read_by.full_user_name }}
-                        {% if feedback.read_by.email %}</a>{% endif %}
-                    </td>
-                    <td class="pr-2 text-right whitespace-nowrap">{{ feedback.created_date }}</td>
-                </tr>
-            {% empty %}
-                <tr>
-                    <td colspan="9" class="px-2 py-3 text-center">
-                        {% if filter_form.has_changed %}
-                            {% trans 'No feedback found with these filters.' %}
-                        {% else %}
-                            {% trans 'No feedback available yet.' %}
-                        {% endif %}
-                    </td>
-                </tr>
-            {% endfor %}
-        </table>
-        <div class="flex flex-col">
-            <div class="flex self-start gap-2 mt-2">
-                <select id="bulk-action">
-                    <option>
-                        {% trans 'Select bulk action' %}
-                    </option>
-                    <option data-bulk-action="{% url 'mark_region_feedback_as_read' region_slug=request.region.slug %}">
-                        {% trans 'Mark as read' %}
-                    </option>
-                    <option data-bulk-action="{% url 'mark_region_feedback_as_unread' region_slug=request.region.slug %}">
-                        {% trans 'Mark as unread' %}
-                    </option>
-                    {% if perms.cms.delete_feedback %}
-                        <option data-bulk-action="{% url 'delete_region_feedback' region_slug=request.region.slug %}">
-                            {% trans 'Delete' %}
-                        </option>
-                    {% endif %}
-                </select>
-                <button id="bulk-action-execute" class="btn" disabled>{% trans 'Execute' %}</button>
-            </div>
+                    </span>
+                    <span class="{% if not feedback.rating_sum_negative %}invisible{% endif %}">
+                        <i data-feather="thumbs-down" class="pl-1"></i> {{ feedback.rating_sum_negative }}
+                </span>
+            </td>
+            <td class="pr-2">
+                {% if feedback.read_by.email %}<a href="mailto:{{ feedback.read_by.email }}" class="hover:underline">{% endif %}
+                {{ feedback.read_by.full_user_name }}
+                {% if feedback.read_by.email %}</a>{% endif %}
+            </td>
+            <td class="pr-2 text-right whitespace-nowrap">{{ feedback.created_date }}</td>
+        </tr>
+    {% empty %}
+        <tr>
+            <td colspan="9" class="px-2 py-3 text-center">
+                {% if filter_form.has_changed %}
+                    {% trans 'No feedback found with these filters.' %}
+                {% else %}
+                    {% trans 'No feedback available yet.' %}
+                {% endif %}
+            </td>
+        </tr>
+    {% endfor %}
+</table>
+{% if region_feedback %}
+    <div class="pt-2 px-2">
+        <div class="inline">
+            <span class="text-gray-800 font-bold" data-list-selection-count>0</span> <span class="text-gray-600">{% trans "Feedback entries selected" %}</span>
         </div>
-        {% include "pagination.html" with url=url chunk=region_feedback %}
-    </form>
+    </div>
+{% endif %}
+<div class="flex flex-col">
+    <div class="flex self-start gap-2 mt-2">
+        <select id="bulk-action">
+            <option>
+                {% trans 'Select bulk action' %}
+            </option>
+            <option data-bulk-action="{% url 'mark_region_feedback_as_read' region_slug=request.region.slug %}">
+                {% trans 'Mark as read' %}
+            </option>
+            <option data-bulk-action="{% url 'mark_region_feedback_as_unread' region_slug=request.region.slug %}">
+                {% trans 'Mark as unread' %}
+            </option>
+            {% if perms.cms.delete_feedback %}
+                <option data-bulk-action="{% url 'delete_region_feedback' region_slug=request.region.slug %}">
+                    {% trans 'Delete' %}
+                </option>
+            {% endif %}
+        </select>
+        <button id="bulk-action-execute" class="btn" disabled>{% trans 'Execute' %}</button>
+    </div>
+</div>
+{% include "pagination.html" with url=url chunk=region_feedback %}
+</form>
 {% endblock content %}

--- a/integreat_cms/cms/templates/linkcheck/link_list_row.html
+++ b/integreat_cms/cms/templates/linkcheck/link_list_row.html
@@ -3,34 +3,38 @@
 {% load content_filters %}
 {% load model_tags %}
 {% load widget_tweaks %}
-
 {% object_translation_has_view_perm request.user item.translation as show_source_link %}
-
 <tr class="border-t border-gray-200 hover:bg-gray-100 text-gray-800">
     <td class="py-3 pl-4">
-      <input type="checkbox" name="selected_ids[]" value="{{ item.link.id }}" class="bulk-select-item">
+        <input type="checkbox"
+               name="selected_ids[]"
+               value="{{ item.link.id }}"
+               class="bulk-select-item"/>
     </td>
-    <td class="pr-2 whitespace-nowrap max-w-lg overflow-hidden text-ellipsis" title="{{ item.link.display_url }}">
-        <a href="{{ item.link.display_url }}" target="_blank" rel="noopener noreferrer" class="text-blue-500 hover:underline">{{ item.link.display_url }}</a>
+    <td class="pr-2 whitespace-nowrap max-w-lg overflow-hidden text-ellipsis"
+        title="{{ item.link.display_url }}">
+        <a href="{{ item.link.display_url }}"
+           target="_blank"
+           rel="noopener noreferrer"
+           class="text-blue-500 hover:underline">{{ item.link.display_url }}</a>
     </td>
     <td class="pr-2 {% if view.kwargs.link_filter == 'invalid' %} text-red-500 {% elif view.kwargs.link_filter == 'valid' %} text-green-500 {% endif %} whitespace-nowrap max-w-lg overflow-hidden text-ellipsis"
         title="{{ item.link.url.message }}">
         {{ item.link.url.message|linkcheck_status_filter }}
     </td>
-    <td class="pr-2 whitespace-nowrap max-w-lg overflow-hidden text-ellipsis" title="{{ item.link.text }}">
+    <td class="pr-2 whitespace-nowrap max-w-lg overflow-hidden text-ellipsis"
+        title="{{ item.link.text }}">
         {{ item.link.text }}
     </td>
     <td class="pr-2">
         {% if show_source_link %}
-            <a href="{{ item.translation.backend_edit_link }}" title="{% trans 'Go to source' %}">
-               {{ item.translation.title }}
-            </a>
+            <a href="{{ item.translation.backend_edit_link }}"
+               title="{% trans 'Go to source' %}">{{ item.translation.title }}</a>
         {% else %}
             {{ item.translation.title }}
         {% endif %}
     </td>
     <td class="pr-2">{% get_model_verbose_name item.translation %}</td>
-
     <td class="text-right pr-4">
         <a title="{% trans 'Replace URL globally' %}"
            href="{% url 'edit_link' link_id=item.link.id link_filter=view.kwargs.link_filter region_slug=request.region.slug %}"
@@ -51,4 +55,3 @@
         </td>
     </tr>
 {% endif %}
-

--- a/integreat_cms/cms/templates/linkcheck/links_by_filter.html
+++ b/integreat_cms/cms/templates/linkcheck/links_by_filter.html
@@ -1,7 +1,6 @@
-{% extends '_base.html' %}
+{% extends "_base.html" %}
 {% load i18n %}
 {% load static %}
-
 {% block content %}
     <h1 class="heading">
         {% if view.kwargs.link_filter == 'valid' %}
@@ -18,39 +17,43 @@
        class="pr-2 {% if view.kwargs.link_filter == 'valid' %}text-black font-bold cursor-default{% else %}bg-transparent hover:underline text-blue-500 hover:text-blue-600 cursor-pointer{% endif %}">
         {% trans 'Valid' %}
         <span class="{% if view.kwargs.link_filter == 'valid' %}text-gray-500 font-normal{% endif %}">
-          ({{ number_valid_links }})
+            ({{ number_valid_links }})
         </span>
     </a> |
     <a href="{% if view.kwargs.link_filter == 'invalid' %}#{% else %}{% url 'linkcheck' region_slug=request.region.slug link_filter='invalid' %}{% endif %}"
        class="pr-2 border-r-1 {% if view.kwargs.link_filter == 'invalid' %}text-black font-bold cursor-default{% else %}bg-transparent hover:underline text-blue-500 hover:text-blue-600 cursor-pointer{% endif %}">
         {% trans 'Invalid' %}
         <span class="{% if view.kwargs.link_filter == 'invalid' %}text-gray-500 font-normal{% endif %}">
-          ({{ number_invalid_links }})
+            ({{ number_invalid_links }})
         </span>
     </a> |
     <a href="{% if view.kwargs.link_filter == 'unchecked' %}#{% else %}{% url 'linkcheck' region_slug=request.region.slug link_filter='unchecked' %}{% endif %}"
        class="pr-2 border-r-1 {% if view.kwargs.link_filter == 'unchecked' %}text-black font-bold cursor-default{% else %}bg-transparent hover:underline text-blue-500 hover:text-blue-600 cursor-pointer{% endif %}">
         {% trans 'Unchecked' %}
         <span class="{% if view.kwargs.link_filter == 'unchecked' %}text-gray-500 font-normal{% endif %}">
-          ({{ number_unchecked_links }})
+            ({{ number_unchecked_links }})
         </span>
     </a> |
     <a href="{% if view.kwargs.link_filter == 'ignored' %}#{% else %}{% url 'linkcheck' region_slug=request.region.slug link_filter='ignored' %}{% endif %}"
        class="{% if view.kwargs.link_filter == 'ignored' %}text-black font-bold cursor-default{% else %}bg-transparent hover:underline text-blue-500 hover:text-blue-600 cursor-pointer{% endif %}">
         {% trans 'Ignored' %}
         <span class="{% if view.kwargs.link_filter == 'ignored' %}text-gray-500 font-normal{% endif %}">
-          ({{ number_ignored_links }})
+            ({{ number_ignored_links }})
         </span>
     </a>
     {% if view.kwargs.link_id %}
-        <form method="POST" id="edit-url-form">{% csrf_token %}</form>
+        <form method="post" id="edit-url-form">
+            {% csrf_token %}
+        </form>
     {% endif %}
-    <form method="POST" id="bulk-action-form" class="table-listing">
+    <form method="post" id="bulk-action-form" class="table-listing">
         {% csrf_token %}
         <table class="w-full mt-4 rounded border border-solid border-gray-200 shadow bg-white">
             <thead>
                 <tr class="border-b border-solid border-gray-200">
-                    <th class="text-sm text-left uppercase py-3 pl-4 min"><input type="checkbox" id="bulk-select-all"></th>
+                    <th class="text-sm text-left uppercase py-3 pl-4 min">
+                        <input type="checkbox" id="bulk-select-all"/>
+                    </th>
                     <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'URL' %}</th>
                     <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Status' %}</th>
                     <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Link text' %}</th>
@@ -64,27 +67,43 @@
                     {% include 'linkcheck/link_list_row.html' %}
                 {% empty %}
                     <tr>
-                        <td colspan="6" class="px-4 py-3">
-                            {% trans 'No links detected yet.' %}
-                        </td>
+                        <td colspan="6" class="px-4 py-3">{% trans 'No links detected yet.' %}</td>
                     </tr>
                 {% endfor %}
             </tbody>
         </table>
+        {% if filtered_links %}
+            <div class="pt-2 px-2">
+                <div class="inline">
+                    <span class="text-gray-800 font-bold"
+                    data-list-selection-count>0</span> <span class="text-gray-600">{% trans "Links selected" %}</span>
+                </div>
+            </div>
+        {% endif %}
         <div class="flex flex-wrap relative w-1/2 mt-5 items-stretch gap-2">
             <select id="bulk-action" name="action" class="w-auto max-w-full">
-                <option>{% trans 'Select bulk action' %}</option>
+                <option>
+                    {% trans 'Select bulk action' %}
+                </option>
                 {% if view.kwargs.link_filter == 'ignored' %}
-                    <option value="unignore" data-bulk-action="{% url 'linkcheck' region_slug=request.region.slug link_filter=view.kwargs.link_filter %}">{% trans 'Unignore' %}</option>
+                    <option value="unignore"
+                            data-bulk-action="{% url 'linkcheck' region_slug=request.region.slug link_filter=view.kwargs.link_filter %}">
+                        {% trans 'Unignore' %}
+                    </option>
                 {% else %}
-                    <option value="recheck" data-bulk-action="{% url 'linkcheck' region_slug=request.region.slug link_filter=view.kwargs.link_filter %}">{% trans 'Recheck' %}</option>
-                    <option value="ignore" data-bulk-action="{% url 'linkcheck' region_slug=request.region.slug link_filter=view.kwargs.link_filter %}">{% trans 'Ignore' %}</option>
+                    <option value="recheck"
+                            data-bulk-action="{% url 'linkcheck' region_slug=request.region.slug link_filter=view.kwargs.link_filter %}">
+                        {% trans 'Recheck' %}
+                    </option>
+                    <option value="ignore"
+                            data-bulk-action="{% url 'linkcheck' region_slug=request.region.slug link_filter=view.kwargs.link_filter %}">
+                        {% trans 'Ignore' %}
+                    </option>
                 {% endif %}
             </select>
             <button id="bulk-action-execute" class="btn" disabled>{% trans 'Execute' %}</button>
         </div>
     </form>
-
     {% url 'linkcheck' as url %}
     {% include 'pagination.html' with url=url chunk=page_obj %}
-{% endblock %}
+{% endblock content %}

--- a/integreat_cms/cms/templates/pages/page_tree.html
+++ b/integreat_cms/cms/templates/pages/page_tree.html
@@ -1,177 +1,215 @@
 {% extends "_base.html" %}
-
 {% load i18n %}
 {% load static %}
 {% load content_filters %}
 {% load page_filters %}
 {% load rules %}
-
 {% block content %}
-{% with filter_form.filters_visible as filters_visible %}
-<div class="table-header">
-    <div class="flex flex-wrap justify-between gap-4">
-        <h1 class="heading">{% trans 'Page Tree' %} <button data-show-tutorial="page-tree" class="hover:text-blue-500"><i data-feather="help-circle" class="align-baseline"></i></button></h1>
-        <a href="{% url 'archived_pages' region_slug=request.region.slug language_slug=language.slug %}" class="font-bold text-sm text-gray-800 flex items-center gap-1 mb-2 hover:underline">
-            <span><i data-feather="archive" class="align-top h-5"></i> {% trans 'Archived pages' %}</span>
-        </a>
-    </div>
-    <div class="flex flex-wrap justify-between gap-4">
-        <div class="flex flex-wrap gap-4">
-            {% include "generic_language_switcher.html" with target='pages' %}
-            {% include "_search_input.html" with object_type="page" related_form='page-filter-form' search_query=filter_form.cleaned_data.query %}
-        </div>
-        <div class="flex flex-wrap gap-4">
-            {% if request.user.expert_mode %}
-            <button id="filter-toggle" class="btn btn-light-blue">
-                <span class="filter-toggle-text {% if filters_visible %}hidden{% endif %}">{% trans 'Show filters' %}</span>
-                <span class="filter-toggle-text {% if not filters_visible %}hidden{% endif %}">{% trans 'Hide filters' %}</span>
-            </button>
-            {% endif %}
-            {% has_perm 'cms.change_page_object' request.user as can_edit_pages %}
-            {% if can_edit_pages %}
-                {% if request.region.default_language == language %}
-                    <a href="{% url 'new_page' region_slug=request.region.slug language_slug=language.slug %}" class="btn">
-                        {% trans 'Create page' %}
-                    </a>
-                {% else %}
-                    {% blocktrans trimmed asvar disabled_button_title with request.region.default_language.translated_name as default_language %}
+    {% with filter_form.filters_visible as filters_visible %}
+        <div class="table-header">
+            <div class="flex flex-wrap justify-between gap-4">
+                <h1 class="heading">
+                    {% trans 'Page Tree' %}
+                    <button data-show-tutorial="page-tree" class="hover:text-blue-500">
+                        <i data-feather="help-circle" class="align-baseline"></i>
+                    </button>
+                </h1>
+                <a href="{% url 'archived_pages' region_slug=request.region.slug language_slug=language.slug %}"
+                   class="font-bold text-sm text-gray-800 flex items-center gap-1 mb-2 hover:underline">
+                    <span><i data-feather="archive" class="align-top h-5"></i> {% trans 'Archived pages' %}</span>
+                </a>
+            </div>
+            <div class="flex flex-wrap justify-between gap-4">
+                <div class="flex flex-wrap gap-4">
+                    {% include "generic_language_switcher.html" with target='pages' %}
+                    {% include "_search_input.html" with object_type="page" related_form='page-filter-form' search_query=filter_form.cleaned_data.query %}
+                </div>
+                <div class="flex flex-wrap gap-4">
+                    {% if request.user.expert_mode %}
+                        <button id="filter-toggle" class="btn btn-light-blue">
+                            <span class="filter-toggle-text {% if filters_visible %}hidden{% endif %}">{% trans 'Show filters' %}</span>
+                            <span class="filter-toggle-text {% if not filters_visible %}hidden{% endif %}">{% trans 'Hide filters' %}</span>
+                        </button>
+                    {% endif %}
+                    {% has_perm 'cms.change_page_object' request.user as can_edit_pages %}
+                    {% if can_edit_pages %}
+                        {% if request.region.default_language == language %}
+                            <a href="{% url 'new_page' region_slug=request.region.slug language_slug=language.slug %}"
+                               class="btn">
+                                {% trans 'Create page' %}
+                            </a>
+                        {% else %}
+                            {% blocktrans trimmed asvar disabled_button_title with request.region.default_language.translated_name as default_language %}
                         You can only create pages in the default language ({{ default_language }}).
                     {% endblocktrans %}
-                    <button title="{{ disabled_button_title }}" class="btn" disabled>
-                        {% trans 'Create page' %}
-                    </button>
-                {% endif %}
-            {% endif %}
-        </div>
-    </div>
-</div>
-<div id="filter-form-container" class="{% if not filters_visible %}hidden{% endif %} w-full mt-4 rounded border border-solid border-gray-200 shadow bg-white">
-    {% include 'pages/_page_filter_form.html' %}
-</div>
-{% endwith %}
-
-<form method="POST" id="bulk-action-form" class="table-listing">
-    {% csrf_token %}
-    <div class="overflow-x-auto">
-        <table {% if not filter_form.is_enabled %} data-delay-event-handlers data-activate-tree-drag-drop {% endif %} class="w-full mt-4 rounded border-2 border-solid border-gray-200 shadow bg-white table-auto">
-            <thead>
-                <tr class="border-b border-solid border-gray-200">
-                    <th class="text-sm text-left uppercase py-3 pl-4 pr-2 min"><input type="checkbox" id="bulk-select-all" class="cursor-wait"></th>
-                    {% if not filter_form.is_enabled %}
-                        <th class="text-sm text-left uppercase py-3 pl-2 pr-2 min">{% trans 'Hierarchy' %}</th>
-                    {% endif %}
-                    <th class="text-sm text-left uppercase py-3 pl-2 pr-2">{% trans 'Title in' %} {{ language.translated_name }}</th>
-                    {% get_current_language as LANGUAGE_CODE %}
-                    {% get_language LANGUAGE_CODE as backend_language %}
-                    {% if backend_language and backend_language != language %}
-                        <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {{ backend_language.translated_name }}</th>
-                    {% endif %}
-                    <th class="text-sm text-center uppercase py-3 pr-6 min">{% trans 'Tags' %}</th>
-                    <th class="text-sm text-left uppercase py-3 px-2">
-                        <div class="lang-grid flags whitespace-nowrap">
-                            {% spaceless %}
-                                {% for lang in languages %}
-                                    <a href="{% url 'pages' region_slug=request.region.slug language_slug=lang.slug %}">
-                                        <span class="fp fp-rounded fp-{{ lang.primary_country_code }}" title="{{ lang.translated_name }}"></span>
-                                    </a>
-                                {% endfor %}
-                            {% endspaceless %}
-                        </div>
-                    </th>
-                    <th class="text-sm text-left uppercase py-3 pl-2 pr-2">{% trans 'Status' %}</th>
-                    <th class="text-sm text-left uppercase py-3 pl-2">{% trans 'Last updated' %}</th>
-                    <th class="text-sm text-right uppercase py-3 pl-2 pr-4 min">{% trans 'Options' %}</th>
-                </tr>
-            </thead>
-            <tbody>
-            {% for page in pages %}
-                {% include "pages/page_tree_node.html" %}
-                {% if forloop.last %}
-                    <tr data-drop-id="{% if page.is_root %}{{ page.id }}{% else %}{{ page.get_cached_ancestors.0.id }}{% endif %}" data-drop-position="right" class="drop drop-between h-3 hidden" title="test"><td colspan="9"><div><span></span></div></td></tr>
-                {% endif %}
-            {% empty %}
-                <tr>
-                    <td></td>
-                    <td colspan="8" class="px-2 py-3">
-                        {% if filter_form.is_enabled %}
-                            {% trans 'No pages found with these filters.' %}
-                        {% else %}
-                            {% trans 'No pages available yet.' %}
+                            <button title="{{ disabled_button_title }}" class="btn" disabled>{% trans 'Create page' %}</button>
                         {% endif %}
-                    </td>
-                </tr>
-            {% endfor %}
-            </tbody>
-        </table>
-    </div>
-    {% if pages %}
-        <div class="pt-2 px-2">
-            {% if not filter_form.is_enabled %}
-                <a id="expand-all-pages" class="text-blue-500 !cursor-wait">{% spaceless %}
-                    <i data-feather="chevron-down" class="align-sub h-5 rounded-full group-hover:bg-blue-500 group-hover:text-white"></i>
-                    {% trans 'Expand all' %}
-                    {% endspaceless %}</a>
-                | <a id="collapse-all-pages" class="text-blue-500 !cursor-wait">{% spaceless %}
-                    <i data-feather="chevron-up" class="align-sub h-5 rounded-full group-hover:bg-blue-500 group-hover:text-white"></i>
-                    {% trans 'Collapse all' %}
-                    {% endspaceless %}</a>
-            {% endif %}
-        </div>
-    {% endif %}
-    <div class="flex flex-wrap gap-2 mt-2">
-        <select id="bulk-action" class="w-auto max-w-full">
-            <option>{% trans 'Select bulk action' %}</option>
-            <option data-bulk-action="{% url 'bulk_archive_pages' region_slug=request.region.slug language_slug=language.slug %}">
-                {% trans 'Archive pages' %}
-            </option>
-            <option
-                id="pdf-export-option"
-                data-bulk-action="{% url 'export_pdf' region_slug=request.region.slug language_slug=language.slug %}"
-                data-target="_blank" data-language-slug="{{ language.slug }}">
-                {% trans 'Export published pages as PDF' %}
-            </option>
-            {% if request.user.expert_mode %}
-                {% with language_translated_name=language.translated_name %}
-                    {% blocktrans asvar xliff_export_all %}Export all pages for {{ language_translated_name }} translation{% endblocktrans %}
-                    {% blocktrans asvar xliff_export_public %}Export only published pages for {{ language_translated_name }} translation{% endblocktrans %}
-                    {% if language == request.region.default_language %}
-                        {% blocktrans asvar xliff_export_disabled %}You cannot export XLIFF files for the default language{% endblocktrans %}
-                        <option disabled title="{{ xliff_export_disabled }}">{{ xliff_export_all }} ({{ XLIFF_EXPORT_VERSION|upper }})</option>
-                        <option disabled title="{{ xliff_export_disabled }}">{{ xliff_export_public }} ({{ XLIFF_EXPORT_VERSION|upper }})</option>
-                    {% else %}
-                        <option data-bulk-action="{% url 'download_xliff' region_slug=request.region.slug language_slug=language.slug %}">
-                            {{ xliff_export_all }} ({{ XLIFF_EXPORT_VERSION|upper }})
-                        </option>
-                        <option data-bulk-action="{% url 'download_xliff_only_public' region_slug=request.region.slug language_slug=language.slug %}">
-                            {{ xliff_export_public }} ({{ XLIFF_EXPORT_VERSION|upper }})
-                        </option>
                     {% endif %}
-                {% endwith %}
+                </div>
+            </div>
+        </div>
+        <div id="filter-form-container"
+             class="{% if not filters_visible %}hidden{% endif %} w-full mt-4 rounded border border-solid border-gray-200 shadow bg-white">
+            {% include 'pages/_page_filter_form.html' %}
+        </div>
+    {% endwith %}
+    <form method="post" id="bulk-action-form" class="table-listing">
+        {% csrf_token %}
+        <div class="overflow-x-auto">
+            <table {% if not filter_form.is_enabled %} data-delay-event-handlers data-activate-tree-drag-drop{% endif %}
+                   class="w-full mt-4 rounded border-2 border-solid border-gray-200 shadow bg-white table-auto">
+                <thead>
+                    <tr class="border-b border-solid border-gray-200">
+                        <th class="text-sm text-left uppercase py-3 pl-4 pr-2 min">
+                            <input type="checkbox" id="bulk-select-all" class="cursor-wait"/>
+                        </th>
+                        {% if not filter_form.is_enabled %}
+                            <th class="text-sm text-left uppercase py-3 pl-2 pr-2 min">{% trans 'Hierarchy' %}</th>
+                        {% endif %}
+                        <th class="text-sm text-left uppercase py-3 pl-2 pr-2">{% trans 'Title in' %} {{ language.translated_name }}</th>
+                        {% get_current_language as LANGUAGE_CODE %}
+                        {% get_language LANGUAGE_CODE as backend_language %}
+                        {% if backend_language and backend_language != language %}
+                            <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Title in' %} {{ backend_language.translated_name }}</th>
+                        {% endif %}
+                        <th class="text-sm text-center uppercase py-3 pr-6 min">{% trans 'Tags' %}</th>
+                        <th class="text-sm text-left uppercase py-3 px-2">
+                            <div class="lang-grid flags whitespace-nowrap">
+                                {% spaceless %}
+                                    {% for lang in languages %}
+                                        <a href="{% url 'pages' region_slug=request.region.slug language_slug=lang.slug %}">
+                                            <span class="fp fp-rounded fp-{{ lang.primary_country_code }}"
+                                                  title="{{ lang.translated_name }}"></span>
+                                        </a>
+                                    {% endfor %}
+                                {% endspaceless %}
+                            </div>
+                        </th>
+                        <th class="text-sm text-left uppercase py-3 pl-2 pr-2">{% trans 'Status' %}</th>
+                        <th class="text-sm text-left uppercase py-3 pl-2">{% trans 'Last updated' %}</th>
+                        <th class="text-sm text-right uppercase py-3 pl-2 pr-4 min">{% trans 'Options' %}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for page in pages %}
+                        {% include "pages/page_tree_node.html" %}
+                        {% if forloop.last %}
+                            <tr data-drop-id="{% if page.is_root %}{{ page.id }}{% else %}{{ page.get_cached_ancestors.0.id }}{% endif %}"
+                                data-drop-position="right"
+                                class="drop drop-between h-3 hidden"
+                                title="test">
+                                <td colspan="9">
+                                    <div>
+                                        <span></span>
+                                    </div>
+                                </td>
+                            </tr>
+                        {% endif %}
+                    {% empty %}
+                        <tr>
+                            <td></td>
+                            <td colspan="8" class="px-2 py-3">
+                                {% if filter_form.is_enabled %}
+                                    {% trans 'No pages found with these filters.' %}
+                                {% else %}
+                                    {% trans 'No pages available yet.' %}
+                                {% endif %}
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+        {% if pages %}
+            <div class="pt-2 px-2">
+                {% if not filter_form.is_enabled %}
+                    <a id="expand-all-pages" class="text-blue-500 !cursor-wait">
+                        {% spaceless %}
+                            <i data-feather="chevron-down"
+                               class="align-sub h-5 rounded-full group-hover:bg-blue-500 group-hover:text-white"></i>
+                            {% trans 'Expand all' %}
+                        {% endspaceless %}
+                    </a>
+                    <span class="text-gray-600 font-default">|</span>
+                    <a id="collapse-all-pages" class="text-blue-500 !cursor-wait">
+                        {% spaceless %}
+                            <i data-feather="chevron-up"
+                               class="align-sub h-5 rounded-full group-hover:bg-blue-500 group-hover:text-white"></i>
+                            {% trans 'Collapse all' %}
+                        {% endspaceless %}
+                        </a>  <span class="text-gray-600 font-default">|</span>
+                    {% endif %}
+                    <div class="inline">
+                        <span class="text-gray-800 font-bold" data-list-selection-count>0</span> <span class="text-gray-600">{% trans "Pages selected" %}</span>
+                    </div>
+                </div>
             {% endif %}
-        </select>
-        <button id="bulk-action-execute" class="btn" disabled>{% trans 'Execute' %}</button>
-    </div>
-</form>
-{% if request.user.expert_mode %}
-    <div class="flex-wrap relative w-auto mt-12">
-        <h3 class="font-bold text-xl">{% trans 'Import XLIFF files' %}</h3>
-        <div class="my-2 text-s text-gray-600">{% trans "Supported file extensions" %}: .zip, .xlf, .xliff</div>
-        <form class="flex flex-wrap h-full mt-2 gap-2" method="post" enctype="multipart/form-data"
-              action="{% url 'upload_xliff' region_slug=request.region.slug language_slug=language.slug %}">
-            <label id="xliff_file_label" for="xliff_file" class="inline-block cursor-pointer bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 m-0 rounded">
-                <i data-feather="upload" class="inline-block pr-1"></i>
-                {% trans 'Select files' %}
-            </label>
-            <span id="xliff_file_label_multiple" class="hidden"> {% trans 'and {} other files' %}</span>
-            <input id="xliff_file" type="file" name="xliff_file" class="hidden" accept=".zip, .xlf, .xliff" multiple>
-            {% csrf_token %}
-            <button id="xliff_file_submit" class="btn" disabled>{% trans 'Import' %}</button>
+            <div class="flex flex-wrap gap-2 mt-2">
+                <select id="bulk-action" class="w-auto max-w-full">
+                    <option>
+                        {% trans 'Select bulk action' %}
+                    </option>
+                    <option data-bulk-action="{% url 'bulk_archive_pages' region_slug=request.region.slug language_slug=language.slug %}">
+                        {% trans 'Archive pages' %}
+                    </option>
+                    <option id="pdf-export-option"
+                            data-bulk-action="{% url 'export_pdf' region_slug=request.region.slug language_slug=language.slug %}"
+                            data-target="_blank"
+                            data-language-slug="{{ language.slug }}">
+                        {% trans 'Export published pages as PDF' %}
+                    </option>
+                    {% if request.user.expert_mode %}
+                        {% with language_translated_name=language.translated_name %}
+                            {% blocktrans asvar xliff_export_all %}Export all pages for {{ language_translated_name }} translation{% endblocktrans %}
+                            {% blocktrans asvar xliff_export_public %}Export only published pages for {{ language_translated_name }} translation{% endblocktrans %}
+                            {% if language == request.region.default_language %}
+                                {% blocktrans asvar xliff_export_disabled %}You cannot export XLIFF files for the default language{% endblocktrans %}
+                                <option disabled title="{{ xliff_export_disabled }}">
+                                    {{ xliff_export_all }} ({{ XLIFF_EXPORT_VERSION|upper }})
+                                </option>
+                                <option disabled title="{{ xliff_export_disabled }}">
+                                    {{ xliff_export_public }} ({{ XLIFF_EXPORT_VERSION|upper }})
+                                </option>
+                            {% else %}
+                                <option data-bulk-action="{% url 'download_xliff' region_slug=request.region.slug language_slug=language.slug %}">
+                                    {{ xliff_export_all }} ({{ XLIFF_EXPORT_VERSION|upper }})
+                                </option>
+                                <option data-bulk-action="{% url 'download_xliff_only_public' region_slug=request.region.slug language_slug=language.slug %}">
+                                    {{ xliff_export_public }} ({{ XLIFF_EXPORT_VERSION|upper }})
+                                </option>
+                            {% endif %}
+                        {% endwith %}
+                    {% endif %}
+                </select>
+                <button id="bulk-action-execute" class="btn" disabled>{% trans 'Execute' %}</button>
+            </div>
         </form>
-    </div>
-{% endif %}
-
-{% include "../generic_confirmation_dialog.html" %}
-{% include "../tutorials/page_tree.html" with tutorial_id="page-tree" hidden=request.user.page_tree_tutorial_seen  %}
-
-
-{% endblock %}
+        {% if request.user.expert_mode %}
+            <div class="flex-wrap relative w-auto mt-12">
+                <h3 class="font-bold text-xl">{% trans 'Import XLIFF files' %}</h3>
+                <div class="my-2 text-s text-gray-600">{% trans "Supported file extensions" %}: .zip, .xlf, .xliff</div>
+                <form class="flex flex-wrap h-full mt-2 gap-2"
+                      method="post"
+                      enctype="multipart/form-data"
+                      action="{% url 'upload_xliff' region_slug=request.region.slug language_slug=language.slug %}">
+                    <label id="xliff_file_label"
+                           for="xliff_file"
+                           class="inline-block cursor-pointer bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 m-0 rounded">
+                        <i data-feather="upload" class="inline-block pr-1"></i>
+                        {% trans 'Select files' %}
+                    </label>
+                    <span id="xliff_file_label_multiple" class="hidden">{% trans 'and {} other files' %}</span>
+                    <input id="xliff_file"
+                           type="file"
+                           name="xliff_file"
+                           class="hidden"
+                           accept=".zip, .xlf, .xliff"
+                           multiple/>
+                    {% csrf_token %}
+                    <button id="xliff_file_submit" class="btn" disabled>{% trans 'Import' %}</button>
+                </form>
+            </div>
+        {% endif %}
+        {% include "../generic_confirmation_dialog.html" %}
+        {% include "../tutorials/page_tree.html" with tutorial_id="page-tree" hidden=request.user.page_tree_tutorial_seen %}
+    {% endblock content %}

--- a/integreat_cms/cms/templates/pages/page_tree_node.html
+++ b/integreat_cms/cms/templates/pages/page_tree_node.html
@@ -7,7 +7,7 @@
 <tr id="page-{{ page.id }}-drop-left" data-drop-id="{{ page.id }}" data-drop-position="left" class="drop {% if not parent_id %} drop-between {% endif %} h-3 -m-3 hidden level-{{ page.relative_depth }}"><td colspan="9"><div><span></span></div></td></tr>
 <tr id="page-{{ page.id }}" data-drop-id="{{ page.id }}" data-drop-position="last-child" class="page-row drop drop-on border-t border-b border-solid border-gray-200 hover:bg-gray-100 level-{{ page.relative_depth }} {% if parent_id %} hidden parent-page-{{ parent_id }} {% endif %}">
     <td class="pl-4">
-        <input type="checkbox" name="selected_ids[]" value="{{ page.id }}" class="bulk-select-item cursor-wait">
+        <input type="checkbox" name="selected_ids[]" value="{{ page.id }}" class="bulk-select-item cursor-wait"/>
     </td>
     {% if not filter_form.is_enabled %}
         <td class="hierarchy single_icon whitespace-nowrap">
@@ -75,11 +75,11 @@
                                     <span title="{% trans 'Translation outdated' %}">
                                         <i data-feather="alert-triangle" class="{% if other_language.slug == language.slug %}text-yellow-500{% else %}text-gray-800{% endif %}"></i>
                                     </span>
-                                {% elif other_status == translation_status.UP_TO_DATE  %}
+                                {% elif other_status == translation_status.UP_TO_DATE %}
                                     <span title="{% trans 'Translation up-to-date' %}">
                                         <i data-feather="check" class="{% if other_language.slug == language.slug %}text-green-500{% else %}text-gray-800{% endif %}"></i>
                                     </span>
-                                {% elif other_status == translation_status.MISSING  %}
+                                {% elif other_status == translation_status.MISSING %}
                                     <span title="{% trans 'Translation missing' %}" class="no-trans">
                                         <i data-feather="x" class="{% if other_language.slug == language.slug %}text-red-500{% else %}text-gray-800{% endif %}"></i>
                                     </span>

--- a/integreat_cms/cms/templates/pois/poi_list.html
+++ b/integreat_cms/cms/templates/pois/poi_list.html
@@ -89,6 +89,13 @@
                 {% endfor %}
             </tbody>
         </table>
+        {% if pois %}
+        <div class="pt-2 px-2">
+            <div class="inline">
+                <span class="text-gray-800 font-bold" data-list-selection-count>0</span> <span class="text-gray-600">{% trans "Locations selected" %}</span>
+            </div>
+        </div>
+        {% endif %}
         <div class="flex flex-wrap gap-2 mt-4">
             <select id="bulk-action" class="w-auto max-w-full">
                 <option>

--- a/integreat_cms/cms/templates/pois/poi_list_row.html
+++ b/integreat_cms/cms/templates/pois/poi_list_row.html
@@ -4,11 +4,11 @@
 
 <tr class="border-t border-gray-200 hover:bg-gray-100 text-gray-800">
     <td class="py-3 pl-4 pr-2">
-        <input type="checkbox" name="selected_ids[]" value="{{ poi.id }}" form="bulk-action-form" class="bulk-select-item">
+        <input type="checkbox" name="selected_ids[]" value="{{ poi.id }}" form="bulk-action-form" class="bulk-select-item"/>
     </td>
     <td class="pr-2">
         <a href="{% url 'edit_poi' poi_id=poi.id region_slug=request.region.slug language_slug=language.slug %}" class="block">
-            {%  if poi_translation %}
+            {% if poi_translation %}
                 {{ poi_translation.title }}
             {% else %}
                 <i>{% trans 'Translation not available' %}</i>
@@ -40,11 +40,11 @@
                             <span title="{% trans 'Translation outdated' %}">
                                 <i data-feather="alert-triangle" class="{% if other_language.slug == language.slug %}text-yellow-500{% else %}text-gray-800{% endif %}"></i>
                             </span>
-                        {% elif other_status == translation_status.UP_TO_DATE  %}
+                        {% elif other_status == translation_status.UP_TO_DATE %}
                             <span title="{% trans 'Translation up-to-date' %}">
                                 <i data-feather="check" class="{% if other_language.slug == language.slug %}text-green-500{% else %}text-gray-800{% endif %}"></i>
                             </span>
-                        {% elif other_status == translation_status.MISSING  %}
+                        {% elif other_status == translation_status.MISSING %}
                             <span title="{% trans 'Translation missing' %}" class="no-trans">
                                 <i data-feather="x" class="{% if other_language.slug == language.slug %}text-red-500{% else %}text-gray-800{% endif %}"></i>
                             </span>

--- a/integreat_cms/cms/templates/push_notifications/push_notification_list.html
+++ b/integreat_cms/cms/templates/push_notifications/push_notification_list.html
@@ -1,70 +1,63 @@
 {% extends "_base.html" %}
-
 {% load i18n %}
 {% load static %}
 {% load push_notification_filters %}
-
 {% block content %}
-<div class="table-header">
-    <h1 class="heading">{% trans 'News' %}</h1>
-    <div class="flex flex-wrap justify-between gap-4">
-        <div class="flex flex-wrap gap-4">
-            {% include "generic_language_switcher.html" with target='push_notifications' %}
-            {% include "search_input_form.html" with object_type="push_notification" language_slug=language.slug %}
+    <div class="table-header">
+        <h1 class="heading">{% trans 'News' %}</h1>
+        <div class="flex flex-wrap justify-between gap-4">
+            <div class="flex flex-wrap gap-4">
+                {% include "generic_language_switcher.html" with target='push_notifications' %}
+                {% include "search_input_form.html" with object_type="push_notification" language_slug=language.slug %}
+            </div>
+            {% if perms.cms.change_pushnotification %}
+                <a href="{% url 'new_push_notification' region_slug=request.region.slug language_slug=language.slug %}"
+                   class="btn">
+                    {% trans 'Create news message' %}
+                </a>
+            {% endif %}
         </div>
-        {% if perms.cms.change_pushnotification %}
-            <a href="{% url 'new_push_notification' region_slug=request.region.slug language_slug=language.slug %}" class="btn">
-                {% trans 'Create news message' %}
-            </a>
-        {% endif %}
     </div>
-</div>
-
-<div class="table-listing">
-    <table class="w-full mt-4 rounded border border-solid border-gray-200 shadow bg-white">
-        <thead>
-            <tr class="border-b border-solid border-gray-200">
-                <th class="text-sm text-left uppercase py-3 pl-4 pr-2">
-                    {% trans 'Title' %}
-                </th>
-                <th class="text-sm text-left uppercase py-3 px-2">
-                    {% trans 'Channel' %}
-                </th>
-                <th class="text-sm text-left uppercase py-3 px-2">
-                    <div class="lang-grid flags whitespace-nowrap">
-                        {% spaceless %}
-                            {% for lang in languages %}
-                                <a href="{% url 'push_notifications' region_slug=request.region.slug language_slug=lang.slug %}">
-                                    <span class="fp fp-rounded fp-{{ lang.primary_country_code }}" title="{{ lang.translated_name }}"></span>
-                                </a>
-                            {% endfor %}
-                        {% endspaceless %}
-                    </div>
-                </th>
-                <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Last updated' %}</th>
-                <th class="text-sm text-left uppercase py-3 px-2 min">
-                    {% trans 'Sent' %}
-                </th>
-            </tr>
-        </thead>
-        <tbody>
-        {% for push_notification in push_notifications %}
-            {% get_translation push_notification language.slug as push_notification_translation %}
-            {% include "push_notifications/push_notification_list_row.html" %}
-        {% empty %}
-            <tr>
-	            <td colspan="4" class="px-4 py-3">
-                    {% if search_query %}
-                        {% trans 'No push notifications found with these filters.' %}
-                    {% else %}
-		                {% trans 'No push notifications available yet.' %}
-                    {% endif %}
-	            </td>
-            </tr>
-        {% endfor %}
-        </tbody>
-    </table>
-</div>
-{% url "push_notifications" as url %}
-{% include "pagination.html" with url=url chunk=push_notifications %}
-{% endblock %}
+    <div class="table-listing">
+        <table class="w-full mt-4 rounded border border-solid border-gray-200 shadow bg-white">
+            <thead>
+                <tr class="border-b border-solid border-gray-200">
+                    <th class="text-sm text-left uppercase py-3 pl-4 pr-2">{% trans 'Title' %}</th>
+                    <th class="text-sm text-left uppercase py-3 px-2">{% trans 'Channel' %}</th>
+                    <th class="text-sm text-left uppercase py-3 px-2">
+                        <div class="lang-grid flags whitespace-nowrap">
+                            {% spaceless %}
+                                {% for lang in languages %}
+                                    <a href="{% url 'push_notifications' region_slug=request.region.slug language_slug=lang.slug %}">
+                                        <span class="fp fp-rounded fp-{{ lang.primary_country_code }}"
+                                              title="{{ lang.translated_name }}"></span>
+                                    </a>
+                                {% endfor %}
+                            {% endspaceless %}
+                        </div>
+                    </th>
+                    <th class="text-sm text-left uppercase py-3 pr-2">{% trans 'Last updated' %}</th>
+                    <th class="text-sm text-left uppercase py-3 px-2 min">{% trans 'Sent' %}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for push_notification in push_notifications %}
+                    {% get_translation push_notification language.slug as push_notification_translation %}
+                    {% include "push_notifications/push_notification_list_row.html" %}
+                {% empty %}
+                    <tr>
+                        <td colspan="4" class="px-4 py-3">
+                            {% if search_query %}
+                                {% trans 'No push notifications found with these filters.' %}
+                            {% else %}
+                                {% trans 'No push notifications available yet.' %}
+                            {% endif %}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    {% url "push_notifications" as url %}
+    {% include "pagination.html" with url=url chunk=push_notifications %}
+{% endblock content %}

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-23 15:41+0000\n"
+"POT-Creation-Date: 2022-05-02 11:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -35,7 +35,7 @@ msgstr "Landkreis"
 #: cms/constants/administrative_division.py:41
 #: cms/forms/feedback/admin_feedback_filter_form.py:15
 #: cms/templates/feedback/_feedback_widget.html:22
-#: cms/templates/feedback/admin_feedback_list.html:36
+#: cms/templates/feedback/admin_feedback_list.html:39
 msgid "Region"
 msgstr "Region"
 
@@ -1562,7 +1562,7 @@ msgstr "Alle Regionen"
 
 #: cms/forms/feedback/region_feedback_filter_form.py:16
 #: cms/templates/analytics/translation_coverage.html:38
-#: cms/templates/feedback/admin_feedback_list.html:32
+#: cms/templates/feedback/admin_feedback_list.html:35
 #: cms/templates/feedback/region_feedback_list.html:35
 #: cms/templates/language_tree/language_tree.html:22
 #: cms/templates/pages/_page_xliff_import_diff.html:30
@@ -1580,7 +1580,7 @@ msgid "All categories"
 msgstr "Alle Kategorien"
 
 #: cms/forms/feedback/region_feedback_filter_form.py:26
-#: cms/templates/feedback/admin_feedback_list.html:30
+#: cms/templates/feedback/admin_feedback_list.html:33
 #: cms/templates/feedback/region_feedback_list.html:33
 msgid "Category"
 msgstr "Kategorie"
@@ -1594,11 +1594,11 @@ msgstr "Kategorie"
 #: cms/templates/imprint/imprint_sbs.html:51
 #: cms/templates/imprint/imprint_sbs.html:115
 #: cms/templates/imprint/imprint_sbs.html:134
-#: cms/templates/linkcheck/links_by_filter.html:55
+#: cms/templates/linkcheck/links_by_filter.html:58
 #: cms/templates/pages/page_form.html:90
 #: cms/templates/pages/page_revisions.html:50
 #: cms/templates/pages/page_sbs.html:59 cms/templates/pages/page_sbs.html:115
-#: cms/templates/pages/page_sbs.html:121 cms/templates/pages/page_tree.html:81
+#: cms/templates/pages/page_sbs.html:121 cms/templates/pages/page_tree.html:88
 #: cms/templates/pages/page_tree_archived.html:67
 #: cms/templates/pois/poi_form.html:57 cms/templates/pois/poi_list.html:67
 #: cms/templates/pois/poi_list_archived.html:33
@@ -1609,8 +1609,8 @@ msgstr "Status"
 
 #: cms/forms/feedback/region_feedback_filter_form.py:37
 #: cms/templates/feedback/_feedback_widget.html:21
-#: cms/templates/feedback/admin_feedback_list.html:34
-#: cms/templates/feedback/admin_feedback_list.html:35
+#: cms/templates/feedback/admin_feedback_list.html:37
+#: cms/templates/feedback/admin_feedback_list.html:38
 #: cms/templates/feedback/region_feedback_list.html:37
 #: cms/templates/feedback/region_feedback_list.html:38
 msgid "Rating"
@@ -2479,7 +2479,7 @@ msgid "thumbnail URL"
 msgstr "Vorschaubild-URL"
 
 #: cms/models/offers/offer_template.py:31 cms/templates/_tinymce_config.html:46
-#: cms/templates/linkcheck/links_by_filter.html:54
+#: cms/templates/linkcheck/links_by_filter.html:57
 #: cms/templates/offertemplates/offertemplate_list.html:22
 #: cms/views/media/media_context_mixin.py:57
 msgid "URL"
@@ -2535,8 +2535,8 @@ msgstr "Ob die Seite explizit archiviert ist oder nicht"
 #: cms/templates/events/event_list.html:64
 #: cms/templates/events/event_list_archived.html:35
 #: cms/templates/events/event_list_archived.html:39
-#: cms/templates/pages/page_form.html:29 cms/templates/pages/page_tree.html:63
-#: cms/templates/pages/page_tree.html:67
+#: cms/templates/pages/page_form.html:29 cms/templates/pages/page_tree.html:69
+#: cms/templates/pages/page_tree.html:73
 #: cms/templates/pages/page_tree_archived.html:50
 #: cms/templates/pages/page_tree_archived.html:54
 #: cms/templates/pois/poi_form.html:27 cms/templates/pois/poi_list.html:51
@@ -3185,7 +3185,7 @@ msgid "Feedback"
 msgstr "Feedback"
 
 #: cms/templates/_base.html:181
-#: cms/templates/push_notifications/push_notification_list.html:9
+#: cms/templates/push_notifications/push_notification_list.html:7
 #: core/settings.py:730
 msgid "News"
 msgstr "Nachrichten"
@@ -3366,22 +3366,22 @@ msgid "Details"
 msgstr "Detailansicht"
 
 #: cms/templates/analytics/_broken_links_widget.html:26
-#: cms/templates/linkcheck/links_by_filter.html:10
+#: cms/templates/linkcheck/links_by_filter.html:9
 msgid "Invalid links"
 msgstr "Ungültige Links"
 
 #: cms/templates/analytics/_broken_links_widget.html:30
-#: cms/templates/linkcheck/links_by_filter.html:8
+#: cms/templates/linkcheck/links_by_filter.html:7
 msgid "Valid links"
 msgstr "Gültige Links"
 
 #: cms/templates/analytics/_broken_links_widget.html:34
-#: cms/templates/linkcheck/links_by_filter.html:14
+#: cms/templates/linkcheck/links_by_filter.html:13
 msgid "Ignored links"
 msgstr "Ignorierte Links"
 
 #: cms/templates/analytics/_broken_links_widget.html:38
-#: cms/templates/linkcheck/links_by_filter.html:12
+#: cms/templates/linkcheck/links_by_filter.html:11
 msgid "Unchecked links"
 msgstr "Nicht geprüfte Links"
 
@@ -3875,18 +3875,18 @@ msgstr "Archivierte Veranstaltungen"
 
 #: cms/templates/events/event_list.html:27
 #: cms/templates/events/event_list_archived.html:16
-#: cms/templates/feedback/admin_feedback_list.html:15
+#: cms/templates/feedback/admin_feedback_list.html:13
 #: cms/templates/feedback/region_feedback_list.html:13
-#: cms/templates/pages/page_tree.html:26
+#: cms/templates/pages/page_tree.html:30
 #: cms/templates/pages/page_tree_archived.html:25
 msgid "Show filters"
 msgstr "Filter einblenden"
 
 #: cms/templates/events/event_list.html:28
 #: cms/templates/events/event_list_archived.html:17
-#: cms/templates/feedback/admin_feedback_list.html:16
+#: cms/templates/feedback/admin_feedback_list.html:14
 #: cms/templates/feedback/region_feedback_list.html:14
-#: cms/templates/pages/page_tree.html:27
+#: cms/templates/pages/page_tree.html:31
 #: cms/templates/pages/page_tree_archived.html:26
 msgid "Hide filters"
 msgstr "Filter ausblenden"
@@ -3922,10 +3922,10 @@ msgstr "Wiederholung"
 #: cms/templates/events/event_list.html:82
 #: cms/templates/events/event_list_archived.html:57
 #: cms/templates/languages/language_list.html:30
-#: cms/templates/linkcheck/links_by_filter.html:59
+#: cms/templates/linkcheck/links_by_filter.html:62
 #: cms/templates/offertemplates/offertemplate_list.html:26
 #: cms/templates/organizations/organization_list.html:23
-#: cms/templates/pages/page_tree.html:83
+#: cms/templates/pages/page_tree.html:90
 #: cms/templates/pages/page_tree_archived.html:69
 #: cms/templates/pois/poi_list.html:72
 #: cms/templates/pois/poi_list_archived.html:38
@@ -3941,48 +3941,52 @@ msgstr "Keine Veranstaltungen mit diesen Filtern gefunden."
 msgid "No upcoming events available."
 msgstr "Keine zukünftigen Veranstaltungen vorhanden."
 
-#: cms/templates/events/event_list.html:106
+#: cms/templates/events/event_list.html:107
+msgid "Events selected"
+msgstr "Veranstaltungen ausgewählt"
+
+#: cms/templates/events/event_list.html:113
 #: cms/templates/events/event_list_archived.html:81
-#: cms/templates/feedback/admin_feedback_list.html:128
-#: cms/templates/feedback/region_feedback_list.html:123
-#: cms/templates/linkcheck/links_by_filter.html:76
-#: cms/templates/pages/page_tree.html:123
+#: cms/templates/feedback/admin_feedback_list.html:138
+#: cms/templates/feedback/region_feedback_list.html:130
+#: cms/templates/linkcheck/links_by_filter.html:86
+#: cms/templates/pages/page_tree.html:150
 #: cms/templates/pages/page_tree_archived.html:92
-#: cms/templates/pois/poi_list.html:95
+#: cms/templates/pois/poi_list.html:102
 #: cms/templates/pois/poi_list_archived.html:56
 msgid "Select bulk action"
 msgstr "Mehrfachaktion auswählen"
 
-#: cms/templates/events/event_list.html:108
+#: cms/templates/events/event_list.html:115
 msgid "Archive events"
 msgstr "Veranstaltungen archivieren"
 
-#: cms/templates/events/event_list.html:112
-#: cms/templates/pois/poi_list.html:102
+#: cms/templates/events/event_list.html:119
+#: cms/templates/pois/poi_list.html:109
 msgid "You cannot translate into the default language"
 msgstr "Sie können nicht in die Standard-Sprache übersetzen"
 
-#: cms/templates/events/event_list.html:113
-#: cms/templates/events/event_list.html:117
-#: cms/templates/events/event_list.html:121
-#: cms/templates/pois/poi_list.html:103 cms/templates/pois/poi_list.html:107
-#: cms/templates/pois/poi_list.html:111
+#: cms/templates/events/event_list.html:120
+#: cms/templates/events/event_list.html:124
+#: cms/templates/events/event_list.html:128
+#: cms/templates/pois/poi_list.html:110 cms/templates/pois/poi_list.html:114
+#: cms/templates/pois/poi_list.html:118
 msgid "Create missing translations automatically"
 msgstr "Fehlende Übersetzungen automatisch erstellen"
 
-#: cms/templates/events/event_list.html:120
-#: cms/templates/pois/poi_list.html:110
+#: cms/templates/events/event_list.html:127
+#: cms/templates/pois/poi_list.html:117
 msgid "This language is not supported by DeepL"
 msgstr "Diese Sprache wird von DeepL nicht unterstützt"
 
-#: cms/templates/events/event_list.html:126
+#: cms/templates/events/event_list.html:133
 #: cms/templates/events/event_list_archived.html:86
-#: cms/templates/feedback/admin_feedback_list.html:135
-#: cms/templates/feedback/region_feedback_list.html:137
-#: cms/templates/linkcheck/links_by_filter.html:84
-#: cms/templates/pages/page_tree.html:152
+#: cms/templates/feedback/admin_feedback_list.html:152
+#: cms/templates/feedback/region_feedback_list.html:144
+#: cms/templates/linkcheck/links_by_filter.html:104
+#: cms/templates/pages/page_tree.html:184
 #: cms/templates/pages/page_tree_archived.html:98
-#: cms/templates/pois/poi_list.html:116
+#: cms/templates/pois/poi_list.html:123
 #: cms/templates/pois/poi_list_archived.html:61
 msgid "Execute"
 msgstr "Ausführen"
@@ -4047,19 +4051,19 @@ msgid "The five most recent entries are listed."
 msgstr "Die fünf aktuellsten Einträge werden aufgeführt."
 
 #: cms/templates/feedback/_feedback_widget.html:19
-#: cms/templates/feedback/admin_feedback_list.html:31
+#: cms/templates/feedback/admin_feedback_list.html:34
 #: cms/templates/feedback/region_feedback_list.html:34
 msgid "Feedback on"
 msgstr "Feedback zu"
 
 #: cms/templates/feedback/_feedback_widget.html:20
-#: cms/templates/feedback/admin_feedback_list.html:33
+#: cms/templates/feedback/admin_feedback_list.html:36
 #: cms/templates/feedback/region_feedback_list.html:36
 msgid "Comment"
 msgstr "Kommentar"
 
 #: cms/templates/feedback/_feedback_widget.html:23
-#: cms/templates/feedback/admin_feedback_list.html:38
+#: cms/templates/feedback/admin_feedback_list.html:41
 #: cms/templates/feedback/region_feedback_list.html:40
 #: cms/templates/imprint/imprint_revisions.html:22
 #: cms/templates/pages/page_revisions.html:26
@@ -4074,45 +4078,50 @@ msgstr "Noch kein Feedback vorhanden."
 msgid "Open feedback list"
 msgstr "Feedback-Liste öffnen"
 
-#: cms/templates/feedback/admin_feedback_list.html:11
+#: cms/templates/feedback/admin_feedback_list.html:9
 msgid "Technical Feedback"
 msgstr "Technisches Feedback"
 
-#: cms/templates/feedback/admin_feedback_list.html:29
+#: cms/templates/feedback/admin_feedback_list.html:30
 #: cms/templates/feedback/region_feedback_list.html:30
 msgid "Select all"
 msgstr "Alle auswählen"
 
-#: cms/templates/feedback/admin_feedback_list.html:35
+#: cms/templates/feedback/admin_feedback_list.html:38
 #: cms/templates/feedback/region_feedback_list.html:38
 msgid "overall"
 msgstr "insgesamt"
 
-#: cms/templates/feedback/admin_feedback_list.html:37
+#: cms/templates/feedback/admin_feedback_list.html:40
 #: cms/templates/feedback/region_feedback_list.html:39
 msgid "Marked as read by"
 msgstr "Als gelesen markiert von"
 
-#: cms/templates/feedback/admin_feedback_list.html:115
+#: cms/templates/feedback/admin_feedback_list.html:118
 msgid "No technical feedback found with these filters."
 msgstr "Kein technisches Feedback mit diesen Filtern gefunden."
 
-#: cms/templates/feedback/admin_feedback_list.html:117
+#: cms/templates/feedback/admin_feedback_list.html:120
 msgid "No technical feedback available yet."
 msgstr "Noch kein technisches Feedback vorhanden."
 
 #: cms/templates/feedback/admin_feedback_list.html:129
-#: cms/templates/feedback/region_feedback_list.html:126
+#: cms/templates/feedback/region_feedback_list.html:122
+msgid "Feedback entries selected"
+msgstr "Feedback Einträge ausgewählt"
+
+#: cms/templates/feedback/admin_feedback_list.html:141
+#: cms/templates/feedback/region_feedback_list.html:133
 msgid "Mark as read"
 msgstr "Als gelesen markieren"
 
-#: cms/templates/feedback/admin_feedback_list.html:130
-#: cms/templates/feedback/region_feedback_list.html:129
+#: cms/templates/feedback/admin_feedback_list.html:144
+#: cms/templates/feedback/region_feedback_list.html:136
 msgid "Mark as unread"
 msgstr "Als ungelesen markieren"
 
-#: cms/templates/feedback/admin_feedback_list.html:132
-#: cms/templates/feedback/region_feedback_list.html:133
+#: cms/templates/feedback/admin_feedback_list.html:148
+#: cms/templates/feedback/region_feedback_list.html:140
 #: cms/templates/language_tree/language_tree.html:29
 msgid "Delete"
 msgstr "Löschen"
@@ -4278,7 +4287,7 @@ msgstr "Permalink"
 #: cms/templates/pages/_page_xliff_import_diff.html:81
 #: cms/templates/pages/page_revisions.html:67
 #: cms/templates/pages/page_revisions.html:80
-#: cms/templates/push_notifications/push_notification_list.html:28
+#: cms/templates/push_notifications/push_notification_list.html:25
 msgid "Title"
 msgstr "Titel"
 
@@ -4344,7 +4353,7 @@ msgid "Create language tree node"
 msgstr "Sprach-Knoten hinzufügen"
 
 #: cms/templates/language_tree/language_tree.html:21
-#: cms/templates/pages/page_tree.html:61
+#: cms/templates/pages/page_tree.html:67
 #: cms/templates/pages/page_tree_archived.html:48
 msgid "Hierarchy"
 msgstr "Hierarchie"
@@ -4489,9 +4498,9 @@ msgstr "Erstellt"
 #: cms/templates/languages/language_list.html:28
 #: cms/templates/offertemplates/offertemplate_list.html:23
 #: cms/templates/pages/_page_xliff_import_diff.html:36
-#: cms/templates/pages/page_tree.html:82
+#: cms/templates/pages/page_tree.html:89
 #: cms/templates/pages/page_tree_archived.html:68
-#: cms/templates/push_notifications/push_notification_list.html:44
+#: cms/templates/push_notifications/push_notification_list.html:39
 #: cms/templates/regions/region_list.html:23
 msgid "Last updated"
 msgstr "Zuletzt aktualisiert"
@@ -4509,55 +4518,59 @@ msgstr "Anzahl an Regionen"
 msgid "No languages available yet."
 msgstr "Noch keine Sprachen vorhanden."
 
-#: cms/templates/linkcheck/link_list_row.html:25
+#: cms/templates/linkcheck/link_list_row.html:32
 msgid "Go to source"
 msgstr "Inhalt aufrufen"
 
-#: cms/templates/linkcheck/link_list_row.html:35
+#: cms/templates/linkcheck/link_list_row.html:39
 msgid "Replace URL globally"
 msgstr "URL zentral ersetzen"
 
-#: cms/templates/linkcheck/links_by_filter.html:19
+#: cms/templates/linkcheck/links_by_filter.html:18
 msgid "Valid"
 msgstr "Gültig"
 
-#: cms/templates/linkcheck/links_by_filter.html:26
+#: cms/templates/linkcheck/links_by_filter.html:25
 msgid "Invalid"
 msgstr "Ungültig"
 
-#: cms/templates/linkcheck/links_by_filter.html:33
+#: cms/templates/linkcheck/links_by_filter.html:32
 msgid "Unchecked"
 msgstr "Nicht geprüft"
 
-#: cms/templates/linkcheck/links_by_filter.html:40
+#: cms/templates/linkcheck/links_by_filter.html:39
 msgid "Ignored"
 msgstr "Ignoriert"
 
-#: cms/templates/linkcheck/links_by_filter.html:56
+#: cms/templates/linkcheck/links_by_filter.html:59
 msgid "Link text"
 msgstr "Link Text"
 
-#: cms/templates/linkcheck/links_by_filter.html:57
+#: cms/templates/linkcheck/links_by_filter.html:60
 msgid "Source"
 msgstr "Quelle"
 
-#: cms/templates/linkcheck/links_by_filter.html:58
+#: cms/templates/linkcheck/links_by_filter.html:61
 msgid "Content type"
 msgstr "Inhaltstyp"
 
-#: cms/templates/linkcheck/links_by_filter.html:68
+#: cms/templates/linkcheck/links_by_filter.html:70
 msgid "No links detected yet."
 msgstr "Es konnten keine Links gefunden werden."
 
-#: cms/templates/linkcheck/links_by_filter.html:78
+#: cms/templates/linkcheck/links_by_filter.html:79
+msgid "Links selected"
+msgstr "Links ausgewählt"
+
+#: cms/templates/linkcheck/links_by_filter.html:91
 msgid "Unignore"
 msgstr "Nicht ignorieren"
 
-#: cms/templates/linkcheck/links_by_filter.html:80
+#: cms/templates/linkcheck/links_by_filter.html:96
 msgid "Recheck"
 msgstr "Erneut prüfen"
 
-#: cms/templates/linkcheck/links_by_filter.html:81
+#: cms/templates/linkcheck/links_by_filter.html:100
 msgid "Ignore"
 msgstr "Ignorieren"
 
@@ -4876,61 +4889,65 @@ msgstr ""
 " Dieses Feld freilassen, um eine eindeutigen Permalink aus dem Titel zu "
 "generieren"
 
-#: cms/templates/pages/page_tree.html:13
+#: cms/templates/pages/page_tree.html:12
 #: cms/templates/pages/page_tree_archived.html:15
 msgid "Page Tree"
 msgstr "Seiten-Baum"
 
-#: cms/templates/pages/page_tree.html:15
+#: cms/templates/pages/page_tree.html:19
 msgid "Archived pages"
 msgstr "Archivierte Seiten"
 
-#: cms/templates/pages/page_tree.html:34 cms/templates/pages/page_tree.html:41
+#: cms/templates/pages/page_tree.html:39 cms/templates/pages/page_tree.html:45
 msgid "Create page"
 msgstr "Seite erstellen"
 
-#: cms/templates/pages/page_tree.html:37
+#: cms/templates/pages/page_tree.html:42
 #, python-format
 msgid ""
 "You can only create pages in the default language (%(default_language)s)."
 msgstr ""
 "Sie können Seiten nur in der Standard-Sprache (%(default_language)s) anlegen."
 
-#: cms/templates/pages/page_tree.html:69
+#: cms/templates/pages/page_tree.html:75
 msgid "Tags"
 msgstr "Tags"
 
-#: cms/templates/pages/page_tree.html:97
+#: cms/templates/pages/page_tree.html:113
 msgid "No pages found with these filters."
 msgstr "Keine Seiten mit diesen Filtern gefunden."
 
-#: cms/templates/pages/page_tree.html:99
+#: cms/templates/pages/page_tree.html:115
 msgid "No pages available yet."
 msgstr "Noch keine Seiten vorhanden."
 
-#: cms/templates/pages/page_tree.html:112
+#: cms/templates/pages/page_tree.html:130
 msgid "Expand all"
 msgstr "Alle ausklappen"
 
-#: cms/templates/pages/page_tree.html:116
+#: cms/templates/pages/page_tree.html:138
 msgid "Collapse all"
 msgstr "Alle einklappen"
 
-#: cms/templates/pages/page_tree.html:125
+#: cms/templates/pages/page_tree.html:143
+msgid "Pages selected"
+msgstr "Seiten ausgewählt"
+
+#: cms/templates/pages/page_tree.html:153
 msgid "Archive pages"
 msgstr "Seiten archivieren"
 
-#: cms/templates/pages/page_tree.html:131
+#: cms/templates/pages/page_tree.html:159
 msgid "Export published pages as PDF"
 msgstr "Veröffentlichte Seiten als PDF exportieren"
 
-#: cms/templates/pages/page_tree.html:135
+#: cms/templates/pages/page_tree.html:163
 #, python-format
 msgid "Export all pages for %(language_translated_name)s translation"
 msgstr ""
 "Alle Seiten für die %(language_translated_name)s-Übersetzung exportieren"
 
-#: cms/templates/pages/page_tree.html:136
+#: cms/templates/pages/page_tree.html:164
 #, python-format
 msgid ""
 "Export only published pages for %(language_translated_name)s translation"
@@ -4938,27 +4955,27 @@ msgstr ""
 "Nur veröffentlichte Seiten für die %(language_translated_name)s-Übersetzung "
 "exportieren"
 
-#: cms/templates/pages/page_tree.html:138
+#: cms/templates/pages/page_tree.html:166
 msgid "You cannot export XLIFF files for the default language"
 msgstr "Sie können keine XLIFF-Dateien für die Standard-Sprache exportieren"
 
-#: cms/templates/pages/page_tree.html:157
+#: cms/templates/pages/page_tree.html:189
 msgid "Import XLIFF files"
 msgstr "XLIFF-Dateien importieren"
 
-#: cms/templates/pages/page_tree.html:158
+#: cms/templates/pages/page_tree.html:190
 msgid "Supported file extensions"
 msgstr "Unterstützte Dateiendungen"
 
-#: cms/templates/pages/page_tree.html:163
+#: cms/templates/pages/page_tree.html:199
 msgid "Select files"
 msgstr "Dateien auswählen"
 
-#: cms/templates/pages/page_tree.html:165
+#: cms/templates/pages/page_tree.html:201
 msgid "and {} other files"
 msgstr "und {} weitere Dateien"
 
-#: cms/templates/pages/page_tree.html:168
+#: cms/templates/pages/page_tree.html:209
 msgid "Import"
 msgstr "Importieren"
 
@@ -5170,7 +5187,11 @@ msgstr "Keine Orte mit diesen Filtern gefunden."
 msgid "No locations available yet."
 msgstr "Noch keine Orte vorhanden."
 
-#: cms/templates/pois/poi_list.html:98
+#: cms/templates/pois/poi_list.html:95
+msgid "Locations selected"
+msgstr "Orte ausgewählt"
+
+#: cms/templates/pois/poi_list.html:105
 msgid "Archive locations"
 msgstr "Orte archivieren"
 
@@ -5211,7 +5232,7 @@ msgid "Edit news message \"%(push_notification_title)s\""
 msgstr "Nachricht \"%(push_notification_title)s\" bearbeiten"
 
 #: cms/templates/push_notifications/push_notification_form.html:18
-#: cms/templates/push_notifications/push_notification_list.html:17
+#: cms/templates/push_notifications/push_notification_list.html:16
 msgid "Create news message"
 msgstr "Neue Nachricht verfassen"
 
@@ -5220,7 +5241,7 @@ msgid "Save & Send"
 msgstr "Speichern & Senden"
 
 #: cms/templates/push_notifications/push_notification_form.html:114
-#: cms/templates/push_notifications/push_notification_list.html:46
+#: cms/templates/push_notifications/push_notification_list.html:40
 msgid "Sent"
 msgstr "Gesendet"
 
@@ -5229,15 +5250,15 @@ msgstr "Gesendet"
 msgid "Message not sent yet"
 msgstr "Nachricht noch nicht gesendet"
 
-#: cms/templates/push_notifications/push_notification_list.html:31
+#: cms/templates/push_notifications/push_notification_list.html:26
 msgid "Channel"
 msgstr "Kanal"
 
-#: cms/templates/push_notifications/push_notification_list.html:58
+#: cms/templates/push_notifications/push_notification_list.html:51
 msgid "No push notifications found with these filters."
 msgstr "Keine Push-Benachrichtigungen mit diesen Filter gefunden."
 
-#: cms/templates/push_notifications/push_notification_list.html:60
+#: cms/templates/push_notifications/push_notification_list.html:53
 msgid "No push notifications available yet."
 msgstr "Noch keine Push-Benachrichtigungen vorhanden."
 
@@ -6805,6 +6826,9 @@ msgstr ""
 "Diese Seite konnte nicht importiert werden, da sie zu einer anderen Region "
 "gehört ({})."
 
+#~ msgid "Broken links selected"
+#~ msgstr "Fehlerhafte Links ausgewählt"
+
 #~ msgid "password reset"
 #~ msgstr "Passwort zurücksetzen"
 
@@ -7651,9 +7675,6 @@ msgstr ""
 
 #~ msgid "Icon"
 #~ msgstr "Icon"
-
-#~ msgid "No icon selected"
-#~ msgstr "Kein Icon ausgewählt"
 
 #~ msgid "Clear"
 #~ msgstr "Löschen"

--- a/integreat_cms/static/src/js/bulk-actions.ts
+++ b/integreat_cms/static/src/js/bulk-actions.ts
@@ -28,6 +28,9 @@
  *
  */
 
+ import { addCheckboxCountListeners } from "./checkbox-count"
+
+
 window.addEventListener("load", () => {
   // On the page tree, the event listeners are set after all subpages have been loaded
   if (!document.querySelector("[data-delay-event-handlers]")) {
@@ -49,11 +52,11 @@ export function setBulkActionEventListeners(){
   selectAllCheckbox.classList.remove("cursor-wait");
   selectAllCheckbox.addEventListener("click", () => {
     // Set all checkboxes to the same value as the "select all" checkbox
-    selectItems.forEach((checkbox) => checkbox.checked = selectAllCheckbox.checked);
+    selectItems.forEach((checkbox) => setCheckboxChecked(checkbox, selectAllCheckbox.checked)); 
     toggleBulkActionButton();
   });
   // Set all checkboxes initially in case the page tree was reloaded
-  selectItems.forEach((checkbox) => checkbox.checked = selectAllCheckbox.checked);
+  selectItems.forEach((checkbox) => setCheckboxChecked(checkbox, selectAllCheckbox.checked));
   // Set event listener for bulk action button
   bulkAction.addEventListener("change", toggleBulkActionButton);
   toggleBulkActionButton();
@@ -75,6 +78,8 @@ export function setBulkActionEventListeners(){
       }
     });
   });
+  // Activate Selection Count for events, feedback and pois
+  addCheckboxCountListeners();
 }
 
 /*
@@ -83,7 +88,7 @@ export function setBulkActionEventListeners(){
 function setCheckboxRecursively(pageId: number, checked: boolean) {
   let page = document.getElementById("page-" + pageId);
   let checkbox = page.querySelector(".bulk-select-item") as HTMLInputElement;
-  checkbox.checked = checked;
+  setCheckboxChecked(checkbox, checked);
   const toggleButton = page.querySelector(".toggle-subpages")
   if (toggleButton){
     let childrenIds: number[] = JSON.parse(toggleButton.getAttribute("data-page-children"));
@@ -109,7 +114,6 @@ function bulkActionExecute(event: Event) {
   // Submit form and execute bulk action
   form.submit();
 }
-
 
 /*
  * Enable/disable the bulk action button
@@ -149,3 +153,11 @@ function hasTranslation(selectItems: HTMLInputElement[]): boolean {
         .querySelector(`.lang-grid .${languageSlug} .no-trans`) === null;
     });
 }
+
+/*
+ * Trigger a custom event for correct calculation of the change triggers.
+ */
+function setCheckboxChecked(checkbox: HTMLInputElement, checked: boolean) {
+  checkbox.checked = checked;
+  checkbox.dispatchEvent(new InputEvent("change"));
+} 

--- a/integreat_cms/static/src/js/checkbox-count.ts
+++ b/integreat_cms/static/src/js/checkbox-count.ts
@@ -1,0 +1,12 @@
+/**
+ * This file contains a function to count and update the number of selected items in the page tree.
+ */
+
+export function addCheckboxCountListeners() {
+  document.querySelectorAll(".bulk-select-item").forEach((el) =>
+    el.addEventListener("change", () => {
+      (document.querySelector("[data-list-selection-count]") as HTMLElement).innerText =
+        document.querySelectorAll(".bulk-select-item:checked").length.toString();
+    })
+  );
+}

--- a/integreat_cms/static/src/js/pages/fetch-subpages.ts
+++ b/integreat_cms/static/src/js/pages/fetch-subpages.ts
@@ -8,18 +8,20 @@ import { setBulkActionEventListeners } from "../bulk-actions";
 import { setToggleSubpagesEventListeners } from "./toggle-subpages";
 import { addDragAndDropListeners } from "../tree-drag-and-drop";
 import { addConfirmationDialogListeners } from "../confirmation-popups";
+import { addCheckboxCountListeners } from "../checkbox-count";
 
 window.addEventListener("load", () => {
-  // load subpages initially
+  // Load subpages initially
   if (document.querySelector("[data-delay-event-handlers]")) {
     let rootPages: HTMLElement[] = Array.from(document.querySelectorAll(".toggle-subpages"));
     console.debug("Loading all subpages");
     Promise.all(rootPages.map(fetchSubpages)).then(() => {
       console.debug("Finished loading all subpages");
-      // render icons for recently added DOM elements
+      // Render icons for recently added DOM elements
       feather.replace({ class: 'inline-block' });
       // Set event handlers
       setToggleSubpagesEventListeners();
+      addCheckboxCountListeners();
       setBulkActionEventListeners();
       addDragAndDropListeners();
       addConfirmationDialogListeners();
@@ -55,7 +57,7 @@ export async function fetchSubpages(collapseSpan: HTMLElement): Promise<number[]
   let descendantIds: number[] = [];
   renderedDescendants.forEach(function(rowToInsert: HTMLTableRowElement) {
     if (rowToInsert.classList.contains("page-row")) {
-      // record children ids to update all ancestors descendants data attribute
+      // Record children ids to update all ancestors descendants data attribute
       let descendantId = parseInt(rowToInsert.dataset.dropId);
       descendantIds.push(descendantId);
       // Check if the descendant is a direct child
@@ -63,9 +65,9 @@ export async function fetchSubpages(collapseSpan: HTMLElement): Promise<number[]
         directChildrenIds.push(descendantId);
       }
     }
-    // insert child into DOM tree
+    // Insert child into DOM tree
     currentRow.after(rowToInsert);
-    // update point to insert next child
+    // Update point to insert next child
     currentRow = rowToInsert;
   });
   // Update descendants to enable drag & drop functionality


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This adds a counter of the selected items to all lists and trees with checkboxes.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add defining data attributes to all checkboxes
- Add selection counter beneath the lists and trees
- Add a custom change event to the page tree for correct handling of AJAX fetching of the subpages.
- Apply formatting to the django templates
- Fix some spelling issues

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1046 
