### PR TITLE
Fix slow recurring event api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ UNRELEASED
 * [ [#1585](https://github.com/digitalfabrik/integreat-cms/issues/1585) ] Hide news after 28 days
 * [ [#1600](https://github.com/digitalfabrik/integreat-cms/issues/1600) ] Improve XLIFF export bulk option description
 * [ [#1511](https://github.com/digitalfabrik/integreat-cms/issues/1511) ] Fix PDF generation for long filenames
+* [ [#1535](https://github.com/digitalfabrik/integreat-cms/issues/1535) ] Fix event api performance
 
 
 2022.6.3

--- a/integreat_cms/api/v3/events.py
+++ b/integreat_cms/api/v3/events.py
@@ -2,8 +2,6 @@
 This module includes functions related to the event API endpoint.
 """
 
-from copy import deepcopy
-
 from datetime import timedelta
 
 from django.conf import settings
@@ -11,26 +9,29 @@ from django.http import JsonResponse
 from django.utils import timezone
 from django.utils.html import strip_tags
 
-from ...cms.models.events.event_translation import EventTranslation
-from ...cms.utils.slug_utils import generate_unique_slug
 from ..decorators import json_response
 from .locations import transform_poi
 
 
-def transform_event(event):
+def transform_event(event, custom_date=None):
     """
     Function to create a JSON from a single event object.
 
     :param event: The event which should be converted
     :type event: ~integreat_cms.cms.models.events.event.Event
 
+    :param custom_date: The date overwrite of the event
+    :type custom_date: ~datetime.date
+
     :return: data necessary for API
     :rtype: dict
     """
     return {
-        "id": event.id,
-        "start_date": event.start_date,
-        "end_date": event.end_date,
+        "id": event.id if not custom_date else None,
+        "start_date": custom_date or event.start_date,
+        "end_date": custom_date + (event.end_date - event.start_date)
+        if custom_date
+        else event.end_date,
         "all_day": event.is_all_day,
         "start_time": event.start_time,
         "end_time": event.end_time,
@@ -39,18 +40,26 @@ def transform_event(event):
     }
 
 
-def transform_event_translation(event_translation):
+def transform_event_translation(event_translation, recurrence_date=None):
     """
     Function to create a JSON from a single event_translation object.
 
     :param event_translation: The event translation object which should be converted
     :type event_translation: ~integreat_cms.cms.models.events.event_translation.EventTranslation
 
+    :param recurrence_date: The recurrence date for the event
+    :type recurrence_date: ~datetime.date
+
     :return: data necessary for API
     :rtype: dict
     """
     event = event_translation.event
-    absolute_url = event_translation.get_absolute_url()
+    slug = (
+        event_translation.slug
+        if not recurrence_date
+        else f"{event_translation.slug}${recurrence_date}"
+    )
+    absolute_url = event_translation.url_prefix + slug + "/"
     return {
         "id": event_translation.id,
         "url": settings.BASE_URL + absolute_url,
@@ -59,12 +68,47 @@ def transform_event_translation(event_translation):
         "modified_gmt": event_translation.last_updated.strftime("%Y-%m-%d %H:%M:%S"),
         "excerpt": strip_tags(event_translation.content),
         "content": event_translation.content,
-        "available_languages": event_translation.available_languages,
+        "available_languages": transform_available_languages(
+            event_translation, recurrence_date
+        )
+        if recurrence_date
+        else event_translation.available_languages_dict,
         "thumbnail": event.icon.url if event.icon else None,
         "location": transform_poi(event.location),
-        "event": transform_event(event),
+        "event": transform_event(event, recurrence_date),
         "hash": None,
     }
+
+
+def transform_available_languages(event_translation, recurrence_date):
+    """
+    Function to create a JSON object of all available translations of an event translation.
+    This is similar to `event_translation.available_languages_dict` embeds the recurrence date in the translation slug.
+
+    :param event_translation: The event translation object which should be converted
+    :type event_translation: ~integreat_cms.cms.models.events.event_translation.EventTranslation
+
+    :param recurrence_date: The date of this event translation
+    :type recurrence_date: ~datetime.date
+
+    :return: data necessary for API
+    :rtype: dict
+    """
+    languages = {}
+
+    for translation in event_translation.foreign_object.available_translations():
+        if translation.language == event_translation.language:
+            continue
+
+        slug = f"{translation.slug}${recurrence_date}"
+        path = translation.url_prefix + slug + "/"
+        languages[translation.language.slug] = {
+            "id": None,
+            "url": settings.BASE_URL + path,
+            "path": path,
+        }
+
+    return languages
 
 
 def transform_event_recurrences(event_translation, today):
@@ -93,12 +137,9 @@ def transform_event_recurrences(event_translation, today):
     ):
         return
 
-    event_length = event.end_date - event.start_date
     start_date = event.start_date
     event_translation.id = None
-    # Store language and slug for usage in loop
-    current_language = event_translation.language
-    current_slug = event_translation.slug
+
     # Calculate all recurrences of this event
     for recurrence_date in recurrence_rule.iter_after(start_date):
         if recurrence_date - max(start_date, today) > timedelta(
@@ -107,52 +148,8 @@ def transform_event_recurrences(event_translation, today):
             break
         if recurrence_date < today or recurrence_date == start_date:
             continue
-        # Create all temporary translations of this recurrence
-        recurrence_translations = {}
-        if event.region.fallback_translations_enabled:
-            languages = event.region.active_languages
-        else:
-            languages = event.public_languages
-        for language in languages:
-            # Create copy in memory to make sure original translation is not affected by changes
-            event_translation = deepcopy(event_translation)
-            # Fake the requested language
-            event_translation.language = language
-            event_translation.slug = generate_unique_slug(
-                **{
-                    "slug": f"{current_slug}-{recurrence_date}",
-                    "manager": EventTranslation.objects,
-                    "object_instance": event_translation,
-                    "foreign_model": "event",
-                    "region": event.region,
-                    "language": language,
-                }
-            )
-            # Reset id to make sure id does not conflict with existing event translation
-            event_translation.event.id = None
-            # Set date to recurrence date
-            event_translation.event.start_date = recurrence_date
-            event_translation.event.end_date = recurrence_date + event_length
-            # Clear cached property in case url with different language was already calculated before
-            try:
-                del event_translation.url_prefix
-            except AttributeError:
-                pass
-            recurrence_translations[language.slug] = event_translation
 
-        # Set the prefetched public translations to make sure the recurrence translations are correctly listed in available languages
-        for recurrence_translation in recurrence_translations.values():
-            recurrence_translation.event.prefetched_public_translations_by_language_slug = (
-                recurrence_translations
-            )
-        # Update translation object with the one with prefetched temporary translations
-        event_translation = recurrence_translations[current_language.slug]
-        # Clear cached property in case available languages with different recurrence was already calculated before
-        try:
-            del event_translation.available_languages
-        except AttributeError:
-            pass
-        yield transform_event_translation(event_translation)
+        yield transform_event_translation(event_translation, recurrence_date)
 
 
 @json_response

--- a/integreat_cms/api/v3/imprint.py
+++ b/integreat_cms/api/v3/imprint.py
@@ -32,7 +32,7 @@ def transform_imprint(imprint_translation):
         "excerpt": strip_tags(imprint_translation.content),
         "content": imprint_translation.content,
         "parent": None,
-        "available_languages": imprint_translation.available_languages,
+        "available_languages": imprint_translation.available_languages_dict,
         "thumbnail": None,
         "hash": None,
     }

--- a/integreat_cms/api/v3/locations.py
+++ b/integreat_cms/api/v3/locations.py
@@ -65,7 +65,7 @@ def transform_poi_translation(poi_translation):
         "modified_gmt": poi_translation.last_updated.strftime("%Y-%m-%d %H:%M:%S"),
         "excerpt": poi_translation.short_description,
         "content": poi_translation.content,
-        "available_languages": poi_translation.available_languages,
+        "available_languages": poi_translation.available_languages_dict,
         "icon": poi.icon.url if poi.icon else None,
         "thumbnail": poi.icon.thumbnail_url if poi.icon else None,
         "website": poi.website if poi.website else None,

--- a/integreat_cms/api/v3/pages.py
+++ b/integreat_cms/api/v3/pages.py
@@ -74,7 +74,7 @@ def transform_page(page_translation):
         "content": page_translation.combined_text,
         "parent": parent,
         "order": order,
-        "available_languages": page_translation.available_languages,
+        "available_languages": page_translation.available_languages_dict,
         "thumbnail": page_translation.page.icon.url
         if page_translation.page.icon
         else None,

--- a/integreat_cms/cms/models/abstract_content_model.py
+++ b/integreat_cms/cms/models/abstract_content_model.py
@@ -120,6 +120,24 @@ class AbstractContentModel(AbstractBaseModel):
         translations = self.prefetched_translations_by_language_slug.values()
         return [translation.language for translation in translations]
 
+    def available_translations(self):
+        """
+        This method returns an iterator over all available translations, respecting the `fallback_translations_enabled` setting.
+
+        :return: An iterator over all translations
+        :rtype: Iterator[:class:`~integreat_cms.cms.models.abstract_content_translation.AbstractContentTranslation`]
+        """
+        # Check if fallback translation should be used
+        if self.fallback_translations_enabled:
+            all_languages = self.region.active_languages
+        else:
+            all_languages = self.public_languages
+
+        for language in all_languages:
+            public_translation = self.get_public_translation(language.slug)
+            if public_translation:
+                yield public_translation
+
     @cached_property
     def public_languages(self):
         """

--- a/integreat_cms/cms/models/abstract_content_translation.py
+++ b/integreat_cms/cms/models/abstract_content_translation.py
@@ -189,7 +189,7 @@ class AbstractContentTranslation(AbstractBaseModel):
         raise NotImplementedError
 
     @cached_property
-    def available_languages(self):
+    def available_languages_dict(self):
         """
         This property checks in which :class:`~integreat_cms.cms.models.languages.language.Language` the content is
         translated apart from ``self.language``
@@ -209,31 +209,24 @@ class AbstractContentTranslation(AbstractBaseModel):
         :rtype: dict
         """
         available_languages = {}
-        # Check if fallback translation should be used
-        if self.foreign_object.fallback_translations_enabled:
-            all_languages = self.foreign_object.region.active_languages
-        else:
-            all_languages = self.foreign_object.public_languages
-        for language in all_languages:
-            if language == self.language:
+
+        for public_translation in self.foreign_object.available_translations():
+            if public_translation.language == self.language:
                 continue
-            public_translation = self.foreign_object.get_public_translation(
-                language.slug
-            )
-            if public_translation:
-                absolute_url = public_translation.get_absolute_url()
-                available_languages[language.slug] = {
-                    "id": public_translation.id,
-                    "url": settings.BASE_URL + absolute_url,
-                    "path": absolute_url,
-                }
+
+            absolute_url = public_translation.get_absolute_url()
+            available_languages[public_translation.language.slug] = {
+                "id": public_translation.id,
+                "url": settings.BASE_URL + absolute_url,
+                "path": absolute_url,
+            }
         return available_languages
 
     @cached_property
     def sitemap_alternates(self):
         """
         This property returns the language alternatives of a content translation for the use in sitemaps.
-        Similar to :func:`~integreat_cms.cms.models.abstract_content_translation.AbstractContentTranslation.available_languages`,
+        Similar to :func:`~integreat_cms.cms.models.abstract_content_translation.AbstractContentTranslation.available_languages_dict`,
         but in a slightly different format.
 
         :return: A list of dictionaries containing the alternative translations of a content translation

--- a/tests/api/expected-outputs/augsburg_ar_events.json
+++ b/tests/api/expected-outputs/augsburg_ar_events.json
@@ -51,8 +51,8 @@
   },
   {
     "id": null,
-    "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung-2030-01-03/",
-    "path": "/augsburg/ar/events/test-veranstaltung-2030-01-03/",
+    "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung$2030-01-03/",
+    "path": "/augsburg/ar/events/test-veranstaltung$2030-01-03/",
     "title": "Test-Veranstaltung",
     "modified_gmt": "2020-01-22 12:46:33",
     "excerpt": "Dies ist die Beschreibung einer Test-Veranstaltung.",
@@ -60,18 +60,18 @@
     "available_languages": {
       "de": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung-2030-01-03/",
-        "path": "/augsburg/de/events/test-veranstaltung-2030-01-03/"
+        "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung$2030-01-03/",
+        "path": "/augsburg/de/events/test-veranstaltung$2030-01-03/"
       },
       "en": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/en/events/test-veranstaltung-2030-01-03/",
-        "path": "/augsburg/en/events/test-veranstaltung-2030-01-03/"
+        "url": "http://localhost:8000/augsburg/en/events/test-event$2030-01-03/",
+        "path": "/augsburg/en/events/test-event$2030-01-03/"
       },
       "fa": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung-2030-01-03/",
-        "path": "/augsburg/fa/events/test-veranstaltung-2030-01-03/"
+        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung$2030-01-03/",
+        "path": "/augsburg/fa/events/test-veranstaltung$2030-01-03/"
       }
     },
     "thumbnail": null,
@@ -101,8 +101,8 @@
   },
   {
     "id": null,
-    "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung-2030-01-15/",
-    "path": "/augsburg/ar/events/test-veranstaltung-2030-01-15/",
+    "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung$2030-01-15/",
+    "path": "/augsburg/ar/events/test-veranstaltung$2030-01-15/",
     "title": "Test-Veranstaltung",
     "modified_gmt": "2020-01-22 12:46:33",
     "excerpt": "Dies ist die Beschreibung einer Test-Veranstaltung.",
@@ -110,18 +110,18 @@
     "available_languages": {
       "de": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung-2030-01-15/",
-        "path": "/augsburg/de/events/test-veranstaltung-2030-01-15/"
+        "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung$2030-01-15/",
+        "path": "/augsburg/de/events/test-veranstaltung$2030-01-15/"
       },
       "en": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/en/events/test-veranstaltung-2030-01-15/",
-        "path": "/augsburg/en/events/test-veranstaltung-2030-01-15/"
+        "url": "http://localhost:8000/augsburg/en/events/test-event$2030-01-15/",
+        "path": "/augsburg/en/events/test-event$2030-01-15/"
       },
       "fa": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung-2030-01-15/",
-        "path": "/augsburg/fa/events/test-veranstaltung-2030-01-15/"
+        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung$2030-01-15/",
+        "path": "/augsburg/fa/events/test-veranstaltung$2030-01-15/"
       }
     },
     "thumbnail": null,
@@ -151,8 +151,8 @@
   },
   {
     "id": null,
-    "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung-2030-01-17/",
-    "path": "/augsburg/ar/events/test-veranstaltung-2030-01-17/",
+    "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung$2030-01-17/",
+    "path": "/augsburg/ar/events/test-veranstaltung$2030-01-17/",
     "title": "Test-Veranstaltung",
     "modified_gmt": "2020-01-22 12:46:33",
     "excerpt": "Dies ist die Beschreibung einer Test-Veranstaltung.",
@@ -160,18 +160,18 @@
     "available_languages": {
       "de": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung-2030-01-17/",
-        "path": "/augsburg/de/events/test-veranstaltung-2030-01-17/"
+        "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung$2030-01-17/",
+        "path": "/augsburg/de/events/test-veranstaltung$2030-01-17/"
       },
       "en": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/en/events/test-veranstaltung-2030-01-17/",
-        "path": "/augsburg/en/events/test-veranstaltung-2030-01-17/"
+        "url": "http://localhost:8000/augsburg/en/events/test-event$2030-01-17/",
+        "path": "/augsburg/en/events/test-event$2030-01-17/"
       },
       "fa": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung-2030-01-17/",
-        "path": "/augsburg/fa/events/test-veranstaltung-2030-01-17/"
+        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung$2030-01-17/",
+        "path": "/augsburg/fa/events/test-veranstaltung$2030-01-17/"
       }
     },
     "thumbnail": null,
@@ -201,8 +201,8 @@
   },
   {
     "id": null,
-    "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung-2030-01-29/",
-    "path": "/augsburg/ar/events/test-veranstaltung-2030-01-29/",
+    "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung$2030-01-29/",
+    "path": "/augsburg/ar/events/test-veranstaltung$2030-01-29/",
     "title": "Test-Veranstaltung",
     "modified_gmt": "2020-01-22 12:46:33",
     "excerpt": "Dies ist die Beschreibung einer Test-Veranstaltung.",
@@ -210,18 +210,18 @@
     "available_languages": {
       "de": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung-2030-01-29/",
-        "path": "/augsburg/de/events/test-veranstaltung-2030-01-29/"
+        "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung$2030-01-29/",
+        "path": "/augsburg/de/events/test-veranstaltung$2030-01-29/"
       },
       "en": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/en/events/test-veranstaltung-2030-01-29/",
-        "path": "/augsburg/en/events/test-veranstaltung-2030-01-29/"
+        "url": "http://localhost:8000/augsburg/en/events/test-event$2030-01-29/",
+        "path": "/augsburg/en/events/test-event$2030-01-29/"
       },
       "fa": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung-2030-01-29/",
-        "path": "/augsburg/fa/events/test-veranstaltung-2030-01-29/"
+        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung$2030-01-29/",
+        "path": "/augsburg/fa/events/test-veranstaltung$2030-01-29/"
       }
     },
     "thumbnail": null,
@@ -251,8 +251,8 @@
   },
   {
     "id": null,
-    "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung-2030-01-31/",
-    "path": "/augsburg/ar/events/test-veranstaltung-2030-01-31/",
+    "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung$2030-01-31/",
+    "path": "/augsburg/ar/events/test-veranstaltung$2030-01-31/",
     "title": "Test-Veranstaltung",
     "modified_gmt": "2020-01-22 12:46:33",
     "excerpt": "Dies ist die Beschreibung einer Test-Veranstaltung.",
@@ -260,18 +260,18 @@
     "available_languages": {
       "de": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung-2030-01-31/",
-        "path": "/augsburg/de/events/test-veranstaltung-2030-01-31/"
+        "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung$2030-01-31/",
+        "path": "/augsburg/de/events/test-veranstaltung$2030-01-31/"
       },
       "en": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/en/events/test-veranstaltung-2030-01-31/",
-        "path": "/augsburg/en/events/test-veranstaltung-2030-01-31/"
+        "url": "http://localhost:8000/augsburg/en/events/test-event$2030-01-31/",
+        "path": "/augsburg/en/events/test-event$2030-01-31/"
       },
       "fa": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung-2030-01-31/",
-        "path": "/augsburg/fa/events/test-veranstaltung-2030-01-31/"
+        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung$2030-01-31/",
+        "path": "/augsburg/fa/events/test-veranstaltung$2030-01-31/"
       }
     },
     "thumbnail": null,

--- a/tests/api/expected-outputs/augsburg_de_events.json
+++ b/tests/api/expected-outputs/augsburg_de_events.json
@@ -51,8 +51,8 @@
   },
   {
     "id": null,
-    "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung-2030-01-03/",
-    "path": "/augsburg/de/events/test-veranstaltung-2030-01-03/",
+    "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung$2030-01-03/",
+    "path": "/augsburg/de/events/test-veranstaltung$2030-01-03/",
     "title": "Test-Veranstaltung",
     "modified_gmt": "2020-01-22 12:46:33",
     "excerpt": "Dies ist die Beschreibung einer Test-Veranstaltung.",
@@ -60,18 +60,18 @@
     "available_languages": {
       "en": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/en/events/test-veranstaltung-2030-01-03/",
-        "path": "/augsburg/en/events/test-veranstaltung-2030-01-03/"
+        "url": "http://localhost:8000/augsburg/en/events/test-event$2030-01-03/",
+        "path": "/augsburg/en/events/test-event$2030-01-03/"
       },
       "ar": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung-2030-01-03/",
-        "path": "/augsburg/ar/events/test-veranstaltung-2030-01-03/"
+        "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung$2030-01-03/",
+        "path": "/augsburg/ar/events/test-veranstaltung$2030-01-03/"
       },
       "fa": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung-2030-01-03/",
-        "path": "/augsburg/fa/events/test-veranstaltung-2030-01-03/"
+        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung$2030-01-03/",
+        "path": "/augsburg/fa/events/test-veranstaltung$2030-01-03/"
       }
     },
     "thumbnail": null,
@@ -101,8 +101,8 @@
   },
   {
     "id": null,
-    "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung-2030-01-15/",
-    "path": "/augsburg/de/events/test-veranstaltung-2030-01-15/",
+    "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung$2030-01-15/",
+    "path": "/augsburg/de/events/test-veranstaltung$2030-01-15/",
     "title": "Test-Veranstaltung",
     "modified_gmt": "2020-01-22 12:46:33",
     "excerpt": "Dies ist die Beschreibung einer Test-Veranstaltung.",
@@ -110,18 +110,18 @@
     "available_languages": {
       "en": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/en/events/test-veranstaltung-2030-01-15/",
-        "path": "/augsburg/en/events/test-veranstaltung-2030-01-15/"
+        "url": "http://localhost:8000/augsburg/en/events/test-event$2030-01-15/",
+        "path": "/augsburg/en/events/test-event$2030-01-15/"
       },
       "ar": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung-2030-01-15/",
-        "path": "/augsburg/ar/events/test-veranstaltung-2030-01-15/"
+        "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung$2030-01-15/",
+        "path": "/augsburg/ar/events/test-veranstaltung$2030-01-15/"
       },
       "fa": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung-2030-01-15/",
-        "path": "/augsburg/fa/events/test-veranstaltung-2030-01-15/"
+        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung$2030-01-15/",
+        "path": "/augsburg/fa/events/test-veranstaltung$2030-01-15/"
       }
     },
     "thumbnail": null,
@@ -151,8 +151,8 @@
   },
   {
     "id": null,
-    "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung-2030-01-17/",
-    "path": "/augsburg/de/events/test-veranstaltung-2030-01-17/",
+    "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung$2030-01-17/",
+    "path": "/augsburg/de/events/test-veranstaltung$2030-01-17/",
     "title": "Test-Veranstaltung",
     "modified_gmt": "2020-01-22 12:46:33",
     "excerpt": "Dies ist die Beschreibung einer Test-Veranstaltung.",
@@ -160,18 +160,18 @@
     "available_languages": {
       "en": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/en/events/test-veranstaltung-2030-01-17/",
-        "path": "/augsburg/en/events/test-veranstaltung-2030-01-17/"
+        "url": "http://localhost:8000/augsburg/en/events/test-event$2030-01-17/",
+        "path": "/augsburg/en/events/test-event$2030-01-17/"
       },
       "ar": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung-2030-01-17/",
-        "path": "/augsburg/ar/events/test-veranstaltung-2030-01-17/"
+        "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung$2030-01-17/",
+        "path": "/augsburg/ar/events/test-veranstaltung$2030-01-17/"
       },
       "fa": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung-2030-01-17/",
-        "path": "/augsburg/fa/events/test-veranstaltung-2030-01-17/"
+        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung$2030-01-17/",
+        "path": "/augsburg/fa/events/test-veranstaltung$2030-01-17/"
       }
     },
     "thumbnail": null,
@@ -201,8 +201,8 @@
   },
   {
     "id": null,
-    "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung-2030-01-29/",
-    "path": "/augsburg/de/events/test-veranstaltung-2030-01-29/",
+    "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung$2030-01-29/",
+    "path": "/augsburg/de/events/test-veranstaltung$2030-01-29/",
     "title": "Test-Veranstaltung",
     "modified_gmt": "2020-01-22 12:46:33",
     "excerpt": "Dies ist die Beschreibung einer Test-Veranstaltung.",
@@ -210,18 +210,18 @@
     "available_languages": {
       "en": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/en/events/test-veranstaltung-2030-01-29/",
-        "path": "/augsburg/en/events/test-veranstaltung-2030-01-29/"
+        "url": "http://localhost:8000/augsburg/en/events/test-event$2030-01-29/",
+        "path": "/augsburg/en/events/test-event$2030-01-29/"
       },
       "ar": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung-2030-01-29/",
-        "path": "/augsburg/ar/events/test-veranstaltung-2030-01-29/"
+        "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung$2030-01-29/",
+        "path": "/augsburg/ar/events/test-veranstaltung$2030-01-29/"
       },
       "fa": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung-2030-01-29/",
-        "path": "/augsburg/fa/events/test-veranstaltung-2030-01-29/"
+        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung$2030-01-29/",
+        "path": "/augsburg/fa/events/test-veranstaltung$2030-01-29/"
       }
     },
     "thumbnail": null,
@@ -251,8 +251,8 @@
   },
   {
     "id": null,
-    "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung-2030-01-31/",
-    "path": "/augsburg/de/events/test-veranstaltung-2030-01-31/",
+    "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung$2030-01-31/",
+    "path": "/augsburg/de/events/test-veranstaltung$2030-01-31/",
     "title": "Test-Veranstaltung",
     "modified_gmt": "2020-01-22 12:46:33",
     "excerpt": "Dies ist die Beschreibung einer Test-Veranstaltung.",
@@ -260,18 +260,18 @@
     "available_languages": {
       "en": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/en/events/test-veranstaltung-2030-01-31/",
-        "path": "/augsburg/en/events/test-veranstaltung-2030-01-31/"
+        "url": "http://localhost:8000/augsburg/en/events/test-event$2030-01-31/",
+        "path": "/augsburg/en/events/test-event$2030-01-31/"
       },
       "ar": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung-2030-01-31/",
-        "path": "/augsburg/ar/events/test-veranstaltung-2030-01-31/"
+        "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung$2030-01-31/",
+        "path": "/augsburg/ar/events/test-veranstaltung$2030-01-31/"
       },
       "fa": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung-2030-01-31/",
-        "path": "/augsburg/fa/events/test-veranstaltung-2030-01-31/"
+        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung$2030-01-31/",
+        "path": "/augsburg/fa/events/test-veranstaltung$2030-01-31/"
       }
     },
     "thumbnail": null,

--- a/tests/api/expected-outputs/augsburg_en_events.json
+++ b/tests/api/expected-outputs/augsburg_en_events.json
@@ -51,8 +51,8 @@
   },
   {
     "id": null,
-    "url": "http://localhost:8000/augsburg/en/events/test-event-2030-01-03/",
-    "path": "/augsburg/en/events/test-event-2030-01-03/",
+    "url": "http://localhost:8000/augsburg/en/events/test-event$2030-01-03/",
+    "path": "/augsburg/en/events/test-event$2030-01-03/",
     "title": "Test-Event",
     "modified_gmt": "2020-01-22 12:46:16",
     "excerpt": "This is the content of a test-event.",
@@ -60,18 +60,18 @@
     "available_languages": {
       "de": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/de/events/test-event-2030-01-03/",
-        "path": "/augsburg/de/events/test-event-2030-01-03/"
+        "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung$2030-01-03/",
+        "path": "/augsburg/de/events/test-veranstaltung$2030-01-03/"
       },
       "ar": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/ar/events/test-event-2030-01-03/",
-        "path": "/augsburg/ar/events/test-event-2030-01-03/"
+        "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung$2030-01-03/",
+        "path": "/augsburg/ar/events/test-veranstaltung$2030-01-03/"
       },
       "fa": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/fa/events/test-event-2030-01-03/",
-        "path": "/augsburg/fa/events/test-event-2030-01-03/"
+        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung$2030-01-03/",
+        "path": "/augsburg/fa/events/test-veranstaltung$2030-01-03/"
       }
     },
     "thumbnail": null,
@@ -101,8 +101,8 @@
   },
   {
     "id": null,
-    "url": "http://localhost:8000/augsburg/en/events/test-event-2030-01-15/",
-    "path": "/augsburg/en/events/test-event-2030-01-15/",
+    "url": "http://localhost:8000/augsburg/en/events/test-event$2030-01-15/",
+    "path": "/augsburg/en/events/test-event$2030-01-15/",
     "title": "Test-Event",
     "modified_gmt": "2020-01-22 12:46:16",
     "excerpt": "This is the content of a test-event.",
@@ -110,18 +110,18 @@
     "available_languages": {
       "de": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/de/events/test-event-2030-01-15/",
-        "path": "/augsburg/de/events/test-event-2030-01-15/"
+        "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung$2030-01-15/",
+        "path": "/augsburg/de/events/test-veranstaltung$2030-01-15/"
       },
       "ar": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/ar/events/test-event-2030-01-15/",
-        "path": "/augsburg/ar/events/test-event-2030-01-15/"
+        "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung$2030-01-15/",
+        "path": "/augsburg/ar/events/test-veranstaltung$2030-01-15/"
       },
       "fa": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/fa/events/test-event-2030-01-15/",
-        "path": "/augsburg/fa/events/test-event-2030-01-15/"
+        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung$2030-01-15/",
+        "path": "/augsburg/fa/events/test-veranstaltung$2030-01-15/"
       }
     },
     "thumbnail": null,
@@ -151,8 +151,8 @@
   },
   {
     "id": null,
-    "url": "http://localhost:8000/augsburg/en/events/test-event-2030-01-17/",
-    "path": "/augsburg/en/events/test-event-2030-01-17/",
+    "url": "http://localhost:8000/augsburg/en/events/test-event$2030-01-17/",
+    "path": "/augsburg/en/events/test-event$2030-01-17/",
     "title": "Test-Event",
     "modified_gmt": "2020-01-22 12:46:16",
     "excerpt": "This is the content of a test-event.",
@@ -160,18 +160,18 @@
     "available_languages": {
       "de": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/de/events/test-event-2030-01-17/",
-        "path": "/augsburg/de/events/test-event-2030-01-17/"
+        "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung$2030-01-17/",
+        "path": "/augsburg/de/events/test-veranstaltung$2030-01-17/"
       },
       "ar": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/ar/events/test-event-2030-01-17/",
-        "path": "/augsburg/ar/events/test-event-2030-01-17/"
+        "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung$2030-01-17/",
+        "path": "/augsburg/ar/events/test-veranstaltung$2030-01-17/"
       },
       "fa": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/fa/events/test-event-2030-01-17/",
-        "path": "/augsburg/fa/events/test-event-2030-01-17/"
+        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung$2030-01-17/",
+        "path": "/augsburg/fa/events/test-veranstaltung$2030-01-17/"
       }
     },
     "thumbnail": null,
@@ -201,8 +201,8 @@
   },
   {
     "id": null,
-    "url": "http://localhost:8000/augsburg/en/events/test-event-2030-01-29/",
-    "path": "/augsburg/en/events/test-event-2030-01-29/",
+    "url": "http://localhost:8000/augsburg/en/events/test-event$2030-01-29/",
+    "path": "/augsburg/en/events/test-event$2030-01-29/",
     "title": "Test-Event",
     "modified_gmt": "2020-01-22 12:46:16",
     "excerpt": "This is the content of a test-event.",
@@ -210,18 +210,18 @@
     "available_languages": {
       "de": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/de/events/test-event-2030-01-29/",
-        "path": "/augsburg/de/events/test-event-2030-01-29/"
+        "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung$2030-01-29/",
+        "path": "/augsburg/de/events/test-veranstaltung$2030-01-29/"
       },
       "ar": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/ar/events/test-event-2030-01-29/",
-        "path": "/augsburg/ar/events/test-event-2030-01-29/"
+        "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung$2030-01-29/",
+        "path": "/augsburg/ar/events/test-veranstaltung$2030-01-29/"
       },
       "fa": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/fa/events/test-event-2030-01-29/",
-        "path": "/augsburg/fa/events/test-event-2030-01-29/"
+        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung$2030-01-29/",
+        "path": "/augsburg/fa/events/test-veranstaltung$2030-01-29/"
       }
     },
     "thumbnail": null,
@@ -251,8 +251,8 @@
   },
   {
     "id": null,
-    "url": "http://localhost:8000/augsburg/en/events/test-event-2030-01-31/",
-    "path": "/augsburg/en/events/test-event-2030-01-31/",
+    "url": "http://localhost:8000/augsburg/en/events/test-event$2030-01-31/",
+    "path": "/augsburg/en/events/test-event$2030-01-31/",
     "title": "Test-Event",
     "modified_gmt": "2020-01-22 12:46:16",
     "excerpt": "This is the content of a test-event.",
@@ -260,18 +260,18 @@
     "available_languages": {
       "de": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/de/events/test-event-2030-01-31/",
-        "path": "/augsburg/de/events/test-event-2030-01-31/"
+        "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung$2030-01-31/",
+        "path": "/augsburg/de/events/test-veranstaltung$2030-01-31/"
       },
       "ar": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/ar/events/test-event-2030-01-31/",
-        "path": "/augsburg/ar/events/test-event-2030-01-31/"
+        "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung$2030-01-31/",
+        "path": "/augsburg/ar/events/test-veranstaltung$2030-01-31/"
       },
       "fa": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/fa/events/test-event-2030-01-31/",
-        "path": "/augsburg/fa/events/test-event-2030-01-31/"
+        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung$2030-01-31/",
+        "path": "/augsburg/fa/events/test-veranstaltung$2030-01-31/"
       }
     },
     "thumbnail": null,

--- a/tests/api/expected-outputs/nurnberg_de_events.json
+++ b/tests/api/expected-outputs/nurnberg_de_events.json
@@ -41,8 +41,8 @@
   },
   {
     "id": null,
-    "url": "http://localhost:8000/nurnberg/de/events/test-veranstaltung-2031-01-03/",
-    "path": "/nurnberg/de/events/test-veranstaltung-2031-01-03/",
+    "url": "http://localhost:8000/nurnberg/de/events/test-veranstaltung$2031-01-03/",
+    "path": "/nurnberg/de/events/test-veranstaltung$2031-01-03/",
     "title": "Test-Veranstaltung",
     "modified_gmt": "2020-01-22 12:46:33",
     "excerpt": "Dies ist die Beschreibung einer Test-Veranstaltung.",
@@ -50,8 +50,8 @@
     "available_languages": {
       "en": {
         "id": null,
-        "url": "http://localhost:8000/nurnberg/en/events/test-veranstaltung-2031-01-03/",
-        "path": "/nurnberg/en/events/test-veranstaltung-2031-01-03/"
+        "url": "http://localhost:8000/nurnberg/en/events/test-event$2031-01-03/",
+        "path": "/nurnberg/en/events/test-event$2031-01-03/"
       }
     },
     "thumbnail": null,
@@ -81,8 +81,8 @@
   },
   {
     "id": null,
-    "url": "http://localhost:8000/nurnberg/de/events/test-veranstaltung-2031-01-15/",
-    "path": "/nurnberg/de/events/test-veranstaltung-2031-01-15/",
+    "url": "http://localhost:8000/nurnberg/de/events/test-veranstaltung$2031-01-15/",
+    "path": "/nurnberg/de/events/test-veranstaltung$2031-01-15/",
     "title": "Test-Veranstaltung",
     "modified_gmt": "2020-01-22 12:46:33",
     "excerpt": "Dies ist die Beschreibung einer Test-Veranstaltung.",
@@ -90,8 +90,8 @@
     "available_languages": {
       "en": {
         "id": null,
-        "url": "http://localhost:8000/nurnberg/en/events/test-veranstaltung-2031-01-15/",
-        "path": "/nurnberg/en/events/test-veranstaltung-2031-01-15/"
+        "url": "http://localhost:8000/nurnberg/en/events/test-event$2031-01-15/",
+        "path": "/nurnberg/en/events/test-event$2031-01-15/"
       }
     },
     "thumbnail": null,
@@ -121,8 +121,8 @@
   },
   {
     "id": null,
-    "url": "http://localhost:8000/nurnberg/de/events/test-veranstaltung-2031-01-17/",
-    "path": "/nurnberg/de/events/test-veranstaltung-2031-01-17/",
+    "url": "http://localhost:8000/nurnberg/de/events/test-veranstaltung$2031-01-17/",
+    "path": "/nurnberg/de/events/test-veranstaltung$2031-01-17/",
     "title": "Test-Veranstaltung",
     "modified_gmt": "2020-01-22 12:46:33",
     "excerpt": "Dies ist die Beschreibung einer Test-Veranstaltung.",
@@ -130,8 +130,8 @@
     "available_languages": {
       "en": {
         "id": null,
-        "url": "http://localhost:8000/nurnberg/en/events/test-veranstaltung-2031-01-17/",
-        "path": "/nurnberg/en/events/test-veranstaltung-2031-01-17/"
+        "url": "http://localhost:8000/nurnberg/en/events/test-event$2031-01-17/",
+        "path": "/nurnberg/en/events/test-event$2031-01-17/"
       }
     },
     "thumbnail": null,
@@ -161,8 +161,8 @@
   },
   {
     "id": null,
-    "url": "http://localhost:8000/nurnberg/de/events/test-veranstaltung-2031-01-29/",
-    "path": "/nurnberg/de/events/test-veranstaltung-2031-01-29/",
+    "url": "http://localhost:8000/nurnberg/de/events/test-veranstaltung$2031-01-29/",
+    "path": "/nurnberg/de/events/test-veranstaltung$2031-01-29/",
     "title": "Test-Veranstaltung",
     "modified_gmt": "2020-01-22 12:46:33",
     "excerpt": "Dies ist die Beschreibung einer Test-Veranstaltung.",
@@ -170,8 +170,8 @@
     "available_languages": {
       "en": {
         "id": null,
-        "url": "http://localhost:8000/nurnberg/en/events/test-veranstaltung-2031-01-29/",
-        "path": "/nurnberg/en/events/test-veranstaltung-2031-01-29/"
+        "url": "http://localhost:8000/nurnberg/en/events/test-event$2031-01-29/",
+        "path": "/nurnberg/en/events/test-event$2031-01-29/"
       }
     },
     "thumbnail": null,
@@ -201,8 +201,8 @@
   },
   {
     "id": null,
-    "url": "http://localhost:8000/nurnberg/de/events/test-veranstaltung-2031-01-31/",
-    "path": "/nurnberg/de/events/test-veranstaltung-2031-01-31/",
+    "url": "http://localhost:8000/nurnberg/de/events/test-veranstaltung$2031-01-31/",
+    "path": "/nurnberg/de/events/test-veranstaltung$2031-01-31/",
     "title": "Test-Veranstaltung",
     "modified_gmt": "2020-01-22 12:46:33",
     "excerpt": "Dies ist die Beschreibung einer Test-Veranstaltung.",
@@ -210,8 +210,8 @@
     "available_languages": {
       "en": {
         "id": null,
-        "url": "http://localhost:8000/nurnberg/en/events/test-veranstaltung-2031-01-31/",
-        "path": "/nurnberg/en/events/test-veranstaltung-2031-01-31/"
+        "url": "http://localhost:8000/nurnberg/en/events/test-event$2031-01-31/",
+        "path": "/nurnberg/en/events/test-event$2031-01-31/"
       }
     },
     "thumbnail": null,

--- a/tests/api/expected-outputs/nurnberg_en_events.json
+++ b/tests/api/expected-outputs/nurnberg_en_events.json
@@ -41,8 +41,8 @@
   },
   {
     "id": null,
-    "url": "http://localhost:8000/nurnberg/en/events/test-event-2031-01-03/",
-    "path": "/nurnberg/en/events/test-event-2031-01-03/",
+    "url": "http://localhost:8000/nurnberg/en/events/test-event$2031-01-03/",
+    "path": "/nurnberg/en/events/test-event$2031-01-03/",
     "title": "Test-Event",
     "modified_gmt": "2020-01-22 12:46:16",
     "excerpt": "This is the content of a test-event.",
@@ -50,8 +50,8 @@
     "available_languages": {
       "de": {
         "id": null,
-        "url": "http://localhost:8000/nurnberg/de/events/test-event-2031-01-03/",
-        "path": "/nurnberg/de/events/test-event-2031-01-03/"
+        "url": "http://localhost:8000/nurnberg/de/events/test-veranstaltung$2031-01-03/",
+        "path": "/nurnberg/de/events/test-veranstaltung$2031-01-03/"
       }
     },
     "thumbnail": null,
@@ -81,8 +81,8 @@
   },
   {
     "id": null,
-    "url": "http://localhost:8000/nurnberg/en/events/test-event-2031-01-15/",
-    "path": "/nurnberg/en/events/test-event-2031-01-15/",
+    "url": "http://localhost:8000/nurnberg/en/events/test-event$2031-01-15/",
+    "path": "/nurnberg/en/events/test-event$2031-01-15/",
     "title": "Test-Event",
     "modified_gmt": "2020-01-22 12:46:16",
     "excerpt": "This is the content of a test-event.",
@@ -90,8 +90,8 @@
     "available_languages": {
       "de": {
         "id": null,
-        "url": "http://localhost:8000/nurnberg/de/events/test-event-2031-01-15/",
-        "path": "/nurnberg/de/events/test-event-2031-01-15/"
+        "url": "http://localhost:8000/nurnberg/de/events/test-veranstaltung$2031-01-15/",
+        "path": "/nurnberg/de/events/test-veranstaltung$2031-01-15/"
       }
     },
     "thumbnail": null,
@@ -121,8 +121,8 @@
   },
   {
     "id": null,
-    "url": "http://localhost:8000/nurnberg/en/events/test-event-2031-01-17/",
-    "path": "/nurnberg/en/events/test-event-2031-01-17/",
+    "url": "http://localhost:8000/nurnberg/en/events/test-event$2031-01-17/",
+    "path": "/nurnberg/en/events/test-event$2031-01-17/",
     "title": "Test-Event",
     "modified_gmt": "2020-01-22 12:46:16",
     "excerpt": "This is the content of a test-event.",
@@ -130,8 +130,8 @@
     "available_languages": {
       "de": {
         "id": null,
-        "url": "http://localhost:8000/nurnberg/de/events/test-event-2031-01-17/",
-        "path": "/nurnberg/de/events/test-event-2031-01-17/"
+        "url": "http://localhost:8000/nurnberg/de/events/test-veranstaltung$2031-01-17/",
+        "path": "/nurnberg/de/events/test-veranstaltung$2031-01-17/"
       }
     },
     "thumbnail": null,
@@ -161,8 +161,8 @@
   },
   {
     "id": null,
-    "url": "http://localhost:8000/nurnberg/en/events/test-event-2031-01-29/",
-    "path": "/nurnberg/en/events/test-event-2031-01-29/",
+    "url": "http://localhost:8000/nurnberg/en/events/test-event$2031-01-29/",
+    "path": "/nurnberg/en/events/test-event$2031-01-29/",
     "title": "Test-Event",
     "modified_gmt": "2020-01-22 12:46:16",
     "excerpt": "This is the content of a test-event.",
@@ -170,8 +170,8 @@
     "available_languages": {
       "de": {
         "id": null,
-        "url": "http://localhost:8000/nurnberg/de/events/test-event-2031-01-29/",
-        "path": "/nurnberg/de/events/test-event-2031-01-29/"
+        "url": "http://localhost:8000/nurnberg/de/events/test-veranstaltung$2031-01-29/",
+        "path": "/nurnberg/de/events/test-veranstaltung$2031-01-29/"
       }
     },
     "thumbnail": null,
@@ -201,8 +201,8 @@
   },
   {
     "id": null,
-    "url": "http://localhost:8000/nurnberg/en/events/test-event-2031-01-31/",
-    "path": "/nurnberg/en/events/test-event-2031-01-31/",
+    "url": "http://localhost:8000/nurnberg/en/events/test-event$2031-01-31/",
+    "path": "/nurnberg/en/events/test-event$2031-01-31/",
     "title": "Test-Event",
     "modified_gmt": "2020-01-22 12:46:16",
     "excerpt": "This is the content of a test-event.",
@@ -210,8 +210,8 @@
     "available_languages": {
       "de": {
         "id": null,
-        "url": "http://localhost:8000/nurnberg/de/events/test-event-2031-01-31/",
-        "path": "/nurnberg/de/events/test-event-2031-01-31/"
+        "url": "http://localhost:8000/nurnberg/de/events/test-veranstaltung$2031-01-31/",
+        "path": "/nurnberg/de/events/test-veranstaltung$2031-01-31/"
       }
     },
     "thumbnail": null,


### PR DESCRIPTION
### Short description
This pr fixes the performance problem regarding the events api.


### Proposed changes
- Don't create new events for recurrences
- Create unique slugs using the `$`-character, which is not allowed in 'normal' slugs

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1535
