### PR TITLE
Add diff-view for source translation in sbs-editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ UNRELEASED
 ----------
 
 * [ [#1635](https://github.com/digitalfabrik/integreat-cms/issues/1635) ] Show Matomo actions in statistics instead of visitors
+* [ [#1449](https://github.com/digitalfabrik/integreat-cms/issues/1449) ] Show diff to last source version in side-by-side view
 
 
 2022.8.2

--- a/integreat_cms/cms/templates/_tinymce_config.html
+++ b/integreat_cms/cms/templates/_tinymce_config.html
@@ -8,12 +8,15 @@
 {% get_files 'editor_content' 'css' as editor_content_css_files %}
 
 {% if language.slug == 'zh-CN' %}
-    {% firstof "body { font-family: 'Noto Sans SC', sans-serif; }" as content_style %}
+    {% firstof "body { font-family: 'Noto Sans SC', sans-serif; }" as font_style %}
 {% elif right_to_left %}
-    {% firstof "body { font-family: 'Lateef', sans-serif; font-size: 1.2rem; }" as content_style %}
+    {% firstof "body { font-family: 'Lateef', sans-serif; font-size: 1.2rem; }" as font_style %}
 {% else %}
-    {% firstof "body { font-family: 'Open Sans', sans-serif; }" as content_style %}
+    {% firstof "body { font-family: 'Open Sans', sans-serif; }" as font_style %}
 {% endif %}
+
+{% comment %} Styling for text diff taken from style.scss {% endcomment %}
+{% firstof font_style|add:"del { background-color: rgb(252 165 165); } ins { background-color: rgb(134 239 172); text-decoration-line: none; }" as content_style %}
 
 <div
         id="tinymce-config-options"

--- a/integreat_cms/cms/templates/pages/page_sbs.html
+++ b/integreat_cms/cms/templates/pages/page_sbs.html
@@ -70,19 +70,38 @@
                                type="text"
                                value="{{ source_page_translation.title }}"
                                disabled>
-                        <div class="mt-4">
-                            <label class="block mt-4 font-bold">{{ page_translation_form.content.label }}</label>
-                            <textarea id="source_translation_tinymce" cols="40" rows="10" class="tinymce_textarea" disabled>{{source_page_translation.content}}</textarea>
+                        <div>
+                            <label class="block font-bold">{{ page_translation_form.content.label }}</label>
+                            <textarea 
+                                id="source_translation_tinymce" 
+                                cols="40" 
+                                rows="10" 
+                                class="tinymce_textarea" 
+                                disabled
+                                data-old="{{ old_translation_content }}" 
+                                data-new="{{ source_page_translation.content }}"
+                            >
+                                {{source_page_translation.content}}
+                            </textarea>
                         </div>
-                        <label>{% trans 'Copy content' %}</label>
-                        <button id="copy-translation-content"
-                                title="{% trans 'Copy content' %}"
-                                class="btn w-full bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded">
-                            {% with source_language=source_page_translation.language.translated_name target_language_name=target_language.translated_name %}
-                                {% blocktrans %}Copy content of {{ source_language }} to {{ target_language_name }}{% endblocktrans %}
-                            {% endwith %}
-                            <i data-feather="arrow-right-circle" class="mr-2"></i>
-                        </button>
+                        <label>{% trans 'Actions' %}</label>
+                        <div class="flex flex-wrap gap-4">
+                            <button id="toggle-translation-diff"
+                                    class="btn grow bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded"
+                                    title="{% if page_translation_form.instance.is_up_to_date %}{% trans 'No changes have been made to the source translation.' %}{% else %}{% trans 'Toggle source translation differences' %}{% endif %}"
+                                    {% if page_translation_form.instance.is_up_to_date %}disabled{% endif %}>
+                                <div class="hidden toggle">{% trans 'Hide source translation differences' %}</div>
+                                <div>{% trans 'Show source translation differences' %}</div>
+                            </button>
+                            <button id="copy-translation-content"
+                                    title="{% trans 'Copy content' %}"
+                                    class="btn grow bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded">
+                                {% with source_language=source_page_translation.language.translated_name target_language_name=target_language.translated_name %}
+                                    {% blocktrans %}Copy content of {{ source_language }} to {{ target_language_name }}{% endblocktrans %}
+                                {% endwith %}
+                                <i data-feather="arrow-right-circle" class="mr-2"></i>
+                            </button>
+                        </div>
                     </div>
                 </div>
                 <div class="border border-blue-500 rounded shadow-2xl">

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-18 10:30+0000\n"
+"POT-Creation-Date: 2022-08-30 10:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1446,7 +1446,7 @@ msgstr "Rechts nach Links"
 #: cms/templates/events/event_list_row.html:51
 #: cms/templates/imprint/imprint_sbs.html:45
 #: cms/templates/imprint/imprint_sbs.html:102
-#: cms/templates/pages/page_sbs.html:51 cms/templates/pages/page_sbs.html:100
+#: cms/templates/pages/page_sbs.html:51 cms/templates/pages/page_sbs.html:119
 #: cms/templates/pages/page_tree_archived_node.html:63
 #: cms/templates/pages/page_tree_node.html:79
 #: cms/templates/pois/poi_list_row.html:48
@@ -1461,7 +1461,7 @@ msgstr "Übersetzung ist aktuell"
 #: cms/templates/events/event_list_row.html:65
 #: cms/templates/imprint/imprint_sbs.html:41
 #: cms/templates/imprint/imprint_sbs.html:98
-#: cms/templates/pages/page_sbs.html:47 cms/templates/pages/page_sbs.html:96
+#: cms/templates/pages/page_sbs.html:47 cms/templates/pages/page_sbs.html:115
 #: cms/templates/pages/page_tree_archived_node.html:55
 #: cms/templates/pages/page_tree_node.html:71
 #: cms/templates/pages/page_tree_node.html:89
@@ -1478,7 +1478,7 @@ msgstr "Wird derzeit übersetzt"
 #: cms/templates/events/event_list_row.html:47
 #: cms/templates/imprint/imprint_sbs.html:37
 #: cms/templates/imprint/imprint_sbs.html:94
-#: cms/templates/pages/page_sbs.html:43 cms/templates/pages/page_sbs.html:92
+#: cms/templates/pages/page_sbs.html:43 cms/templates/pages/page_sbs.html:111
 #: cms/templates/pages/page_tree_archived_node.html:59
 #: cms/templates/pages/page_tree_node.html:75
 #: cms/templates/pois/poi_list_row.html:44
@@ -1691,8 +1691,8 @@ msgstr "Kategorie"
 #: cms/templates/linkcheck/links_by_filter.html:59
 #: cms/templates/pages/page_form.html:106
 #: cms/templates/pages/page_revisions.html:50
-#: cms/templates/pages/page_sbs.html:61 cms/templates/pages/page_sbs.html:117
-#: cms/templates/pages/page_sbs.html:123 cms/templates/pages/page_tree.html:88
+#: cms/templates/pages/page_sbs.html:61 cms/templates/pages/page_sbs.html:136
+#: cms/templates/pages/page_sbs.html:142 cms/templates/pages/page_tree.html:88
 #: cms/templates/pages/page_tree_archived.html:67
 #: cms/templates/pois/poi_form.html:63 cms/templates/pois/poi_list.html:67
 #: cms/templates/pois/poi_list_archived.html:33
@@ -1886,7 +1886,7 @@ msgid "Password"
 msgstr "Passwort"
 
 #: cms/forms/users/password_reset_form.py:21
-#: cms/templates/_tinymce_config.html:29
+#: cms/templates/_tinymce_config.html:33
 msgid "Email"
 msgstr "Email"
 
@@ -2611,7 +2611,7 @@ msgstr ""
 msgid "thumbnail URL"
 msgstr "Vorschaubild-URL"
 
-#: cms/models/offers/offer_template.py:31 cms/templates/_tinymce_config.html:48
+#: cms/models/offers/offer_template.py:31 cms/templates/_tinymce_config.html:52
 #: cms/templates/linkcheck/links_by_filter.html:57
 #: cms/templates/offertemplates/offertemplate_list.html:22
 #: cms/views/media/media_context_mixin.py:58
@@ -3362,7 +3362,7 @@ msgid "Contents"
 msgstr "Inhalte"
 
 #: cms/templates/_base.html:143 cms/templates/_base.html:232
-#: cms/templates/_tinymce_config.html:54
+#: cms/templates/_tinymce_config.html:58
 #: cms/views/media/media_context_mixin.py:29
 msgid "Media Library"
 msgstr "Medienbibliothek"
@@ -3433,8 +3433,8 @@ msgstr "Angebots-Vorlagen"
 #: cms/templates/imprint/imprint_sbs.html:135
 #: cms/templates/pages/page_form.html:100
 #: cms/templates/pages/page_revisions.html:24
-#: cms/templates/pages/page_sbs.html:58 cms/templates/pages/page_sbs.html:114
-#: cms/templates/pages/page_sbs.html:120 cms/templates/pois/poi_form.html:58
+#: cms/templates/pages/page_sbs.html:58 cms/templates/pages/page_sbs.html:133
+#: cms/templates/pages/page_sbs.html:139 cms/templates/pois/poi_form.html:58
 msgid "Version"
 msgstr "Version"
 
@@ -3480,41 +3480,41 @@ msgstr "Suchen"
 msgid "Reset search"
 msgstr "Suche zurücksetzen"
 
-#: cms/templates/_tinymce_config.html:23
+#: cms/templates/_tinymce_config.html:27
 msgid "Do not translate the selected text."
 msgstr "Der markierte Text wird nicht übersetzt."
 
-#: cms/templates/_tinymce_config.html:24
+#: cms/templates/_tinymce_config.html:28
 msgid "Do not translate"
 msgstr "Nicht übersetzen"
 
-#: cms/templates/_tinymce_config.html:25
+#: cms/templates/_tinymce_config.html:29
 #: cms/templates/events/_event_filter_form.html:32
 msgid "Location"
 msgstr "Ort"
 
-#: cms/templates/_tinymce_config.html:27
+#: cms/templates/_tinymce_config.html:31
 #: cms/templates/push_notifications/push_notification_form.html:60
 msgid "Link"
 msgstr "Link"
 
-#: cms/templates/_tinymce_config.html:31
+#: cms/templates/_tinymce_config.html:35
 msgid "Phone"
 msgstr "Telefon"
 
-#: cms/templates/_tinymce_config.html:33
+#: cms/templates/_tinymce_config.html:37
 msgid "Opening Hours"
 msgstr "Öffnungszeiten"
 
-#: cms/templates/_tinymce_config.html:35
+#: cms/templates/_tinymce_config.html:39
 msgid "Hint"
 msgstr "Tipp"
 
-#: cms/templates/_tinymce_config.html:37
+#: cms/templates/_tinymce_config.html:41
 msgid "Group"
 msgstr "Gruppe"
 
-#: cms/templates/_tinymce_config.html:39
+#: cms/templates/_tinymce_config.html:43
 #: cms/templates/events/event_form.html:44
 #: cms/templates/imprint/imprint_form.html:29
 #: cms/templates/imprint/imprint_sbs.html:25
@@ -3523,46 +3523,46 @@ msgstr "Gruppe"
 msgid "Update"
 msgstr "Aktualisieren"
 
-#: cms/templates/_tinymce_config.html:40
+#: cms/templates/_tinymce_config.html:44
 #: cms/views/media/media_context_mixin.py:52
 msgid "Submit"
 msgstr "Speichern"
 
-#: cms/templates/_tinymce_config.html:41
+#: cms/templates/_tinymce_config.html:45
 #: cms/templates/generic_confirmation_dialog.html:22
 #: cms/templates/linkcheck/link_list_row.html:65
 msgid "Cancel"
 msgstr "Abbrechen"
 
-#: cms/templates/_tinymce_config.html:42
+#: cms/templates/_tinymce_config.html:46
 msgid "- no results -"
 msgstr "- keine Ergebnisse -"
 
-#: cms/templates/_tinymce_config.html:44
+#: cms/templates/_tinymce_config.html:48
 msgid "Link..."
 msgstr "Link..."
 
-#: cms/templates/_tinymce_config.html:45
+#: cms/templates/_tinymce_config.html:49
 msgid "Remove link"
 msgstr "Link entfernen"
 
-#: cms/templates/_tinymce_config.html:46
+#: cms/templates/_tinymce_config.html:50
 msgid "Open link"
 msgstr "Link öffnen"
 
-#: cms/templates/_tinymce_config.html:47
+#: cms/templates/_tinymce_config.html:51
 msgid "Add Link"
 msgstr "Link hinzufügen"
 
-#: cms/templates/_tinymce_config.html:49
+#: cms/templates/_tinymce_config.html:53
 msgid "Text to display"
 msgstr "Anzuzeigender Text"
 
-#: cms/templates/_tinymce_config.html:50
+#: cms/templates/_tinymce_config.html:54
 msgid "Or link to existing content"
 msgstr "Oder auf bestehende Inhalte verlinken"
 
-#: cms/templates/_tinymce_config.html:55
+#: cms/templates/_tinymce_config.html:59
 msgid "Media Library..."
 msgstr "Medienbibliothek..."
 
@@ -4060,7 +4060,8 @@ msgstr "Auf Google Maps öffnen"
 
 #: cms/templates/events/event_form.html:328
 #: cms/templates/imprint/imprint_form.html:120
-#: cms/templates/pages/page_form.html:285 cms/templates/pois/poi_form.html:218
+#: cms/templates/pages/page_form.html:285 cms/templates/pages/page_sbs.html:87
+#: cms/templates/pois/poi_form.html:218
 #: cms/templates/regions/region_list.html:25
 #: cms/templates/settings/user_settings.html:93
 msgid "Actions"
@@ -4528,34 +4529,34 @@ msgstr ""
 
 #: cms/templates/imprint/imprint_sbs.html:79
 #: cms/templates/imprint/imprint_sbs.html:81
-#: cms/templates/pages/page_sbs.html:77 cms/templates/pages/page_sbs.html:79
+#: cms/templates/pages/page_sbs.html:97
 msgid "Copy content"
 msgstr "Inhalt kopieren"
 
 #: cms/templates/imprint/imprint_sbs.html:84
-#: cms/templates/pages/page_sbs.html:82
+#: cms/templates/pages/page_sbs.html:100
 #, python-format
 msgid "Copy content of %(source_language)s to %(target_language_name)s"
 msgstr "Inhalt von %(source_language)s nach %(target_language_name)s kopieren"
 
 #: cms/templates/imprint/imprint_sbs.html:107
-#: cms/templates/pages/page_sbs.html:105
+#: cms/templates/pages/page_sbs.html:124
 msgid "Create Translation"
 msgstr "Übersetzung erstellen"
 
 #: cms/templates/imprint/imprint_sbs.html:136
-#: cms/templates/pages/page_sbs.html:121
+#: cms/templates/pages/page_sbs.html:140
 msgid "New"
 msgstr "Neu"
 
 #: cms/templates/imprint/imprint_sbs.html:139
 #: cms/templates/imprint/imprint_sbs.html:142
-#: cms/templates/pages/page_sbs.html:124
+#: cms/templates/pages/page_sbs.html:143
 msgid "Not saved yet"
 msgstr "Noch nicht gespeichert"
 
 #: cms/templates/imprint/imprint_sbs.html:149
-#: cms/templates/pages/page_sbs.html:136
+#: cms/templates/pages/page_sbs.html:155
 #: cms/templatetags/content_filters.py:104
 msgid "Implications on other translations"
 msgstr "Auswirkungen auf andere Übersetzungen"
@@ -5143,7 +5144,23 @@ msgstr ""
 "Übersetze \"%(page_title)s\" von %(source_language)s nach "
 "%(target_language_name)s"
 
-#: cms/templates/pages/page_sbs.html:129
+#: cms/templates/pages/page_sbs.html:91
+msgid "No changes have been made to the source translation."
+msgstr "Die Quellübersetzung wurde nicht geändert."
+
+#: cms/templates/pages/page_sbs.html:91
+msgid "Toggle source translation differences"
+msgstr "Änderungen der Quellübersetzung anzeigen"
+
+#: cms/templates/pages/page_sbs.html:93
+msgid "Hide source translation differences"
+msgstr "Änderungen der Quellübersetzung verbergen"
+
+#: cms/templates/pages/page_sbs.html:94
+msgid "Show source translation differences"
+msgstr "Änderungen der Quellübersetzung anzeigen"
+
+#: cms/templates/pages/page_sbs.html:148
 msgid " Leave blank to generate unique permalink from title"
 msgstr ""
 " Dieses Feld freilassen, um eine eindeutigen Permalink aus dem Titel zu "
@@ -6333,7 +6350,7 @@ msgstr "Feedback wurde erfolgreich gelöscht"
 
 #: cms/views/form_views.py:97 cms/views/imprint/imprint_sbs_view.py:209
 #: cms/views/language_tree/language_tree_node_form_view.py:105
-#: cms/views/pages/page_sbs_view.py:202 cms/views/roles/role_form_view.py:93
+#: cms/views/pages/page_sbs_view.py:207 cms/views/roles/role_form_view.py:93
 #: cms/views/settings/user_settings_view.py:91
 #: cms/views/settings/user_settings_view.py:108
 #: cms/views/users/region_user_form_view.py:95
@@ -6413,7 +6430,7 @@ msgstr "Die Revision wurde erfolgreich wiederhergestellt"
 
 #: cms/views/imprint/imprint_sbs_view.py:81
 #: cms/views/imprint/imprint_sbs_view.py:166
-#: cms/views/pages/page_sbs_view.py:59 cms/views/pages/page_sbs_view.py:157
+#: cms/views/pages/page_sbs_view.py:59 cms/views/pages/page_sbs_view.py:162
 #, python-brace-format
 msgid ""
 "You cannot use the side-by-side-view for the region's default language (in "
@@ -6424,7 +6441,7 @@ msgstr ""
 
 #: cms/views/imprint/imprint_sbs_view.py:99
 #: cms/views/imprint/imprint_sbs_view.py:183
-#: cms/views/pages/page_sbs_view.py:78 cms/views/pages/page_sbs_view.py:175
+#: cms/views/pages/page_sbs_view.py:78 cms/views/pages/page_sbs_view.py:180
 #, python-brace-format
 msgid ""
 "You cannot use the side-by-side-view if the source translation (in this case "
@@ -8225,9 +8242,6 @@ msgstr ""
 
 #~ msgid "Insert content here"
 #~ msgstr "Inhalt hier eingeben"
-
-#~ msgid "This change does not require an update of the translations"
-#~ msgstr "Diese Änderung erfordert keine angepasste Übersetzung"
 
 #~ msgid "Frequency"
 #~ msgstr "Häufigkeit"

--- a/integreat_cms/static/src/js/pages/sbs-copy-content.ts
+++ b/integreat_cms/static/src/js/pages/sbs-copy-content.ts
@@ -1,3 +1,4 @@
+import HtmlDiff from "htmldiff-js";
 import tinymce from "tinymce";
 
 /**
@@ -14,19 +15,41 @@ window.addEventListener("load", () => {
   if (copyTranslation) {
     copyTranslation.addEventListener("click", (event) => {
       event.preventDefault();
-      const source_translation_tinymce = tinymce.get(
-        "source_translation_tinymce"
-      );
+      const source_translation_content = document.getElementById("source_translation_tinymce").dataset.new;
       const target_translation_tinymce = tinymce.get(
         "target_translation_tinymce"
       );
-      target_translation_tinymce.setContent(
-        source_translation_tinymce.getContent()
-      );
+      target_translation_tinymce.setContent(source_translation_content);
 
       const source_translation_title = document.getElementById("source_translation_title") as HTMLInputElement;
       const target_translation_title = document.getElementById("target_translation_title") as HTMLInputElement;
       target_translation_title.value = source_translation_title.value;
     });
   }
+
+  // Render diffs
+  const source_editor = document.getElementById("source_translation_tinymce") as HTMLElement
+  const oldText = source_editor?.dataset.old;
+  const newText = source_editor?.dataset.new;
+  if (source_editor) {
+    source_editor.setAttribute("data-diff", HtmlDiff.execute(oldText, newText));
+  }
+
+  const toggleButton = document.getElementById("toggle-translation-diff");
+  toggleButton.addEventListener("click", (event) => {
+    event.preventDefault();
+
+    // Update Button text
+    toggleButton.querySelectorAll(":scope > div").forEach((child) => child.classList.toggle("hidden"));
+
+    const show_diff = !toggleButton.querySelector(".toggle").classList.contains("hidden");
+    const editor = tinymce.get("source_translation_tinymce");
+    if (show_diff) {
+      const diffText = source_editor?.dataset.diff;
+      editor.setContent(diffText);
+    } else {
+      const text = source_editor?.dataset.new;
+      editor.setContent(text);
+    }
+  })
 });


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr adds functionality to render the diff of the source translation since the last update of the target translation in the side-by-side page editor.


### Proposed changes
<!-- Describe this PR in more detail. -->
- Render the diff of the source translation in sbs-view
- Add a button to toggle between the normal view and the diff view
- Remove disabled tinymce editor instance in source translation for better consistency

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->
Fixes: #1449,  Fixes: #1573
