### PR TITLE
Add drag and drop for media file upload and enable multiple files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ UNRELEASED
 * [ [#1422](https://github.com/digitalfabrik/integreat-cms/issues/1422) ] Keep pagination settings in broken link checker when performing replacement
 * [ [#1405](https://github.com/digitalfabrik/integreat-cms/issues/1405) ] Show same URLs only once in broken link checker
 * [ [#1438](https://github.com/digitalfabrik/integreat-cms/issues/1438) ] Fix error in page form when page-specific permissions are enabled
+* [ [#1292](https://github.com/digitalfabrik/integreat-cms/issues/1292) ] Add multi-file upload via drag and drop
 
 
 2022.5.0

--- a/integreat_cms/cms/views/media/media_context_mixin.py
+++ b/integreat_cms/cms/views/media/media_context_mixin.py
@@ -29,6 +29,7 @@ class MediaContextMixin(ContextMixin):
                 "heading_media_library": _("Media Library"),
                 "heading_create_directory": _("Create Directory"),
                 "heading_upload_file": _("Upload File"),
+                "text_upload_area": _("Click or drop files here for upload."),
                 "heading_media_root": _("Home"),
                 "heading_directory_properties": _("Directory Properties"),
                 "heading_file_properties": _("File Properties"),
@@ -73,6 +74,9 @@ class MediaContextMixin(ContextMixin):
                 "text_dir_delete_confirm": _(
                     "Please confirm that you really want to delete this directory"
                 ),
+                "text_error_invalid_file_type": _(
+                    "This file type is not supported. Supported types are:"
+                ),
                 "text_error": (
                     _("An error has occurred.") + " " + _("Please try again later.")
                 ),
@@ -81,9 +85,12 @@ class MediaContextMixin(ContextMixin):
                     + " "
                     + _("Please try again later.")
                 ),
+                "text_allowed_media_types": ", ".join(
+                    map(str, dict(allowed_media.UPLOAD_CHOICES).values())
+                ),
             },
             "expertMode": self.request.user.expert_mode,
-            "allowedMediaTypes": ", ".join(dict(allowed_media.CHOICES)),
+            "allowedMediaTypes": ", ".join(dict(allowed_media.UPLOAD_CHOICES)),
         }
         kwargs = (
             {"region_slug": self.request.region.slug} if self.request.region else {}

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-05-15 22:22+0000\n"
+"POT-Creation-Date: 2022-05-18 17:17+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -2569,7 +2569,7 @@ msgstr "Vorschaubild-URL"
 #: cms/models/offers/offer_template.py:31 cms/templates/_tinymce_config.html:46
 #: cms/templates/linkcheck/links_by_filter.html:57
 #: cms/templates/offertemplates/offertemplate_list.html:22
-#: cms/views/media/media_context_mixin.py:57
+#: cms/views/media/media_context_mixin.py:58
 msgid "URL"
 msgstr "URL"
 
@@ -3377,7 +3377,7 @@ msgstr "Redaktionssystem"
 
 #: cms/templates/_search_input.html:13 cms/templates/_search_input.html:33
 #: cms/templates/events/_event_filter_form.html:34
-#: cms/views/media/media_context_mixin.py:55
+#: cms/views/media/media_context_mixin.py:56
 msgid "Search"
 msgstr "Suchen"
 
@@ -3422,7 +3422,7 @@ msgid "Update"
 msgstr "Aktualisieren"
 
 #: cms/templates/_tinymce_config.html:38
-#: cms/views/media/media_context_mixin.py:51
+#: cms/views/media/media_context_mixin.py:52
 msgid "Submit"
 msgstr "Speichern"
 
@@ -3675,15 +3675,15 @@ msgstr "Nachricht abschicken"
 #: cms/templates/chat/_chat_widget.html:29
 #: cms/templates/statistics/_statistics_widget.html:22
 #: cms/templates/statistics/statistics_overview.html:18
-#: cms/views/media/media_context_mixin.py:80
+#: cms/views/media/media_context_mixin.py:84
 msgid "A network error has occurred."
 msgstr "Ein Netzwerkfehler ist aufgetreten."
 
 #: cms/templates/chat/_chat_widget.html:29
 #: cms/templates/statistics/_statistics_widget.html:22
 #: cms/templates/statistics/statistics_overview.html:18
-#: cms/views/media/media_context_mixin.py:77
-#: cms/views/media/media_context_mixin.py:82
+#: cms/views/media/media_context_mixin.py:81
+#: cms/views/media/media_context_mixin.py:86
 msgid "Please try again later."
 msgstr "Bitte versuchen Sie es später erneut."
 
@@ -4711,7 +4711,7 @@ msgid "Create new offer template"
 msgstr "Neue Angebots-Vorlage erstellen"
 
 #: cms/templates/offertemplates/offertemplate_form.html:22
-#: cms/views/media/media_context_mixin.py:41
+#: cms/views/media/media_context_mixin.py:42
 msgid "Create"
 msgstr "Erstellen"
 
@@ -6365,135 +6365,143 @@ msgid "Upload File"
 msgstr "Datei hochladen"
 
 #: cms/views/media/media_context_mixin.py:32
+msgid "Click or drop files here for upload."
+msgstr "Klicken Sie hier oder legen Sie die Dateien zum Hochladen hier ab."
+
+#: cms/views/media/media_context_mixin.py:33
 msgid "Home"
 msgstr "Home"
 
-#: cms/views/media/media_context_mixin.py:33
+#: cms/views/media/media_context_mixin.py:34
 msgid "Directory Properties"
 msgstr "Ordner-Eigenschaften"
 
-#: cms/views/media/media_context_mixin.py:34
+#: cms/views/media/media_context_mixin.py:35
 msgid "File Properties"
 msgstr "Datei-Eigenschaften"
 
-#: cms/views/media/media_context_mixin.py:35
+#: cms/views/media/media_context_mixin.py:36
 msgid "Search results for"
 msgstr "Suchergebnisse für"
 
-#: cms/views/media/media_context_mixin.py:36
+#: cms/views/media/media_context_mixin.py:37
 msgid "Upload"
 msgstr "Hochladen"
 
-#: cms/views/media/media_context_mixin.py:37
+#: cms/views/media/media_context_mixin.py:38
 msgid "Upload file"
 msgstr "Datei hochladen"
 
-#: cms/views/media/media_context_mixin.py:38
+#: cms/views/media/media_context_mixin.py:39
 msgid "Save file"
 msgstr "Datei speichern"
 
-#: cms/views/media/media_context_mixin.py:39
+#: cms/views/media/media_context_mixin.py:40
 msgid "Delete file"
 msgstr "Datei löschen"
 
-#: cms/views/media/media_context_mixin.py:40
+#: cms/views/media/media_context_mixin.py:41
 msgid "Show file"
 msgstr "Datei anzeigen"
 
-#: cms/views/media/media_context_mixin.py:42
+#: cms/views/media/media_context_mixin.py:43
 msgid "Enter directory"
 msgstr "Verzeichnis betreten"
 
-#: cms/views/media/media_context_mixin.py:43
+#: cms/views/media/media_context_mixin.py:44
 msgid "Create directory"
 msgstr "Verzeichnis erstellen"
 
-#: cms/views/media/media_context_mixin.py:44
+#: cms/views/media/media_context_mixin.py:45
 msgid "Rename directory"
 msgstr "Verzeichnis umbenennen"
 
-#: cms/views/media/media_context_mixin.py:45
+#: cms/views/media/media_context_mixin.py:46
 msgid "Delete directory"
 msgstr "Verzeichnis löschen"
 
-#: cms/views/media/media_context_mixin.py:47
+#: cms/views/media/media_context_mixin.py:48
 msgid "You can only delete empty directories"
 msgstr "Es können nur leere Verzeichnisse gelöscht werden"
 
-#: cms/views/media/media_context_mixin.py:49
+#: cms/views/media/media_context_mixin.py:50
 msgid "Back"
 msgstr "Zurück"
 
-#: cms/views/media/media_context_mixin.py:50
+#: cms/views/media/media_context_mixin.py:51
 msgid "Close detail view"
 msgstr "Detailansicht schließen"
 
-#: cms/views/media/media_context_mixin.py:52
+#: cms/views/media/media_context_mixin.py:53
 msgid "Select"
 msgstr "Auswählen"
 
-#: cms/views/media/media_context_mixin.py:53
+#: cms/views/media/media_context_mixin.py:54
 msgid "Select file"
 msgstr "Datei auswählen"
 
-#: cms/views/media/media_context_mixin.py:54
+#: cms/views/media/media_context_mixin.py:55
 msgid "Replace file"
 msgstr "Datei ersetzen"
 
-#: cms/views/media/media_context_mixin.py:56
+#: cms/views/media/media_context_mixin.py:57
 msgid "File name:"
 msgstr "Dateiname:"
 
-#: cms/views/media/media_context_mixin.py:58
+#: cms/views/media/media_context_mixin.py:59
 msgid "Directory name:"
 msgstr "Verzeichnisname:"
 
-#: cms/views/media/media_context_mixin.py:59
+#: cms/views/media/media_context_mixin.py:60
 msgid "File format:"
 msgstr "Dateiformat:"
 
-#: cms/views/media/media_context_mixin.py:60
+#: cms/views/media/media_context_mixin.py:61
 msgid "File size:"
 msgstr "Dateigröße:"
 
-#: cms/views/media/media_context_mixin.py:61
+#: cms/views/media/media_context_mixin.py:62
 msgid "File uploaded on:"
 msgstr "Datei hochgeladen am:"
 
-#: cms/views/media/media_context_mixin.py:62
+#: cms/views/media/media_context_mixin.py:63
 msgid "Directory created on:"
 msgstr "Verzeichnis erstellt am:"
 
-#: cms/views/media/media_context_mixin.py:63
+#: cms/views/media/media_context_mixin.py:64
 msgid "Alternative text:"
 msgstr "Alternativer Text:"
 
-#: cms/views/media/media_context_mixin.py:64
+#: cms/views/media/media_context_mixin.py:65
 msgid "Enter directory name here"
 msgstr "Verzeichnisname hier eingeben"
 
-#: cms/views/media/media_context_mixin.py:65
+#: cms/views/media/media_context_mixin.py:66
 msgid "This file is read-only and cannot be edited."
 msgstr "Diese Datei ist schreibgeschützt und kann nicht bearbeitet werden."
 
-#: cms/views/media/media_context_mixin.py:67
+#: cms/views/media/media_context_mixin.py:68
 msgid "This directory is read-only and cannot be edited."
 msgstr ""
 "Dieses Verzeichnis ist schreibgeschützt und kann nicht bearbeitet werden."
 
-#: cms/views/media/media_context_mixin.py:69
+#: cms/views/media/media_context_mixin.py:70
 msgid "Only images can be selected as an icon."
 msgstr "Es können nur Bilder als Icon ausgewählt werden."
 
-#: cms/views/media/media_context_mixin.py:71
+#: cms/views/media/media_context_mixin.py:72
 msgid "Please confirm that you really want to delete this file"
 msgstr "Bitte bestätigen Sie, dass diese Datei gelöscht werden soll"
 
-#: cms/views/media/media_context_mixin.py:74
+#: cms/views/media/media_context_mixin.py:75
 msgid "Please confirm that you really want to delete this directory"
 msgstr "Bitte bestätigen Sie, dass dieses Verzeichnis gelöscht werden soll"
 
-#: cms/views/media/media_context_mixin.py:77
+#: cms/views/media/media_context_mixin.py:78
+msgid "This file type is not supported. Supported types are:"
+msgstr "Dieser Dateityp wird nicht unterstützt. Unterstützte Typen sind:"
+
+#: cms/views/media/media_context_mixin.py:81
 msgid "An error has occurred."
 msgstr "Es ist ein Fehler aufgetreten."
 

--- a/integreat_cms/static/src/js/media-management/library.tsx
+++ b/integreat_cms/static/src/js/media-management/library.tsx
@@ -244,6 +244,7 @@ export default function Library({
               submitForm={submitForm}
               setUploadFile={setUploadFile}
               isLoading={isLoading}
+              refreshState={[refresh, setRefresh]}
             />
           )}
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,9 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "integreat-cms",
+      "dependencies": {
+        "dropzone": "^6.0.0-beta.2"
+      },
       "devDependencies": {
         "@babel/cli": "^7.17.6",
         "@babel/core": "^7.17.5",
@@ -12,6 +14,7 @@
         "@babel/plugin-transform-runtime": "^7.17.0",
         "@babel/preset-env": "^7.16.11",
         "@tailwindcss/forms": "^0.5.0",
+        "@types/dropzone": "^5.7.4",
         "@types/feather-icons": "^4.7.0",
         "@types/history": "^5.0.0",
         "@types/tinymce": "^4.6.4",
@@ -1906,6 +1909,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.2.14.tgz",
+      "integrity": "sha512-wpCQMhf5p5GhNg2MmGKXzUNwxe7zRiCsmqYsamez2beP7mKPCSiu+BjZcdN95yYSzO857kr0VfQewmGpS77nqA=="
+    },
     "node_modules/@tailwindcss/forms": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.0.tgz",
@@ -1925,6 +1933,15 @@
       "dev": true,
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/@types/dropzone": {
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/@types/dropzone/-/dropzone-5.7.4.tgz",
+      "integrity": "sha512-9kLJ2YAmVRWYrHvDoa95pQzHF0HUMKcznsS7FM1Mht5Yieec+HMB6Ybfm+ocvLjvFCvgyYGFTp4nzNFxhZmo3g==",
+      "dev": true,
+      "dependencies": {
+        "@types/jquery": "*"
       }
     },
     "node_modules/@types/eslint": {
@@ -3435,6 +3452,15 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/dropzone": {
+      "version": "6.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/dropzone/-/dropzone-6.0.0-beta.2.tgz",
+      "integrity": "sha512-k44yLuFFhRk53M8zP71FaaNzJYIzr99SKmpbO/oZKNslDjNXQsBTdfLs+iONd0U0L94zzlFzRnFdqbLcs7h9fQ==",
+      "dependencies": {
+        "@swc/helpers": "^0.2.13",
+        "just-extend": "^5.0.0"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.4.110",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.110.tgz",
@@ -4331,6 +4357,11 @@
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
+    },
+    "node_modules/just-extend": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-5.1.1.tgz",
+      "integrity": "sha512-b+z6yF1d4EOyDgylzQo5IminlUmzSeqR1hs/bzjBNjuGras4FXq/6TrzjxfN0j+TmI0ltJzTNlqXUMCniciwKQ=="
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -8729,6 +8760,11 @@
         "fastq": "^1.6.0"
       }
     },
+    "@swc/helpers": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.2.14.tgz",
+      "integrity": "sha512-wpCQMhf5p5GhNg2MmGKXzUNwxe7zRiCsmqYsamez2beP7mKPCSiu+BjZcdN95yYSzO857kr0VfQewmGpS77nqA=="
+    },
     "@tailwindcss/forms": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.0.tgz",
@@ -8743,6 +8779,15 @@
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
       "integrity": "sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==",
       "dev": true
+    },
+    "@types/dropzone": {
+      "version": "5.7.4",
+      "resolved": "https://registry.npmjs.org/@types/dropzone/-/dropzone-5.7.4.tgz",
+      "integrity": "sha512-9kLJ2YAmVRWYrHvDoa95pQzHF0HUMKcznsS7FM1Mht5Yieec+HMB6Ybfm+ocvLjvFCvgyYGFTp4nzNFxhZmo3g==",
+      "dev": true,
+      "requires": {
+        "@types/jquery": "*"
+      }
     },
     "@types/eslint": {
       "version": "8.4.1",
@@ -9866,6 +9911,15 @@
         "domhandler": "^4.2.0"
       }
     },
+    "dropzone": {
+      "version": "6.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/dropzone/-/dropzone-6.0.0-beta.2.tgz",
+      "integrity": "sha512-k44yLuFFhRk53M8zP71FaaNzJYIzr99SKmpbO/oZKNslDjNXQsBTdfLs+iONd0U0L94zzlFzRnFdqbLcs7h9fQ==",
+      "requires": {
+        "@swc/helpers": "^0.2.13",
+        "just-extend": "^5.0.0"
+      }
+    },
     "electron-to-chromium": {
       "version": "1.4.110",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.110.tgz",
@@ -10524,6 +10578,11 @@
         "graceful-fs": "^4.1.6",
         "universalify": "^2.0.0"
       }
+    },
+    "just-extend": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-5.1.1.tgz",
+      "integrity": "sha512-b+z6yF1d4EOyDgylzQo5IminlUmzSeqR1hs/bzjBNjuGras4FXq/6TrzjxfN0j+TmI0ltJzTNlqXUMCniciwKQ=="
     },
     "kind-of": {
       "version": "6.0.3",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@babel/plugin-transform-runtime": "^7.17.0",
     "@babel/preset-env": "^7.16.11",
     "@tailwindcss/forms": "^0.5.0",
+    "@types/dropzone": "^5.7.4",
     "@types/feather-icons": "^4.7.0",
     "@types/history": "^5.0.0",
     "@types/tinymce": "^4.6.4",
@@ -53,5 +54,8 @@
     "webpack-bundle-tracker": "^1.4.0",
     "webpack-cli": "^4.9.2",
     "whatwg-fetch": "^3.6.2"
+  },
+  "dependencies": {
+    "dropzone": "^6.0.0-beta.2"
   }
 }


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr substitutes our current file upload form with a drag and drop area. This also enables to upload multiple files due through an internal queue.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add Dropzone library
- Use it in the media library

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1292
