### PR TITLE
Hide news after 28 days

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ UNRELEASED
 * [ [#1581](https://github.com/digitalfabrik/integreat-cms/issues/1581) ] Improve wording of minor edit label
 * [ [#1580](https://github.com/digitalfabrik/integreat-cms/issues/1580) ] Improve user list
 * [ [#1504](https://github.com/digitalfabrik/integreat-cms/issues/1504) ] Keep filters on pagination
+* [ [#1585](https://github.com/digitalfabrik/integreat-cms/issues/1585) ] Hide news after 28 days
 
 
 2022.6.3

--- a/integreat_cms/cms/models/push_notifications/push_notification.py
+++ b/integreat_cms/cms/models/push_notifications/push_notification.py
@@ -22,8 +22,8 @@ class PushNotification(AbstractBaseModel):
     )
     channel = models.CharField(
         max_length=60,
-        choices=settings.CHANNELS,
-        default=settings.CHANNELS[0][0],
+        choices=settings.FCM_CHANNELS,
+        default=settings.FCM_CHANNELS[0][0],
         verbose_name=_("channel"),
     )
     draft = models.BooleanField(

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -115,6 +115,12 @@ FCM_KEY = os.environ.get("INTEGREAT_CMS_FCM_KEY")
 #: This is ``True`` if :attr:`~integreat_cms.core.settings.FCM_KEY` is set, ``False`` otherwise.
 FCM_ENABLED = bool(FCM_KEY)
 
+#: The available push notification channels
+FCM_CHANNELS = (("news", _("News")),)
+
+#: How many days push notifications are shown in the apps
+FCM_HISTORY_DAYS = 28
+
 
 ###########
 # GVZ API #
@@ -767,14 +773,6 @@ LINKCHECK_IGNORED_URL_TYPES = [
 LINKCHECK_EXCLUDE_ARCHIVED_PAGES = bool(
     strtobool(os.environ.get("INTEGREAT_CMS_LINKCHECK_EXCLUDE_ARCHIVED_PAGES", "False"))
 )
-
-
-#############################
-# Push Notification Channel #
-#############################
-
-#: The available push notification channels
-CHANNELS = (("news", _("News")),)
 
 
 #########################

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-10 11:48+0000\n"
+"POT-Creation-Date: 2022-07-16 14:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -3376,7 +3376,7 @@ msgstr "Feedback"
 
 #: cms/templates/_base.html:181
 #: cms/templates/push_notifications/push_notification_list.html:7
-#: core/settings.py:777
+#: core/settings.py:119
 msgid "News"
 msgstr "Nachrichten"
 

--- a/tests/api/expected-outputs/nurnberg_de_fcm.json
+++ b/tests/api/expected-outputs/nurnberg_de_fcm.json
@@ -1,9 +1,1 @@
-[
-  {
-    "id": "1",
-    "title": "Test DE",
-    "message": "Test DE Inhalt",
-    "timestamp": "2022-03-05 11:31:33",
-    "channel": "news"
-  }
-]
+[]

--- a/tests/api/expected-outputs/nurnberg_en_fcm.json
+++ b/tests/api/expected-outputs/nurnberg_en_fcm.json
@@ -1,9 +1,1 @@
-[
-  {
-    "id": "2",
-    "title": "Test EN",
-    "message": "Test EN content",
-    "timestamp": "2022-03-05 11:31:33",
-    "channel": "news"
-  }
-]
+[]


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Hide news after 28 days

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add new setting `FCM_HISTORY_DAYS`
- Filter news in api endpoint that are older than the configured value

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1585