### PR TITLE
Deliver only the default language title in poi api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ UNRELEASED
 
 * [ [#1528](https://github.com/digitalfabrik/integreat-cms/issues/1528) ] Fix list view layouts for long titles
 * [ [#1510](https://github.com/digitalfabrik/integreat-cms/issues/1510) ] Limit event duration to 7 days
+* [ [#1512](https://github.com/digitalfabrik/integreat-cms/issues/1512) ] Deliver location names in the api in the default language only
 
 
 2022.6.3

--- a/integreat_cms/api/v3/events.py
+++ b/integreat_cms/api/v3/events.py
@@ -50,14 +50,6 @@ def transform_event_translation(event_translation):
     :rtype: dict
     """
     event = event_translation.event
-    if event.location:
-        location_translation = (
-            event.location.get_public_translation(event_translation.language.slug)
-            or event.location.best_translation
-        )
-    else:
-        location_translation = None
-
     absolute_url = event_translation.get_absolute_url()
     return {
         "id": event_translation.id,
@@ -69,7 +61,7 @@ def transform_event_translation(event_translation):
         "content": event_translation.content,
         "available_languages": event_translation.available_languages,
         "thumbnail": event.icon.url if event.icon else None,
-        "location": transform_poi(event.location, location_translation),
+        "location": transform_poi(event.location),
         "event": transform_event(event),
         "hash": None,
     }

--- a/integreat_cms/api/v3/locations.py
+++ b/integreat_cms/api/v3/locations.py
@@ -8,22 +8,17 @@ from django.http import JsonResponse
 from ..decorators import json_response
 
 
-def transform_poi(poi, poi_translation):
+def transform_poi(poi):
     """
     Function to create a JSON from a single poi object.
-    Because the json requires a translated name, `poi_translation` has to be
-    passed as the second parameter.
 
     :param poi: The poi object which should be converted
     :type poi: ~integreat_cms.cms.models.pois.poi.POI
 
-    :param poi_translation: The translation of the POI which should be used for the title
-    :type poi_translation: ~integreat_cms.cms.models.pois.poi_translation.POITranslation
-
     :return: data necessary for API
     :rtype: dict
     """
-    if not poi or not poi_translation:
+    if not poi:
         return {
             "id": None,
             "name": None,
@@ -38,7 +33,7 @@ def transform_poi(poi, poi_translation):
         }
     return {
         "id": poi.id,
-        "name": poi_translation.title,
+        "name": poi.default_translation.title,
         "address": poi.address,
         "town": poi.city,
         "state": None,
@@ -66,7 +61,7 @@ def transform_poi_translation(poi_translation):
         "id": poi_translation.id,
         "url": settings.BASE_URL + poi_translation.get_absolute_url(),
         "path": poi_translation.get_absolute_url(),
-        "title": poi_translation.title,
+        "title": poi.default_translation.title,
         "modified_gmt": poi_translation.last_updated.strftime("%Y-%m-%d %H:%M:%S"),
         "excerpt": poi_translation.short_description,
         "content": poi_translation.content,
@@ -76,7 +71,7 @@ def transform_poi_translation(poi_translation):
         "website": poi.website if poi.website else None,
         "email": poi.email if poi.email else None,
         "phone_number": poi.phone_number if poi.phone_number else None,
-        "location": transform_poi(poi, poi_translation),
+        "location": transform_poi(poi),
         "hash": None,
     }
 

--- a/integreat_cms/cms/forms/pois/poi_translation_form.py
+++ b/integreat_cms/cms/forms/pois/poi_translation_form.py
@@ -62,10 +62,14 @@ class POITranslationForm(CustomContentModelForm):
                 "Changed POST data 'status' manually to %r", data.get("status")
             )
 
+        default_language_title = kwargs.pop("default_language_title", None)
+
         # Instantiate CustomModelForm
         super().__init__(**kwargs)
 
         self.fields["slug"].required = False
+        if default_language_title:
+            self.fields["title"].initial = default_language_title
 
     def save(self, commit=True):
         """

--- a/integreat_cms/cms/templates/pois/poi_form.html
+++ b/integreat_cms/cms/templates/pois/poi_form.html
@@ -72,6 +72,11 @@
                             {% endif %}
                         </div>
                         {% render_field poi_translation_form.title|add_error_class:"border-red-500" class+="mb-2" %}
+                        {% if language != request.region.default_language %}
+                            <div class="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-600 px-4 py-1 mb-2">
+                                {% blocktrans %}The name is currently displayed to users only in the default language{% endblocktrans %}
+                            </div>
+                        {% endif %}
                         <div id="link-container" class="flex items-center">
                             <label for="{{ poi_translation_form.slug.id_for_label }}" class="mr-2">{{ poi_translation_form.slug.label }}:</label>
                             <a id="slug-link"

--- a/integreat_cms/cms/views/pois/poi_form_view.py
+++ b/integreat_cms/cms/views/pois/poi_form_view.py
@@ -78,7 +78,9 @@ class POIFormView(
 
         poi_form = POIForm(instance=poi, disabled=disabled)
         poi_translation_form = POITranslationForm(
-            instance=poi_translation, disabled=disabled
+            instance=poi_translation,
+            disabled=disabled,
+            default_language_title=poi.default_translation.title if poi else None,
         )
         url_link = f"{settings.WEBAPP_URL}/{region.slug}/{language.slug}/{poi_translation_form.instance.url_infix}/"
         return render(

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-24 13:50+0000\n"
+"POT-Creation-Date: 2022-06-29 11:37+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -3991,7 +3991,7 @@ msgid "Submit for review"
 msgstr "Zur Überprüfung vorlegen"
 
 #: cms/templates/events/event_form.html:92
-#: cms/templates/pages/page_form.html:145 cms/templates/pois/poi_form.html:80
+#: cms/templates/pages/page_form.html:145 cms/templates/pois/poi_form.html:85
 msgid "Edit"
 msgstr "Bearbeiten"
 
@@ -4002,7 +4002,7 @@ msgstr "Bearbeiten"
 #: cms/templates/imprint/imprint_sbs.html:129
 #: cms/templates/pages/page_form.html:130
 #: cms/templates/pages/page_form.html:149
-#: cms/templates/pages/page_form.html:236 cms/templates/pois/poi_form.html:84
+#: cms/templates/pages/page_form.html:236 cms/templates/pois/poi_form.html:89
 msgid "Copy to clipboard"
 msgstr "In die Zwischenablage kopieren"
 
@@ -4010,7 +4010,7 @@ msgstr "In die Zwischenablage kopieren"
 #: cms/templates/imprint/imprint_form.html:96
 #: cms/templates/pages/page_form.html:175
 #: cms/templates/pages/page_revisions.html:58
-#: cms/templates/pois/poi_form.html:114
+#: cms/templates/pois/poi_form.html:119
 msgid "Minor edit"
 msgstr "Geringfügige Änderung"
 
@@ -4018,7 +4018,7 @@ msgstr "Geringfügige Änderung"
 #: cms/templates/imprint/imprint_form.html:100
 #: cms/templates/imprint/imprint_sbs.html:149
 #: cms/templates/pages/page_form.html:179 cms/templates/pages/page_sbs.html:136
-#: cms/templates/pois/poi_form.html:118
+#: cms/templates/pois/poi_form.html:123
 msgid "Implications on other translations"
 msgstr "Auswirkungen auf andere Übersetzungen"
 
@@ -4046,7 +4046,7 @@ msgstr ""
 "bestehenden Veranstaltungsortes einzutippen"
 
 #: cms/templates/events/event_form.html:283
-#: cms/templates/pois/poi_form.html:137
+#: cms/templates/pois/poi_form.html:142
 msgid "Address"
 msgstr "Adresse"
 
@@ -4056,7 +4056,7 @@ msgstr "Auf Google Maps öffnen"
 
 #: cms/templates/events/event_form.html:328
 #: cms/templates/imprint/imprint_form.html:114
-#: cms/templates/pages/page_form.html:285 cms/templates/pois/poi_form.html:214
+#: cms/templates/pages/page_form.html:285 cms/templates/pois/poi_form.html:219
 #: cms/templates/regions/region_list.html:25
 #: cms/templates/settings/user_settings.html:93
 msgid "Actions"
@@ -5340,11 +5340,15 @@ msgstr "Neue Übersetzung des Ortes erstellen"
 msgid "Create new location"
 msgstr "Neuen Ort erstellen"
 
-#: cms/templates/pois/poi_form.html:132 cms/templates/pois/poi_form.html:153
+#: cms/templates/pois/poi_form.html:77
+msgid "The name is currently displayed to users only in the default language"
+msgstr "Der Name wird Benutzern momentan nur in der Standardsprache angezeigt"
+
+#: cms/templates/pois/poi_form.html:137 cms/templates/pois/poi_form.html:158
 msgid "Position"
 msgstr "Position"
 
-#: cms/templates/pois/poi_form.html:155
+#: cms/templates/pois/poi_form.html:160
 msgid ""
 "If you leave these fields blank, they are automatically derived from the "
 "address."
@@ -5352,50 +5356,50 @@ msgstr ""
 "Wenn Sie diese Felder leer lassen, werden sie automatisch aus der Adresse "
 "abgeleitet."
 
-#: cms/templates/pois/poi_form.html:172
+#: cms/templates/pois/poi_form.html:177
 msgid "Contact details"
 msgstr "Kontaktdaten"
 
-#: cms/templates/pois/poi_form.html:174
+#: cms/templates/pois/poi_form.html:179
 msgid "currently not publicly visible"
 msgstr "aktuell nicht öffentlich sichtbar"
 
-#: cms/templates/pois/poi_form.html:221 cms/templates/pois/poi_form.html:223
+#: cms/templates/pois/poi_form.html:226 cms/templates/pois/poi_form.html:228
 #: cms/templates/pois/poi_list_archived_row.html:59
 msgid "Restore location"
 msgstr "Ort wiederherstellen"
 
-#: cms/templates/pois/poi_form.html:229
+#: cms/templates/pois/poi_form.html:234
 msgid "Restore this location"
 msgstr "Diesen Ort wiederherstellen"
 
-#: cms/templates/pois/poi_form.html:233 cms/templates/pois/poi_form.html:235
+#: cms/templates/pois/poi_form.html:238 cms/templates/pois/poi_form.html:240
 #: cms/templates/pois/poi_list_row.html:106
 msgid "Archive location"
 msgstr "Ort archivieren"
 
-#: cms/templates/pois/poi_form.html:241
+#: cms/templates/pois/poi_form.html:246
 msgid "Archive this location"
 msgstr "Diesen Ort archivieren"
 
-#: cms/templates/pois/poi_form.html:248 cms/templates/pois/poi_form.html:270
+#: cms/templates/pois/poi_form.html:253 cms/templates/pois/poi_form.html:275
 #: cms/templates/pois/poi_list_archived_row.html:72
 #: cms/templates/pois/poi_list_row.html:119
 msgid "Delete location"
 msgstr "Ort löschen"
 
-#: cms/templates/pois/poi_form.html:254
+#: cms/templates/pois/poi_form.html:259
 msgid "You cannot delete a location which is referenced by an event."
 msgstr ""
 "Der Ort kann nicht gelöscht werden, da er von einem Event verwendet wird."
 
-#: cms/templates/pois/poi_form.html:256
+#: cms/templates/pois/poi_form.html:261
 msgid "To delete this location, you have to delete this event first:"
 msgid_plural "To delete this location, you have to delete these events first:"
 msgstr[0] "Löschen Sie zuerst diese Veranstaltung, um den Ort zu löschen:"
 msgstr[1] "Löschen Sie zuerst diese Veranstaltungen, um den Ort zu löschen:"
 
-#: cms/templates/pois/poi_form.html:276
+#: cms/templates/pois/poi_form.html:281
 msgid "Delete this location"
 msgstr "Diesen Ort löschen"
 
@@ -6255,7 +6259,7 @@ msgstr ""
 
 #: cms/views/events/event_form_view.py:199
 #: cms/views/imprint/imprint_form_view.py:216
-#: cms/views/pages/page_form_view.py:271 cms/views/pois/poi_form_view.py:166
+#: cms/views/pages/page_form_view.py:271 cms/views/pois/poi_form_view.py:168
 msgid "No changes detected, autosave skipped"
 msgstr "Keine Änderungen vorgenommen, automatisches Speichern übersprungen"
 
@@ -6264,7 +6268,7 @@ msgid "Event \"{}\" was successfully created"
 msgstr "Veranstaltung \"{}\" wurde erfolgreich erstellt"
 
 #: cms/views/events/event_form_view.py:239
-#: cms/views/pages/page_form_view.py:302 cms/views/pois/poi_form_view.py:190
+#: cms/views/pages/page_form_view.py:302 cms/views/pois/poi_form_view.py:192
 msgid "No changes detected, but date refreshed"
 msgstr "Keine Änderungen vorgenommen, aber Datum aktualisiert"
 
@@ -6869,11 +6873,11 @@ msgstr "Alle Übersetzungen dieses Ortes werden gelöscht."
 msgid "You cannot edit this location because it is archived."
 msgstr "Sie können diesen Ort nicht bearbeiten, da er archiviert ist."
 
-#: cms/views/pois/poi_form_view.py:185
+#: cms/views/pois/poi_form_view.py:187
 msgid "Location \"{}\" was successfully created"
 msgstr "Ort \"{}\" wurde erfolgreich erstellt"
 
-#: cms/views/pois/poi_form_view.py:200
+#: cms/views/pois/poi_form_view.py:202
 msgid ""
 "The distance between the manually entered coordinates and the coordinates of "
 "the address is {}km."
@@ -6881,7 +6885,7 @@ msgstr ""
 "Der Abstand zwischen den manuell eingegebenen Koordinaten und den "
 "Koordinaten der Adresse beträgt {}km."
 
-#: cms/views/pois/poi_form_view.py:202
+#: cms/views/pois/poi_form_view.py:204
 msgid "Please make sure the entered values are correct."
 msgstr "Bitte vergewissern Sie sich, dass die eingegebenen Werte korrekt sind."
 

--- a/tests/api/expected-outputs/augsburg_en_locations.json
+++ b/tests/api/expected-outputs/augsburg_en_locations.json
@@ -3,7 +3,7 @@
     "id": 3,
     "url": "http://localhost:8000/augsburg/en/locations/test-location/",
     "path": "/augsburg/en/locations/test-location/",
-    "title": "Test location",
+    "title": "Test-Ort",
     "modified_gmt": "2020-01-22 12:52:56",
     "excerpt": "Short description of the test location",
     "content": "<p>Content of the test location</p>",
@@ -31,7 +31,7 @@
     "phone_number": null,
     "location": {
       "id": 4,
-      "name": "Test location",
+      "name": "Test-Ort",
       "address": "Test-Stra\u00dfe 3",
       "town": "Augsburg",
       "state": null,

--- a/tests/api/expected-outputs/nurnberg_en_events.json
+++ b/tests/api/expected-outputs/nurnberg_en_events.json
@@ -17,7 +17,7 @@
     "thumbnail": null,
     "location": {
       "id": 5,
-      "name": "Test location",
+      "name": "Test-Ort",
       "address": "Test-Stra\u00dfe 3",
       "town": "N\u00fcrnberg",
       "state": null,
@@ -57,7 +57,7 @@
     "thumbnail": null,
     "location": {
       "id": 5,
-      "name": "Test location",
+      "name": "Test-Ort",
       "address": "Test-Stra\u00dfe 3",
       "town": "N\u00fcrnberg",
       "state": null,
@@ -97,7 +97,7 @@
     "thumbnail": null,
     "location": {
       "id": 5,
-      "name": "Test location",
+      "name": "Test-Ort",
       "address": "Test-Stra\u00dfe 3",
       "town": "N\u00fcrnberg",
       "state": null,
@@ -137,7 +137,7 @@
     "thumbnail": null,
     "location": {
       "id": 5,
-      "name": "Test location",
+      "name": "Test-Ort",
       "address": "Test-Stra\u00dfe 3",
       "town": "N\u00fcrnberg",
       "state": null,
@@ -177,7 +177,7 @@
     "thumbnail": null,
     "location": {
       "id": 5,
-      "name": "Test location",
+      "name": "Test-Ort",
       "address": "Test-Stra\u00dfe 3",
       "town": "N\u00fcrnberg",
       "state": null,
@@ -217,7 +217,7 @@
     "thumbnail": null,
     "location": {
       "id": 5,
-      "name": "Test location",
+      "name": "Test-Ort",
       "address": "Test-Stra\u00dfe 3",
       "town": "N\u00fcrnberg",
       "state": null,

--- a/tests/api/expected-outputs/nurnberg_en_locations.json
+++ b/tests/api/expected-outputs/nurnberg_en_locations.json
@@ -3,7 +3,7 @@
     "id": 6,
     "url": "http://localhost:8000/nurnberg/en/locations/test-location/",
     "path": "/nurnberg/en/locations/test-location/",
-    "title": "Test location",
+    "title": "Test-Ort",
     "modified_gmt": "2020-01-22 12:52:56",
     "excerpt": "Short description of the test location",
     "content": "<p>Content of the test location</p>",
@@ -21,7 +21,7 @@
     "phone_number": null,
     "location": {
       "id": 5,
-      "name": "Test location",
+      "name": "Test-Ort",
       "address": "Test-Stra\u00dfe 3",
       "town": "N\u00fcrnberg",
       "state": null,


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr changes the poi api so that only the default language titles of pois are delivered, in order to prevent rendering problems of the titles on the map.

### Proposed changes
<!-- Describe this PR in more detail. -->
- deliver default language poi name in api
- Show note in poi form that the translated title will not be shown to users
- Prefill the title of new poi translations

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1512
