### PR TITLE
Fix bug where page with archived sibling cannot be saved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ UNRELEASED
 * [ [#1460](https://github.com/digitalfabrik/integreat-cms/issues/1460) ] Only show status in broken link checker for expert users
 * [ [#742](https://github.com/digitalfabrik/integreat-cms/issues/742) ] Add default bounding box to region API
 * [ [#1406](https://github.com/digitalfabrik/integreat-cms/issues/1406) ] Hide sub-headings in PDF table of contents
+* [ [#1478](https://github.com/digitalfabrik/integreat-cms/issues/1478) ] Fix bug where page with archived sibling cannot be saved
 
 
 2022.5.2

--- a/integreat_cms/cms/forms/pages/page_form.py
+++ b/integreat_cms/cms/forms/pages/page_form.py
@@ -158,8 +158,12 @@ class PageForm(CustomModelForm, CustomTreeNodeForm):
                 for page in parent_queryset.cache_tree(archived=False)
             ]
         )
+        ref_node_choices = [("", "---------")]
+        ref_node_choices.extend(
+            [(page.id, str(page)) for page in parent_queryset.cache_tree()]
+        )
         self.fields["parent"].choices = cached_parent_choices
-        self.fields["_ref_node_id"].choices = cached_parent_choices
+        self.fields["_ref_node_id"].choices = ref_node_choices
 
     def _clean_cleaned_data(self):
         """

--- a/tests/cms/views/view_config.py
+++ b/tests/cms/views/view_config.py
@@ -435,6 +435,17 @@ VIEWS = [
             ),
             (
                 "edit_page",
+                PRIV_STAFF_ROLES + [MANAGEMENT, EDITOR, AUTHOR],
+                {
+                    "title": "new title",
+                    "mirrored_page_region": "",
+                    "_ref_node_id": 24,  # Archived ref node
+                    "_position": "right",
+                    "submit_draft": True,
+                },
+            ),
+            (
+                "edit_page",
                 PRIV_STAFF_ROLES + [MANAGEMENT, EDITOR],
                 {
                     "title": "new title",


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fix bug where page with archived sibling cannot be saved.
This should only make the page form a bit slower, but as a quick fix I think it's sufficient.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Allow archived pages as ref nodes

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1478
