### PR TITLE
Log GET parameters of failed HTTP requests

### DIFF
--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -16,7 +16,7 @@ from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import ugettext_lazy as _
 
 from ..nominatim_api.utils import BoundingBox
-from .logging_formatter import ColorFormatter
+from .logging_formatter import ColorFormatter, RequestFormatter
 
 
 ###################
@@ -429,6 +429,7 @@ LOGGING = {
     "disable_existing_loggers": False,
     "formatters": {
         "console": {
+            "()": RequestFormatter,
             "format": "{asctime} \x1b[1m{levelname}\x1b[0m {name} - {message}",
             "datefmt": "%b %d %H:%M:%S",
             "style": "{",
@@ -440,6 +441,7 @@ LOGGING = {
             "style": "{",
         },
         "logfile": {
+            "()": RequestFormatter,
             "format": "{asctime} {levelname:7} {name} - {message}",
             "datefmt": "%b %d %H:%M:%S",
             "style": "{",

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-09-28 12:51+0000\n"
+"POT-Creation-Date: 2022-09-28 14:50+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -7357,15 +7357,15 @@ msgid "Superuser permissions need to be set by another superuser."
 msgstr ""
 "Administratorrechte müssen von einem anderen Administrator vergeben werden."
 
-#: core/settings.py:615
+#: core/settings.py:617
 msgid "German"
 msgstr "Deutsch"
 
-#: core/settings.py:616
+#: core/settings.py:618
 msgid "English"
 msgstr "Englisch"
 
-#: core/settings.py:617
+#: core/settings.py:619
 msgid "Dutch"
 msgstr "Niederländisch"
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Log GET parameters of failed HTTP requests

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add logging formatter to modify the log records of the `django.request` module


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
If we receive any kind of secrets/keys via GET-parameters, this would expose them to the log.
However, I don't think that we do this anywhere...


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1714


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
