### PR TITLE
Bugfix #1579: Only use the first street number for latitude and longitude

### DIFF
--- a/integreat_cms/cms/forms/pois/poi_form.py
+++ b/integreat_cms/cms/forms/pois/poi_form.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from django import forms
 from django.conf import settings
@@ -63,7 +64,7 @@ class POIForm(CustomModelForm):
         if settings.NOMINATIM_API_ENABLED:
             nominatim_api_client = NominatimApiClient()
             latitude, longitude = nominatim_api_client.get_coordinates(
-                street=cleaned_data.get("address"),
+                street=re.search(r'\d+', cleaned_data.get("address")).group() + " " + re.sub(r'[0-9-]', '', cleaned_data.get("address")),
                 postalcode=cleaned_data.get("postcode"),
                 city=cleaned_data.get("city"),
             )


### PR DESCRIPTION
### Short description
Easiest fix would be to only use the first street number for latitude and longitude / API-Call to Nominatim.
### Resolved issues

Fixes: #1579
