### PR TITLE
API: slugify page slugs, fixes #1401

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ UNRELEASED
 * [ [#1408](https://github.com/digitalfabrik/integreat-cms/issues/1408) ] Remove duplication of push API tokens for pages during duplication process
 * [ [#1404](https://github.com/digitalfabrik/integreat-cms/issues/1404) ] Fix performance issue for select all on huge page trees
 * [ [#1403](https://github.com/digitalfabrik/integreat-cms/issues/1403) ] Fix problem with cache when removing language in a region
+* [ [#1401](https://github.com/digitalfabrik/integreat-cms/issues/1401) ] Support WordPress slugs by applying slugify on API parameters
 
 
 2022.5.0

--- a/integreat_cms/api/v3/pages.py
+++ b/integreat_cms/api/v3/pages.py
@@ -9,6 +9,7 @@ from django.http import JsonResponse, Http404
 from django.shortcuts import get_object_or_404
 from django.views.decorators.csrf import csrf_exempt
 from django.utils.html import strip_tags
+from django.utils.text import slugify
 
 from ...cms.models import Page
 from ...cms.forms import PageTranslationForm
@@ -142,7 +143,7 @@ def get_single_page(request, language_slug):
         # Strip leading and trailing slashes to avoid ambiguous urls
         url = request.GET.get("url").strip("/")
         # The last path component of the url is the page translation slug
-        page_translation_slug = url.split("/")[-1]
+        page_translation_slug = slugify(url.split("/")[-1], allow_unicode=True)
         # Get page by filtering for translation slug and translation language slug
         filtered_pages = region.pages.filter(
             translations__slug=page_translation_slug,


### PR DESCRIPTION
### Short description
Apply the slugify function on all API page endpoint slugs. This should make all calls to children endpoints compatible with old WordPress slugs. This should do no harm (except of some compute time), as we only have slugs in our database that were cleaned by the slugify function.


### Proposed changes
Use the [slugify](https://docs.djangoproject.com/en/4.0/ref/utils/#django.utils.text.slugify) function to clean page translation slugs in API requests.

### Resolved issues
Fixes: #1401
