### PR TITLE
Fix error when importing legacy XLIFF files from WordPress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ UNRELEASED
 
 * [ [#1471](https://github.com/digitalfabrik/integreat-cms/issues/1471) ] Add statistic settings to region form again
 * [ [#1473](https://github.com/digitalfabrik/integreat-cms/issues/1473) ] Fix offers compatibility with web app
+* [ [#1476](https://github.com/digitalfabrik/integreat-cms/issues/1476) ] Fix error when importing legacy XLIFF files from WordPress
 
 
 2022.5.1

--- a/integreat_cms/xliff/xliff1_serializer.py
+++ b/integreat_cms/xliff/xliff1_serializer.py
@@ -173,11 +173,14 @@ class Deserializer(base_serializer.Deserializer):
                 ) from e
             page_translation_slug = page_link.pop()
             region_slug, language_slug = page_link[:2]
-            page = Page.objects.get(
+            page = Page.objects.filter(
                 region__slug=region_slug,
                 translations__slug=page_translation_slug,
                 translations__language__slug=language_slug,
-            )
+            ).first()
+            if not page:
+                # If no page matches the link, just raise the initial error
+                raise e
 
         logger.debug(
             "Referenced original page: %r",


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fix error when importing legacy XLIFF files from WordPress


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1476
