### PR TITLE
Removed excessive message print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ UNRELEASED
 
 * [ [#951](https://github.com/digitalfabrik/integreat-cms/issues/951) ] Add possibility to create categories for POIs
 * [ [#1742](https://github.com/digitalfabrik/integreat-cms/issues/1742) ] Add last modified date to media sidebar
+* [ [#1703](https://github.com/digitalfabrik/integreat-cms/issues/1703) ] Remove pending account activation warning when user form is submitted with errors
 
 
 2022.10.0

--- a/integreat_cms/cms/views/users/region_user_form_view.py
+++ b/integreat_cms/cms/views/users/region_user_form_view.py
@@ -126,9 +126,6 @@ class RegionUserFormView(TemplateView):
                 user_id=region_user_form.instance.id,
             )
 
-        if not region_user_form.instance.is_active:
-            messages.info(request, _("Pending account activation"))
-
         return render(
             request,
             self.template_name,

--- a/integreat_cms/cms/views/users/user_form_view.py
+++ b/integreat_cms/cms/views/users/user_form_view.py
@@ -133,9 +133,6 @@ class UserFormView(TemplateView):
                 user_id=user_form.instance.id,
             )
 
-        if not user_form.instance.is_active:
-            messages.info(request, _("Pending account activation"))
-
         return render(
             request,
             self.template_name,

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -7435,8 +7435,7 @@ msgid "User {} was successfully removed from this region."
 msgstr "Benutzer {} wurde erfolgreich von dieser Region entfernt."
 
 #: cms/views/users/region_user_form_view.py:53
-#: cms/views/users/region_user_form_view.py:130
-#: cms/views/users/user_form_view.py:51 cms/views/users/user_form_view.py:137
+#: cms/views/users/user_form_view.py:51
 msgid "Pending account activation"
 msgstr "Aktivierung des Benutzerkontos noch ausstehend"
 


### PR DESCRIPTION
### Short description
Bug summary: when creating a user whose name already exists, the system displays the message "Pending account activation", which is incorrect.

### Proposed changes
Removed excessive message print 

### Side effects
Didn't find any.

### Resolved issues
Fixes: #1703

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
