### PR TITLE
Fix border of selected media library item

### DIFF
--- a/integreat_cms/static/src/js/media-management/component/file-entry.tsx
+++ b/integreat_cms/static/src/js/media-management/component/file-entry.tsx
@@ -19,9 +19,9 @@ export default function FileEntry({ file, active, onClick, mediaTranslations, gl
     <div
       title={mediaTranslations.btn_show_file}
       className={cn(
-        "relative w-full flex flex-col justify-between cursor-pointer border-2 rounded border-white p-2 overflow-hidden",
+        "relative w-full flex flex-col justify-between cursor-pointer border-2 rounded p-2 overflow-hidden",
         { "border-blue-500": active },
-        { "hover:border-blue-200": !active }
+        { "border-white hover:border-blue-200": !active }
       )}
       onClick={onClick}
     >


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
I noticed that selected media library items no longer have the blue border and fixed that by setting the white border only for inactive elements.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Fix border of selected media library items
