### PR TITLE
Change XLIFF bulk action description, fixes #1600

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ UNRELEASED
 * [ [#1580](https://github.com/digitalfabrik/integreat-cms/issues/1580) ] Improve user list
 * [ [#1504](https://github.com/digitalfabrik/integreat-cms/issues/1504) ] Keep filters on pagination
 * [ [#1585](https://github.com/digitalfabrik/integreat-cms/issues/1585) ] Hide news after 28 days
+* [ [#1600](https://github.com/digitalfabrik/integreat-cms/issues/1600) ] Improve XLIFF export bulk option description
 
 
 2022.6.3

--- a/integreat_cms/cms/templates/pages/page_tree.html
+++ b/integreat_cms/cms/templates/pages/page_tree.html
@@ -160,22 +160,22 @@
                     </option>
                     {% if request.user.expert_mode %}
                         {% with language_translated_name=language.translated_name %}
-                            {% blocktrans asvar xliff_export_all %}Export selected pages for {{ language_translated_name }} translation{% endblocktrans %}
-                            {% blocktrans asvar xliff_export_public %}Export only published pages for {{ language_translated_name }} translation{% endblocktrans %}
+                            {% blocktrans asvar xliff_export_public %}Export published pages for {{ language_translated_name }} translation{% endblocktrans %}
+                            {% blocktrans asvar xliff_export_all %}Export unpublished (⚠️) and published pages for {{ language_translated_name }} translation{% endblocktrans %}
                             {% if language == request.region.default_language %}
                                 {% blocktrans asvar xliff_export_disabled %}You cannot export XLIFF files for the default language{% endblocktrans %}
                                 <option disabled title="{{ xliff_export_disabled }}">
-                                    {{ xliff_export_all }} ({{ XLIFF_EXPORT_VERSION|upper }})
+                                    {{ xliff_export_public }} ({{ XLIFF_EXPORT_VERSION|upper }})
                                 </option>
                                 <option disabled title="{{ xliff_export_disabled }}">
-                                    {{ xliff_export_public }} ({{ XLIFF_EXPORT_VERSION|upper }})
-                                </option>
-                            {% else %}
-                                <option data-bulk-action="{% url 'download_xliff' region_slug=request.region.slug language_slug=language.slug %}">
                                     {{ xliff_export_all }} ({{ XLIFF_EXPORT_VERSION|upper }})
                                 </option>
+                            {% else %}
                                 <option data-bulk-action="{% url 'download_xliff_only_public' region_slug=request.region.slug language_slug=language.slug %}">
                                     {{ xliff_export_public }} ({{ XLIFF_EXPORT_VERSION|upper }})
+                                </option>
+                                <option data-bulk-action="{% url 'download_xliff' region_slug=request.region.slug language_slug=language.slug %}">
+                                    {{ xliff_export_all }} ({{ XLIFF_EXPORT_VERSION|upper }})
                                 </option>
                             {% endif %}
                         {% endwith %}

--- a/integreat_cms/cms/views/pages/page_bulk_actions.py
+++ b/integreat_cms/cms/views/pages/page_bulk_actions.py
@@ -100,9 +100,13 @@ class ExportXliffView(PageBulkActionMixin, BulkActionView):
             messages.success(
                 request,
                 __(
-                    _("XLIFF file for translation to {} successfully created.").format(
-                        target_language
-                    ),
+                    _(
+                        "XLIFF file with published pages only for translation to {} successfully created."
+                    ).format(target_language)
+                    if self.only_public
+                    else _(
+                        "XLIFF file with unpublished and published pages for translation to {} successfully created."
+                    ).format(target_language),
                     _(
                         "If the download does not start automatically, please click {}here{}."
                     ).format(

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-18 10:31+0000\n"
+"POT-Creation-Date: 2022-07-18 13:11+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -5174,18 +5174,19 @@ msgstr "Veröffentlichte Seiten als PDF exportieren"
 
 #: cms/templates/pages/page_tree.html:163
 #, python-format
-msgid "Export selected pages for %(language_translated_name)s translation"
+msgid "Export published pages for %(language_translated_name)s translation"
 msgstr ""
-"Ausgewählte Seiten für die %(language_translated_name)s-Übersetzung "
+"Nur veröffentlichte Seiten für die %(language_translated_name)s-Übersetzung "
 "exportieren"
 
 #: cms/templates/pages/page_tree.html:164
 #, python-format
 msgid ""
-"Export only published pages for %(language_translated_name)s translation"
+"Export unpublished (⚠️) and published pages for %(language_translated_name)s "
+"translation"
 msgstr ""
-"Nur veröffentlichte Seiten für die %(language_translated_name)s-Übersetzung "
-"exportieren"
+"Nicht (⚠️) veröffentlichte und veröffentlichte Seiten für die "
+"%(language_translated_name)s-Übersetzung exportieren"
 
 #: cms/templates/pages/page_tree.html:166
 msgid "You cannot export XLIFF files for the default language"
@@ -6728,11 +6729,23 @@ msgstr ""
 msgid "Marked all translations of this page as up-to-date"
 msgstr "Alle Übersetzungen dieser Seite als aktuell markiert."
 
-#: cms/views/pages/page_bulk_actions.py:103
-msgid "XLIFF file for translation to {} successfully created."
-msgstr "XLIFF Datei für die Übersetzung nach {} wurde erfolgreich erstellt."
+#: cms/views/pages/page_bulk_actions.py:104
+msgid ""
+"XLIFF file with published pages only for translation to {} successfully "
+"created."
+msgstr ""
+"XLIFF Datei nur mit veröffentlichten Seiten für die Übersetzung nach{} wurde "
+"erfolgreich erstellt."
 
-#: cms/views/pages/page_bulk_actions.py:107
+#: cms/views/pages/page_bulk_actions.py:108
+msgid ""
+"XLIFF file with unpublished and published pages for translation to {} "
+"successfully created."
+msgstr ""
+"XLIFF Datei mit nicht veröffentlichten und veröffentlichten Seitenfür die "
+"Übersetzung nach {} wurde erfolgreich erstellt."
+
+#: cms/views/pages/page_bulk_actions.py:111
 msgid "If the download does not start automatically, please click {}here{}."
 msgstr ""
 "Wenn der Download nicht automatisch startet, klicken Sie bitte {}hier{}."
@@ -7134,6 +7147,11 @@ msgid "This page belongs to another region ({})."
 msgstr ""
 "Diese Seite konnte nicht importiert werden, da sie zu einer anderen Region "
 "gehört ({})."
+
+#~ msgid "Export selected pages for %(language_translated_name)s translation"
+#~ msgstr ""
+#~ "Ausgewählte Seiten für die %(language_translated_name)s-Übersetzung "
+#~ "exportieren"
 
 #~ msgid "Organization"
 #~ msgstr "Organisation"


### PR DESCRIPTION
### Short description
Change the pages bulk action drop down menu to reduce the risk of accidentally selecting the wrong XLIFF option.


### Proposed changes
- Change the order of bulk actions
- Change caption

### Resolved issues
Fixes: #1600
