### PR TITLE
Increase timeout for SUMM.AI to 10 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 UNRELEASED
 ----------
 
+* [ [#1734](https://github.com/digitalfabrik/integreat-cms/issues/1734) ] Increase timeout for SUMM.AI API client
+
 
 2022.9.5
 --------

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -699,6 +699,9 @@ SUMM_AI_TEST_MODE = strtobool(
     os.environ.get("INTEGREAT_CMS_SUMM_AI_TEST_MODE", str(DEBUG))
 )
 
+#: The timeout in minutes for requests to the SUMM.AI API
+SUMM_AI_TIMEOUT = 10
+
 #: The language slugs for German
 SUMM_AI_GERMAN_LANGUAGE_SLUG = os.environ.get(
     "INTEGREAT_CMS_SUMM_AI_GERMAN_LANGUAGE_SLUG", "de"

--- a/integreat_cms/summ_ai_api/summ_ai_api_client.py
+++ b/integreat_cms/summ_ai_api/summ_ai_api_client.py
@@ -122,7 +122,9 @@ class SummAiApiClient:
         :returns: The list of completed text fields
         :rtype: list [ ~integreat_cms.summ_ai_api.utils.TextField ]
         """
-        async with aiohttp.ClientSession() as session:
+        # Set a custom SUMM.AI timeout
+        timeout = aiohttp.ClientTimeout(total=60 * settings.SUMM_AI_TIMEOUT)
+        async with aiohttp.ClientSession(timeout=timeout) as session:
             # Create tasks for each text field
             tasks = [
                 loop.create_task(self.translate_text_field(session, text_field))


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Increase timeout for SUMM.AI to 10 minutes (the default timeout of aiohttp was 5 minutes).

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
