### PR TITLE
Make order of coordinates fields consistent

### DIFF
--- a/integreat_cms/cms/templates/pois/poi_form.html
+++ b/integreat_cms/cms/templates/pois/poi_form.html
@@ -127,12 +127,12 @@
                         <div>
                             <label>{% trans 'Position' %}</label>
                             <div class="help-text">{% trans 'If you leave these fields blank, they are automatically derived from the address.' %}</div>
-                            <label for="{{ poi_form.longitude.id_for_label }}" class="secondary">{{ poi_form.longitude.label }}</label>
-                            {% render_field poi_form.longitude|add_error_class:"border-red-500" %}
-                            <div class="help-text">{{ poi_form.longitude.help_text }}</div>
                             <label for="{{ poi_form.latitude.id_for_label }}" class="secondary">{{ poi_form.latitude.label }}</label>
                             {% render_field poi_form.latitude|add_error_class:"border-red-500" %}
                             <div class="help-text">{{ poi_form.latitude.help_text }}</div>
+                            <label for="{{ poi_form.longitude.id_for_label }}" class="secondary">{{ poi_form.longitude.label }}</label>
+                            {% render_field poi_form.longitude|add_error_class:"border-red-500" %}
+                            <div class="help-text">{{ poi_form.longitude.help_text }}</div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Make order of coordinates fields consistent

### Proposed changes
<!-- Describe this PR in more detail. -->

- Latitude is typically given first, then longitude second
