### PR TITLE
Hide archived pages in various selections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ UNRELEASED
 * [ [#1292](https://github.com/digitalfabrik/integreat-cms/issues/1292) ] Add multi-file upload via drag and drop
 * [ [#1442](https://github.com/digitalfabrik/integreat-cms/issues/1442) ] Add author role (formerly organizer)
 * [ [#1461](https://github.com/digitalfabrik/integreat-cms/issues/1461) ] Display warning on leaving page after editing a page description
+* [ [#1283](https://github.com/digitalfabrik/integreat-cms/issues/1283) ] Remove archived pages from several settings/options
 
 
 2022.5.0

--- a/integreat_cms/cms/forms/pages/page_form.py
+++ b/integreat_cms/cms/forms/pages/page_form.py
@@ -145,14 +145,18 @@ class PageForm(CustomModelForm, CustomTreeNodeForm):
         # Set choices of mirrored_page field manually to make use of cache_tree()
         logger.debug("Set choices for mirrored page field:")
         self.fields["mirrored_page"].choices = [
-            (page.id, str(page)) for page in mirrored_page_queryset.cache_tree()
+            (page.id, str(page))
+            for page in mirrored_page_queryset.cache_tree(archived=False)
         ]
 
         # Set choices of parent and _ref_node_id fields manually to make use of cache_tree()
         logger.debug("Set choices for parent field:")
         cached_parent_choices = [("", "---------")]
         cached_parent_choices.extend(
-            [(page.id, str(page)) for page in parent_queryset.cache_tree()]
+            [
+                (page.id, str(page))
+                for page in parent_queryset.cache_tree(archived=False)
+            ]
         )
         self.fields["parent"].choices = cached_parent_choices
         self.fields["_ref_node_id"].choices = cached_parent_choices

--- a/integreat_cms/cms/views/pages/page_actions.py
+++ b/integreat_cms/cms/views/pages/page_actions.py
@@ -763,11 +763,15 @@ def get_page_order_table_ajax(request, region_slug, parent_id=None, page_id=None
     else:
         page = None
 
-    if parent_id:
-        parent = get_object_or_404(region.pages, id=parent_id)
+    if parent_id or page:
+        parent = (
+            get_object_or_404(region.pages, id=parent_id) if parent_id else page.parent
+        )
         siblings = parent.cached_children
     else:
         siblings = region.get_root_pages()
+
+    siblings = [sibling for sibling in siblings if not sibling.explicitly_archived]
 
     logger.debug(
         "Page order table for page %r and siblings %r",

--- a/integreat_cms/cms/views/pages/page_form_view.py
+++ b/integreat_cms/cms/views/pages/page_form_view.py
@@ -150,13 +150,16 @@ class PageFormView(
         # Pass siblings to template to enable rendering of page order table
         if page:
             siblings = (
-                page.region_siblings.prefetch_translations().prefetch_public_translations()
+                page.region_siblings.prefetch_translations()
+                .prefetch_public_translations()
+                .filter(explicitly_archived=page.explicitly_archived)
             )
         else:
             siblings = (
                 region.get_root_pages()
                 .prefetch_translations()
                 .prefetch_public_translations()
+                .filter(explicitly_archived=False)
             )
 
         return render(
@@ -314,6 +317,9 @@ class PageFormView(
             siblings = page_form.instance.region_siblings
         else:
             siblings = region.get_root_pages()
+        siblings = siblings.filter(
+            explicitly_archived=page_form.instance.explicitly_archived
+        )
 
         return render(
             request,

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-05-22 09:19+0000\n"
+"POT-Creation-Date: 2022-05-22 09:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -6137,7 +6137,7 @@ msgstr ""
 
 #: cms/views/events/event_form_view.py:198
 #: cms/views/imprint/imprint_form_view.py:216
-#: cms/views/pages/page_form_view.py:266 cms/views/pois/poi_form_view.py:163
+#: cms/views/pages/page_form_view.py:269 cms/views/pois/poi_form_view.py:163
 msgid "No changes detected, autosave skipped"
 msgstr "Keine Änderungen vorgenommen, automatisches Speichern übersprungen"
 
@@ -6146,7 +6146,7 @@ msgid "Event \"{}\" was successfully created"
 msgstr "Veranstaltung \"{}\" wurde erfolgreich erstellt"
 
 #: cms/views/events/event_form_view.py:229
-#: cms/views/pages/page_form_view.py:297 cms/views/pois/poi_form_view.py:177
+#: cms/views/pages/page_form_view.py:300 cms/views/pois/poi_form_view.py:177
 msgid "No changes detected, but date refreshed"
 msgstr "Keine Änderungen vorgenommen, aber Datum aktualisiert"
 
@@ -6228,7 +6228,7 @@ msgid "Imprint was successfully created"
 msgstr "Impressum wurde erfolgreich erstellt"
 
 #: cms/views/imprint/imprint_form_view.py:288
-#: cms/views/pages/page_form_view.py:369
+#: cms/views/pages/page_form_view.py:375
 #, python-brace-format
 msgid "{source_language} to {target_language}"
 msgstr "{source_language} nach {target_language}"
@@ -6682,7 +6682,7 @@ msgstr ""
 "Sie haben nicht die nötige Berechtigung, um diese Seite zu veröffentlichen, "
 "aber Sie können Änderungen vornehmen und diese zur Überprüfung vorlegen."
 
-#: cms/views/pages/page_form_view.py:290
+#: cms/views/pages/page_form_view.py:293
 msgid "Page \"{}\" was successfully created"
 msgstr "Seite \"{}\" wurde erfolgreich erstellt"
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr hides archived pages in the page form in the parent page selection, the page order selection, and the mirrored page selection.
Additionally, the page order selection should update correctly now when selecting '----------' as parent page after selecting something else as parent page.


### Proposed changes
<!-- Describe this PR in more detail. -->
- Add filters to exclude archived pages

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1283