### PR TITLE
Urlencode links when copied to clipboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ UNRELEASED
 * [ [#1520](https://github.com/digitalfabrik/integreat-cms/issues/1520) ] Fix button name in side-by-side view
 * [ [#1502](https://github.com/digitalfabrik/integreat-cms/issues/1502) ] Do not check links in archived pages
 * [ [#1258](https://github.com/digitalfabrik/integreat-cms/issues/1258) ] Add possibility to mark pages as up-to-date
+* [ [#1539](https://github.com/digitalfabrik/integreat-cms/issues/1539) ] Urlencode permalinks when copying to clipboard
 
 
 2022.6.0

--- a/integreat_cms/static/src/js/forms/update-permalink.ts
+++ b/integreat_cms/static/src/js/forms/update-permalink.ts
@@ -63,7 +63,7 @@ window.addEventListener("load", () => {
 
   document.getElementById("copy-slug-btn")?.addEventListener("click", function(e){
     // copy whole permalink to clipboard
-    copyToClipboard(document.getElementById("slug-link").textContent);
+    copyToClipboard(encodeURI(document.getElementById("slug-link").textContent));
   });
 
   document.getElementById("restore-slug-btn")?.addEventListener("click", function(e){


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr changes the copy to clipboard button in the content forms to encode links, so they can be used on platforms which don't have unicode support.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Apply the builtin `encodeURI` function to the copied text 

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1539
