### PR TITLE
Only check availability of external APIs once

### DIFF
--- a/integreat_cms/cms/apps.py
+++ b/integreat_cms/cms/apps.py
@@ -1,4 +1,6 @@
 import logging
+import os
+import sys
 
 from django.apps import AppConfig
 from django.contrib.auth.signals import (
@@ -21,12 +23,25 @@ class CmsConfig(AppConfig):
     :type name: str
     """
 
+    #: The name of this app config
     name = "integreat_cms.cms"
+
+    #: Whether the availability of external APIs should be checked
+    test_external_apis = False
 
     # pylint: disable=unused-import,import-outside-toplevel
     def ready(self):
         # Implicitly connect a signal handlers decorated with @receiver.
         from .signals import feedback_signals
+
+        # Determine whether the availability of external APIs should be checked
+        self.test_external_apis = (
+            # Either the dev server is started with the "runserver" command,
+            # but it's not the main process (to ignore autoreloads)
+            ("runserver" in sys.argv and "RUN_MAIN" not in os.environ)
+            # or the prod server is started via wsgi
+            or "APACHE_PID_FILE" in os.environ
+        )
 
 
 authlog = logging.getLogger("auth")

--- a/integreat_cms/deepl_api/apps.py
+++ b/integreat_cms/deepl_api/apps.py
@@ -1,13 +1,11 @@
 """
 Configuration of DeepL API app
 """
-import os
-import sys
 import logging
 
 from deepl.exceptions import DeepLException
 
-from django.apps import AppConfig
+from django.apps import apps, AppConfig
 from django.conf import settings
 
 from .utils import DeepLApi
@@ -29,7 +27,7 @@ class DeepLApiConfig(AppConfig):
         Checking if API is available
         """
         # Only check availability if running a server
-        if "runserver" in sys.argv or "APACHE_PID_FILE" in os.environ:
+        if apps.get_app_config("cms").test_external_apis:
             if settings.DEEPL_ENABLED:
                 try:
                     deepl = DeepLApi()
@@ -56,7 +54,7 @@ class DeepLApiConfig(AppConfig):
                         "DeepL API is available at: %r", deepl.translator._server_url
                     )
                 except (DeepLException, AssertionError) as e:
-                    logger.exception(e)
+                    logger.error(e)
                     logger.error(
                         "DeepL API is unavailable. You won't be able to "
                         "automatically translate events and locations."

--- a/integreat_cms/gvz_api/apps.py
+++ b/integreat_cms/gvz_api/apps.py
@@ -1,12 +1,11 @@
 """
 Configuration of GVZ API app
 """
-import os
-import sys
 import logging
 import json
 import requests
-from django.apps import AppConfig
+
+from django.apps import apps, AppConfig
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
@@ -25,7 +24,7 @@ class GvzApiConfig(AppConfig):
         Checking if API is available
         """
         # Only check availability if running a server
-        if "runserver" in sys.argv or "APACHE_PID_FILE" in os.environ:
+        if apps.get_app_config("cms").test_external_apis:
             if settings.GVZ_API_ENABLED:
                 try:
                     response = requests.get(f"{settings.GVZ_API_URL}/api/", timeout=3)
@@ -39,7 +38,7 @@ class GvzApiConfig(AppConfig):
                     requests.exceptions.Timeout,
                     AssertionError,
                 ) as e:
-                    logger.exception(e)
+                    logger.error(e)
                     logger.error(
                         "GVZ API is unavailable. You won't be able to "
                         "automatically import region coordinates and aliases."

--- a/integreat_cms/nominatim_api/apps.py
+++ b/integreat_cms/nominatim_api/apps.py
@@ -1,11 +1,9 @@
 """
 Configuration of Nominatim API app
 """
-import os
-import sys
 import logging
 
-from django.apps import AppConfig
+from django.apps import apps, AppConfig
 from django.conf import settings
 
 from .nominatim_api_client import NominatimApiClient
@@ -25,7 +23,7 @@ class NominatimApiConfig(AppConfig):
         Checking if API is available
         """
         # Only check availability if running a server
-        if "runserver" in sys.argv or "APACHE_PID_FILE" in os.environ:
+        if apps.get_app_config("cms").test_external_apis:
             # If Nominatim API is enabled, check availability
             if settings.NOMINATIM_API_ENABLED:
                 NominatimApiClient().check_availability()

--- a/integreat_cms/nominatim_api/nominatim_api_client.py
+++ b/integreat_cms/nominatim_api/nominatim_api_client.py
@@ -77,7 +77,7 @@ class NominatimApiClient:
                 logger.debug("Nominatim API did not return a match")
             return result
         except GeopyError as e:
-            logger.exception(e)
+            logger.error(e)
             logger.error("Nominatim API call failed")
             return None
 
@@ -91,8 +91,7 @@ class NominatimApiClient:
                 "Nominatim API is available at: %r",
                 settings.NOMINATIM_API_URL,
             )
-        except (GeopyError, AssertionError) as e:
-            logger.exception(e)
+        except AssertionError:
             logger.error(
                 "Nominatim API unavailable. You won't be able to "
                 "automatically import location coordinates."

--- a/integreat_cms/summ_ai_api/apps.py
+++ b/integreat_cms/summ_ai_api/apps.py
@@ -2,11 +2,9 @@
 Configuration of SUMM.AI API app
 """
 import logging
-import os
-import sys
 
 from django.conf import settings
-from django.apps import AppConfig
+from django.apps import apps, AppConfig
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +21,7 @@ class SummAiApiConfig(AppConfig):
         Inform about the SUMM.AI configuration
         """
         # Only check if running a server
-        if "runserver" in sys.argv or "APACHE_PID_FILE" in os.environ:
+        if apps.get_app_config("cms").test_external_apis:
             if not settings.SUMM_AI_ENABLED:
                 logger.info("SUMM.AI API is disabled")
             elif settings.SUMM_AI_TEST_MODE:


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
I was bothered by the verbosity of each server reload after a change to a Python file, so I removed the API availability checks in those cases. Especially when working on the road, this is a bit annoying.
I think it is enough to check the availability once after the first start of the server.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Disable the re-check on every autoreload of the dev server
- Decrease verbosity of availability check exceptions

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
