### PR TITLE
Remove warning from poi contact details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ UNRELEASED
 ----------
 
 * [ [#1390](https://github.com/digitalfabrik/integreat-cms/issues/1390) ] Move files via drag and drop
+* [ [#1606](https://github.com/digitalfabrik/integreat-cms/issues/1606) ] Remove warning at POI contacts
 
 
 2022.7.0

--- a/integreat_cms/cms/templates/pois/poi_form.html
+++ b/integreat_cms/cms/templates/pois/poi_form.html
@@ -176,7 +176,6 @@
                             <i data-feather="phone" class="pb-1"></i>
                             {% trans 'Contact details' %}
                         </h3>
-                        ({% trans 'currently not publicly visible' %})
                     </div>
                     <div class="px-4 pb-4 divide-y divide-gray-200 space-y-2">
                         <div>

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-27 12:05+0000\n"
+"POT-Creation-Date: 2022-07-27 13:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -4059,7 +4059,7 @@ msgstr "Auf Google Maps öffnen"
 
 #: cms/templates/events/event_form.html:328
 #: cms/templates/imprint/imprint_form.html:114
-#: cms/templates/pages/page_form.html:285 cms/templates/pois/poi_form.html:219
+#: cms/templates/pages/page_form.html:285 cms/templates/pois/poi_form.html:218
 #: cms/templates/regions/region_list.html:25
 #: cms/templates/settings/user_settings.html:93
 msgid "Actions"
@@ -5370,46 +5370,42 @@ msgstr ""
 msgid "Contact details"
 msgstr "Kontaktdaten"
 
-#: cms/templates/pois/poi_form.html:179
-msgid "currently not publicly visible"
-msgstr "aktuell nicht öffentlich sichtbar"
-
-#: cms/templates/pois/poi_form.html:226 cms/templates/pois/poi_form.html:228
+#: cms/templates/pois/poi_form.html:225 cms/templates/pois/poi_form.html:227
 #: cms/templates/pois/poi_list_archived_row.html:59
 msgid "Restore location"
 msgstr "Ort wiederherstellen"
 
-#: cms/templates/pois/poi_form.html:234
+#: cms/templates/pois/poi_form.html:233
 msgid "Restore this location"
 msgstr "Diesen Ort wiederherstellen"
 
-#: cms/templates/pois/poi_form.html:238 cms/templates/pois/poi_form.html:240
+#: cms/templates/pois/poi_form.html:237 cms/templates/pois/poi_form.html:239
 #: cms/templates/pois/poi_list_row.html:106
 msgid "Archive location"
 msgstr "Ort archivieren"
 
-#: cms/templates/pois/poi_form.html:246
+#: cms/templates/pois/poi_form.html:245
 msgid "Archive this location"
 msgstr "Diesen Ort archivieren"
 
-#: cms/templates/pois/poi_form.html:253 cms/templates/pois/poi_form.html:275
+#: cms/templates/pois/poi_form.html:252 cms/templates/pois/poi_form.html:274
 #: cms/templates/pois/poi_list_archived_row.html:72
 #: cms/templates/pois/poi_list_row.html:119
 msgid "Delete location"
 msgstr "Ort löschen"
 
-#: cms/templates/pois/poi_form.html:259
+#: cms/templates/pois/poi_form.html:258
 msgid "You cannot delete a location which is referenced by an event."
 msgstr ""
 "Der Ort kann nicht gelöscht werden, da er von einem Event verwendet wird."
 
-#: cms/templates/pois/poi_form.html:261
+#: cms/templates/pois/poi_form.html:260
 msgid "To delete this location, you have to delete this event first:"
 msgid_plural "To delete this location, you have to delete these events first:"
 msgstr[0] "Löschen Sie zuerst diese Veranstaltung, um den Ort zu löschen:"
 msgstr[1] "Löschen Sie zuerst diese Veranstaltungen, um den Ort zu löschen:"
 
-#: cms/templates/pois/poi_form.html:281
+#: cms/templates/pois/poi_form.html:280
 msgid "Delete this location"
 msgstr "Diesen Ort löschen"
 
@@ -7162,6 +7158,9 @@ msgid "This page belongs to another region ({})."
 msgstr ""
 "Diese Seite konnte nicht importiert werden, da sie zu einer anderen Region "
 "gehört ({})."
+
+#~ msgid "currently not publicly visible"
+#~ msgstr "aktuell nicht öffentlich sichtbar"
 
 #~ msgid "Export selected pages for %(language_translated_name)s translation"
 #~ msgstr ""


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR removes the warning from the contact details in the POI form.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1606 
