### PR TITLE
Add spacing to sidebar to improve view on small screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ UNRELEASED
 * [ [#1000](https://github.com/digitalfabrik/integreat-cms/issues/1000) ] Auto-complete address and coordinates of locations
 * [ [#1434](https://github.com/digitalfabrik/integreat-cms/issues/1434) ] Add display of HIX values to nudge users to write easier texts
 * [ [#1770](https://github.com/digitalfabrik/integreat-cms/issues/1770) ] Fix error in SUMM.AI translation if paragraph contains only special characters
+* [ [#1710](https://github.com/digitalfabrik/integreat-cms/issues/1710) ] Add spacing to sidebar to improve view on small screens
 
 
 2022.10.0

--- a/integreat_cms/cms/templates/_base.html
+++ b/integreat_cms/cms/templates/_base.html
@@ -96,7 +96,7 @@
                 <div class="h-full w-full bg-{{ BRANDING }}-logo-white hover:bg-{{ BRANDING }}-logo-hover bg-contain bg-center bg-no-repeat"></div>
             </a>
         </div>
-        <div id="menu" class="pb-2 overflow-y-auto {{ BRANDING }}-branding">
+        <div id="menu" class="pb-10 overflow-y-auto {{ BRANDING }}-branding">
             {% if request.region %}
                 <a href="{% url 'dashboard' region_slug=request.region.slug %}"
                    class="{% if current_menu_item == 'region_dashboard' %} active{% endif %}">

--- a/integreat_cms/static/src/css/style.scss
+++ b/integreat_cms/static/src/css/style.scss
@@ -52,7 +52,7 @@ header {
 
 nav#primary-navigation {
   #menu {
-    max-height: calc(100vh - 50px);
+    max-height: calc(100vh - 56px);
     a {
       @apply relative block p-3 pl-6;
     }


### PR DESCRIPTION
### Short description
I added spacing to the sidebar to improve the view on small screens. At the moment the last menu point ("Language Tree")  disappears behind the version number on small screens.


### Proposed changes

- I added 3rem padding-bottom to the sidebar hard coded in the scss file
- Initially I wanted to use the tailwind class "pb-12" since this equals to 3rem, but for me it didn't work. Neither Chrome nor Firefox registered this class. However p-12 worked, which is strange since if p-12 is working, also pb-12 should be working. [See more about this here](https://tailwindcss.com/docs/customizing-spacing#default-spacing-scale).
- Optionally I could also add a custom class for "pb-12" equaling to 3rem to the tailwind config file, but I'm not sure if we're going to use that class ever again


### Side effects

- Couldn't find any in Chrome or Firefox


### Resolved issues

Fixes: #1710 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
