### PR TITLE
Improve wording of minor edit label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ UNRELEASED
 * [ [#1528](https://github.com/digitalfabrik/integreat-cms/issues/1528) ] Fix list view layouts for long titles
 * [ [#1510](https://github.com/digitalfabrik/integreat-cms/issues/1510) ] Limit event duration to 7 days
 * [ [#1512](https://github.com/digitalfabrik/integreat-cms/issues/1512) ] Deliver location names in the api in the default language only
+* [ [#1581](https://github.com/digitalfabrik/integreat-cms/issues/1581) ] Improve wording of minor edit label
 
 
 2022.6.3

--- a/integreat_cms/cms/templates/events/event_form.html
+++ b/integreat_cms/cms/templates/events/event_form.html
@@ -123,7 +123,7 @@
                         </h3>
                     </div>
                     <div class="w-full px-4 pb-4 rounded shadow bg-white">
-                        <label>{% trans 'Implications on other translations' %}</label>
+                        <label>{% minor_edit_label request.region language %}</label>
                         {% render_field event_translation_form.minor_edit %}
                         <label for="{{ event_translation_form.minor_edit.id_for_label }}"
                             class="secondary">

--- a/integreat_cms/cms/templates/imprint/imprint_form.html
+++ b/integreat_cms/cms/templates/imprint/imprint_form.html
@@ -97,7 +97,7 @@
                             </h3>
                         </div>
                         <div class="w-full px-4 pb-4 rounded shadow bg-white">
-                            <label>{% trans 'Implications on other translations' %}</label>
+                            <label>{% minor_edit_label request.region language %}</label>
                             {% render_field imprint_translation_form.minor_edit %}
                             <label for="{{ imprint_translation_form.minor_edit.id_for_label }}"
                                    class="secondary">

--- a/integreat_cms/cms/templates/pages/page_form.html
+++ b/integreat_cms/cms/templates/pages/page_form.html
@@ -176,7 +176,7 @@
                             </h3>
                         </div>
                         <div class="w-full px-4 pb-4 rounded shadow bg-white">
-                            <label>{% trans 'Implications on other translations' %}</label>
+                            <label>{% minor_edit_label request.region language %}</label>
                             {% render_field page_translation_form.minor_edit %}
                             <label for="{{ page_translation_form.minor_edit.id_for_label }}"
                                    class="secondary">

--- a/integreat_cms/cms/templates/pois/poi_form.html
+++ b/integreat_cms/cms/templates/pois/poi_form.html
@@ -120,7 +120,7 @@
                             </h3>
                         </div>
                         <div class="w-full px-4 pb-4 rounded shadow bg-white">
-                            <label>{% trans 'Implications on other translations' %}</label>
+                            <label>{% minor_edit_label request.region language %}</label>
                             {% render_field poi_translation_form.minor_edit %}
                             <label for="{{ poi_translation_form.minor_edit.id_for_label }}"
                                    class="secondary">

--- a/integreat_cms/cms/templatetags/content_filters.py
+++ b/integreat_cms/cms/templatetags/content_filters.py
@@ -84,6 +84,28 @@ def get_language(language_slug):
 
 
 @register.simple_tag
+def minor_edit_label(region, language):
+    """
+    This tag returns the label of the minor edit field of the given form
+
+    :param region: current region
+    :type region: ~integreat_cms.cms.models.regions.region.Region
+
+    :param language: The current language
+    :type language: ~integreat_cms.cms.models.languages.language.Language
+
+    :return: The minor edit label
+    :rtype: str
+    """
+    language_node = region.language_node_by_slug[language.slug]
+    if language_node.is_leaf():
+        return _("Implications on the translation status")
+    if language_node.is_root():
+        return _("Implications on other translations")
+    return _("Implications on the status of this and other translations")
+
+
+@register.simple_tag
 def minor_edit_help_text(region, language, translation_form):
     """
     This tag returns the help text of the minor edit field of the given form

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-06-29 11:37+0000\n"
+"POT-Creation-Date: 2022-06-30 09:45+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -4014,14 +4014,6 @@ msgstr "In die Zwischenablage kopieren"
 msgid "Minor edit"
 msgstr "Geringfügige Änderung"
 
-#: cms/templates/events/event_form.html:126
-#: cms/templates/imprint/imprint_form.html:100
-#: cms/templates/imprint/imprint_sbs.html:149
-#: cms/templates/pages/page_form.html:179 cms/templates/pages/page_sbs.html:136
-#: cms/templates/pois/poi_form.html:123
-msgid "Implications on other translations"
-msgstr "Auswirkungen auf andere Übersetzungen"
-
 #: cms/templates/events/event_form.html:140
 msgid "Date and time"
 msgstr "Datum und Uhrzeit"
@@ -4548,6 +4540,12 @@ msgstr "Neu"
 #: cms/templates/pages/page_sbs.html:124
 msgid "Not saved yet"
 msgstr "Noch nicht gespeichert"
+
+#: cms/templates/imprint/imprint_sbs.html:149
+#: cms/templates/pages/page_sbs.html:136
+#: cms/templatetags/content_filters.py:104
+msgid "Implications on other translations"
+msgstr "Auswirkungen auf andere Übersetzungen"
 
 #: cms/templates/language_tree/language_tree.html:7
 msgid "Language tree"
@@ -6006,13 +6004,21 @@ msgstr "Kein Mitarbeiter"
 msgid "No administrator"
 msgstr "Kein Administrator"
 
+#: cms/templatetags/content_filters.py:102
+msgid "Implications on the translation status"
+msgstr "Auswirkungen auf den Übersetzungsstatus"
+
 #: cms/templatetags/content_filters.py:105
+msgid "Implications on the status of this and other translations"
+msgstr "Auswirkungen auf den Status dieser und anderer Übersetzungen"
+
+#: cms/templatetags/content_filters.py:127
 msgid "Tick if this edit should not change the status of this translation."
 msgstr ""
 "Kreuzen Sie an, wenn diese Änderung den Status dieser Übersetzung nicht "
 "ändern soll."
 
-#: cms/templatetags/content_filters.py:109
+#: cms/templatetags/content_filters.py:131
 msgid ""
 "Tick if this edit should not change the status of this translation and does "
 "not require an update of translations in other languages."


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Improve wording of minor edit label

### Proposed changes
<!-- Describe this PR in more detail. -->
Before, the label always was "implications on other translations", but for translations that are not the default translation, this is not correct. For languages that are further down the language tree (either leaf nodes or somewhere between the default language and a leaf node), the minor edit field not only impacts the other translations, but the current translation as well.
This change of the wording reflects the actual implications of the minor edit field.