### PR TITLE
Make UI languages configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 UNRELEASED
 ----------
 
+* [ [#1649](https://github.com/digitalfabrik/integreat-cms/issues/1649) ] Make UI languages configurable
+
 
 2022.8.1
 --------

--- a/example-configs/integreat-cms.ini
+++ b/example-configs/integreat-cms.ini
@@ -18,6 +18,13 @@ COMPANY = Tür an Tür – Digitalfabrik gGmbH
 COMPANY_URL = https://tuerantuer.de/digitalfabrik/
 # The branding of the CMS [optional, defaults to "integreat", must be one of ["integreat", "malte", "aschaffenburg"]]
 BRANDING = integreat
+# The list of languages which are available in the UI [optional, defaults to "de" and "en"]
+LANGUAGES =
+	de
+	en
+	nl
+# The default UI language [optional, defaults to "de"]
+LANGUAGE_CODE = de
 
 [secrets]
 # The secret key for this installation [required]

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -604,12 +604,30 @@ EMAIL_USE_SSL = bool(strtobool(os.environ.get("INTEGREAT_CMS_EMAIL_USE_SSL", "Fa
 # INTERNATIONALIZATION #
 ########################
 
-#: A list of all available languages (see :setting:`django:LANGUAGES` and :doc:`django:topics/i18n/index`)
-LANGUAGES = (
-    ("de", _("German")),
-    ("en", _("English")),
-    ("nl", _("Dutch")),
-)
+#: A list of all available languages with locale files for translated strings
+AVAILABLE_LANGUAGES = {
+    "de": _("German"),
+    "en": _("English"),
+    "nl": _("Dutch"),
+}
+
+#: The default UI languages
+DEFAULT_LANGUAGES = ["de", "en"]
+
+#: The list of languages which are available in the UI
+#: (see :setting:`django:LANGUAGES` and :doc:`django:topics/i18n/index`)
+LANGUAGES = [
+    (language, AVAILABLE_LANGUAGES[language])
+    for language in filter(
+        None,
+        (
+            language.strip()
+            for language in os.environ.get(
+                "INTEGREAT_CMS_LANGUAGES", "\n".join(DEFAULT_LANGUAGES)
+            ).splitlines()
+        ),
+    )
+]
 
 #: A list of directories where Django looks for translation files
 #: (see :setting:`django:LOCALE_PATHS` and :doc:`django:topics/i18n/index`)
@@ -617,7 +635,7 @@ LOCALE_PATHS = (os.path.join(BASE_DIR, "locale"),)
 
 #: A string representing the language slug for this installation
 #: (see :setting:`django:LANGUAGE_CODE` and :doc:`django:topics/i18n/index`)
-LANGUAGE_CODE = "de"
+LANGUAGE_CODE = os.environ.get("INTEGREAT_CMS_LANGUAGE_CODE", "de")
 
 #: A string representing the time zone for this installation
 #: (see :setting:`django:TIME_ZONE` and :doc:`django:topics/i18n/index`)


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Make UI languages configurable

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add new settings `LANGUAGES` and `LANGUAGE_CODE` to the config file
- make `de` and `en` the default languages and `nl` optional

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1649
