### PR TITLE
Improve XLIFF export error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@ UNRELEASED
 ----------
 
 * [ [#1628](https://github.com/digitalfabrik/integreat-cms/issues/1628) ] Add Dutch UI language
+* [ [#1549](https://github.com/digitalfabrik/integreat-cms/issues/1549) ] Add multilingual XLIFF export
+* [ [#1636](https://github.com/digitalfabrik/integreat-cms/issues/1636) ] Improve XLIFF export error messages
 
 
 2022.8.0
@@ -15,7 +17,6 @@ UNRELEASED
 * [ [#1534](https://github.com/digitalfabrik/integreat-cms/issues/1534) ] Invalidate cache after moving nodes
 * [ [#1535](https://github.com/digitalfabrik/integreat-cms/issues/1535) ] Fix event api performance
 * [ [#1604](https://github.com/digitalfabrik/integreat-cms/issues/1604) ] Show no broken links from restored versions
-* [ [#1549](https://github.com/digitalfabrik/integreat-cms/issues/1549) ] Add multilingual XLIFF export
 
 
 2022.7.0

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-17 09:04+0000\n"
+"POT-Creation-Date: 2022-08-18 10:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -3604,7 +3604,7 @@ msgstr "Ein Serverfehler ist aufgetreten."
 #: cms/templates/analytics/_broken_links_widget.html:26
 #: cms/templates/chat/_chat_widget.html:30
 #: cms/templates/statistics/_statistics_widget.html:23
-#: cms/templates/statistics/statistics_overview.html:19 xliff/utils.py:253
+#: cms/templates/statistics/statistics_overview.html:19 xliff/utils.py:261
 msgid "Please contact the administrator."
 msgstr "Bitte kontaktieren Sie einen Administrator."
 
@@ -4955,7 +4955,7 @@ msgstr "Vorschau"
 msgid "Source Code"
 msgstr "Quellcode"
 
-#: cms/templates/pages/_page_xliff_import_diff.html:80 xliff/utils.py:501
+#: cms/templates/pages/_page_xliff_import_diff.html:80 xliff/utils.py:509
 msgid "No changes detected."
 msgstr "Keine Änderungen vorgenommen."
 
@@ -6768,15 +6768,15 @@ msgid ""
 "XLIFF file with published pages only for translation to {} successfully "
 "created."
 msgstr ""
-"XLIFF Datei nur mit veröffentlichten Seiten für die Übersetzung nach{} wurde "
-"erfolgreich erstellt."
+"XLIFF-Datei nur mit veröffentlichten Seiten für die Übersetzung nach {} "
+"wurde erfolgreich erstellt."
 
 #: cms/views/pages/page_bulk_actions.py:111
 msgid ""
 "XLIFF file with unpublished and published pages for translation to {} "
 "successfully created."
 msgstr ""
-"XLIFF Datei mit nicht veröffentlichten und veröffentlichten Seiten für die "
+"XLIFF-Datei mit nicht veröffentlichten und veröffentlichten Seiten für die "
 "Übersetzung nach {} wurde erfolgreich erstellt."
 
 #: cms/views/pages/page_bulk_actions.py:114
@@ -7158,52 +7158,56 @@ msgstr "{} \"{}\" wurde erfolgreich übersetzt"
 msgid "{} \"{}\" could not be automatically translated."
 msgstr "{} \"{}\" konnte nicht automatisch übersetzt werden."
 
-#: xliff/utils.py:159
+#: xliff/utils.py:164
 msgid ""
-"Page {} does not have a source translation in {} and therefore cannot be "
+"Page {} does not have a {}source translation in {} and therefore cannot be "
 "exported as XLIFF for translation to {}."
 msgstr ""
-"Die Seite {} hat keine Quell-Übersetzung auf {} und kann deshalb nicht als "
+"Die Seite {} hat keine {}Quell-Übersetzung auf {} und kann deshalb nicht als "
 "XLIFF für die Übersetzung nach {} exportiert werden."
 
-#: xliff/utils.py:181
+#: xliff/utils.py:168
+msgid "published"
+msgstr "veröffentliche"
+
+#: xliff/utils.py:189
 msgid "An unexpected error has occurred while exporting page {}."
 msgstr ""
 "Es ist ein unerwarteter Fehler beim Exportieren der Seite {} aufgetreten."
 
-#: xliff/utils.py:184 xliff/utils.py:271
+#: xliff/utils.py:192 xliff/utils.py:279
 msgid "Please try again or contact the administrator."
 msgstr ""
 "Bitte versuchen Sie es erneut oder kontaktieren Sie einen Administrator."
 
-#: xliff/utils.py:251
+#: xliff/utils.py:259
 msgid "The page referenced in XLIFF file \"{}\" could not be found."
 msgstr "Die Seite der XLIFF-Datei \"{}\" konnte nicht gefunden werden."
 
-#: xliff/utils.py:269
+#: xliff/utils.py:277
 msgid "An unexpected error has occurred while importing XLIFF file \"{}\"."
 msgstr ""
-"Es ist ein unerwarteter Fehler beim Importieren der XLIFF Datei \"{}\" "
+"Es ist ein unerwarteter Fehler beim Importieren der XLIFF-Datei \"{}\" "
 "aufgetreten."
 
-#: xliff/utils.py:380
+#: xliff/utils.py:388
 msgid "Page {} could not be imported successfully because of the errors: {}"
 msgstr "Die Seite {} konnte nicht importiert werden aufgrund der Fehler: {}"
 
-#: xliff/utils.py:397
+#: xliff/utils.py:405
 msgid "Page {} was imported without changes."
 msgstr "Seite {} wurde ohne Änderungen importiert."
 
-#: xliff/utils.py:417
+#: xliff/utils.py:425
 msgid "Page {} was imported successfully."
 msgstr "Seite {} wurde erfolgreich importiert."
 
-#: xliff/utils.py:450
+#: xliff/utils.py:458
 msgid "You don't have the permission to import this page."
 msgstr ""
 "Sie haben nicht die nötige Berechtigung, um diese Seite zu importieren."
 
-#: xliff/utils.py:459
+#: xliff/utils.py:467
 msgid "This page belongs to another region ({})."
 msgstr ""
 "Diese Seite konnte nicht importiert werden, da sie zu einer anderen Region "
@@ -7588,7 +7592,7 @@ msgstr ""
 #~ "Alle Seiten außer den oben aufgeführten wurden erfolgreich importiert."
 
 #~ msgid "All XLIFF files were imported successfully."
-#~ msgstr "Alle XLIFF Dateien wurden erfolgreich importiert."
+#~ msgstr "Alle XLIFF-Dateien wurden erfolgreich importiert."
 
 #~ msgid "None of the pages could be imported successfully."
 #~ msgstr "Keine der Seiten konnte erfolgreich importiert werden."

--- a/integreat_cms/xliff/utils.py
+++ b/integreat_cms/xliff/utils.py
@@ -72,6 +72,8 @@ def pages_to_xliff_file(request, pages, target_languages, only_public=False):
                 )
             except RuntimeError as e:
                 messages.error(request, e)
+            except RuntimeWarning as e:
+                messages.warning(request, e)
     # Check how many XLIFF files were created
     if len(xliff_paths) == 0:
         return None
@@ -127,7 +129,9 @@ def page_to_xliff(page, target_language, dir_name, only_public=False):
     :param only_public: Whether only public versions should be exported
     :type only_public: bool
 
-    :raises RuntimeError: If the selected page translation does not have a source translation
+    :raises RuntimeWarning: If the selected page translation does not have a source translation
+
+    :raises RuntimeError: When an unexpected error occurs during serialization
 
     :return: The path of the generated XLIFF file
     :rtype: str
@@ -150,16 +154,20 @@ def page_to_xliff(page, target_language, dir_name, only_public=False):
     if not source_translation:
         source_language = page.region.get_source_language(target_language.slug)
         logger.warning(
-            "Page translation %r does not have a source translation in %r and therefore cannot be exported to XLIFF.",
+            "Page translation %r does not have a %ssource translation in %r and therefore cannot be exported to XLIFF.",
             target_page_translation,
+            "published " if only_public else "",
             source_language,
         )
-        raise RuntimeError(
+        raise RuntimeWarning(
             _(
-                "Page {} does not have a source translation in {} and "
+                "Page {} does not have a {}source translation in {} and "
                 "therefore cannot be exported as XLIFF for translation to {}."
             ).format(
-                target_page_translation.readable_title, source_language, target_language
+                target_page_translation.readable_title,
+                _("published") + " " if only_public else "",
+                source_language,
+                target_language,
             )
         )
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Improve XLIFF export error messages

### Proposed changes
<!-- Describe this PR in more detail. -->
- Show warning instead of error when a page cannot be exported to XLIFF because of a missing source translation (see https://issues.tuerantuer.org/browse/KOMMUNE-385 for reference)
- Indicate whether only no public or no source translation at all exists

