### PR TITLE
show unsaved warning when only changing tinymce editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ UNRELEASED
 * [ [#1438](https://github.com/digitalfabrik/integreat-cms/issues/1438) ] Fix error in page form when page-specific permissions are enabled
 * [ [#1292](https://github.com/digitalfabrik/integreat-cms/issues/1292) ] Add multi-file upload via drag and drop
 * [ [#1442](https://github.com/digitalfabrik/integreat-cms/issues/1442) ] Add author role (formerly organizer)
+* [ [#1461](https://github.com/digitalfabrik/integreat-cms/issues/1461) ] Display warning on leaving page after editing a page description
 
 
 2022.5.0

--- a/integreat_cms/static/src/js/forms/autosave.ts
+++ b/integreat_cms/static/src/js/forms/autosave.ts
@@ -1,6 +1,5 @@
 import { getCsrfToken } from "../utils/csrf-token";
 import tinymce from "tinymce";
-import { markContentSaved } from "../unsaved-warning";
 
 export async function autosaveEditor() {
   const form = document.getElementById("content_form") as HTMLFormElement;
@@ -16,5 +15,9 @@ export async function autosaveEditor() {
   });
   // Set the form action to the url of the server response to make sure new pages aren't created multiple times
   form.action = data.url;
-  markContentSaved();
+  
+  // mark the content as saved
+  document.querySelectorAll("[data-unsaved-warning]").forEach((element) => {
+    element.dispatchEvent(new Event("autosave"))
+  })
 }

--- a/integreat_cms/static/src/js/forms/tinymce-init.ts
+++ b/integreat_cms/static/src/js/forms/tinymce-init.ts
@@ -192,6 +192,10 @@ window.addEventListener("load", () => {
       readonly: !!tinymceConfig.getAttribute("data-readonly"),
       init_instance_callback: function (editor: Editor) {
         editor.on("StoreDraft", autosaveEditor);
+        // when the editor becomes dirty, send an input event, so that the unsaved warning can be shown
+        editor.on("dirty", () => document.querySelectorAll("[data-unsaved-warning]").forEach((element) => {
+          element.dispatchEvent(new Event("input"))
+        }));
       },
     });
   }

--- a/integreat_cms/static/src/js/unsaved-warning.ts
+++ b/integreat_cms/static/src/js/unsaved-warning.ts
@@ -2,13 +2,12 @@
  * This file contains a function to warn the user when they leave a content without saving
  */
 
-let confirmed = false;
-let edited = false;
+let dirty = false;
 
 
 window.addEventListener("beforeunload", (event) => {
   // trigger only when something is edited and no submit/save button clicked
-  if (edited && !confirmed) {
+  if (dirty) {
     event.preventDefault();
     event.returnValue = "This content is not saved. Would you leave the page?";
   }
@@ -19,19 +18,19 @@ window.addEventListener("load", () => {
   const form = document.querySelector("[data-unsaved-warning]");
   // checks whether the user typed something in the content
   form?.addEventListener("input", () => {
-    edited = true;
-    console.debug("editing detected, enabled beforeunload warning");
-  }, { once: true });
+    if (!dirty) {
+      console.debug("editing detected, enabled beforeunload warning");
+    }
+    dirty = true;
+  });
   // checks whether the user has saved or submitted the content
   form?.addEventListener("submit", () => {
-    confirmed = true;
+    dirty = false;
     console.debug("form submitted, disabled beforeunload warning");
   });
+  // removes the warning on autosave
+  form?.addEventListener("autosave", () => {
+    dirty = false;
+    console.debug("Autosave, disabled beforeunload warning");
+  })
 });
-
-/**
- * This function marks the form as submitted, so no unsaved warning will be shown
- */
-export function markContentSaved() {
-  confirmed = true;
-}


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr fixes a bug where no autosave warning was shown after editing the body of a page.
The bug is caused by tinymce not (anymore?) bubbling up the input event, which is used by the autosave mechanism to determine when to show the warning.
Additionally this pr fixes a related bug that caused `unsaved-warnings.ts` to be loaded twice.


### Proposed changes
<!-- Describe this PR in more detail. -->
- Manually create an input event when the editor state changes to 'dirty'
- Use a custom event to notify the unsaved-changes script that an autosave occrured

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1461
