### PR TITLE
Fix broken inline icons in PDF exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ UNRELEASED
 ----------
 
 * [ [#1759](https://github.com/digitalfabrik/integreat-cms/issues/1759) ] Add line break between images in PDF exports
+* [ [#1537](https://github.com/digitalfabrik/integreat-cms/issues/1537) ] Fix broken inline icons in PDF exports
 * [ [#951](https://github.com/digitalfabrik/integreat-cms/issues/951) ] Add possibility to create categories for POIs
 * [ [#1742](https://github.com/digitalfabrik/integreat-cms/issues/1742) ] Add last modified date to media sidebar
 * [ [#1703](https://github.com/digitalfabrik/integreat-cms/issues/1703) ] Remove pending account activation warning when user form is submitted with errors

--- a/integreat_cms/cms/utils/pdf_utils.py
+++ b/integreat_cms/cms/utils/pdf_utils.py
@@ -15,8 +15,8 @@ from django.template.loader import get_template
 from django.utils.text import capfirst
 from django.utils.translation import ugettext as _
 from django.views.decorators.cache import never_cache
-
 from xhtml2pdf import pisa
+from xhtml2pdf.default import DEFAULT_CSS
 
 
 from .text_utils import truncate_bytewise
@@ -110,10 +110,18 @@ def generate_pdf(region, language_slug, pages):
         html = get_template("pages/page_pdf.html").render(context)
         # Save empty file
         pdf_storage.save(filename, ContentFile(""))
+
+        # Get fixed version of default pdf styling (see https://github.com/digitalfabrik/integreat-cms/issues/1537)
+        fixed_css = DEFAULT_CSS.replace("background-color: transparent;", "", 1)
+
         # Write PDF content into file
         with pdf_storage.open(filename, "w+b") as pdf_file:
             pisa_status = pisa.CreatePDF(
-                html, dest=pdf_file, link_callback=link_callback, encoding="UTF-8"
+                html,
+                dest=pdf_file,
+                link_callback=link_callback,
+                encoding="UTF-8",
+                default_css=fixed_css,
             )
         # pylint: disable=no-member
         if pisa_status.err:

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -6394,7 +6394,7 @@ msgid "No valid pages selected for PDF generation."
 msgstr ""
 "Es wurden keine gültigen Seiten zur Erzeugung der PDF-Datei ausgewählt."
 
-#: cms/utils/pdf_utils.py:127
+#: cms/utils/pdf_utils.py:135
 msgid "The PDF could not be successfully generated."
 msgstr "PDF-Datei konnte nicht erfolgreich erzeugt werden."
 


### PR DESCRIPTION
### Short description
Fix broken inline icons in PDF exports by removing the css rule causing the issue.


### Proposed changes
- `default_css` for PDF exports is no longer provided by `xhtml2pdf`, but by a local copy with the fix applied
- I'll open a PR with `xhtml2pdf` to fix this upstream, so we can remove the local copy again

### Side effects
- none that I know of

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1537


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
