### PR TITLE
Fix short url copy button position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ UNRELEASED
 * [ [#1502](https://github.com/digitalfabrik/integreat-cms/issues/1502) ] Do not check links in archived pages
 * [ [#1258](https://github.com/digitalfabrik/integreat-cms/issues/1258) ] Add possibility to mark pages as up-to-date
 * [ [#1539](https://github.com/digitalfabrik/integreat-cms/issues/1539) ] Urlencode permalinks when copying to clipboard
+* [ [#1542](https://github.com/digitalfabrik/integreat-cms/issues/1542) ] Fix short url copy button
 
 
 2022.6.0

--- a/integreat_cms/cms/templates/imprint/imprint_form.html
+++ b/integreat_cms/cms/templates/imprint/imprint_form.html
@@ -54,17 +54,19 @@
                         {% render_field imprint_translation_form.title|add_error_class:"border-red-500" class+="mb-2" %}
                         {% if imprint_translation_form.instance.id %}
                             {% if request.region.short_urls_enabled and request.user.expert_mode %}
-                                <label class="inline-block">{% trans 'Short URL' %}:</label>
-                                <a href="{{ imprint_translation_form.instance.short_url }}"
-                                   target="_blank"
-                                   rel="noopener noreferrer"
-                                   class="text-blue-500 hover:underline">{{ imprint_translation_form.instance.short_url }}</a>
-                                <a href="#"
-                                   data-copy-to-clipboard="{{ imprint_translation_form.instance.short_url }}"
-                                   title="{% trans 'Copy to clipboard' %}"
-                                   class=" text-gray-800 hover:text-blue-500">
-                                    <i data-feather="copy"></i>
-                                </a>
+                                <div class="flex items-center">
+                                    <label class="inline-block mr-2">{% trans 'Short URL' %}:</label>
+                                    <a href="{{ imprint_translation_form.instance.short_url }}"
+                                       target="_blank"
+                                       rel="noopener noreferrer"
+                                       class="text-blue-500 hover:underline">{{ imprint_translation_form.instance.short_url }}</a>
+                                    <a href="#"
+                                       data-copy-to-clipboard="{{ imprint_translation_form.instance.short_url }}"
+                                       title="{% trans 'Copy to clipboard' %}"
+                                       class="mx-2 text-gray-800 hover:text-blue-500">
+                                        <i data-feather="copy"></i>
+                                    </a>
+                                </div>
                             {% endif %}
                         {% endif %}
                         <div id="link-container" class="flex items-center">

--- a/integreat_cms/cms/templates/pages/page_form.html
+++ b/integreat_cms/cms/templates/pages/page_form.html
@@ -121,18 +121,19 @@
                         {% render_field page_translation_form.title|add_error_class:"border-red-500" class+="mb-2" %}
                         {% if page_translation_form.instance.id %}
                             {% if request.region.short_urls_enabled and request.user.expert_mode %}
-                                <label class="inline-block">{% trans 'Short URL' %}:</label>
-                                <a href="{{ page_translation_form.instance.short_url }}"
-                                   target="_blank"
-                                   rel="noopener noreferrer"
-                                   class="text-blue-500 hover:underline">{{ page_translation_form.instance.short_url }}</a>
-                                <a href="#"
-                                   data-copy-to-clipboard="{{ page_translation_form.instance.short_url }}"
-                                   title="{% trans 'Copy to clipboard' %}"
-                                   class="px-2 text-gray-800 hover:text-blue-500">
-                                    <i data-feather="copy"></i>
-                                </a>
-                                <br />
+                                <div class="flex items-center">
+                                    <label class="inline-block mr-2">{% trans 'Short URL' %}:</label>
+                                    <a href="{{ page_translation_form.instance.short_url }}"
+                                       target="_blank"
+                                       rel="noopener noreferrer"
+                                       class="text-blue-500 hover:underline">{{ page_translation_form.instance.short_url }}</a>
+                                    <a href="#"
+                                       data-copy-to-clipboard="{{ page_translation_form.instance.short_url }}"
+                                       title="{% trans 'Copy to clipboard' %}"
+                                       class="mx-2 text-gray-800 hover:text-blue-500">
+                                        <i data-feather="copy"></i>
+                                    </a>
+                                </div>
                             {% endif %}
                         {% endif %}
                         <div id="link-container" class="flex items-center">

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-13 15:24+0000\n"
+"POT-Creation-Date: 2022-06-13 18:34+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -3946,33 +3946,33 @@ msgid "Submit for review"
 msgstr "Zur Überprüfung vorlegen"
 
 #: cms/templates/events/event_form.html:92
-#: cms/templates/pages/page_form.html:146 cms/templates/pois/poi_form.html:80
+#: cms/templates/pages/page_form.html:147 cms/templates/pois/poi_form.html:80
 msgid "Edit"
 msgstr "Bearbeiten"
 
 #: cms/templates/events/event_form.html:96
-#: cms/templates/imprint/imprint_form.html:64
-#: cms/templates/imprint/imprint_form.html:78
+#: cms/templates/imprint/imprint_form.html:65
+#: cms/templates/imprint/imprint_form.html:80
 #: cms/templates/imprint/imprint_sbs.html:67
 #: cms/templates/imprint/imprint_sbs.html:131
-#: cms/templates/pages/page_form.html:131
-#: cms/templates/pages/page_form.html:150
-#: cms/templates/pages/page_form.html:237 cms/templates/pois/poi_form.html:84
+#: cms/templates/pages/page_form.html:132
+#: cms/templates/pages/page_form.html:151
+#: cms/templates/pages/page_form.html:238 cms/templates/pois/poi_form.html:84
 msgid "Copy to clipboard"
 msgstr "In die Zwischenablage kopieren"
 
 #: cms/templates/events/event_form.html:122
-#: cms/templates/imprint/imprint_form.html:94
-#: cms/templates/pages/page_form.html:176
+#: cms/templates/imprint/imprint_form.html:96
+#: cms/templates/pages/page_form.html:177
 #: cms/templates/pages/page_revisions.html:58
 #: cms/templates/pois/poi_form.html:114
 msgid "Minor edit"
 msgstr "Geringfügige Änderung"
 
 #: cms/templates/events/event_form.html:126
-#: cms/templates/imprint/imprint_form.html:98
+#: cms/templates/imprint/imprint_form.html:100
 #: cms/templates/imprint/imprint_sbs.html:151
-#: cms/templates/pages/page_form.html:180 cms/templates/pages/page_sbs.html:140
+#: cms/templates/pages/page_form.html:181 cms/templates/pages/page_sbs.html:140
 #: cms/templates/pois/poi_form.html:118
 msgid "Implications on other translations"
 msgstr "Auswirkungen auf andere Übersetzungen"
@@ -4010,8 +4010,8 @@ msgid "Open on Google Maps"
 msgstr "Auf Google Maps öffnen"
 
 #: cms/templates/events/event_form.html:328
-#: cms/templates/imprint/imprint_form.html:112
-#: cms/templates/pages/page_form.html:286 cms/templates/pois/poi_form.html:213
+#: cms/templates/imprint/imprint_form.html:114
+#: cms/templates/pages/page_form.html:287 cms/templates/pois/poi_form.html:213
 #: cms/templates/regions/region_list.html:25
 #: cms/templates/settings/user_settings.html:93
 msgid "Actions"
@@ -4368,45 +4368,45 @@ msgstr "Impressum erstellen"
 msgid "Show"
 msgstr "Anzeigen"
 
-#: cms/templates/imprint/imprint_form.html:57
-#: cms/templates/pages/page_form.html:124
+#: cms/templates/imprint/imprint_form.html:58
+#: cms/templates/pages/page_form.html:125
 msgid "Short URL"
 msgstr "Kurz-URL"
 
-#: cms/templates/imprint/imprint_form.html:71
+#: cms/templates/imprint/imprint_form.html:73
 #: cms/templates/imprint/imprint_sbs.html:60
 #: cms/templates/imprint/imprint_sbs.html:124
 #: cms/templates/imprint/imprint_sbs.html:143
 msgid "Link to the imprint"
 msgstr "Link zum Impressum"
 
-#: cms/templates/imprint/imprint_form.html:116
-#: cms/templates/imprint/imprint_form.html:117
+#: cms/templates/imprint/imprint_form.html:118
+#: cms/templates/imprint/imprint_form.html:119
 msgid "Delete imprint"
 msgstr "Impressum löschen"
 
-#: cms/templates/imprint/imprint_form.html:119
+#: cms/templates/imprint/imprint_form.html:121
 msgid "Please confirm that you really want to delete the imprint"
 msgstr "Bitte bestätigen Sie, dass das Impressum gelöscht werden soll"
 
-#: cms/templates/imprint/imprint_form.html:120
+#: cms/templates/imprint/imprint_form.html:122
 msgid "All translations of the imprint will also be deleted."
 msgstr "Alle Übersetzungen des Impressums werden gelöscht."
 
-#: cms/templates/imprint/imprint_form.html:124
+#: cms/templates/imprint/imprint_form.html:126
 msgid "Delete the imprint"
 msgstr "Das Impressum löschen"
 
-#: cms/templates/imprint/imprint_form.html:133
+#: cms/templates/imprint/imprint_form.html:135
 msgid "Side-by-Side view"
 msgstr "Side-by-Side-Ansicht"
 
-#: cms/templates/imprint/imprint_form.html:137
-#: cms/templates/pages/page_form.html:438
+#: cms/templates/imprint/imprint_form.html:139
+#: cms/templates/pages/page_form.html:439
 msgid "Direction of translation"
 msgstr "Übersetzungsrichtung"
 
-#: cms/templates/imprint/imprint_form.html:151
+#: cms/templates/imprint/imprint_form.html:153
 msgid "Show translations side by side"
 msgstr "Übersetzungen nebeneinander anzeigen"
 
@@ -4912,31 +4912,31 @@ msgstr "Übersetzungsprozess abbrechen"
 msgid "Archived, because a parent page is archived"
 msgstr "Archiviert, weil eine übergeordnete Seite archiviert ist"
 
-#: cms/templates/pages/page_form.html:194
+#: cms/templates/pages/page_form.html:195
 msgid "Settings of the page"
 msgstr "Einstellungen der Seite"
 
-#: cms/templates/pages/page_form.html:203
+#: cms/templates/pages/page_form.html:204
 msgid "Positioning"
 msgstr "Anordnung"
 
-#: cms/templates/pages/page_form.html:208
+#: cms/templates/pages/page_form.html:209
 msgid "Order"
 msgstr "Reihenfolge"
 
-#: cms/templates/pages/page_form.html:212
+#: cms/templates/pages/page_form.html:213
 msgid "Embed live content"
 msgstr "Live-Inhalte einbinden"
 
-#: cms/templates/pages/page_form.html:242
+#: cms/templates/pages/page_form.html:243
 msgid "Access token was successfully copied to clipboard"
 msgstr "Zugangs-Token wurde erfolgreich in die Zwischenablage kopiert."
 
-#: cms/templates/pages/page_form.html:255
+#: cms/templates/pages/page_form.html:256
 msgid "Additional permissions for this page"
 msgstr "Zusätzliche Berechtigungen für diese Seite"
 
-#: cms/templates/pages/page_form.html:257
+#: cms/templates/pages/page_form.html:258
 msgid ""
 "This affects only users, who don't have the permission to change arbitrary "
 "pages anyway."
@@ -4944,27 +4944,27 @@ msgstr ""
 "Dies betrifft nur Benutzer, die nicht ohnehin die Berechtigung haben, "
 "beliebige Seiten zu ändern."
 
-#: cms/templates/pages/page_form.html:292
+#: cms/templates/pages/page_form.html:293
 msgid "Refresh date"
 msgstr "Datum aktualisieren"
 
-#: cms/templates/pages/page_form.html:294
-#: cms/templates/pages/page_form.html:300
+#: cms/templates/pages/page_form.html:295
+#: cms/templates/pages/page_form.html:301
 msgid "Mark this page as up-to-date"
 msgstr "Seite als aktuell markieren"
 
-#: cms/templates/pages/page_form.html:305
-#: cms/templates/pages/page_form.html:307
-#: cms/templates/pages/page_form.html:317
+#: cms/templates/pages/page_form.html:306
+#: cms/templates/pages/page_form.html:308
+#: cms/templates/pages/page_form.html:318
 #: cms/templates/pages/page_tree_archived_node.html:113
 msgid "Restore page"
 msgstr "Seite wiederherstellen"
 
-#: cms/templates/pages/page_form.html:313
+#: cms/templates/pages/page_form.html:314
 msgid "Restore this page"
 msgstr "Diese Seite wiederherstellen"
 
-#: cms/templates/pages/page_form.html:322
+#: cms/templates/pages/page_form.html:323
 msgid "To restore this page, you have to restore its parent page:"
 msgid_plural ""
 "To restore this page, you have to restore all its archived parent pages:"
@@ -4975,31 +4975,31 @@ msgstr[1] ""
 "Um diese Seite wiederherzustellen, müssen Sie alle ihre archivierten "
 "übergeordneten Seiten wiederherstellen:"
 
-#: cms/templates/pages/page_form.html:337
-#: cms/templates/pages/page_form.html:339
+#: cms/templates/pages/page_form.html:338
+#: cms/templates/pages/page_form.html:340
 #: cms/templates/pages/page_tree_node.html:141
 msgid "Archive page"
 msgstr "Seite archivieren"
 
-#: cms/templates/pages/page_form.html:346
+#: cms/templates/pages/page_form.html:347
 msgid "Archive this page"
 msgstr "Diese Seite archivieren"
 
-#: cms/templates/pages/page_form.html:351
-#: cms/templates/pages/page_form.html:415
+#: cms/templates/pages/page_form.html:352
+#: cms/templates/pages/page_form.html:416
 #: cms/templates/pages/page_tree_archived_node.html:135
 #: cms/templates/pages/page_tree_node.html:158
 msgid "Delete page"
 msgstr "Seite löschen"
 
-#: cms/templates/pages/page_form.html:358
+#: cms/templates/pages/page_form.html:359
 #: cms/templates/pages/page_tree_archived_node.html:127
 #: cms/templates/pages/page_tree_node.html:150
 #: cms/views/pages/page_actions.py:262
 msgid "You cannot delete a page which has subpages."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
 
-#: cms/templates/pages/page_form.html:360
+#: cms/templates/pages/page_form.html:361
 msgid "To delete this page, you have to delete or move its subpage first:"
 msgid_plural ""
 "To delete this page, you have to delete or move its subpages first:"
@@ -5010,7 +5010,7 @@ msgstr[1] ""
 "Um diese Seite zu löschen, müssen Sie zuerst ihre Unterseiten löschen oder "
 "verschieben:"
 
-#: cms/templates/pages/page_form.html:379
+#: cms/templates/pages/page_form.html:380
 #: cms/templates/pages/page_tree_archived_node.html:131
 #: cms/templates/pages/page_tree_node.html:154
 #: cms/views/pages/page_actions.py:267
@@ -5021,7 +5021,7 @@ msgstr ""
 "Diese Seite kann nicht gelöscht werden, da sie von einer anderen Seite als "
 "Live-Inhalt eingebunden wurde."
 
-#: cms/templates/pages/page_form.html:383
+#: cms/templates/pages/page_form.html:384
 msgid ""
 "To delete this page, you have to remove the embedded live content from this "
 "page first:"
@@ -5035,15 +5035,15 @@ msgstr[1] ""
 "Um diese Seite zu löschen, müssen Sie den eingebetteten Live-Inhalt von "
 "dieser Seiten entfernen:"
 
-#: cms/templates/pages/page_form.html:422
+#: cms/templates/pages/page_form.html:423
 msgid "Delete this page"
 msgstr "Diese Seite löschen"
 
-#: cms/templates/pages/page_form.html:433
+#: cms/templates/pages/page_form.html:434
 msgid "Translator view"
 msgstr "Übersetzeransicht"
 
-#: cms/templates/pages/page_form.html:453
+#: cms/templates/pages/page_form.html:454
 msgid "Show translator view"
 msgstr "Übersetzeransicht anzeigen"
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr fixes the position of the copy short url button in the page form and imprint form to make it consistent with the normal page url.

![grafik](https://user-images.githubusercontent.com/78504586/173393763-b2ecc112-04c5-4006-bfb9-da1c7a900e51.png)


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1542 
