### PR TITLE
Auto-complete address and coordinates of locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ UNRELEASED
 * [ [#1742](https://github.com/digitalfabrik/integreat-cms/issues/1742) ] Add last modified date to media sidebar
 * [ [#1703](https://github.com/digitalfabrik/integreat-cms/issues/1703) ] Remove pending account activation warning when user form is submitted with errors
 * [ [#1684](https://github.com/digitalfabrik/integreat-cms/issues/1684) ] Set filesize limit for uploads to 3MB
+* [ [#1000](https://github.com/digitalfabrik/integreat-cms/issues/1000) ] Auto-complete address and coordinates of locations
 
 
 2022.10.0

--- a/integreat_cms/cms/templates/pois/poi_form.html
+++ b/integreat_cms/cms/templates/pois/poi_form.html
@@ -140,6 +140,7 @@
                     <div class="flex flex-col flex-auto px-4 pb-4 divide-y divide-gray-200 space-y-2">
                         <div>
                             <label>{% trans 'Address' %}</label>
+                            <div id="nominatim-error" class="bg-red-100 border-l-4 border-red-500 text-red-500 px-4 py-3 my-2 hidden" role="alert"></div>
                             <label for="{{ poi_form.address.id_for_label }}" class="secondary">{{ poi_form.address.label }}</label>
                             {% render_field poi_form.address|add_error_class:"border-red-500" %}
                             <label for="{{ poi_form.postcode.id_for_label }}" class="secondary">{{ poi_form.postcode.label }}</label>
@@ -156,9 +157,13 @@
                         </div>
                         <div>
                             <label>{% trans 'Position' %}</label>
-                            <div class="help-text">
-                                {% trans 'If you leave these fields blank, they are automatically derived from the address.' %}
+                            <div>
+                                <input type="checkbox" id="auto-fill-coordinates" data-url="{% url 'auto_complete_poi_address' %}" checked>
+                                <label for="auto-fill-coordinates" class="secondary !inline">
+                                    {% trans 'Derive coordinates automatically from address' %}
+                                </label>
                             </div>
+
                             <label for="{{ poi_form.latitude.id_for_label }}" class="secondary">{{ poi_form.latitude.label }}</label>
                             {% render_field poi_form.latitude|add_error_class:"border-red-500" %}
                             <div class="help-text">{{ poi_form.latitude.help_text }}</div>

--- a/integreat_cms/cms/urls/protected.py
+++ b/integreat_cms/cms/urls/protected.py
@@ -429,6 +429,11 @@ urlpatterns = [
             [
                 path("", include(media_ajax_urlpatterns)),
                 path(
+                    "locations/auto-complete-address/",
+                    pois.auto_complete_address,
+                    name="auto_complete_poi_address",
+                ),
+                path(
                     "chat/",
                     include(
                         [

--- a/integreat_cms/cms/views/pois/__init__.py
+++ b/integreat_cms/cms/views/pois/__init__.py
@@ -7,5 +7,6 @@ from .poi_actions import (
     archive_poi,
     restore_poi,
     delete_poi,
+    auto_complete_address,
 )
 from .poi_list_view import POIListView

--- a/integreat_cms/cms/views/pois/poi_actions.py
+++ b/integreat_cms/cms/views/pois/poi_actions.py
@@ -1,18 +1,23 @@
 """
 This module contains view actions for objects related to POIs.
 """
+import json
 import logging
 
+from django.conf import settings
 from django.contrib import messages
-from django.http import Http404
+from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import render, redirect
 from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
 
 from linkcheck.models import Link
 
+from ....api.decorators import json_response
 from ...decorators import permission_required
 from ...models import POI
+
+from ....nominatim_api.nominatim_api_client import NominatimApiClient
 
 logger = logging.getLogger(__name__)
 
@@ -170,3 +175,51 @@ def view_poi(request, poi_id, region_slug, language_slug):
         raise Http404
 
     return render(request, template_name, {"poi_translation": poi_translation})
+
+
+@json_response
+@require_POST
+@permission_required("cms.view_poi")
+def auto_complete_address(request):
+    """
+    Autocomplete location address and coordinates
+
+    :param request: The current request
+    :type request: ~django.http.HttpRequest
+
+    :raises ~django.http.Http404: If no location was found for the given address
+
+    :return: The address and coordinates of the location
+    :rtype: ~django.http.JsonResponse
+    """
+    data = json.loads(request.body.decode("utf-8"))
+
+    if not settings.NOMINATIM_API_ENABLED:
+        return HttpResponse(_("Location service is disabled"), status_code=503)
+
+    street_input = data.get("street")
+    postcode_input = data.get("postcode")
+    city_input = data.get("city")
+
+    nominatim_api_client = NominatimApiClient()
+
+    result = nominatim_api_client.search(
+        street=street_input,
+        postalcode=postcode_input,
+        city=city_input,
+        addressdetails=True,
+    )
+
+    if not result:
+        raise Http404(_("Address could not be found"))
+
+    address = result.raw.get("address", {})
+    return JsonResponse(
+        data={
+            "postcode": address.get("postcode"),
+            "city": address.get("city"),
+            "country": address.get("country"),
+            "longitude": result.longitude,
+            "latitude": result.latitude,
+        }
+    )

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-15 16:25+0000\n"
+"POT-Creation-Date: 2022-10-15 23:05+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -4182,7 +4182,7 @@ msgstr "Auf Google Maps öffnen"
 #: cms/templates/imprint/imprint_form.html:120
 #: cms/templates/pages/page_form.html:285 cms/templates/pages/page_sbs.html:87
 #: cms/templates/poicategories/poicategory_list.html:31
-#: cms/templates/pois/poi_form.html:233
+#: cms/templates/pois/poi_form.html:238
 #: cms/templates/regions/region_list.html:25
 #: cms/templates/settings/user_settings.html:93
 msgid "Actions"
@@ -5637,58 +5637,54 @@ msgstr "Neuen Ort erstellen"
 msgid "The name is currently displayed to users only in the default language"
 msgstr "Der Name wird Benutzern momentan nur in der Standardsprache angezeigt"
 
-#: cms/templates/pois/poi_form.html:137 cms/templates/pois/poi_form.html:158
+#: cms/templates/pois/poi_form.html:137 cms/templates/pois/poi_form.html:159
 msgid "Position"
 msgstr "Position"
 
-#: cms/templates/pois/poi_form.html:160
-msgid ""
-"If you leave these fields blank, they are automatically derived from the "
-"address."
-msgstr ""
-"Wenn Sie diese Felder leer lassen, werden sie automatisch aus der Adresse "
-"abgeleitet."
+#: cms/templates/pois/poi_form.html:163
+msgid "Derive coordinates automatically from address"
+msgstr "Koordinaten automatisch aus der Adresse ableiten"
 
-#: cms/templates/pois/poi_form.html:177
+#: cms/templates/pois/poi_form.html:182
 msgid "Contact details"
 msgstr "Kontaktdaten"
 
-#: cms/templates/pois/poi_form.html:240 cms/templates/pois/poi_form.html:242
+#: cms/templates/pois/poi_form.html:245 cms/templates/pois/poi_form.html:247
 #: cms/templates/pois/poi_list_archived_row.html:65
 msgid "Restore location"
 msgstr "Ort wiederherstellen"
 
-#: cms/templates/pois/poi_form.html:248
+#: cms/templates/pois/poi_form.html:253
 msgid "Restore this location"
 msgstr "Diesen Ort wiederherstellen"
 
-#: cms/templates/pois/poi_form.html:252 cms/templates/pois/poi_form.html:254
+#: cms/templates/pois/poi_form.html:257 cms/templates/pois/poi_form.html:259
 #: cms/templates/pois/poi_list_row.html:112
 msgid "Archive location"
 msgstr "Ort archivieren"
 
-#: cms/templates/pois/poi_form.html:260
+#: cms/templates/pois/poi_form.html:265
 msgid "Archive this location"
 msgstr "Diesen Ort archivieren"
 
-#: cms/templates/pois/poi_form.html:267 cms/templates/pois/poi_form.html:289
+#: cms/templates/pois/poi_form.html:272 cms/templates/pois/poi_form.html:294
 #: cms/templates/pois/poi_list_archived_row.html:78
 #: cms/templates/pois/poi_list_row.html:125
 msgid "Delete location"
 msgstr "Ort löschen"
 
-#: cms/templates/pois/poi_form.html:273
+#: cms/templates/pois/poi_form.html:278
 msgid "You cannot delete a location which is referenced by an event."
 msgstr ""
 "Der Ort kann nicht gelöscht werden, da er von einem Event verwendet wird."
 
-#: cms/templates/pois/poi_form.html:275
+#: cms/templates/pois/poi_form.html:280
 msgid "To delete this location, you have to delete this event first:"
 msgid_plural "To delete this location, you have to delete these events first:"
 msgstr[0] "Löschen Sie zuerst diese Veranstaltung, um den Ort zu löschen:"
 msgstr[1] "Löschen Sie zuerst diese Veranstaltungen, um den Ort zu löschen:"
 
-#: cms/templates/pois/poi_form.html:295
+#: cms/templates/pois/poi_form.html:300
 msgid "Delete this location"
 msgstr "Diesen Ort löschen"
 
@@ -7234,17 +7230,25 @@ msgstr ""
 msgid "This XLIFF import is no longer available."
 msgstr "Dieser XLIFF Import ist nicht länger verfügbar."
 
-#: cms/views/pois/poi_actions.py:50
+#: cms/views/pois/poi_actions.py:55
 msgid "Location was successfully archived"
 msgstr "Ort wurde erfolgreich archiviert"
 
-#: cms/views/pois/poi_actions.py:93
+#: cms/views/pois/poi_actions.py:98
 msgid "Location was successfully restored"
 msgstr "Ort wurde erfolgreich wiederhergestellt"
 
-#: cms/views/pois/poi_actions.py:129
+#: cms/views/pois/poi_actions.py:134
 msgid "Location was successfully deleted"
 msgstr "Ort wurde erfolgreich gelöscht"
+
+#: cms/views/pois/poi_actions.py:198
+msgid "Location service is disabled"
+msgstr "Ortung ist deaktiviert"
+
+#: cms/views/pois/poi_actions.py:214
+msgid "Address could not be found"
+msgstr "Adresse konnte nicht gefunden werden"
 
 #: cms/views/pois/poi_context_mixin.py:32
 msgid "Please confirm that you really want to archive this location"
@@ -7566,6 +7570,16 @@ msgid "This page belongs to another region ({})."
 msgstr ""
 "Diese Seite konnte nicht importiert werden, da sie zu einer anderen Region "
 "gehört ({})."
+
+#~ msgid "No coordinates found for this address"
+#~ msgstr "Keine Koordinaten für diese Adresse gefunden"
+
+#~ msgid ""
+#~ "If you leave these fields blank, they are automatically derived from the "
+#~ "address."
+#~ msgstr ""
+#~ "Wenn Sie diese Felder leer lassen, werden sie automatisch aus der Adresse "
+#~ "abgeleitet."
 
 #~ msgid "No POI categories found with these filters."
 #~ msgstr "Keine POI kategorie mit diesen Filtern gefunden."

--- a/integreat_cms/nominatim_api/nominatim_api_client.py
+++ b/integreat_cms/nominatim_api/nominatim_api_client.py
@@ -42,7 +42,9 @@ class NominatimApiClient:
             logger.exception(e)
             logger.error("Nominatim API client could not be initialized")
 
-    def search(self, query_str=None, exactly_one=True, **query_dict):
+    def search(
+        self, query_str=None, exactly_one=True, addressdetails=False, **query_dict
+    ):
         r"""
         Search for a given query, either by string or by dict.
         ``query_str`` and ``query_dict`` are mutually exclusive.
@@ -54,6 +56,9 @@ class NominatimApiClient:
 
         :param exactly_one: Whether only one result should be returned
         :type exactly_one: bool
+
+        :param addressdetails: Whether address details should be returned
+        :type addressdetails: bool
 
         :param \**query_dict: The query as dictionary
         :type \**query_dict: dict
@@ -70,6 +75,7 @@ class NominatimApiClient:
             result = self.geolocator.geocode(
                 query,
                 exactly_one=exactly_one,
+                addressdetails=addressdetails,
             )
             if result:
                 logger.debug("Nominatim API search result: %r", result.raw)

--- a/integreat_cms/static/src/index.ts
+++ b/integreat_cms/static/src/index.ts
@@ -74,6 +74,8 @@ import "./js/tutorial-overlay.ts";
 
 import "./js/unsaved-warning";
 
+import "./js/pois/poi-actions.ts"
+
 window.addEventListener('DOMContentLoaded', () => {
   create_icons_at(document.documentElement);
   const event = new Event("icon-load");

--- a/integreat_cms/static/src/js/pois/poi-actions.ts
+++ b/integreat_cms/static/src/js/pois/poi-actions.ts
@@ -1,0 +1,95 @@
+import { getCsrfToken } from "../utils/csrf-token";
+
+window.addEventListener("load", () => {
+  document.getElementById("id_address")?.addEventListener("focusout", autoCompleteAddress);
+  document.getElementById("id_postcode")?.addEventListener("focusout", autoCompleteAddress);
+  document.getElementById("id_city")?.addEventListener("focusout", autoCompleteAddress);
+
+  let longitude = document.getElementById("id_longitude") as HTMLInputElement;
+  let latitude = document.getElementById("id_latitude") as HTMLInputElement;
+
+  document.getElementById("auto-fill-coordinates")?.addEventListener("input", ({ target }) => {
+    if ((target as HTMLInputElement).checked) {
+      autoCompleteAddress();
+    } else {
+      // Reset to initial value
+      longitude.value = longitude.dataset.initial;
+      latitude.value = latitude.dataset.initial;
+    }
+  });
+
+  // Add possibility to reset coordinates to initial values
+  if (longitude?.value) {
+    // If the initial value was set, always restore this one
+    longitude.dataset.initial = longitude.value;
+  } else {
+    // Else, restore the last manual input
+    longitude?.addEventListener("focusout", () => {
+      longitude.dataset.initial = longitude.value;
+    });
+  }
+  if (latitude?.value) {
+    latitude.dataset.initial = latitude.value;
+  } else {
+    latitude?.addEventListener("focusout", () => {
+      latitude.dataset.initial = latitude.value;
+    });
+  }
+});
+
+async function autoCompleteAddress() {
+  let street = (document.getElementById("id_address") as HTMLInputElement).value;
+  let postcode = (document.getElementById("id_postcode") as HTMLInputElement).value;
+  let city = (document.getElementById("id_city") as HTMLInputElement).value;
+
+  // Only try auto filling if street and either postcode or city are given
+  if (street.trim().length == 0 || (postcode.trim().length == 0 && city.trim().length == 0)) {
+    return;
+  }
+
+  let autoFillCoordinates = document.getElementById("auto-fill-coordinates") as HTMLInputElement;
+  let error = document.getElementById("nominatim-error");
+  error.classList.add("hidden");
+
+  const response = await fetch(autoFillCoordinates.dataset.url, {
+    method: "POST",
+    headers: {
+      "X-CSRFToken": getCsrfToken(),
+    },
+    body: JSON.stringify({
+      street: street,
+      postcode: postcode,
+      city: city,
+    }),
+  });
+
+  const data = await response.json();
+
+  if (response.status != 200) {
+    error.textContent = data.error;
+    error.classList.remove("hidden");
+    return;
+  }
+
+  updateField("postcode", data.postcode);
+  updateField("city", data.city);
+  updateField("country", data.country);
+
+  if (autoFillCoordinates.checked) {
+    updateField("longitude", data.longitude);
+    updateField("latitude", data.latitude);
+  }
+}
+
+function updateField(fieldName: string, value: string) {
+  let field = document.getElementById(`id_${fieldName}`) as HTMLInputElement;
+  // Only fill value if it was changed
+  if (field.value != value) {
+    field.value = value;
+    field.classList.add("!border-green-500");
+    // Reset green border after 5 seconds
+    setTimeout(() => {
+      field.classList.remove("!border-green-500");
+    }, 5000);
+  }
+}


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Currently coordinates of a POI appears (if left blank) first after the POI is saved.
This PR auto fills coordinates live while editing when the address of POI is completed.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add event listeners in the address fields.
- Coordinates will be searched live while an user is filling the address fields.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- So far not known


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Part of: #1000


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
