### PR TITLE
Adapt offers API to web app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ UNRELEASED
 ----------
 
 * [ [#1471](https://github.com/digitalfabrik/integreat-cms/issues/1471) ] Add statistic settings to region form again
+* [ [#1473](https://github.com/digitalfabrik/integreat-cms/issues/1473) ] Fix offers compatibility with web app
 
 
 2022.5.1

--- a/integreat_cms/api/v3/offers.py
+++ b/integreat_cms/api/v3/offers.py
@@ -50,6 +50,8 @@ def get_post_data(offer, region):
     post_data = offer.post_data
     if offer.use_postal_code == postal_code.POST:
         post_data.update({"search-plz": region.postal_code})
+    if not post_data:
+        return None
     return post_data
 
 

--- a/tests/api/api_config.py
+++ b/tests/api/api_config.py
@@ -88,6 +88,12 @@ API_ENDPOINTS = [
         "tests/api/expected-outputs/nurnberg_ar_fcm.json",
         200,
     ),
+    (
+        "/api/augsburg/de/extras/",
+        "/augsburg/de/wp-json/extensions/v3/extras/",
+        "tests/api/expected-outputs/augsburg-offers.json",
+        200,
+    ),
 ]
 
 #: This list contains the config for all API feedback views

--- a/tests/api/expected-outputs/augsburg-offers.json
+++ b/tests/api/expected-outputs/augsburg-offers.json
@@ -1,0 +1,24 @@
+[{
+  "name": "IHK Lehrstellenb\u00f6rse",
+  "alias": "ihk-lehrstellenboerse",
+  "url": "https://www.ihk-lehrstellenboerse.de/joboffers/search.html?distance=1&location=86150",
+  "post": null,
+  "thumbnail": "https://cms.integreat-app.de/wp-content/uploads/extra-thumbnails/ihk-lehrstellenboerse.png"
+}, {
+  "name": "Lehrstellenradar",
+  "alias": "lehrstellen-radar",
+  "url": "https://www.lehrstellen-radar.de/5100,0,lsrlist.html",
+  "post": {
+    "search-ls": "1",
+    "search-pr": "1",
+    "search-radius": "50",
+    "search-plz": "86150"
+  },
+  "thumbnail": "https://cms.integreat-app.de/wp-content/uploads/extra-thumbnails/lehrstellen-radar.jpg"
+}, {
+  "name": "Sprungbrett",
+  "alias": "sprungbrett",
+  "url": "https://web.integreat-app.de/proxy/sprungbrett/app-search-internships?location=86150",
+  "post": null,
+  "thumbnail": "https://cms.integreat-app.de/wp-content/uploads/extra-thumbnails/sprungbrett.jpg"
+}]


### PR DESCRIPTION
### Short description
The web app expects a null value instead of an empty dict in the offers API for the `post` attribute.


### Proposed changes
Convert the empty dict to null when delivering the information via API.