### PR TITLE
Rename 'locations on map' to 'locations'

### DIFF
--- a/integreat_cms/cms/models/feedback/map_feedback.py
+++ b/integreat_cms/cms/models/feedback/map_feedback.py
@@ -18,7 +18,7 @@ class MapFeedback(Feedback):
         :return: The name of the object this feedback refers to
         :rtype: str
         """
-        return _("Locations on map")
+        return _("Locations")
 
     @cached_property
     def object_url(self):

--- a/integreat_cms/cms/templates/_base.html
+++ b/integreat_cms/cms/templates/_base.html
@@ -163,7 +163,7 @@
                     <div class="{% if current_menu_item|in_list:'pois,pois_form' %} active {% endif %}">
                         <a href="{% url 'pois' region_slug=request.region.slug %}">
                             <i data-feather="map-pin"></i>
-                            {% trans 'Locations on Map' %}
+                            {% trans 'Locations' %}
                         </a>
                     </div>
                 {% endif %}

--- a/integreat_cms/cms/templates/pois/poi_list.html
+++ b/integreat_cms/cms/templates/pois/poi_list.html
@@ -8,7 +8,7 @@
     {% get_language LANGUAGE_CODE as backend_language %}
     <div class="table-header">
         <div class="flex flex-wrap justify-between">
-            <h1 class="heading">{% trans 'Locations on map' %}</h1>
+            <h1 class="heading">{% trans 'Locations' %}</h1>
             <a href="{% url 'archived_pois' region_slug=request.region.slug language_slug=language.slug %}"
                class="font-bold text-sm text-gray-800 flex items-center gap-1 pb-2 hover:underline">
                 <span>

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-05-22 08:01+0000\n"
+"POT-Creation-Date: 2022-05-22 09:19+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -2282,9 +2282,10 @@ msgstr "Impressum"
 msgid "imprint feedback"
 msgstr "Impressums-Feedback"
 
-#: cms/models/feedback/map_feedback.py:21 cms/templates/pois/poi_list.html:11
-msgid "Locations on map"
-msgstr "Orte auf Karte"
+#: cms/models/feedback/map_feedback.py:21 cms/templates/_base.html:166
+#: cms/templates/pois/poi_list.html:11
+msgid "Locations"
+msgstr "Orte"
 
 #: cms/models/feedback/map_feedback.py:52
 #: cms/models/feedback/map_feedback.py:54
@@ -3288,10 +3289,6 @@ msgstr "Seiten"
 #: cms/templates/_base.html:158 cms/templates/events/event_list.html:10
 msgid "Events"
 msgstr "Veranstaltungen"
-
-#: cms/templates/_base.html:166
-msgid "Locations on Map"
-msgstr "Orte auf Karte"
 
 #: cms/templates/_base.html:174 cms/templates/_base.html:275
 #: cms/templates/feedback/region_feedback_list.html:9
@@ -7004,6 +7001,12 @@ msgid "This page belongs to another region ({})."
 msgstr ""
 "Diese Seite konnte nicht importiert werden, da sie zu einer anderen Region "
 "gehört ({})."
+
+#~ msgid "Locations on Map"
+#~ msgstr "Orte auf Karte"
+
+#~ msgid "Locations on map"
+#~ msgstr "Orte auf Karte"
 
 #~ msgid "404 Not Found"
 #~ msgstr "404 Nicht gefunden"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr renames the 'locations on map' view to 'locations', to avoid confusion.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1457
