### PR TITLE
Do not raise exception in migration if global media directory is not empty

### DIFF
--- a/integreat_cms/cms/migrations/0022_rename_media_directories.py
+++ b/integreat_cms/cms/migrations/0022_rename_media_directories.py
@@ -15,21 +15,15 @@ RESET = "\x1b[0;39m"
 
 def ensure_exists(path):
     """
-    Make sure the given path exists and is empty
+    Make sure the given path exists
 
     :param path: The path that should be created if not exists
     :type path: pathlib.PosixPath
-
-    :raises RuntimeError: If the path is not empty
 
     :return: The existing path
     :rtype: pathlib.PosixPath
     """
     path.mkdir(parents=True, exist_ok=True)
-    if any(path.iterdir()):
-        raise RuntimeError(
-            f"{ERROR}Error:{RESET} Directory {INFO}media/{path.relative_to(settings.MEDIA_ROOT)}/{RESET} is not empty!",
-        )
     return path
 
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
I noticed that with my latest migration, local tests do not work anymore if the global media directory already exists and is not empty.
I forgot that the migrations are executed every time for the tests, even when the data migration on the hard drive is already completed.
So I fixed it by not explicitly raising the exception in this case - if problems on the production migration arise, there will still be an exception, just not as pretty anymore.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Do not raise exception in migration if global media directory exists and is not empty
