### PR TITLE
Fix docstring type of the request object

### DIFF
--- a/integreat_cms/cms/views/authentication/mfa/mfa_assert_view.py
+++ b/integreat_cms/cms/views/authentication/mfa/mfa_assert_view.py
@@ -27,7 +27,7 @@ class MfaAssertView(View):
         """
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :return: The mfa challenge as JSON
         :rtype: ~django.http.JsonResponse

--- a/integreat_cms/cms/views/authentication/mfa/mfa_verify_view.py
+++ b/integreat_cms/cms/views/authentication/mfa/mfa_verify_view.py
@@ -24,7 +24,7 @@ class MfaVerifyView(View):
         """
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :return: The mfa challenge as JSON
         :rtype: ~django.http.JsonResponse

--- a/integreat_cms/cms/views/bulk_action_views.py
+++ b/integreat_cms/cms/views/bulk_action_views.py
@@ -112,7 +112,7 @@ class BulkAutoTranslateView(BulkActionView):
         Translate multiple objects automatically
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list
@@ -158,7 +158,7 @@ class BulkActionEasyGermanView(BulkActionView):
         Translate multiple objects automatically to Easy German
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list
@@ -221,7 +221,7 @@ class BulkUpdateBooleanFieldView(BulkActionView):
         Update the fields of the selected objects and redirect
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list

--- a/integreat_cms/cms/views/imprint/imprint_actions.py
+++ b/integreat_cms/cms/views/imprint/imprint_actions.py
@@ -24,7 +24,7 @@ def delete_imprint(request, region_slug):
     Delete imprint object
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
 
     :param region_slug: The slug of the current region
     :type region_slug: str
@@ -61,7 +61,7 @@ def expand_imprint_translation_id(request, imprint_translation_id):
     Searches for an imprint translation with corresponding ID and redirects browser to web app
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
 
     :param imprint_translation_id: The id of the requested imprint translation
     :type imprint_translation_id: int

--- a/integreat_cms/cms/views/imprint/imprint_form_view.py
+++ b/integreat_cms/cms/views/imprint/imprint_form_view.py
@@ -40,7 +40,7 @@ class ImprintFormView(TemplateView, MediaContextMixin):
         Render :class:`~integreat_cms.cms.forms.imprint.imprint_translation_form.ImprintTranslationForm`
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list

--- a/integreat_cms/cms/views/imprint/imprint_revision_view.py
+++ b/integreat_cms/cms/views/imprint/imprint_revision_view.py
@@ -31,7 +31,7 @@ class ImprintRevisionView(TemplateView):
         Render imprint page revision slider
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list
@@ -107,7 +107,7 @@ class ImprintRevisionView(TemplateView):
         Restore a previous revision of an imprint page translation
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list

--- a/integreat_cms/cms/views/imprint/imprint_sbs_view.py
+++ b/integreat_cms/cms/views/imprint/imprint_sbs_view.py
@@ -35,7 +35,7 @@ class ImprintSideBySideView(TemplateView):
         Render :class:`~integreat_cms.cms.forms.imprint.imprint_translation_form.ImprintTranslationForm` on the side by side view
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list
@@ -126,7 +126,7 @@ class ImprintSideBySideView(TemplateView):
         :class:`~integreat_cms.cms.models.pages.imprint_page_translation.ImprintPageTranslation` object
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list

--- a/integreat_cms/cms/views/language_tree/language_tree_actions.py
+++ b/integreat_cms/cms/views/language_tree/language_tree_actions.py
@@ -28,7 +28,7 @@ def move_language_tree_node(request, region_slug, pk, target_id, target_position
     This action moves the given language tree node to the given position relative to the given target.
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
 
     :param region_slug: The slug of the region which language tree should be modified
     :type region_slug: str
@@ -88,7 +88,7 @@ def delete_language_tree_node(request, region_slug, pk):
     and all page translations for this language
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
 
     :param region_slug: The slug of the region which language node should be deleted
     :type region_slug: str

--- a/integreat_cms/cms/views/language_tree/language_tree_bulk_actions.py
+++ b/integreat_cms/cms/views/language_tree/language_tree_bulk_actions.py
@@ -47,7 +47,7 @@ class LanguageTreeBulkActionView(BulkUpdateBooleanFieldView):
         Execute bulk action for language tree node and flush the cache
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list

--- a/integreat_cms/cms/views/linkcheck/linkcheck_stats_view.py
+++ b/integreat_cms/cms/views/linkcheck/linkcheck_stats_view.py
@@ -19,7 +19,7 @@ class LinkcheckStatsView(View):
         Retrieve the stats about valid/invalid/unchecked/ignored links
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list

--- a/integreat_cms/cms/views/pages/page_actions.py
+++ b/integreat_cms/cms/views/pages/page_actions.py
@@ -35,7 +35,7 @@ def archive_page(request, page_id, region_slug, language_slug):
     Archive page object
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
 
     :param page_id: The id of the page which should be archived
     :type page_id: int
@@ -85,7 +85,7 @@ def restore_page(request, page_id, region_slug, language_slug):
     Restore page object (set ``archived=False``)
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
 
     :param page_id: The id of the page which should be restored
     :type page_id: int
@@ -160,7 +160,7 @@ def preview_page_ajax(request, page_id, region_slug, language_slug):
     Preview page object
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
 
     :param page_id: The id of the page which should be viewed
     :type page_id: int
@@ -208,7 +208,7 @@ def get_page_content_ajax(request, region_slug, language_slug, page_id):
     Get content of a page translation based on language slug
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
 
     :param region_slug: The slug of the current region
     :type region_slug: str
@@ -240,7 +240,7 @@ def delete_page(request, page_id, region_slug, language_slug):
     Delete page object
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
 
     :param page_id: The id of the page which should be deleted
     :type page_id: int
@@ -356,7 +356,7 @@ def upload_xliff(request, region_slug, language_slug):
     Upload and import an XLIFF file
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
 
     :param region_slug: The slug of the current region
     :type region_slug: str
@@ -461,7 +461,7 @@ def move_page(request, region_slug, language_slug, page_id, target_id, position)
     Move a page object in the page tree
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
 
     :param region_slug: The slug of the current region
     :type region_slug: str
@@ -527,7 +527,7 @@ def grant_page_permission_ajax(request, region_slug):
     Grant a user editing or publishing permissions on a specific page object
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
 
     :param region_slug: The slug of the current region
     :type region_slug: str
@@ -643,7 +643,7 @@ def revoke_page_permission_ajax(request, region_slug):
     Remove a page permission for a given user and page
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
 
     :param region_slug: The slug of the current region
     :type region_slug: str
@@ -754,7 +754,7 @@ def get_page_order_table_ajax(request, region_slug, parent_id=None, page_id=None
     This is used in the page form to change the order of a page relative to its siblings.
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
 
     :param region_slug: The slug of the current region
     :type region_slug: str
@@ -806,7 +806,7 @@ def render_mirrored_page_field(request, region_slug, language_slug):
     Retrieve the rendered mirrored page field template
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
 
     :param region_slug: The slug of the current region
     :type region_slug: str
@@ -851,7 +851,7 @@ def refresh_date(
     Refresh the date for all translations of a corresponding page
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
 
     :param page_id: The id of the page of the current page form
     :type page_id: int

--- a/integreat_cms/cms/views/pages/page_bulk_actions.py
+++ b/integreat_cms/cms/views/pages/page_bulk_actions.py
@@ -39,7 +39,7 @@ class GeneratePdfView(PageBulkActionMixin, BulkActionView):
         Apply the bulk action on every item in the queryset and redirect
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list
@@ -75,7 +75,7 @@ class ExportXliffView(PageBulkActionMixin, BulkActionView):
         The pages get extracted from request.GET attribute and the request is forwarded to :func:`~integreat_cms.xliff.utils.pages_to_xliff_file`
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list
@@ -137,7 +137,7 @@ class ExportMultiLanguageXliffView(PageBulkActionMixin, BulkActionView):
         The pages get extracted from request.GET attribute and the request is forwarded to :func:`~integreat_cms.xliff.utils.pages_to_xliff_file`
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list

--- a/integreat_cms/cms/views/pages/page_form_view.py
+++ b/integreat_cms/cms/views/pages/page_form_view.py
@@ -44,7 +44,7 @@ class PageFormView(
         Render :class:`~integreat_cms.cms.forms.pages.page_form.PageForm` and :class:`~integreat_cms.cms.forms.pages.page_translation_form.PageTranslationForm`
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list
@@ -231,7 +231,7 @@ class PageFormView(
         see :doc:`django:topics/http/file-uploads`
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list

--- a/integreat_cms/cms/views/pages/page_revision_view.py
+++ b/integreat_cms/cms/views/pages/page_revision_view.py
@@ -31,7 +31,7 @@ class PageRevisionView(PageContextMixin, TemplateView):
         Render page revision slider
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list
@@ -110,7 +110,7 @@ class PageRevisionView(PageContextMixin, TemplateView):
         Restore a previous revision of a page translation
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list

--- a/integreat_cms/cms/views/pages/page_sbs_view.py
+++ b/integreat_cms/cms/views/pages/page_sbs_view.py
@@ -36,7 +36,7 @@ class PageSideBySideView(
         Render :class:`~integreat_cms.cms.forms.pages.page_translation_form.PageTranslationForm` on the side by side view
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list
@@ -130,7 +130,7 @@ class PageSideBySideView(
         :class:`~integreat_cms.cms.models.pages.page_translation.PageTranslation` object
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list

--- a/integreat_cms/cms/views/pages/page_tree_view.py
+++ b/integreat_cms/cms/views/pages/page_tree_view.py
@@ -45,7 +45,7 @@ class PageTreeView(TemplateView, PageContextMixin, SummAiContextMixin):
         Render page tree
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list

--- a/integreat_cms/cms/views/pages/page_xliff_import_view.py
+++ b/integreat_cms/cms/views/pages/page_xliff_import_view.py
@@ -61,7 +61,7 @@ class PageXliffImportView(TemplateView, PageContextMixin):
         Redirect to page tree if XLIFF directory does not exist
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list
@@ -101,7 +101,7 @@ class PageXliffImportView(TemplateView, PageContextMixin):
         Confirm the xliff import
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list

--- a/integreat_cms/cms/views/pages/partial_page_tree_view.py
+++ b/integreat_cms/cms/views/pages/partial_page_tree_view.py
@@ -22,7 +22,7 @@ class PartialPageTreeView(TemplateView, PageContextMixin):
         Retrieve the rendered subtree of a given root page
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list

--- a/integreat_cms/cms/views/poi_categories/poi_category_form_view.py
+++ b/integreat_cms/cms/views/poi_categories/poi_category_form_view.py
@@ -107,7 +107,7 @@ class POICategoryMixin(
         Check whether the formset is valid and delegate to the respective function
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list
@@ -207,7 +207,7 @@ class POICategoryUpdateView(POICategoryMixin, UpdateView):
         object and save the formset
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list

--- a/integreat_cms/cms/views/pois/poi_actions.py
+++ b/integreat_cms/cms/views/pois/poi_actions.py
@@ -24,7 +24,7 @@ def archive_poi(request, poi_id, region_slug, language_slug):
     Archive POI object
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
 
     :param poi_id: The id of the POI which should be archived
     :type poi_id: int
@@ -65,7 +65,7 @@ def restore_poi(request, poi_id, region_slug, language_slug):
     Restore POI object (set ``archived=False``)
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
 
     :param poi_id: The id of the POI which should be restored
     :type poi_id: int
@@ -108,7 +108,7 @@ def delete_poi(request, poi_id, region_slug, language_slug):
     Delete POI object
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
 
     :param poi_id: The id of the POI which should be deleted
     :type poi_id: int
@@ -144,7 +144,7 @@ def view_poi(request, poi_id, region_slug, language_slug):
     View POI object
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
 
     :param poi_id: The id of the POI which should be viewed
     :type poi_id: int

--- a/integreat_cms/cms/views/pois/poi_form_view.py
+++ b/integreat_cms/cms/views/pois/poi_form_view.py
@@ -43,7 +43,7 @@ class POIFormView(
         Render :class:`~integreat_cms.cms.forms.pois.poi_form.POIForm` and :class:`~integreat_cms.cms.forms.pois.poi_translation_form.POITranslationForm`
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list
@@ -103,7 +103,7 @@ class POIFormView(
         :class:`~integreat_cms.cms.models.pois.poi_translation.POITranslation` objects
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list

--- a/integreat_cms/cms/views/pois/poi_list_view.py
+++ b/integreat_cms/cms/views/pois/poi_list_view.py
@@ -51,7 +51,7 @@ class POIListView(TemplateView, POIContextMixin, SummAiContextMixin):
         Render POI list
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list
@@ -138,7 +138,7 @@ class POIListView(TemplateView, POIContextMixin, SummAiContextMixin):
         Apply the query and filter the rendered pois
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
         :param \*args: The supplied arguments
         :type \*args: list
         :param \**kwargs: The supplied keyword arguments

--- a/integreat_cms/cms/views/push_notifications/push_notification_list_view.py
+++ b/integreat_cms/cms/views/push_notifications/push_notification_list_view.py
@@ -124,7 +124,7 @@ class PushNotificationListView(TemplateView):
         Apply the query and filter the rendered push notifications
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
         :param \*args: The supplied arguments
         :type \*args: list
         :param \**kwargs: The supplied keyword arguments

--- a/integreat_cms/cms/views/regions/region_actions.py
+++ b/integreat_cms/cms/views/regions/region_actions.py
@@ -24,7 +24,7 @@ def delete_region(request, *args, **kwargs):
     are manually removed.
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
 
     :param \*args: The supplied arguments
     :type \*args: list

--- a/integreat_cms/cms/views/regions/region_list_view.py
+++ b/integreat_cms/cms/views/regions/region_list_view.py
@@ -29,7 +29,7 @@ class RegionListView(TemplateView):
         Render region list
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list
@@ -70,7 +70,7 @@ class RegionListView(TemplateView):
         Apply the query and filter the rendered regions
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list

--- a/integreat_cms/cms/views/roles/role_form_view.py
+++ b/integreat_cms/cms/views/roles/role_form_view.py
@@ -30,7 +30,7 @@ class RoleFormView(TemplateView):
         Render :class:`~integreat_cms.cms.forms.roles.role_form.RoleForm`
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list
@@ -64,7 +64,7 @@ class RoleFormView(TemplateView):
         Submit :class:`~integreat_cms.cms.forms.roles.role_form.RoleForm` and save :class:`~django.contrib.auth.models.Group` object
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list

--- a/integreat_cms/cms/views/settings/mfa/delete_user_mfa_key_view.py
+++ b/integreat_cms/cms/views/settings/mfa/delete_user_mfa_key_view.py
@@ -28,7 +28,7 @@ class DeleteUserMfaKeyView(TemplateView):
         Render mfa-deletion view
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list
@@ -75,7 +75,7 @@ class DeleteUserMfaKeyView(TemplateView):
         Delete a multi-factor-authentication key
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \**kwargs: The supplied keyword arguments
         :type \**kwargs: dict

--- a/integreat_cms/cms/views/settings/mfa/get_mfa_challenge_view.py
+++ b/integreat_cms/cms/views/settings/mfa/get_mfa_challenge_view.py
@@ -27,7 +27,7 @@ class GetMfaChallengeView(View):
         Return MFA challenge
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list

--- a/integreat_cms/cms/views/settings/mfa/register_user_mfa_key_view.py
+++ b/integreat_cms/cms/views/settings/mfa/register_user_mfa_key_view.py
@@ -38,7 +38,7 @@ class RegisterUserMfaKeyView(CreateView):
         Called asynchronously by JavaScript.
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list

--- a/integreat_cms/cms/views/settings/user_settings_view.py
+++ b/integreat_cms/cms/views/settings/user_settings_view.py
@@ -27,7 +27,7 @@ class UserSettingsView(TemplateView):
         :class:`~integreat_cms.cms.forms.users.user_password_form.UserPasswordForm`
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list
@@ -61,7 +61,7 @@ class UserSettingsView(TemplateView):
         object
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list

--- a/integreat_cms/cms/views/statistics/statistics_view.py
+++ b/integreat_cms/cms/views/statistics/statistics_view.py
@@ -28,7 +28,7 @@ class AnalyticsView(TemplateView):
         Render statistics of access numbers tracked by Matomo
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list

--- a/integreat_cms/cms/views/users/region_user_actions.py
+++ b/integreat_cms/cms/views/users/region_user_actions.py
@@ -22,7 +22,7 @@ def delete_region_user(request, region_slug, user_id):
     This view deletes a region user
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
 
     :param region_slug: The slug of the current region
     :type region_slug: str
@@ -65,7 +65,7 @@ def resend_activation_link_region(request, region_slug, user_id):
     Resends an activation link to a region user
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
 
     :param region_slug: The slug of the current region
     :type region_slug: str

--- a/integreat_cms/cms/views/users/region_user_form_view.py
+++ b/integreat_cms/cms/views/users/region_user_form_view.py
@@ -30,7 +30,7 @@ class RegionUserFormView(TemplateView):
         Render :class:`~integreat_cms.cms.forms.users.user_form.UserForm` for region users
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list
@@ -68,7 +68,7 @@ class RegionUserFormView(TemplateView):
         object for region users
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list

--- a/integreat_cms/cms/views/users/region_user_list_view.py
+++ b/integreat_cms/cms/views/users/region_user_list_view.py
@@ -29,7 +29,7 @@ class RegionUserListView(TemplateView):
         Render region user list
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list
@@ -78,7 +78,7 @@ class RegionUserListView(TemplateView):
         Apply the query and filter the rendered users
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
         :param \*args: The supplied arguments
         :type \*args: list
         :param \**kwargs: The supplied keyword arguments

--- a/integreat_cms/cms/views/users/user_actions.py
+++ b/integreat_cms/cms/views/users/user_actions.py
@@ -21,7 +21,7 @@ def delete_user(request, user_id):
     This view deletes a user
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
 
     :param user_id: The id of the user which should be deleted
     :type user_id: int
@@ -46,7 +46,7 @@ def resend_activation_link(request, user_id):
     Resends an activation link to an user
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
 
     :param user_id: users id to send the activation link
     :type user_id: int

--- a/integreat_cms/cms/views/users/user_form_view.py
+++ b/integreat_cms/cms/views/users/user_form_view.py
@@ -31,7 +31,7 @@ class UserFormView(TemplateView):
         Render :class:`~integreat_cms.cms.forms.users.user_form.UserForm`
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list
@@ -65,7 +65,7 @@ class UserFormView(TemplateView):
         Submit :class:`~integreat_cms.cms.forms.users.user_form.UserForm` and save :class:`~integreat_cms.cms.models.users.user.User`
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list

--- a/integreat_cms/cms/views/users/user_list_view.py
+++ b/integreat_cms/cms/views/users/user_list_view.py
@@ -29,7 +29,7 @@ class UserListView(TemplateView):
         Render user list
 
         :param request: The current request
-        :type request: ~django.http.HttpResponse
+        :type request: ~django.http.HttpRequest
 
         :param \*args: The supplied arguments
         :type \*args: list

--- a/integreat_cms/cms/views/utils/content_edit_lock.py
+++ b/integreat_cms/cms/views/utils/content_edit_lock.py
@@ -18,7 +18,7 @@ def content_edit_lock_heartbeat(request, region_slug=None):
     who is editing some content.
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
 
     :param region_slug: The slug of the current region, unused
     :type region_slug: str
@@ -60,7 +60,7 @@ def content_edit_lock_release(request, region_slug=None):
     This function handles unlock requests
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
 
     :param region_slug: The slug of the current region, unused
     :type region_slug: str

--- a/integreat_cms/cms/views/utils/search_content_ajax.py
+++ b/integreat_cms/cms/views/utils/search_content_ajax.py
@@ -49,7 +49,7 @@ def search_content_ajax(request, region_slug=None, language_slug=None):
     higher than results which only match through their text content.
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
 
     :param region_slug: The slug of the current region
     :type region_slug: str

--- a/integreat_cms/cms/views/utils/slugify_ajax.py
+++ b/integreat_cms/cms/views/utils/slugify_ajax.py
@@ -13,7 +13,7 @@ def slugify_ajax(request, region_slug, language_slug, model_type):
     """checks the current user input for title and generates unique slug for permalink
 
     :param request: The current request
-    :type request: ~django.http.HttpResponse
+    :type request: ~django.http.HttpRequest
     :param region_slug: region identifier
     :type region_slug: str
     :param language_slug: language slug


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
There appears to be a copy-paste error of the `:type request:` field in docstrings in many files, where a wrong type is specified.


### Proposed changes
<!-- Describe this PR in more detail. -->
- Change all occurences of `:type request: ~django.http.HttpResponse` to `:type request: ~django.http.HttpRequest`.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
/


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->
/


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
