### PR TITLE
Limit number of recurring events returned from the api

### DIFF
--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -76,6 +76,9 @@ AUTHOR_CHAT_HISTORY_DAYS = 30
 #: The time span up to which recurrent events should be returned by the api
 API_EVENTS_MAX_TIME_SPAN_DAYS = 31
 
+#: The maximum number of events to return from events api, temporary workaround
+API_MAX_COUNT_EVENTS = 30
+
 #: The company operating this CMS
 COMPANY = os.environ.get("INTEGREAT_CMS_COMPANY", "Tür an Tür – Digitalfabrik gGmbH")
 

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-27 13:12+0000\n"
+"POT-Creation-Date: 2022-07-27 14:25+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -3382,7 +3382,7 @@ msgstr "Feedback"
 
 #: cms/templates/_base.html:181
 #: cms/templates/push_notifications/push_notification_list.html:7
-#: core/settings.py:119
+#: core/settings.py:122
 msgid "News"
 msgstr "Nachrichten"
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr limits the number of recurring events returned from the events api until a better solution is implemented.
This change is because the app struggles with many events.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add a setting to control the maximum number of recurring events, currently 30
- Limit number of recurring  events returned