### PR TITLE
Allow only users with publish permission to unpublish page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 UNRELEASED
 ----------
 
+* [ [#1445](https://github.com/digitalfabrik/integreat-cms/issues/1445) ] Allow only users with publish permission to unpublish page
+
 
 2022.6.1
 --------

--- a/integreat_cms/cms/templates/pages/page_form.html
+++ b/integreat_cms/cms/templates/pages/page_form.html
@@ -56,11 +56,9 @@
                         class="btn btn-gray">
                         {% trans 'Preview' %}
                     </button>
-                    {% if can_edit_page %}
-                        <button name="submit_draft" class="btn btn-gray">{% trans 'Save as draft' %}</button>
-                    {% endif %}
                     {% has_perm 'cms.publish_page_object' request.user page as can_publish_page %}
                     {% if can_publish_page %}
+                        <button name="submit_draft" class="btn btn-gray">{% trans 'Save as draft' %}</button>
                         <button name="submit_public" class="btn whitespace-nowrap">
                             {% if page_translation_form.instance.status == PUBLIC %}
                                 {% trans 'Update' %}

--- a/integreat_cms/cms/templates/pages/page_revisions.html
+++ b/integreat_cms/cms/templates/pages/page_revisions.html
@@ -82,16 +82,13 @@
         </div>
     </div>
     <div class="w-full p-4 flex justify-end gap-4">
-        {% has_perm 'cms.change_page_object' request.user page as can_edit_page %}
         {% if not page.archived %}
-            {% if can_edit_page %}
+            {% has_perm 'cms.publish_page_object' request.user page as can_publish_page %}
+            {% if can_publish_page %}
                 <button name="submit_draft" class="btn btn-gray">{% trans 'Restore this version as draft' %}</button>
-                {% has_perm 'cms.publish_page_object' request.user page as can_publish_page %}
-                {% if can_publish_page %}
-                    <button name="submit_public" class="btn">{% trans 'Restore and publish this version' %}</button>
-                {% else %}
-                    <button name="submit_review" class="btn">{% trans 'Restore this version and submit for review' %}</button>
-                {% endif %}
+                <button name="submit_public" class="btn">{% trans 'Restore and publish this version' %}</button>
+            {% else %}
+                <button name="submit_review" class="btn">{% trans 'Restore this version and submit for review' %}</button>
             {% endif %}
         {% endif %}
     </div>

--- a/integreat_cms/cms/templates/pages/page_sbs.html
+++ b/integreat_cms/cms/templates/pages/page_sbs.html
@@ -20,20 +20,17 @@
                        class="bg-gray-400 hover:bg-gray-500 cursor-pointer text-white font-bold py-3 px-4 rounded">
                         {% trans 'Go Back to Page Editor' %}
                     </a>
-                    {% has_perm 'cms.change_page_object' request.user source_page_translation.page as can_change_page_object %}
                     {% if not source_page_translation.page.archived %}
-                        {% if can_change_page_object %}
-                            <button name="submit_draft" class="btn btn-gray">{% trans 'Save as draft' %}</button>
-                        {% endif %}
                         {% has_perm 'cms.publish_page_object' request.user source_page_translation.page as can_publish_page %}
                         {% if can_publish_page %}
+                            <button name="submit_draft" class="btn btn-gray">{% trans 'Save as draft' %}</button>
                             <button name="submit_public" class="btn">
                                 {% if page_translation_form.instance.status == PUBLIC %}
                                     {% trans 'Update' %}
                                 {% else %}
                                     {% trans 'Publish' %}
                                 {% endif %}
-                            </button>
+                            </button> 
                         {% else %}
                             <button name="submit_review" class="btn">{% trans 'Submit for review' %}</button>
                         {% endif %}

--- a/integreat_cms/cms/views/pages/page_form_view.py
+++ b/integreat_cms/cms/views/pages/page_form_view.py
@@ -253,9 +253,11 @@ class PageFormView(
             # Add error messages
             page_form.add_error_messages(request)
             page_translation_form.add_error_messages(request)
-        elif (
-            not request.user.has_perm("cms.publish_page_object", page_form.instance)
-            and page_translation_form.cleaned_data.get("status") == status.PUBLIC
+        elif not request.user.has_perm(
+            "cms.publish_page_object", page_form.instance
+        ) and (
+            page_translation_form.cleaned_data.get("status")
+            in [status.DRAFT, status.PUBLIC]
         ):
             # Raise PermissionDenied if user wants to publish page but doesn't have the permission
             raise PermissionDenied(

--- a/integreat_cms/cms/views/pages/page_revision_view.py
+++ b/integreat_cms/cms/views/pages/page_revision_view.py
@@ -174,6 +174,10 @@ class PageRevisionView(TemplateView):
         revision.version = current_revision.version + 1
 
         if request.POST.get("submit_draft"):
+            if not request.user.has_perm("cms.publish_page_object", page):
+                raise PermissionDenied(
+                    f"{request.user!r} does not have the permission to restore {revision!r} of {page!r} as draft"
+                )
             revision.status = status.DRAFT
         elif request.POST.get("submit_review"):
             revision.status = status.REVIEW

--- a/integreat_cms/cms/views/pages/page_sbs_view.py
+++ b/integreat_cms/cms/views/pages/page_sbs_view.py
@@ -190,9 +190,9 @@ class PageSideBySideView(TemplateView, PageContextMixin):
         elif not page_translation_form.has_changed():
             # Add "no changes" messages
             messages.info(request, _("No changes made"))
-        elif (
-            not request.user.has_perm("cms.publish_page_object", page)
-            and page_translation_form.cleaned_data.get("status") == status.PUBLIC
+        elif not request.user.has_perm("cms.publish_page_object", page) and (
+            page_translation_form.cleaned_data.get("status")
+            in [status.DRAFT, status.PUBLIC]
         ):
             # Raise PermissionDenied if user wants to publish page but doesn't have the permission
             raise PermissionDenied(

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-13 18:34+0000\n"
+"POT-Creation-Date: 2022-06-14 13:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1372,7 +1372,7 @@ msgstr "Versteckt"
 
 #: cms/constants/region_status.py:18 cms/models/pages/page.py:323
 #: cms/models/regions/region.py:622 cms/templates/events/event_form.html:76
-#: cms/templates/pages/page_form.html:111
+#: cms/templates/pages/page_form.html:109
 #: cms/templates/pages/page_tree_archived_node.html:81
 #: cms/templates/pois/poi_form.html:66
 msgid "Archived"
@@ -1445,7 +1445,7 @@ msgstr "Rechts nach Links"
 #: cms/templates/events/event_list_row.html:47
 #: cms/templates/imprint/imprint_sbs.html:47
 #: cms/templates/imprint/imprint_sbs.html:104
-#: cms/templates/pages/page_sbs.html:55 cms/templates/pages/page_sbs.html:104
+#: cms/templates/pages/page_sbs.html:52 cms/templates/pages/page_sbs.html:101
 #: cms/templates/pages/page_tree_archived_node.html:63
 #: cms/templates/pages/page_tree_node.html:79
 #: cms/templates/pois/poi_list_row.html:44
@@ -1460,7 +1460,7 @@ msgstr "Übersetzung ist aktuell"
 #: cms/templates/events/event_list_row.html:61
 #: cms/templates/imprint/imprint_sbs.html:43
 #: cms/templates/imprint/imprint_sbs.html:100
-#: cms/templates/pages/page_sbs.html:51 cms/templates/pages/page_sbs.html:100
+#: cms/templates/pages/page_sbs.html:48 cms/templates/pages/page_sbs.html:97
 #: cms/templates/pages/page_tree_archived_node.html:55
 #: cms/templates/pages/page_tree_node.html:71
 #: cms/templates/pages/page_tree_node.html:89
@@ -1477,7 +1477,7 @@ msgstr "Wird derzeit übersetzt"
 #: cms/templates/events/event_list_row.html:43
 #: cms/templates/imprint/imprint_sbs.html:39
 #: cms/templates/imprint/imprint_sbs.html:96
-#: cms/templates/pages/page_sbs.html:47 cms/templates/pages/page_sbs.html:96
+#: cms/templates/pages/page_sbs.html:44 cms/templates/pages/page_sbs.html:93
 #: cms/templates/pages/page_tree_archived_node.html:59
 #: cms/templates/pages/page_tree_node.html:75
 #: cms/templates/pois/poi_list_row.html:40
@@ -1679,10 +1679,10 @@ msgstr "Kategorie"
 #: cms/templates/imprint/imprint_sbs.html:121
 #: cms/templates/imprint/imprint_sbs.html:140
 #: cms/templates/linkcheck/links_by_filter.html:59
-#: cms/templates/pages/page_form.html:108
+#: cms/templates/pages/page_form.html:106
 #: cms/templates/pages/page_revisions.html:50
-#: cms/templates/pages/page_sbs.html:65 cms/templates/pages/page_sbs.html:121
-#: cms/templates/pages/page_sbs.html:127 cms/templates/pages/page_tree.html:88
+#: cms/templates/pages/page_sbs.html:62 cms/templates/pages/page_sbs.html:118
+#: cms/templates/pages/page_sbs.html:124 cms/templates/pages/page_tree.html:88
 #: cms/templates/pages/page_tree_archived.html:67
 #: cms/templates/pois/poi_form.html:63 cms/templates/pois/poi_list.html:67
 #: cms/templates/pois/poi_list_archived.html:33
@@ -3379,10 +3379,10 @@ msgstr "Angebots-Vorlagen"
 #: cms/templates/imprint/imprint_sbs.html:54
 #: cms/templates/imprint/imprint_sbs.html:118
 #: cms/templates/imprint/imprint_sbs.html:137
-#: cms/templates/pages/page_form.html:102
+#: cms/templates/pages/page_form.html:100
 #: cms/templates/pages/page_revisions.html:24
-#: cms/templates/pages/page_sbs.html:62 cms/templates/pages/page_sbs.html:118
-#: cms/templates/pages/page_sbs.html:124 cms/templates/pois/poi_form.html:58
+#: cms/templates/pages/page_sbs.html:59 cms/templates/pages/page_sbs.html:115
+#: cms/templates/pages/page_sbs.html:121 cms/templates/pois/poi_form.html:58
 msgid "Version"
 msgstr "Version"
 
@@ -3461,7 +3461,7 @@ msgstr "Tipp"
 #: cms/templates/_tinymce_config.html:37
 #: cms/templates/events/event_form.html:44
 #: cms/templates/imprint/imprint_sbs.html:27
-#: cms/templates/pages/page_form.html:66 cms/templates/pages/page_sbs.html:32
+#: cms/templates/pages/page_form.html:64 cms/templates/pages/page_sbs.html:29
 #: cms/templates/pois/poi_form.html:38
 msgid "Update"
 msgstr "Aktualisieren"
@@ -3927,7 +3927,7 @@ msgstr "Veranstaltung erstellen"
 #: cms/templates/events/event_form.html:40
 #: cms/templates/imprint/imprint_form.html:26
 #: cms/templates/imprint/imprint_sbs.html:24
-#: cms/templates/pages/page_form.html:60 cms/templates/pages/page_sbs.html:26
+#: cms/templates/pages/page_form.html:61 cms/templates/pages/page_sbs.html:26
 #: cms/templates/pois/poi_form.html:35
 msgid "Save as draft"
 msgstr "Als Entwurf speichern"
@@ -3935,18 +3935,18 @@ msgstr "Als Entwurf speichern"
 #: cms/templates/events/event_form.html:46
 #: cms/templates/imprint/imprint_form.html:27
 #: cms/templates/imprint/imprint_sbs.html:29
-#: cms/templates/pages/page_form.html:68 cms/templates/pages/page_sbs.html:34
+#: cms/templates/pages/page_form.html:66 cms/templates/pages/page_sbs.html:31
 #: cms/templates/pois/poi_form.html:40
 msgid "Publish"
 msgstr "Veröffentlichen"
 
 #: cms/templates/events/event_form.html:50
-#: cms/templates/pages/page_form.html:72 cms/templates/pages/page_sbs.html:38
+#: cms/templates/pages/page_form.html:70 cms/templates/pages/page_sbs.html:35
 msgid "Submit for review"
 msgstr "Zur Überprüfung vorlegen"
 
 #: cms/templates/events/event_form.html:92
-#: cms/templates/pages/page_form.html:147 cms/templates/pois/poi_form.html:80
+#: cms/templates/pages/page_form.html:145 cms/templates/pois/poi_form.html:80
 msgid "Edit"
 msgstr "Bearbeiten"
 
@@ -3955,15 +3955,15 @@ msgstr "Bearbeiten"
 #: cms/templates/imprint/imprint_form.html:80
 #: cms/templates/imprint/imprint_sbs.html:67
 #: cms/templates/imprint/imprint_sbs.html:131
-#: cms/templates/pages/page_form.html:132
-#: cms/templates/pages/page_form.html:151
-#: cms/templates/pages/page_form.html:238 cms/templates/pois/poi_form.html:84
+#: cms/templates/pages/page_form.html:130
+#: cms/templates/pages/page_form.html:149
+#: cms/templates/pages/page_form.html:236 cms/templates/pois/poi_form.html:84
 msgid "Copy to clipboard"
 msgstr "In die Zwischenablage kopieren"
 
 #: cms/templates/events/event_form.html:122
 #: cms/templates/imprint/imprint_form.html:96
-#: cms/templates/pages/page_form.html:177
+#: cms/templates/pages/page_form.html:175
 #: cms/templates/pages/page_revisions.html:58
 #: cms/templates/pois/poi_form.html:114
 msgid "Minor edit"
@@ -3972,7 +3972,7 @@ msgstr "Geringfügige Änderung"
 #: cms/templates/events/event_form.html:126
 #: cms/templates/imprint/imprint_form.html:100
 #: cms/templates/imprint/imprint_sbs.html:151
-#: cms/templates/pages/page_form.html:181 cms/templates/pages/page_sbs.html:140
+#: cms/templates/pages/page_form.html:179 cms/templates/pages/page_sbs.html:137
 #: cms/templates/pois/poi_form.html:118
 msgid "Implications on other translations"
 msgstr "Auswirkungen auf andere Übersetzungen"
@@ -4011,7 +4011,7 @@ msgstr "Auf Google Maps öffnen"
 
 #: cms/templates/events/event_form.html:328
 #: cms/templates/imprint/imprint_form.html:114
-#: cms/templates/pages/page_form.html:287 cms/templates/pois/poi_form.html:213
+#: cms/templates/pages/page_form.html:285 cms/templates/pois/poi_form.html:213
 #: cms/templates/regions/region_list.html:25
 #: cms/templates/settings/user_settings.html:93
 msgid "Actions"
@@ -4314,7 +4314,7 @@ msgid "No feedback available yet."
 msgstr "Noch kein Feedback vorhanden."
 
 #: cms/templates/generic_confirmation_dialog.html:12
-#: cms/templates/pages/page_form.html:85
+#: cms/templates/pages/page_form.html:83
 msgid "Warning"
 msgstr "Warnung"
 
@@ -4364,12 +4364,12 @@ msgid "Create imprint"
 msgstr "Impressum erstellen"
 
 #: cms/templates/imprint/imprint_form.html:47
-#: cms/templates/pages/page_form.html:106
+#: cms/templates/pages/page_form.html:104
 msgid "Show"
 msgstr "Anzeigen"
 
 #: cms/templates/imprint/imprint_form.html:58
-#: cms/templates/pages/page_form.html:125
+#: cms/templates/pages/page_form.html:123
 msgid "Short URL"
 msgstr "Kurz-URL"
 
@@ -4402,7 +4402,7 @@ msgid "Side-by-Side view"
 msgstr "Side-by-Side-Ansicht"
 
 #: cms/templates/imprint/imprint_form.html:139
-#: cms/templates/pages/page_form.html:439
+#: cms/templates/pages/page_form.html:437
 msgid "Direction of translation"
 msgstr "Übersetzungsrichtung"
 
@@ -4465,7 +4465,7 @@ msgid "Restore this version as draft"
 msgstr "Diese Version als Entwurf wiederherstellen"
 
 #: cms/templates/imprint/imprint_revisions.html:79
-#: cms/templates/pages/page_revisions.html:91
+#: cms/templates/pages/page_revisions.html:89
 msgid "Restore and publish this version"
 msgstr "Diese Version wiederherstellen und veröffentlichen"
 
@@ -4478,29 +4478,29 @@ msgstr ""
 
 #: cms/templates/imprint/imprint_sbs.html:81
 #: cms/templates/imprint/imprint_sbs.html:83
-#: cms/templates/pages/page_sbs.html:81 cms/templates/pages/page_sbs.html:83
+#: cms/templates/pages/page_sbs.html:78 cms/templates/pages/page_sbs.html:80
 msgid "Copy content"
 msgstr "Inhalt kopieren"
 
 #: cms/templates/imprint/imprint_sbs.html:86
-#: cms/templates/pages/page_sbs.html:86
+#: cms/templates/pages/page_sbs.html:83
 #, python-format
 msgid "Copy content of %(source_language)s to %(target_language_name)s"
 msgstr "Inhalt von %(source_language)s nach %(target_language_name)s kopieren"
 
 #: cms/templates/imprint/imprint_sbs.html:109
-#: cms/templates/pages/page_sbs.html:109
+#: cms/templates/pages/page_sbs.html:106
 msgid "Create Translation"
 msgstr "Übersetzung erstellen"
 
 #: cms/templates/imprint/imprint_sbs.html:138
-#: cms/templates/pages/page_sbs.html:125
+#: cms/templates/pages/page_sbs.html:122
 msgid "New"
 msgstr "Neu"
 
 #: cms/templates/imprint/imprint_sbs.html:141
 #: cms/templates/imprint/imprint_sbs.html:144
-#: cms/templates/pages/page_sbs.html:128
+#: cms/templates/pages/page_sbs.html:125
 msgid "Not saved yet"
 msgstr "Noch nicht gespeichert"
 
@@ -4899,44 +4899,44 @@ msgstr "Neue Übersetzung erstellen"
 msgid "Create new page"
 msgstr "Neue Seite erstellen"
 
-#: cms/templates/pages/page_form.html:86
+#: cms/templates/pages/page_form.html:84
 msgid "Translation in progress"
 msgstr "Übersetzung wird durchgeführt"
 
-#: cms/templates/pages/page_form.html:91
+#: cms/templates/pages/page_form.html:89
 msgid "Cancel translation process"
 msgstr "Übersetzungsprozess abbrechen"
 
-#: cms/templates/pages/page_form.html:113
+#: cms/templates/pages/page_form.html:111
 #: cms/templates/pages/page_tree_archived_node.html:85
 msgid "Archived, because a parent page is archived"
 msgstr "Archiviert, weil eine übergeordnete Seite archiviert ist"
 
-#: cms/templates/pages/page_form.html:195
+#: cms/templates/pages/page_form.html:193
 msgid "Settings of the page"
 msgstr "Einstellungen der Seite"
 
-#: cms/templates/pages/page_form.html:204
+#: cms/templates/pages/page_form.html:202
 msgid "Positioning"
 msgstr "Anordnung"
 
-#: cms/templates/pages/page_form.html:209
+#: cms/templates/pages/page_form.html:207
 msgid "Order"
 msgstr "Reihenfolge"
 
-#: cms/templates/pages/page_form.html:213
+#: cms/templates/pages/page_form.html:211
 msgid "Embed live content"
 msgstr "Live-Inhalte einbinden"
 
-#: cms/templates/pages/page_form.html:243
+#: cms/templates/pages/page_form.html:241
 msgid "Access token was successfully copied to clipboard"
 msgstr "Zugangs-Token wurde erfolgreich in die Zwischenablage kopiert."
 
-#: cms/templates/pages/page_form.html:256
+#: cms/templates/pages/page_form.html:254
 msgid "Additional permissions for this page"
 msgstr "Zusätzliche Berechtigungen für diese Seite"
 
-#: cms/templates/pages/page_form.html:258
+#: cms/templates/pages/page_form.html:256
 msgid ""
 "This affects only users, who don't have the permission to change arbitrary "
 "pages anyway."
@@ -4944,27 +4944,27 @@ msgstr ""
 "Dies betrifft nur Benutzer, die nicht ohnehin die Berechtigung haben, "
 "beliebige Seiten zu ändern."
 
-#: cms/templates/pages/page_form.html:293
+#: cms/templates/pages/page_form.html:291
 msgid "Refresh date"
 msgstr "Datum aktualisieren"
 
-#: cms/templates/pages/page_form.html:295
-#: cms/templates/pages/page_form.html:301
+#: cms/templates/pages/page_form.html:293
+#: cms/templates/pages/page_form.html:299
 msgid "Mark this page as up-to-date"
 msgstr "Seite als aktuell markieren"
 
+#: cms/templates/pages/page_form.html:304
 #: cms/templates/pages/page_form.html:306
-#: cms/templates/pages/page_form.html:308
-#: cms/templates/pages/page_form.html:318
+#: cms/templates/pages/page_form.html:316
 #: cms/templates/pages/page_tree_archived_node.html:113
 msgid "Restore page"
 msgstr "Seite wiederherstellen"
 
-#: cms/templates/pages/page_form.html:314
+#: cms/templates/pages/page_form.html:312
 msgid "Restore this page"
 msgstr "Diese Seite wiederherstellen"
 
-#: cms/templates/pages/page_form.html:323
+#: cms/templates/pages/page_form.html:321
 msgid "To restore this page, you have to restore its parent page:"
 msgid_plural ""
 "To restore this page, you have to restore all its archived parent pages:"
@@ -4975,31 +4975,31 @@ msgstr[1] ""
 "Um diese Seite wiederherzustellen, müssen Sie alle ihre archivierten "
 "übergeordneten Seiten wiederherstellen:"
 
+#: cms/templates/pages/page_form.html:336
 #: cms/templates/pages/page_form.html:338
-#: cms/templates/pages/page_form.html:340
 #: cms/templates/pages/page_tree_node.html:141
 msgid "Archive page"
 msgstr "Seite archivieren"
 
-#: cms/templates/pages/page_form.html:347
+#: cms/templates/pages/page_form.html:345
 msgid "Archive this page"
 msgstr "Diese Seite archivieren"
 
-#: cms/templates/pages/page_form.html:352
-#: cms/templates/pages/page_form.html:416
+#: cms/templates/pages/page_form.html:350
+#: cms/templates/pages/page_form.html:414
 #: cms/templates/pages/page_tree_archived_node.html:135
 #: cms/templates/pages/page_tree_node.html:158
 msgid "Delete page"
 msgstr "Seite löschen"
 
-#: cms/templates/pages/page_form.html:359
+#: cms/templates/pages/page_form.html:357
 #: cms/templates/pages/page_tree_archived_node.html:127
 #: cms/templates/pages/page_tree_node.html:150
 #: cms/views/pages/page_actions.py:262
 msgid "You cannot delete a page which has subpages."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
 
-#: cms/templates/pages/page_form.html:361
+#: cms/templates/pages/page_form.html:359
 msgid "To delete this page, you have to delete or move its subpage first:"
 msgid_plural ""
 "To delete this page, you have to delete or move its subpages first:"
@@ -5010,7 +5010,7 @@ msgstr[1] ""
 "Um diese Seite zu löschen, müssen Sie zuerst ihre Unterseiten löschen oder "
 "verschieben:"
 
-#: cms/templates/pages/page_form.html:380
+#: cms/templates/pages/page_form.html:378
 #: cms/templates/pages/page_tree_archived_node.html:131
 #: cms/templates/pages/page_tree_node.html:154
 #: cms/views/pages/page_actions.py:267
@@ -5021,7 +5021,7 @@ msgstr ""
 "Diese Seite kann nicht gelöscht werden, da sie von einer anderen Seite als "
 "Live-Inhalt eingebunden wurde."
 
-#: cms/templates/pages/page_form.html:384
+#: cms/templates/pages/page_form.html:382
 msgid ""
 "To delete this page, you have to remove the embedded live content from this "
 "page first:"
@@ -5035,15 +5035,15 @@ msgstr[1] ""
 "Um diese Seite zu löschen, müssen Sie den eingebetteten Live-Inhalt von "
 "dieser Seiten entfernen:"
 
-#: cms/templates/pages/page_form.html:423
+#: cms/templates/pages/page_form.html:421
 msgid "Delete this page"
 msgstr "Diese Seite löschen"
 
-#: cms/templates/pages/page_form.html:434
+#: cms/templates/pages/page_form.html:432
 msgid "Translator view"
 msgstr "Übersetzeransicht"
 
-#: cms/templates/pages/page_form.html:454
+#: cms/templates/pages/page_form.html:452
 msgid "Show translator view"
 msgstr "Übersetzeransicht anzeigen"
 
@@ -5057,7 +5057,7 @@ msgstr "Versionen der Seite \"%(page_title)s\""
 msgid "Go Back to Page Editor"
 msgstr "Zurück zum Seiten-Editor"
 
-#: cms/templates/pages/page_revisions.html:93
+#: cms/templates/pages/page_revisions.html:91
 msgid "Restore this version and submit for review"
 msgstr "Diese Revision wiederherstellen und zum Review vorlegen"
 
@@ -5070,7 +5070,7 @@ msgstr ""
 "Übersetze \"%(page_title)s\" von %(source_language)s nach "
 "%(target_language_name)s"
 
-#: cms/templates/pages/page_sbs.html:133
+#: cms/templates/pages/page_sbs.html:130
 msgid " Leave blank to generate unique permalink from title"
 msgstr ""
 " Dieses Feld freilassen, um eine eindeutigen Permalink aus dem Titel zu "
@@ -6185,7 +6185,7 @@ msgstr ""
 
 #: cms/views/events/event_form_view.py:199
 #: cms/views/imprint/imprint_form_view.py:216
-#: cms/views/pages/page_form_view.py:269 cms/views/pois/poi_form_view.py:166
+#: cms/views/pages/page_form_view.py:271 cms/views/pois/poi_form_view.py:166
 msgid "No changes detected, autosave skipped"
 msgstr "Keine Änderungen vorgenommen, automatisches Speichern übersprungen"
 
@@ -6194,7 +6194,7 @@ msgid "Event \"{}\" was successfully created"
 msgstr "Veranstaltung \"{}\" wurde erfolgreich erstellt"
 
 #: cms/views/events/event_form_view.py:230
-#: cms/views/pages/page_form_view.py:300 cms/views/pois/poi_form_view.py:180
+#: cms/views/pages/page_form_view.py:302 cms/views/pois/poi_form_view.py:180
 msgid "No changes detected, but date refreshed"
 msgstr "Keine Änderungen vorgenommen, aber Datum aktualisiert"
 
@@ -6276,7 +6276,7 @@ msgid "Imprint was successfully created"
 msgstr "Impressum wurde erfolgreich erstellt"
 
 #: cms/views/imprint/imprint_form_view.py:288
-#: cms/views/pages/page_form_view.py:375
+#: cms/views/pages/page_form_view.py:377
 #, python-brace-format
 msgid "{source_language} to {target_language}"
 msgstr "{source_language} nach {target_language}"
@@ -6295,7 +6295,7 @@ msgstr ""
 "Diese Revision ist identisch mit der aktuellen Version dieser Übersetzung."
 
 #: cms/views/imprint/imprint_revision_view.py:170
-#: cms/views/pages/page_revision_view.py:189
+#: cms/views/pages/page_revision_view.py:193
 msgid "The revision was successfully restored"
 msgstr "Die Revision wurde erfolgreich wiederhergestellt"
 
@@ -6728,7 +6728,7 @@ msgstr ""
 "Sie haben nicht die nötige Berechtigung, um diese Seite zu veröffentlichen, "
 "aber Sie können Änderungen vornehmen und diese zur Überprüfung vorlegen."
 
-#: cms/views/pages/page_form_view.py:293
+#: cms/views/pages/page_form_view.py:295
 msgid "Page \"{}\" was successfully created"
 msgstr "Seite \"{}\" wurde erfolgreich erstellt"
 

--- a/tests/cms/views/view_config.py
+++ b/tests/cms/views/view_config.py
@@ -150,7 +150,7 @@ VIEWS = [
             ("new_page", STAFF_ROLES + [MANAGEMENT, EDITOR, AUTHOR]),
             (
                 "new_page",
-                PRIV_STAFF_ROLES + [MANAGEMENT, EDITOR, AUTHOR],
+                PRIV_STAFF_ROLES + [MANAGEMENT, EDITOR],
                 {
                     "title": "new page",
                     "mirrored_page_region": "",
@@ -424,7 +424,7 @@ VIEWS = [
             ("edit_page", STAFF_ROLES + [MANAGEMENT, EDITOR, AUTHOR]),
             (
                 "edit_page",
-                PRIV_STAFF_ROLES + [MANAGEMENT, EDITOR, AUTHOR],
+                PRIV_STAFF_ROLES + [MANAGEMENT, EDITOR],
                 {
                     "title": "new title",
                     "mirrored_page_region": "",
@@ -435,7 +435,7 @@ VIEWS = [
             ),
             (
                 "edit_page",
-                PRIV_STAFF_ROLES + [MANAGEMENT, EDITOR, AUTHOR],
+                PRIV_STAFF_ROLES + [MANAGEMENT, EDITOR],
                 {
                     "title": "new title",
                     "mirrored_page_region": "",


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR tries to solve the problem that users who are not allowed to publish a page can unpublish the page by storing it as draft.

### Proposed changes
<!-- Describe this PR in more detail. -->
- "Save/Restore as Draft" Button will not be shown to users anymore, who do not have publishing right.
- This change is applied to Edit Page (where users edit page content) and Versions (where users manage past versions).


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->
Fixes: #1445
