### PR TITLE
Limit event duration to 7 days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ UNRELEASED
 ----------
 
 * [ [#1528](https://github.com/digitalfabrik/integreat-cms/issues/1528) ] Fix list view layouts for long titles
+* [ [#1510](https://github.com/digitalfabrik/integreat-cms/issues/1510) ] Limit event duration to 7 days
 
 
 2022.6.3

--- a/integreat_cms/cms/forms/events/event_form.py
+++ b/integreat_cms/cms/forms/events/event_form.py
@@ -1,6 +1,6 @@
 import logging
 
-from datetime import time
+from datetime import time, timedelta
 
 from django import forms
 from django.utils.translation import ugettext_lazy as _
@@ -95,6 +95,16 @@ class EventForm(CustomModelForm):
         # make self.data mutable to allow values to be changed manually
         self.data = self.data.copy()
 
+        if cleaned_data["end_date"] - cleaned_data["start_date"] > timedelta(6):
+            self.add_error(
+                "end_date",
+                forms.ValidationError(
+                    _(
+                        "The maximum duration for events is 7 days. Consider using recurring events if the event is not continuous."
+                    ),
+                    code="invalid",
+                ),
+            )
         if cleaned_data.get("is_all_day"):
             cleaned_data["start_time"] = time.min
             self.data["start_time"] = time.min

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-24 08:36+0000\n"
+"POT-Creation-Date: 2022-06-24 13:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1594,19 +1594,28 @@ msgstr ""
 "Entweder muss der Veranstaltungsort deaktiviert werden oder es muss ein "
 "gültiger Ort angegeben werden"
 
-#: cms/forms/events/event_form.py:110
+#: cms/forms/events/event_form.py:103
+msgid ""
+"The maximum duration for events is 7 days. Consider using recurring events "
+"if the event is not continuous."
+msgstr ""
+"Die maximale Veranstaltungsdauer beträgt 7 Tage. Verwenden Sie "
+"wiederkehrende Veranstaltungen, wenn die Veranstaltung nicht kontinuierlich "
+"stattfindet."
+
+#: cms/forms/events/event_form.py:120
 msgid "If the event is not all-day, the start time is required"
 msgstr ""
 "Wenn die Veranstaltung nicht ganztägig ist, muss eine Start-Uhrzeit "
 "angegeben werden"
 
-#: cms/forms/events/event_form.py:118
+#: cms/forms/events/event_form.py:128
 msgid "If the event is not all-day, the end time is required"
 msgstr ""
 "Wenn die Veranstaltung nicht ganztägig ist, muss eine End-Uhrzeit angegeben "
 "werden"
 
-#: cms/forms/events/event_form.py:134 cms/forms/events/event_form.py:148
+#: cms/forms/events/event_form.py:144 cms/forms/events/event_form.py:158
 msgid "The end of the event can't be before the start of the event"
 msgstr "Das Ende der Veranstaltung kann nicht vor seinem Beginn sein"
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR limits the maximal duration of an event to 7 days.

### Proposed changes
<!-- Describe this PR in more detail. -->
- It is no longer allowed to create an one-time event with duration longer than 7 days or to change the duration of an one-time event to over 7 days.
- A small explanation for this limitation is added on the event editor page above the date inputs fields.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1510 
