### PR TITLE
Do not run dependency review on push event

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -6,8 +6,6 @@
 # Public documentation: https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/about-dependency-review#dependency-review-enforcement
 name: "Dependency Review"
 on:
-  push:
-    branches: [develop]
   pull_request:
     branches: [develop]
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Dependency review apparently does not support the push event and just works on pull requests...
