### PR TITLE
Change statistics Matomo API requests, fixes #1635

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 UNRELEASED
 ----------
 
+* [ [#1635](https://github.com/digitalfabrik/integreat-cms/issues/1635) ] Show Matomo actions in statistics instead of visitors
+
 
 2022.8.2
 --------

--- a/integreat_cms/cms/utils/matomo_api_manager.py
+++ b/integreat_cms/cms/utils/matomo_api_manager.py
@@ -190,7 +190,7 @@ class MatomoApiManager:
         query_params = {
             "date": f"{start_date},{end_date}",
             "idSite": self.matomo_id,
-            "method": "VisitsSummary.getVisits",
+            "method": "VisitsSummary.getActions",
             "period": period,
         }
 
@@ -298,7 +298,7 @@ class MatomoApiManager:
             "filter_limit": "-1",
             "format_metrics": "1",
             "idSite": self.matomo_id,
-            "method": "VisitsSummary.getVisits",
+            "method": "VisitsSummary.getActions",
             "period": period,
         }
         logger.debug(


### PR DESCRIPTION
### Short description
When retrieving the number of Integreat CMS API requests from Matomo, use the getActions instead of getVisitors API method. This should avoid the problem that Matomo sometimes attributes multiple actions to the same visitor by chance.

### Resolved issues
Fixes: #1635 
