### PR TITLE
Fix status of minor edit translation with only one public version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ UNRELEASED
 * [ [#1390](https://github.com/digitalfabrik/integreat-cms/issues/1390) ] Move files via drag and drop
 * [ [#1606](https://github.com/digitalfabrik/integreat-cms/issues/1606) ] Remove warning at POI contacts
 * [ [#1571](https://github.com/digitalfabrik/integreat-cms/issues/1571) ] Show offline downloads in statistics
+* [ [#1464](https://github.com/digitalfabrik/integreat-cms/issues/1464) ] Fix status of translation with only minor public version
 
 
 2022.7.0

--- a/integreat_cms/cms/views/pages/page_form_view.py
+++ b/integreat_cms/cms/views/pages/page_form_view.py
@@ -288,6 +288,30 @@ class PageFormView(
                 page_translation_form.instance.page.translations.filter(
                     language__in=languages
                 ).update(status=status.DRAFT)
+            # If the translation is minor change and there is no major public version
+            if (page_translation_form.instance.minor_edit is True) and (
+                not page_translation_form.instance.major_public_version
+            ):
+                # and if it is the first version, save it as major public
+                if page_translation_form.instance.version == 1:
+                    page_translation_form.instance.minor_edit = False
+                    page_translation_form.save()
+                    messages.info(
+                        request,
+                        _(
+                            'Page "{}" was saved as major version. The first version is not allowed to be a minor edit.'
+                        ).format(page_translation_form.instance.title),
+                    )
+                # or if there are only draft and/or minor public version, change them to public major version
+                else:
+                    language_tree_node = region.language_node_by_slug.get(language.slug)
+                    languages = [language] + [
+                        node.language for node in language_tree_node.get_descendants()
+                    ]
+                    page_translation_form.instance.page.translations.filter(
+                        language__in=languages
+                    ).update(status=status.PUBLIC)
+
             # Add the success message and redirect to the edit page
             if not page_instance:
                 messages.success(

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-07-27 14:22+0000\n"
+"POT-Creation-Date: 2022-08-02 09:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -6281,7 +6281,7 @@ msgid "Event \"{}\" was successfully created"
 msgstr "Veranstaltung \"{}\" wurde erfolgreich erstellt"
 
 #: cms/views/events/event_form_view.py:239
-#: cms/views/pages/page_form_view.py:302 cms/views/pois/poi_form_view.py:192
+#: cms/views/pages/page_form_view.py:326 cms/views/pois/poi_form_view.py:192
 msgid "No changes detected, but date refreshed"
 msgstr "Keine Änderungen vorgenommen, aber Datum aktualisiert"
 
@@ -6363,7 +6363,7 @@ msgid "Imprint was successfully created"
 msgstr "Impressum wurde erfolgreich erstellt"
 
 #: cms/views/imprint/imprint_form_view.py:288
-#: cms/views/pages/page_form_view.py:377
+#: cms/views/pages/page_form_view.py:401
 #, python-brace-format
 msgid "{source_language} to {target_language}"
 msgstr "{source_language} nach {target_language}"
@@ -6838,7 +6838,15 @@ msgstr ""
 "Sie haben nicht die nötige Berechtigung, um diese Seite zu veröffentlichen, "
 "aber Sie können Änderungen vornehmen und diese zur Überprüfung vorlegen."
 
-#: cms/views/pages/page_form_view.py:295
+#: cms/views/pages/page_form_view.py:302
+msgid ""
+"Page \"{}\" was saved as major version. The first version is not allowed to "
+"be a minor edit."
+msgstr ""
+"Seite \"{}\" wurde als große Änderung gespeichert. Die erste Version darf "
+"keine geringfügige Änderung sein."
+
+#: cms/views/pages/page_form_view.py:319
 msgid "Page \"{}\" was successfully created"
 msgstr "Seite \"{}\" wurde erfolgreich erstellt"
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR is to solve the problem that the status of translations with only single public version is broken when the public version is minor edit.

This is a successor of PR https://github.com/digitalfabrik/integreat-cms/pull/1588 .

### Proposed changes
<!-- Describe this PR in more detail. -->

- If the translation is the first version, save it as major version.
- Otherwise, change the past versions to public. 
- No change in status calculation.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1464
