### PR TITLE
Only validate event duration if dates are valid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ UNRELEASED
 
 * [ [#1635](https://github.com/digitalfabrik/integreat-cms/issues/1635) ] Show Matomo actions in statistics instead of visitors
 * [ [#1449](https://github.com/digitalfabrik/integreat-cms/issues/1449) ] Show diff to last source version in side-by-side view
+* [ [#1656](https://github.com/digitalfabrik/integreat-cms/issues/1656) ] Only validate event duration if dates are valid
 
 
 2022.8.2

--- a/integreat_cms/cms/forms/events/event_form.py
+++ b/integreat_cms/cms/forms/events/event_form.py
@@ -95,16 +95,6 @@ class EventForm(CustomModelForm):
         # make self.data mutable to allow values to be changed manually
         self.data = self.data.copy()
 
-        if cleaned_data["end_date"] - cleaned_data["start_date"] > timedelta(6):
-            self.add_error(
-                "end_date",
-                forms.ValidationError(
-                    _(
-                        "The maximum duration for events is 7 days. Consider using recurring events if the event is not continuous."
-                    ),
-                    code="invalid",
-                ),
-            )
         if cleaned_data.get("is_all_day"):
             cleaned_data["start_time"] = time.min
             self.data["start_time"] = time.min
@@ -160,6 +150,16 @@ class EventForm(CustomModelForm):
                                 code="invalid",
                             ),
                         )
+            elif cleaned_data["end_date"] - cleaned_data["start_date"] > timedelta(6):
+                self.add_error(
+                    "end_date",
+                    forms.ValidationError(
+                        _(
+                            "The maximum duration for events is 7 days. Consider using recurring events if the event is not continuous."
+                        ),
+                        code="invalid",
+                    ),
+                )
 
         logger.debug("EventForm validated [2] with cleaned data %r", cleaned_data)
         return cleaned_data

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-08-30 10:50+0000\n"
+"POT-Creation-Date: 2022-08-31 10:57+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1595,7 +1595,23 @@ msgstr ""
 "Entweder muss der Veranstaltungsort deaktiviert werden oder es muss ein "
 "gültiger Ort angegeben werden"
 
-#: cms/forms/events/event_form.py:103
+#: cms/forms/events/event_form.py:110
+msgid "If the event is not all-day, the start time is required"
+msgstr ""
+"Wenn die Veranstaltung nicht ganztägig ist, muss eine Start-Uhrzeit "
+"angegeben werden"
+
+#: cms/forms/events/event_form.py:118
+msgid "If the event is not all-day, the end time is required"
+msgstr ""
+"Wenn die Veranstaltung nicht ganztägig ist, muss eine End-Uhrzeit angegeben "
+"werden"
+
+#: cms/forms/events/event_form.py:134 cms/forms/events/event_form.py:148
+msgid "The end of the event can't be before the start of the event"
+msgstr "Das Ende der Veranstaltung kann nicht vor seinem Beginn sein"
+
+#: cms/forms/events/event_form.py:158
 msgid ""
 "The maximum duration for events is 7 days. Consider using recurring events "
 "if the event is not continuous."
@@ -1603,22 +1619,6 @@ msgstr ""
 "Die maximale Veranstaltungsdauer beträgt 7 Tage. Verwenden Sie "
 "wiederkehrende Veranstaltungen, wenn die Veranstaltung nicht kontinuierlich "
 "stattfindet."
-
-#: cms/forms/events/event_form.py:120
-msgid "If the event is not all-day, the start time is required"
-msgstr ""
-"Wenn die Veranstaltung nicht ganztägig ist, muss eine Start-Uhrzeit "
-"angegeben werden"
-
-#: cms/forms/events/event_form.py:128
-msgid "If the event is not all-day, the end time is required"
-msgstr ""
-"Wenn die Veranstaltung nicht ganztägig ist, muss eine End-Uhrzeit angegeben "
-"werden"
-
-#: cms/forms/events/event_form.py:144 cms/forms/events/event_form.py:158
-msgid "The end of the event can't be before the start of the event"
-msgstr "Das Ende der Veranstaltung kann nicht vor seinem Beginn sein"
 
 #: cms/forms/events/recurrence_rule_form.py:19
 msgid "Recurrence ends"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
If one of the dates are missing or invalid, the previous solution caused a `KeyError`

### Proposed changes
<!-- Describe this PR in more detail. -->

- Only validate the event duration if the dates itself are valid