### PR TITLE
Fix legacy media urls in PDF export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ UNRELEASED
 * [ [#726](https://github.com/digitalfabrik/integreat-cms/issues/726) ] Add additional fields to location model
 * [ [#1311](https://github.com/digitalfabrik/integreat-cms/issues/1311) ] Fix last_updated field when cloning regions
 * [ [#1384](https://github.com/digitalfabrik/integreat-cms/issues/1384) ] Phone numbers and emails addresses marked as invalid links
+* [ [#1350](https://github.com/digitalfabrik/integreat-cms/issues/1350) ] Fix legacy media urls in PDF export
 
 
 2022.4.2

--- a/integreat_cms/cms/utils/pdf_utils.py
+++ b/integreat_cms/cms/utils/pdf_utils.py
@@ -2,6 +2,8 @@ import hashlib
 import logging
 import os
 
+from urllib.parse import urlparse
+
 from django.conf import settings
 from django.contrib.staticfiles import finders
 from django.db.models import Min
@@ -133,6 +135,14 @@ def link_callback(uri, rel):
     :return: The absolute path on the file system according to django's static file settings
     :rtype: str
     """
+    parsed_uri = urlparse(uri)
+    # When the uri is an absolute URL to an allowed host, convert it to an absolute local path
+    if parsed_uri.hostname in settings.ALLOWED_HOSTS:
+        uri = parsed_uri.path
+        # When the url contains the legacy media url, replace it with the new pattern
+        LEGACY_MEDIA_URL = "/wp-content/uploads/"
+        if LEGACY_MEDIA_URL in uri:
+            uri = f"/media/{uri.partition(LEGACY_MEDIA_URL)[2]}"
     if uri.startswith(settings.MEDIA_URL):
         # Get absolute path for media files
         path = os.path.join(settings.MEDIA_ROOT, uri.replace(settings.MEDIA_URL, ""))

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-05-06 11:15+0000\n"
+"POT-Creation-Date: 2022-05-06 12:32+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -5787,12 +5787,12 @@ msgstr "Unbekannt"
 msgid "CW"
 msgstr "KW"
 
-#: cms/utils/pdf_utils.py:67
+#: cms/utils/pdf_utils.py:69
 msgid "No valid pages selected for PDF generation."
 msgstr ""
 "Es wurden keine gültigen Seiten zur Erzeugung der PDF-Datei ausgewählt."
 
-#: cms/utils/pdf_utils.py:115
+#: cms/utils/pdf_utils.py:117
 msgid "The PDF could not be successfully generated."
 msgstr "PDF-Datei konnte nicht erfolgreich erzeugt werden."
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
(Hopefully) fix legacy media urls in PDF export.
Since the directory structure of the media export is still in progress, we might need to adapt this slightly in the future, but I hope this already fixes most problems.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Convert image urls to absolute paths on allowed hosts
- Convert the legacy url pattern `/region-slug/wp-content/uploads/` to the new path `/media/`

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes (partially): #1350
