### PR TITLE
Fix translation state when pubishing minor edit

### DIFF
--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-05 07:57+0000\n"
+"POT-Creation-Date: 2022-08-05 10:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -6282,7 +6282,7 @@ msgid "Event \"{}\" was successfully created"
 msgstr "Veranstaltung \"{}\" wurde erfolgreich erstellt"
 
 #: cms/views/events/event_form_view.py:239
-#: cms/views/pages/page_form_view.py:326 cms/views/pois/poi_form_view.py:192
+#: cms/views/pages/page_form_view.py:325 cms/views/pois/poi_form_view.py:192
 msgid "No changes detected, but date refreshed"
 msgstr "Keine Änderungen vorgenommen, aber Datum aktualisiert"
 
@@ -6364,7 +6364,7 @@ msgid "Imprint was successfully created"
 msgstr "Impressum wurde erfolgreich erstellt"
 
 #: cms/views/imprint/imprint_form_view.py:289
-#: cms/views/pages/page_form_view.py:401
+#: cms/views/pages/page_form_view.py:400
 #, python-brace-format
 msgid "{source_language} to {target_language}"
 msgstr "{source_language} nach {target_language}"
@@ -6839,15 +6839,15 @@ msgstr ""
 "Sie haben nicht die nötige Berechtigung, um diese Seite zu veröffentlichen, "
 "aber Sie können Änderungen vornehmen und diese zur Überprüfung vorlegen."
 
-#: cms/views/pages/page_form_view.py:302
+#: cms/views/pages/page_form_view.py:301
 msgid ""
-"Page \"{}\" was saved as major version. The first version is not allowed to "
+"The \"minor edit\" option was disabled because the first version can never "
 "be a minor edit."
 msgstr ""
-"Seite \"{}\" wurde als große Änderung gespeichert. Die erste Version darf "
-"keine geringfügige Änderung sein."
+"Die \"geringfügige Änderung\"-Option wurde deaktiviert, da die erste Version "
+"niemals eine geringfügige Änderung sein kann."
 
-#: cms/views/pages/page_form_view.py:319
+#: cms/views/pages/page_form_view.py:318
 msgid "Page \"{}\" was successfully created"
 msgstr "Seite \"{}\" wurde erfolgreich erstellt"
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This would be my suggestion to fix the translation state calculation

### Proposed changes
<!-- Describe this PR in more detail. -->
- Don't allow the first version to be a minor edit (identical to before)
- When a page is published and a minor edit, also publish the past versions to make sure the status is calculated correctly (and the minor change is actually a minor change and not a transition from a draft page to a public page)

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1464
Fixes: #1622
