### PR TITLE
Instruct tinymce to paste as text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 UNRELEASED
 ----------
 
+* [ [#1501](https://github.com/digitalfabrik/integreat-cms/issues/1501) ] Remove formatting when content is pasted into tinymce editor
+
 
 2022.5.4
 --------

--- a/integreat_cms/static/src/js/forms/tinymce-init.ts
+++ b/integreat_cms/static/src/js/forms/tinymce-init.ts
@@ -14,6 +14,7 @@ import "tinymce/plugins/image";
 import "tinymce/plugins/link";
 import "tinymce/plugins/lists";
 import "tinymce/plugins/media";
+import "tinymce/plugins/paste";
 import "tinymce/plugins/preview";
 import "tinymce/plugins/wordcount";
 import "tinymce-i18n/langs/de.js";
@@ -104,7 +105,7 @@ window.addEventListener("load", () => {
       autosave_interval: "120s",
       forced_root_block: true,
       plugins:
-        "code fullscreen autosave preview media image lists directionality wordcount hr charmap",
+        "code fullscreen autosave preview media image lists directionality wordcount hr charmap paste",
       external_plugins: {
         autolink_tel: tinymceConfig.getAttribute("data-custom-plugins"),
         mediacenter: tinymceConfig.getAttribute("data-custom-plugins"),
@@ -117,6 +118,7 @@ window.addEventListener("load", () => {
       relative_urls: false,
       remove_script_host: false,
       branding: false,
+      paste_as_text: true,
       toolbar:
         "bold italic underline forecolor | bullist numlist | styleselect | undo redo | ltr rtl notranslate | aligncenter indent outdent | link openmediacenter | export",
       style_formats: [


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr removes all formatting that gets applied when pasting into the tinymce editor.
Pasting links should still work, since the editor automatically converts text that looks like a link into a link.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1501 
