### PR TITLE
Fix page order table for root pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ UNRELEASED
 ----------
 
 * [ [#1664](https://github.com/digitalfabrik/integreat-cms/issues/1664) ] Fix media library and content edit lock in sbs view
+* [ [#1660](https://github.com/digitalfabrik/integreat-cms/issues/1660) ] Fix moving pages to the root level from the page form
 
 
 2022.8.3

--- a/integreat_cms/cms/views/pages/page_actions.py
+++ b/integreat_cms/cms/views/pages/page_actions.py
@@ -771,20 +771,17 @@ def get_page_order_table_ajax(request, region_slug, parent_id=None, page_id=None
 
     region = request.region
 
-    if page_id:
-        page = get_object_or_404(region.pages, id=page_id)
-    else:
-        page = None
+    page = get_object_or_404(region.pages, id=page_id) if page_id else None
 
-    if parent_id or page:
-        parent = (
-            get_object_or_404(region.pages, id=parent_id) if parent_id else page.parent
-        )
-        siblings = parent.cached_children
+    if parent_id:
+        parent = get_object_or_404(region.pages, id=parent_id)
+        siblings = [
+            sibling
+            for sibling in parent.cached_children
+            if not sibling.explicitly_archived
+        ]
     else:
-        siblings = region.get_root_pages()
-
-    siblings = [sibling for sibling in siblings if not sibling.explicitly_archived]
+        siblings = region.get_root_pages().filter(explicitly_archived=False)
 
     logger.debug(
         "Page order table for page %r and siblings %r",

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-09-06 11:11+0000\n"
+"POT-Creation-Date: 2022-09-06 11:30+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -6762,7 +6762,7 @@ msgid "Success: The user \"{}\" cannot publish this page anymore."
 msgstr ""
 "Erfolg: Der Nutzer \"{}\" kann diese Seite nun nicht mehr veröffentlichen"
 
-#: cms/views/pages/page_actions.py:899
+#: cms/views/pages/page_actions.py:896
 msgid "Marked all translations of this page as up-to-date"
 msgstr "Alle Übersetzungen dieser Seite als aktuell markiert."
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
The page order table in the page form did not work correctly for root pages.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Fix page order table for root pages

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1660
