### PR TITLE
Invalidate cache after moving nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ UNRELEASED
 * [ [#1571](https://github.com/digitalfabrik/integreat-cms/issues/1571) ] Show offline downloads in statistics
 * [ [#1464](https://github.com/digitalfabrik/integreat-cms/issues/1464) ] Fix status of translation with only minor public version
 * [ [#1623](https://github.com/digitalfabrik/integreat-cms/issues/1623) ] Fix imprint publish/update button
+* [ [#1534](https://github.com/digitalfabrik/integreat-cms/issues/1534) ] Invalidate cache after moving nodes
 
 
 2022.7.0

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-04 15:28+0000\n"
+"POT-Creation-Date: 2022-08-05 07:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -6419,11 +6419,11 @@ msgstr ""
 msgid "A region can only have one root language."
 msgstr "Eine Region kann nur eine Standard-Sprache besitzen."
 
-#: cms/views/language_tree/language_tree_actions.py:67
+#: cms/views/language_tree/language_tree_actions.py:68
 msgid "The language tree node \"{}\" was successfully moved."
 msgstr "Der Sprach-Knoten \"{}\" wurde erfolgreich verschoben."
 
-#: cms/views/language_tree/language_tree_actions.py:145
+#: cms/views/language_tree/language_tree_actions.py:139
 msgid ""
 "The language tree node \"{}\" and all corresponding translations were "
 "successfully deleted."


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR invalidates the cache of all lanuage-related objects after a language node is moved.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Export the manual invalidation into a separate function
- Use the function after moving and deleting language nodes

However, our cache behavior is still pretty strange and I opened issue #1618 for a deeper investigation to get rid of this workarounds.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1534
