### PR TITLE
Fix horizontal align of page form save buttons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 UNRELEASED
 ----------
 
+* [ [#1516](https://github.com/digitalfabrik/integreat-cms/issues/1516) ] Fix save buttons alignment
+
 
 2022.6.0
 --------

--- a/integreat_cms/cms/templates/events/event_form.html
+++ b/integreat_cms/cms/templates/events/event_form.html
@@ -16,7 +16,7 @@
         {% get_current_language as LANGUAGE_CODE %}
         {% get_language LANGUAGE_CODE as current_language %}
         <div class="flex flex-wrap justify-between gap-4 mb-4">
-            <h1 class="heading">
+            <h1 class="heading overflow-hidden text-ellipsis">
                 {% if event_form.instance.id %}
                     {% if event_translation_form.instance.id %}
                         {% with event_translation_form.instance.title as event_title %}
@@ -36,7 +36,7 @@
             </h1>
             {% if perms.cms.change_event %}
                 {% if not event_form.instance.id or not event_form.instance.archived %}
-                    <div class="flex flex-wrap gap-4">
+                    <div class="flex flex-wrap gap-4 ml-auto mr-0">
                         <button name="submit_draft" class="btn btn-gray">{% trans 'Save as draft' %}</button>
                         {% if perms.cms.publish_event %}
                             <button name="submit_public" class="btn">

--- a/integreat_cms/cms/templates/languages/language_form.html
+++ b/integreat_cms/cms/templates/languages/language_form.html
@@ -6,7 +6,7 @@
 <form method="post" data-unsaved-warning>
     {% csrf_token %}
     <div class="flex flex-wrap mb-4 justify-between">
-        <h1 class="heading">
+        <h1 class="heading overflow-hidden text-ellipsis">
           {% if form.instance.id %}
             {% with form.instance.translated_name as translated_language_name %}
             {% blocktrans %}Edit language "{{ translated_language_name }}"{% endblocktrans %}
@@ -16,7 +16,7 @@
           {% endif %}
         </h1>
         {% if perms.cms.change_language %}
-            <button class="btn">{% trans 'Save' %}</button>
+            <button class="btn ml-auto mr-0">{% trans 'Save' %}</button>
         {% endif %}
     </div>
 

--- a/integreat_cms/cms/templates/pages/_page_order_table.html
+++ b/integreat_cms/cms/templates/pages/_page_order_table.html
@@ -2,7 +2,7 @@
 {% load content_filters %}
 {% load page_filters %}
 <div class="table-listing">
-    <table data-activate-page-order class="w-full mt-4 rounded border border-solid border-gray-200 shadow bg-white table-auto cursor-default">
+    <table data-activate-page-order class="w-full mt-4 rounded border border-solid border-gray-200 shadow bg-white table-auto cursor-default break-all">
         <tbody>
             {% for sibling in siblings %}
                 {% if sibling == page %}

--- a/integreat_cms/cms/templates/pages/page_form.html
+++ b/integreat_cms/cms/templates/pages/page_form.html
@@ -18,7 +18,7 @@
           data-unsaved-warning>
         {% csrf_token %}
         <div class="w-full flex flex-wrap justify-between mb-6">
-            <h1 class="heading">
+            <h1 class="heading overflow-hidden text-ellipsis">
                 {% if page %}
                     {% if page_translation_form.instance.id %}
                         {% with page_translation_form.instance.title as page_title %}
@@ -37,7 +37,7 @@
                 {% endif %}
             </h1>
             {% if not page_form.instance.id or not page_form.instance.archived %}
-                <div class="flex flex-wrap gap-4">
+                <div class="flex flex-wrap gap-4 ml-auto mr-0">
                     <button
                         name="preview_page"
                         type="button"

--- a/integreat_cms/cms/templates/pois/poi_form.html
+++ b/integreat_cms/cms/templates/pois/poi_form.html
@@ -13,7 +13,7 @@
           data-unsaved-warning>
         {% csrf_token %}
         <div class="w-full flex flex-wrap justify-between mb-4">
-            <h1 class="heading">
+            <h1 class="heading overflow-hidden text-ellipsis">
                 {% if poi_form.instance.id %}
                     {% if poi_translation_form.instance.id %}
                         {% with poi_translation_form.instance.title as poi_title %}
@@ -31,7 +31,7 @@
                 {% endif %}
             </h1>
             {% if not poi_form.instance.archived and perms.cms.change_poi %}
-                <div class="flex flex-wrap gap-4">
+                <div class="flex flex-wrap gap-4 ml-auto mr-0">
                     <button name="submit_draft" class="btn btn-gray">{% trans 'Save as draft' %}</button>
                     <button name="submit_public" class="btn">
                         {% if poi_translation_form.instance.status == PUBLIC %}

--- a/integreat_cms/cms/templates/push_notifications/push_notification_form.html
+++ b/integreat_cms/cms/templates/push_notifications/push_notification_form.html
@@ -9,7 +9,7 @@
         {% csrf_token %}
         <div class="flex flex-wrap">
             <div class="w-full flex flex-wrap justify-between gap-4 mb-6">
-                <h1 class="heading">
+                <h1 class="heading overflow-hidden text-ellipsis">
                     {% if push_notification_form.instance.id %}
                         {% with push_notification_form.instance as push_notification_title %}
                             {% blocktrans %}Edit news message "{{ push_notification_title }}"{% endblocktrans %}
@@ -18,7 +18,7 @@
                         {% trans 'Create news message' %}
                     {% endif %}
                 </h1>
-                <div class="flex flex-wrap gap-4">
+                <div class="flex flex-wrap gap-4 ml-auto mr-0">
                     {% if perms.cms.change_pushnotification %}
                         <button name="submit_save" class="btn btn-gray">{% trans 'Save' %}</button>
                     {% endif %}

--- a/integreat_cms/cms/templates/regions/region_form.html
+++ b/integreat_cms/cms/templates/regions/region_form.html
@@ -8,7 +8,7 @@
 <form enctype="multipart/form-data" method="post" data-unsaved-warning>
     {% csrf_token %}
     <div class="flex flex-wrap justify-between mb-4">
-        <h1 class="heading">
+        <h1 class="heading overflow-hidden text-ellipsis">
             {% if form.initial %}
                 {% with form.name.value as region_name %}
                     {% blocktrans %}Edit region "{{ region_name }}"{% endblocktrans %}
@@ -18,7 +18,7 @@
             {% endif %}
         </h1>
         {% if perms.cms.change_region %}
-            <button class="btn">{% trans 'Save' %}</button>
+            <button class="btn ml-auto mr-0">{% trans 'Save' %}</button>
         {% endif %}
     </div>
 

--- a/integreat_cms/cms/templates/users/user_form.html
+++ b/integreat_cms/cms/templates/users/user_form.html
@@ -6,7 +6,7 @@
 <form method="post" data-unsaved-warning>
     {% csrf_token %}
     <div class="flex justify-between mb-4">
-        <h1 class="heading">
+        <h1 class="heading overflow-hidden text-ellipsis">
             {% if user_form.instance.id %}
                 {% with user_form.username.value as user_name %}
                     {% blocktrans %}Edit user "{{ user_name }}"{% endblocktrans %}


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr fixes the horizontal alignment of the page form save buttons and prevents horizontal scroll for very long page titles
![grafik](https://user-images.githubusercontent.com/78504586/172189095-46506c0b-6d41-4e73-90b8-f4fab89c5d6a.png)

### Proposed changes
<!-- Describe this PR in more detail. -->
- Specify alignment for the button row
- Add overflow: ellipsis to page title
- Specify word wrap-all behavior for the page order table to show long titles in multiple lines

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1516
