### PR TITLE
Invalidate translations when removing LanguageTreeNode, fixes #1403

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ UNRELEASED
 * [ [#1402](https://github.com/digitalfabrik/integreat-cms/issues/1402) ] Also duplicate imprints for new regions
 * [ [#1408](https://github.com/digitalfabrik/integreat-cms/issues/1408) ] Remove duplication of push API tokens for pages during duplication process
 * [ [#1404](https://github.com/digitalfabrik/integreat-cms/issues/1404) ] Fix performance issue for select all on huge page trees
+* [ [#1403](https://github.com/digitalfabrik/integreat-cms/issues/1403) ] Fix problem with cache when removing language in a region
 
 
 2022.5.0

--- a/integreat_cms/cms/views/language_tree/language_tree_actions.py
+++ b/integreat_cms/cms/views/language_tree/language_tree_actions.py
@@ -11,6 +11,7 @@ from django.views.decorators.http import require_POST
 from django.db import transaction
 
 from treebeard.exceptions import InvalidPosition, InvalidMoveToDescendant
+from cacheops import invalidate_obj
 
 from ...constants import position
 from ...decorators import permission_required
@@ -128,6 +129,16 @@ def delete_language_tree_node(request, region_slug, language_tree_node_id):
 
     logger.debug("%r deleted by %r", language_node, request.user)
     language_node.delete()
+
+    for page in region.pages.all():
+        invalidate_obj(page)
+    for event in region.events.all():
+        invalidate_obj(event)
+    for poi in region.pois.all():
+        invalidate_obj(poi)
+    for push_notification in region.push_notifications.all():
+        invalidate_obj(push_notification)
+
     messages.success(
         request,
         _(

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-05-11 23:00+0000\n"
+"POT-Creation-Date: 2022-05-14 14:33+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -6182,15 +6182,15 @@ msgstr ""
 "Sie können die Side-by-Side-Ansicht nicht verwenden, wenn die Quell-"
 "Übersetzung (in diesem Fall {source_language}) nicht existiert."
 
-#: cms/views/language_tree/language_tree_actions.py:58
+#: cms/views/language_tree/language_tree_actions.py:59
 msgid "A region can only have one root language."
 msgstr "Eine Region kann nur eine Standard-Sprache besitzen."
 
-#: cms/views/language_tree/language_tree_actions.py:66
+#: cms/views/language_tree/language_tree_actions.py:67
 msgid "The language tree node \"{}\" was successfully moved."
 msgstr "Der Sprach-Knoten \"{}\" wurde erfolgreich verschoben."
 
-#: cms/views/language_tree/language_tree_actions.py:134
+#: cms/views/language_tree/language_tree_actions.py:145
 msgid ""
 "The language tree node \"{}\" and all corresponding translations were "
 "successfully deleted."


### PR DESCRIPTION
This change flushes all content models after removing a LanguageTreeNode. It seems the problem described in #1403 only exists for page translations and no other content models, but I added them to be safe in the future.

One caveat though: Initially I tried to flush the PageTranslation objects which seemed to make more sense to me but that did not help. I'm not 100% sure why this fixes the issue. https://github.com/Suor/django-cacheops/blob/master/README.rst does not really explain how related objects are handled.

Fixes #1403 