### PR TITLE
Only disable region form if SUMM.AI disabled

### DIFF
--- a/integreat_cms/cms/forms/regions/region_form.py
+++ b/integreat_cms/cms/forms/regions/region_form.py
@@ -144,7 +144,10 @@ class RegionForm(CustomModelForm):
         # Do not require coordinates because they might be automatically filled
         self.fields["latitude"].required = False
         self.fields["longitude"].required = False
-        if not settings.SUMM_AI_ENABLED:
+        # Disable SUMM.AI option if locally and globally disabled
+        if not settings.SUMM_AI_ENABLED and not (
+            self.instance and self.instance.summ_ai_enabled
+        ):
             self.fields["summ_ai_enabled"].disabled = True
 
     def save(self, commit=True):

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-09-28 15:54+0000\n"
+"POT-Creation-Date: 2022-10-01 23:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -1862,17 +1862,17 @@ msgstr "Keine Inhalte übernehmen"
 msgid "Timezone area"
 msgstr "Region der Zeitzone"
 
-#: cms/forms/regions/region_form.py:199
+#: cms/forms/regions/region_form.py:202
 msgid "Statistics can only be enabled when a valid access token is supplied."
 msgstr ""
 "Statistiken können nur aktiviert werden, wenn ein gültiges Zugangstoken "
 "eingegeben wurde."
 
-#: cms/forms/regions/region_form.py:211
+#: cms/forms/regions/region_form.py:214
 msgid "The provided access token is invalid."
 msgstr "Das eingegebene Zugangstoken ist ungültig."
 
-#: cms/forms/regions/region_form.py:239 cms/forms/regions/region_form.py:249
+#: cms/forms/regions/region_form.py:242 cms/forms/regions/region_form.py:252
 msgid ""
 "Could not retrieve the coordinates automatically, please fill the field "
 "manually."
@@ -1880,23 +1880,23 @@ msgstr ""
 "Die Koordinaten konnten nicht automatisch abgerufen werden, bitte füllen Sie "
 "das Feld manuell aus."
 
-#: cms/forms/regions/region_form.py:322
+#: cms/forms/regions/region_form.py:325
 msgid "'{}' is already selected as administrative division."
 msgstr "'{}' ist bereits als Verwaltungseinheit ausgewählt."
 
-#: cms/forms/regions/region_form.py:327
+#: cms/forms/regions/region_form.py:330
 msgid "Please select '{}' as administrative division."
 msgstr "Bitte wählen Sie '{}' als Verwaltungseinheit."
 
-#: cms/forms/regions/region_form.py:338
+#: cms/forms/regions/region_form.py:341
 msgid "Please set {} as default language for this region."
 msgstr "Bitte setzen Sie '{}' als Standard-Sprache für diese Region."
 
-#: cms/forms/regions/region_form.py:344
+#: cms/forms/regions/region_form.py:347
 msgid "Please enable '{}'."
 msgstr "Bitte aktivieren Sie '{}'."
 
-#: cms/forms/regions/region_form.py:359
+#: cms/forms/regions/region_form.py:362
 msgid ""
 "You cannot include the administrative division into the name and use a "
 "custom prefix at the same time."
@@ -1904,11 +1904,11 @@ msgstr ""
 "Sie können nicht gleichzeitig die Verwaltungseinheit dem Namen hinzufügen "
 "und ein benutzerdefiniertes Präfix verwenden."
 
-#: cms/forms/regions/region_form.py:377
+#: cms/forms/regions/region_form.py:380
 msgid "Enter a valid JSON."
 msgstr "Bitte ein gültiges JSON-Objekt eingeben."
 
-#: cms/forms/regions/region_form.py:390
+#: cms/forms/regions/region_form.py:393
 #: cms/templates/regions/region_form.html:192
 msgid "Currently SUMM.AI is globally deactivated"
 msgstr "Derzeit ist SUMM.AI global deaktiviert"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Prevent a locked form if SUMM.AI is globally disabled but locally enabled

### Proposed changes
<!-- Describe this PR in more detail. -->

Only disable region form if SUMM.AI disabled

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
Now, the warning is no longer shown when the "invalid" form is opened (the error only appears when the invalid form is submitted)


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1725


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
