### PR TITLE
Fix documentation build

### DIFF
--- a/integreat_cms/xliff/base_serializer.py
+++ b/integreat_cms/xliff/base_serializer.py
@@ -1,7 +1,7 @@
 """
 This module contains the abstract base classes for the XLIFF serializers.
 It makes use of the existing Django serialization functionality (see :doc:`django:topics/serialization` and
-:ref:`django:topics/serialization:xml`).
+:ref:`django:topics/serialization:serialization formats`).
 
 It extends :django-source:`django/core/serializers/base.py` and
 :django-source:`django/core/serializers/xml_serializer.py`.
@@ -39,7 +39,7 @@ class XMLGeneratorWithCDATA(SimplerXMLGenerator):
 class Serializer(xml_serializer.Serializer):
     """
     Abstract base XLIFF serializer class. Inherits basic XML initialization from the default xml_serializer of Django
-    (see :ref:`django:topics/serialization:xml`).
+    (see :ref:`django:topics/serialization:serialization formats`).
 
     The XLIFF file can be extended by writing to ``self.xml``, which is an instance of
     :class:`~integreat_cms.xliff.base_serializer.XMLGeneratorWithCDATA`.


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Apparently, Django changed something in its documentation, which breaks our intersphinx mappings.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Change link to xml serializer
