### PR TITLE
Fix PDF generation for long filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ UNRELEASED
 * [ [#1504](https://github.com/digitalfabrik/integreat-cms/issues/1504) ] Keep filters on pagination
 * [ [#1585](https://github.com/digitalfabrik/integreat-cms/issues/1585) ] Hide news after 28 days
 * [ [#1600](https://github.com/digitalfabrik/integreat-cms/issues/1600) ] Improve XLIFF export bulk option description
+* [ [#1511](https://github.com/digitalfabrik/integreat-cms/issues/1511) ] Fix PDF generation for long filenames
 
 
 2022.6.3

--- a/integreat_cms/cms/utils/text_utils.py
+++ b/integreat_cms/cms/utils/text_utils.py
@@ -17,3 +17,23 @@ def lowfirst(string):
     :rtype: str
     """
     return string and str(string)[0].lower() + str(string)[1:]
+
+
+def truncate_bytewise(string, length):
+    """
+    Truncate a UTF-8 encoded string to a maximum byte length.
+
+    :param string: The input text
+    :type string: str
+
+    :param length: The maximum length of the text in byte representation
+    :type length: int
+
+    :return: The truncated text
+    :rtype: str
+    """
+    encoded_string = string.encode()
+    try:
+        return encoded_string[:length].decode()
+    except UnicodeDecodeError as e:
+        return encoded_string[: e.start].decode()

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -6032,12 +6032,12 @@ msgstr "Unbekannt"
 msgid "CW"
 msgstr "KW"
 
-#: cms/utils/pdf_utils.py:69
+#: cms/utils/pdf_utils.py:71
 msgid "No valid pages selected for PDF generation."
 msgstr ""
 "Es wurden keine gültigen Seiten zur Erzeugung der PDF-Datei ausgewählt."
 
-#: cms/utils/pdf_utils.py:117
+#: cms/utils/pdf_utils.py:127
 msgid "The PDF could not be successfully generated."
 msgstr "PDF-Datei konnte nicht erfolgreich erzeugt werden."
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the ```OSError``` when exporting pages with very long titles. It does this by truncating filenames to at most 250 characters (and an additional file extension). 

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1511
