### PR TITLE
Fix button name in side-by-side view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ UNRELEASED
 
 * [ [#1516](https://github.com/digitalfabrik/integreat-cms/issues/1516) ] Fix save buttons alignment
 
+* [ [#1520](https://github.com/digitalfabrik/integreat-cms/issues/1520) ] Fix button name in side-by-side view
 
 2022.6.0
 --------

--- a/integreat_cms/cms/templates/imprint/imprint_sbs.html
+++ b/integreat_cms/cms/templates/imprint/imprint_sbs.html
@@ -22,7 +22,13 @@
                     </a>
                     {% if perms.cms.change_imprintpage %}
                         <button name="submit_draft" class="btn btn-gray">{% trans 'Save as draft' %}</button>
-                        <button name="submit_public" class="btn">{% trans 'Publish' %}</button>
+                        <button name="submit_public" class="btn">
+                            {% if imprint_translation_form.instance.status == PUBLIC %}
+                                {% trans 'Update' %}
+                            {% else %}
+                                {% trans 'Publish' %}
+                            {% endif %}
+                        </button>
                     {% endif %}
                 </div>
             </div>

--- a/integreat_cms/cms/templates/pages/page_sbs.html
+++ b/integreat_cms/cms/templates/pages/page_sbs.html
@@ -27,7 +27,13 @@
                         {% endif %}
                         {% has_perm 'cms.publish_page_object' request.user source_page_translation.page as can_publish_page %}
                         {% if can_publish_page %}
-                            <button name="submit_public" class="btn">{% trans 'Publish' %}</button>
+                            <button name="submit_public" class="btn">
+                                {% if page_translation_form.instance.status == PUBLIC %}
+                                    {% trans 'Update' %}
+                                {% else %}
+                                    {% trans 'Publish' %}
+                                {% endif %}
+                            </button>
                         {% else %}
                             <button name="submit_review" class="btn">{% trans 'Submit for review' %}</button>
                         {% endif %}

--- a/integreat_cms/cms/views/imprint/imprint_sbs_view.py
+++ b/integreat_cms/cms/views/imprint/imprint_sbs_view.py
@@ -11,6 +11,7 @@ from django.views.generic import TemplateView
 from ...decorators import permission_required
 from ...forms import ImprintTranslationForm
 from ...models import Language, ImprintPage
+from ...constants import status
 
 logger = logging.getLogger(__name__)
 
@@ -29,6 +30,7 @@ class ImprintSideBySideView(TemplateView):
         "current_menu_item": "imprint",
         "WEBAPP_URL": settings.WEBAPP_URL,
         "IMPRINT_SLUG": settings.IMPRINT_SLUG,
+        "PUBLIC": status.PUBLIC,
     }
 
     def get(self, request, *args, **kwargs):

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-01 14:41+0000\n"
+"POT-Creation-Date: 2022-06-08 20:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1443,9 +1443,9 @@ msgstr "Rechts nach Links"
 #: cms/templates/_form_language_tabs.html:81
 #: cms/templates/events/event_list_archived_row.html:47
 #: cms/templates/events/event_list_row.html:47
-#: cms/templates/imprint/imprint_sbs.html:41
-#: cms/templates/imprint/imprint_sbs.html:98
-#: cms/templates/pages/page_sbs.html:49 cms/templates/pages/page_sbs.html:98
+#: cms/templates/imprint/imprint_sbs.html:47
+#: cms/templates/imprint/imprint_sbs.html:104
+#: cms/templates/pages/page_sbs.html:55 cms/templates/pages/page_sbs.html:104
 #: cms/templates/pages/page_tree_archived_node.html:63
 #: cms/templates/pages/page_tree_node.html:79
 #: cms/templates/pois/poi_list_row.html:44
@@ -1458,9 +1458,9 @@ msgstr "Übersetzung ist aktuell"
 #: cms/templates/events/event_list_archived_row.html:39
 #: cms/templates/events/event_list_row.html:39
 #: cms/templates/events/event_list_row.html:61
-#: cms/templates/imprint/imprint_sbs.html:37
-#: cms/templates/imprint/imprint_sbs.html:94
-#: cms/templates/pages/page_sbs.html:45 cms/templates/pages/page_sbs.html:94
+#: cms/templates/imprint/imprint_sbs.html:43
+#: cms/templates/imprint/imprint_sbs.html:100
+#: cms/templates/pages/page_sbs.html:51 cms/templates/pages/page_sbs.html:100
 #: cms/templates/pages/page_tree_archived_node.html:55
 #: cms/templates/pages/page_tree_node.html:71
 #: cms/templates/pages/page_tree_node.html:89
@@ -1475,9 +1475,9 @@ msgstr "Wird derzeit übersetzt"
 #: cms/templates/_form_language_tabs.html:77
 #: cms/templates/events/event_list_archived_row.html:43
 #: cms/templates/events/event_list_row.html:43
-#: cms/templates/imprint/imprint_sbs.html:33
-#: cms/templates/imprint/imprint_sbs.html:90
-#: cms/templates/pages/page_sbs.html:41 cms/templates/pages/page_sbs.html:90
+#: cms/templates/imprint/imprint_sbs.html:39
+#: cms/templates/imprint/imprint_sbs.html:96
+#: cms/templates/pages/page_sbs.html:47 cms/templates/pages/page_sbs.html:96
 #: cms/templates/pages/page_tree_archived_node.html:59
 #: cms/templates/pages/page_tree_node.html:75
 #: cms/templates/pois/poi_list_row.html:40
@@ -1675,14 +1675,14 @@ msgstr "Kategorie"
 #: cms/templates/events/event_list_archived.html:52
 #: cms/templates/imprint/imprint_form.html:49
 #: cms/templates/imprint/imprint_revisions.html:46
-#: cms/templates/imprint/imprint_sbs.html:51
-#: cms/templates/imprint/imprint_sbs.html:115
-#: cms/templates/imprint/imprint_sbs.html:134
+#: cms/templates/imprint/imprint_sbs.html:57
+#: cms/templates/imprint/imprint_sbs.html:121
+#: cms/templates/imprint/imprint_sbs.html:140
 #: cms/templates/linkcheck/links_by_filter.html:59
 #: cms/templates/pages/page_form.html:99
 #: cms/templates/pages/page_revisions.html:50
-#: cms/templates/pages/page_sbs.html:59 cms/templates/pages/page_sbs.html:115
-#: cms/templates/pages/page_sbs.html:121 cms/templates/pages/page_tree.html:88
+#: cms/templates/pages/page_sbs.html:65 cms/templates/pages/page_sbs.html:121
+#: cms/templates/pages/page_sbs.html:127 cms/templates/pages/page_tree.html:88
 #: cms/templates/pages/page_tree_archived.html:67
 #: cms/templates/pois/poi_form.html:63 cms/templates/pois/poi_list.html:67
 #: cms/templates/pois/poi_list_archived.html:33
@@ -3376,13 +3376,13 @@ msgstr "Angebots-Vorlagen"
 #: cms/templates/_base.html:280 cms/templates/events/event_form.html:68
 #: cms/templates/imprint/imprint_form.html:43
 #: cms/templates/imprint/imprint_revisions.html:20
-#: cms/templates/imprint/imprint_sbs.html:48
-#: cms/templates/imprint/imprint_sbs.html:112
-#: cms/templates/imprint/imprint_sbs.html:131
+#: cms/templates/imprint/imprint_sbs.html:54
+#: cms/templates/imprint/imprint_sbs.html:118
+#: cms/templates/imprint/imprint_sbs.html:137
 #: cms/templates/pages/page_form.html:93
 #: cms/templates/pages/page_revisions.html:24
-#: cms/templates/pages/page_sbs.html:56 cms/templates/pages/page_sbs.html:112
-#: cms/templates/pages/page_sbs.html:118 cms/templates/pois/poi_form.html:58
+#: cms/templates/pages/page_sbs.html:62 cms/templates/pages/page_sbs.html:118
+#: cms/templates/pages/page_sbs.html:124 cms/templates/pois/poi_form.html:58
 msgid "Version"
 msgstr "Version"
 
@@ -3460,7 +3460,9 @@ msgstr "Tipp"
 
 #: cms/templates/_tinymce_config.html:37
 #: cms/templates/events/event_form.html:44
-#: cms/templates/pages/page_form.html:57 cms/templates/pois/poi_form.html:38
+#: cms/templates/imprint/imprint_sbs.html:27
+#: cms/templates/pages/page_form.html:57 cms/templates/pages/page_sbs.html:32
+#: cms/templates/pois/poi_form.html:38
 msgid "Update"
 msgstr "Aktualisieren"
 
@@ -3932,14 +3934,14 @@ msgstr "Als Entwurf speichern"
 
 #: cms/templates/events/event_form.html:46
 #: cms/templates/imprint/imprint_form.html:27
-#: cms/templates/imprint/imprint_sbs.html:25
-#: cms/templates/pages/page_form.html:59 cms/templates/pages/page_sbs.html:30
+#: cms/templates/imprint/imprint_sbs.html:29
+#: cms/templates/pages/page_form.html:59 cms/templates/pages/page_sbs.html:34
 #: cms/templates/pois/poi_form.html:40
 msgid "Publish"
 msgstr "Veröffentlichen"
 
 #: cms/templates/events/event_form.html:50
-#: cms/templates/pages/page_form.html:63 cms/templates/pages/page_sbs.html:32
+#: cms/templates/pages/page_form.html:63 cms/templates/pages/page_sbs.html:38
 msgid "Submit for review"
 msgstr "Zur Überprüfung vorlegen"
 
@@ -3951,8 +3953,8 @@ msgstr "Bearbeiten"
 #: cms/templates/events/event_form.html:96
 #: cms/templates/imprint/imprint_form.html:64
 #: cms/templates/imprint/imprint_form.html:78
-#: cms/templates/imprint/imprint_sbs.html:61
-#: cms/templates/imprint/imprint_sbs.html:125
+#: cms/templates/imprint/imprint_sbs.html:67
+#: cms/templates/imprint/imprint_sbs.html:131
 #: cms/templates/pages/page_form.html:122
 #: cms/templates/pages/page_form.html:141
 #: cms/templates/pages/page_form.html:228 cms/templates/pois/poi_form.html:84
@@ -3969,8 +3971,8 @@ msgstr "Geringfügige Änderung"
 
 #: cms/templates/events/event_form.html:126
 #: cms/templates/imprint/imprint_form.html:98
-#: cms/templates/imprint/imprint_sbs.html:145
-#: cms/templates/pages/page_form.html:171 cms/templates/pages/page_sbs.html:134
+#: cms/templates/imprint/imprint_sbs.html:151
+#: cms/templates/pages/page_form.html:171 cms/templates/pages/page_sbs.html:140
 #: cms/templates/pois/poi_form.html:118
 msgid "Implications on other translations"
 msgstr "Auswirkungen auf andere Übersetzungen"
@@ -4372,9 +4374,9 @@ msgid "Short URL"
 msgstr "Kurz-URL"
 
 #: cms/templates/imprint/imprint_form.html:71
-#: cms/templates/imprint/imprint_sbs.html:54
-#: cms/templates/imprint/imprint_sbs.html:118
-#: cms/templates/imprint/imprint_sbs.html:137
+#: cms/templates/imprint/imprint_sbs.html:60
+#: cms/templates/imprint/imprint_sbs.html:124
+#: cms/templates/imprint/imprint_sbs.html:143
 msgid "Link to the imprint"
 msgstr "Link zum Impressum"
 
@@ -4474,31 +4476,31 @@ msgid ""
 msgstr ""
 "Übersetze das Impressum von %(source_language)s nach %(target_language_name)s"
 
-#: cms/templates/imprint/imprint_sbs.html:75
-#: cms/templates/imprint/imprint_sbs.html:77
-#: cms/templates/pages/page_sbs.html:75 cms/templates/pages/page_sbs.html:77
+#: cms/templates/imprint/imprint_sbs.html:81
+#: cms/templates/imprint/imprint_sbs.html:83
+#: cms/templates/pages/page_sbs.html:81 cms/templates/pages/page_sbs.html:83
 msgid "Copy content"
 msgstr "Inhalt kopieren"
 
-#: cms/templates/imprint/imprint_sbs.html:80
-#: cms/templates/pages/page_sbs.html:80
+#: cms/templates/imprint/imprint_sbs.html:86
+#: cms/templates/pages/page_sbs.html:86
 #, python-format
 msgid "Copy content of %(source_language)s to %(target_language_name)s"
 msgstr "Inhalt von %(source_language)s nach %(target_language_name)s kopieren"
 
-#: cms/templates/imprint/imprint_sbs.html:103
-#: cms/templates/pages/page_sbs.html:103
+#: cms/templates/imprint/imprint_sbs.html:109
+#: cms/templates/pages/page_sbs.html:109
 msgid "Create Translation"
 msgstr "Übersetzung erstellen"
 
-#: cms/templates/imprint/imprint_sbs.html:132
-#: cms/templates/pages/page_sbs.html:119
+#: cms/templates/imprint/imprint_sbs.html:138
+#: cms/templates/pages/page_sbs.html:125
 msgid "New"
 msgstr "Neu"
 
-#: cms/templates/imprint/imprint_sbs.html:135
-#: cms/templates/imprint/imprint_sbs.html:138
-#: cms/templates/pages/page_sbs.html:122
+#: cms/templates/imprint/imprint_sbs.html:141
+#: cms/templates/imprint/imprint_sbs.html:144
+#: cms/templates/pages/page_sbs.html:128
 msgid "Not saved yet"
 msgstr "Noch nicht gespeichert"
 
@@ -5059,7 +5061,7 @@ msgstr ""
 "Übersetze \"%(page_title)s\" von %(source_language)s nach "
 "%(target_language_name)s"
 
-#: cms/templates/pages/page_sbs.html:127
+#: cms/templates/pages/page_sbs.html:133
 msgid " Leave blank to generate unique permalink from title"
 msgstr ""
 " Dieses Feld freilassen, um eine eindeutigen Permalink aus dem Titel zu "
@@ -6214,7 +6216,7 @@ msgstr "Feedback wurde als ungelesen markiert"
 msgid "Feedback was successfully deleted"
 msgstr "Feedback wurde erfolgreich gelöscht"
 
-#: cms/views/form_views.py:97 cms/views/imprint/imprint_sbs_view.py:207
+#: cms/views/form_views.py:97 cms/views/imprint/imprint_sbs_view.py:209
 #: cms/views/language_tree/language_tree_node_form_view.py:105
 #: cms/views/pages/page_sbs_view.py:192 cms/views/roles/role_form_view.py:93
 #: cms/views/settings/user_settings_view.py:91
@@ -6255,7 +6257,7 @@ msgstr ""
 "underline'>Revision %(revision)s</a> in den Apps angezeigt."
 
 #: cms/views/imprint/imprint_form_view.py:121
-#: cms/views/imprint/imprint_sbs_view.py:65
+#: cms/views/imprint/imprint_sbs_view.py:67
 msgid "You don't have the permission to edit the imprint."
 msgstr ""
 "Sie haben nicht die nötige Berechtigung, um das Impressum zu bearbeiten."
@@ -6288,8 +6290,8 @@ msgstr ""
 msgid "The revision was successfully restored"
 msgstr "Die Revision wurde erfolgreich wiederhergestellt"
 
-#: cms/views/imprint/imprint_sbs_view.py:79
-#: cms/views/imprint/imprint_sbs_view.py:164
+#: cms/views/imprint/imprint_sbs_view.py:81
+#: cms/views/imprint/imprint_sbs_view.py:166
 #: cms/views/pages/page_sbs_view.py:59 cms/views/pages/page_sbs_view.py:147
 #, python-brace-format
 msgid ""
@@ -6299,8 +6301,8 @@ msgstr ""
 "Sie können die Side-by-Side-Ansicht nicht für die Standard-Sprache (in "
 "diesem Fall {default_language}) verwenden."
 
-#: cms/views/imprint/imprint_sbs_view.py:97
-#: cms/views/imprint/imprint_sbs_view.py:181
+#: cms/views/imprint/imprint_sbs_view.py:99
+#: cms/views/imprint/imprint_sbs_view.py:183
 #: cms/views/pages/page_sbs_view.py:78 cms/views/pages/page_sbs_view.py:165
 #, python-brace-format
 msgid ""


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the text on the button in side-by-side view so that it says "Publish" when the shown translation is not yet published but "Update" when already published.

### Proposed changes
<!-- Describe this PR in more detail. -->
- The change has been applied for side-by-side view for page.
- I cannot find any side-by-side view for event and location. Could anybody show me where the feature is?
- but for Imprint side-by-side view is available. Should the change be also here applied?

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1520 
