### PR TITLE
Use str path converter for unicode slugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ UNRELEASED
 * [ [#1046](https://github.com/digitalfabrik/integreat-cms/issues/1046) ] Show number of selected items in lists and page tree
 * [ [#1000](https://github.com/digitalfabrik/integreat-cms/issues/1000) ] Automatically derive location coordinates from address
 * [ [#1180](https://github.com/digitalfabrik/integreat-cms/issues/1180) ] Make coordinates optional for locations not on map
+* [ [#1380](https://github.com/digitalfabrik/integreat-cms/issues/1380) ] Fix url resolving for regions with non-ascii slugs
 
 
 2022.4.2

--- a/integreat_cms/cms/urls/protected.py
+++ b/integreat_cms/cms/urls/protected.py
@@ -186,7 +186,7 @@ urlpatterns = [
                     name="new_region",
                 ),
                 path(
-                    "<slug:slug>/",
+                    "<slug>/",
                     include(
                         [
                             path(
@@ -316,7 +316,7 @@ urlpatterns = [
                     name="new_organization",
                 ),
                 path(
-                    "<slug:slug>/",
+                    "<slug>/",
                     include(
                         [
                             path(
@@ -438,7 +438,7 @@ urlpatterns = [
         ),
     ),
     path(
-        "<slug:region_slug>/",
+        "<region_slug>/",
         include(
             [
                 path("", dashboard.DashboardView.as_view(), name="dashboard"),

--- a/integreat_cms/cms/utils/slug_utils.py
+++ b/integreat_cms/cms/utils/slug_utils.py
@@ -92,8 +92,11 @@ def generate_unique_slug(**kwargs):
                 code="invalid",
                 params={"fallback": _(fallback)},
             )
+        # Check whether slug field supports unicode
+        # pylint: disable=protected-access
+        allow_unicode = object_instance._meta.get_field("slug").allow_unicode
         # slugify to make sure slug doesn't contain special chars etc.
-        slug = slugify(cleaned_data[fallback], allow_unicode=True)
+        slug = slugify(cleaned_data[fallback], allow_unicode=allow_unicode)
         # If the title/name field didn't contain valid characters for a slug, we use a hardcoded fallback slug
         if not slug:
             slug = foreign_model


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
The slug path converter only matches strings consisting of ASCII letters or numbers, plus the hyphen and underscore characters.
The default str path converter matches any non-empty string, excluding the path separator, '/'.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Use str path converter for unicode slugs

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1380
