### PR TITLE
Show no broken links from old versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ UNRELEASED
 * [ [#1623](https://github.com/digitalfabrik/integreat-cms/issues/1623) ] Fix imprint publish/update button
 * [ [#1534](https://github.com/digitalfabrik/integreat-cms/issues/1534) ] Invalidate cache after moving nodes
 * [ [#1535](https://github.com/digitalfabrik/integreat-cms/issues/1535) ] Fix event api performance
+* [ [#1604](https://github.com/digitalfabrik/integreat-cms/issues/#1604) ] Show no broken links from restored versions
 
 
 2022.7.0

--- a/integreat_cms/cms/views/pages/page_revision_view.py
+++ b/integreat_cms/cms/views/pages/page_revision_view.py
@@ -169,7 +169,7 @@ class PageRevisionView(TemplateView):
                     "language_slug": language.slug,
                 },
             )
-
+        current_revision.links.all().delete()
         revision.pk = None
         revision.version = current_revision.version + 1
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR solves the problem that links in old versions are shown in the link checker.

### Proposed changes
<!-- Describe this PR in more detail. -->
-<s> Links in draft versions are not shown in the link check.</s>
-<s>Only links in public versions are detected.</s>
- This bug happens when an old version is restored, because deletion of the old links will not be called during restoration, unlike case of creating a new version.
- The old links will be now deleted at restoration too.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1604
