### PR TITLE
Use lucide icon provider

### DIFF
--- a/integreat_cms/cms/templates/_base.html
+++ b/integreat_cms/cms/templates/_base.html
@@ -12,7 +12,7 @@
                target="_blank"
                rel="noopener noreferrer"
                class="relative px-2 pt-4 text-gray-800 hover:bg-gray-200 border-r border-gray-400">
-                <i data-feather="sliders"></i>
+                <i icon-name="sliders"></i>
                 {% trans 'Django Admin' %}
             </a>
         {% endif %}
@@ -34,15 +34,15 @@
                 {% if request.region %}
                     <a href="{% url 'dashboard' region_slug=request.region.slug %}"
                        class="block whitespace-nowrap">
-                        <i data-feather="home"></i>
+                        <i icon-name="home"></i>
                         {{ request.region.full_name }}
-                        {% if request.region_selection or user.is_superuser or user.is_staff %}<i data-feather="chevron-down"></i>{% endif %}
+                        {% if request.region_selection or user.is_superuser or user.is_staff %}<i icon-name="chevron-down"></i>{% endif %}
                     </a>
                 {% else %}
                     <a href="{% url 'admin_dashboard' %}" class="block whitespace-nowrap">
-                        <i data-feather="grid"></i>
+                        <i icon-name="grid"></i>
                         {% trans 'Network Management' %}
-                        {% if request.region_selection or user.is_superuser or user.is_staff %}<i data-feather="chevron-down"></i>{% endif %}
+                        {% if request.region_selection or user.is_superuser or user.is_staff %}<i icon-name="chevron-down"></i>{% endif %}
                     </a>
                 {% endif %}
             </div>
@@ -51,7 +51,7 @@
                 {% for region in request.region_selection %}
                     <a href="{% url 'dashboard' region_slug=region.slug %}"
                        class="block whitespace-nowrap px-4 py-3 text-gray-800 hover:bg-gray-300">
-                        <i data-feather="home"></i>
+                        <i icon-name="home"></i>
                         {{ region.full_name }}
                     </a>
                 {% endfor %}
@@ -59,7 +59,7 @@
                     {% if request.region %}
                         <a href="{% url 'admin_dashboard' %}"
                            class="block whitespace-nowrap px-4 py-3 text-gray-800 hover:bg-gray-300 rounded-b">
-                            <i data-feather="grid"></i>
+                            <i icon-name="grid"></i>
                             {% trans 'Network Management' %}
                         </a>
                     {% endif %}
@@ -70,20 +70,20 @@
              class="relative px-2 text-gray-800 flex flex-col justify-center cursor-pointer hover:bg-gray-200">
             <a href="{% if request.region %}{% url 'user_settings' region_slug=request.region.slug %}{% else %}{% url 'user_settings' %}{% endif %}"
                class="relative block whitespace-nowrap">
-                <i data-feather="user"></i>
+                <i icon-name="user"></i>
                 {{ request.user.full_user_name }}
-                <i data-feather="chevron-down"></i>
+                <i icon-name="chevron-down"></i>
             </a>
             <div id="user-menu"
                  class="absolute hidden shadow rounded-b top-full right-0 bg-gray-200">
                 <a href="{% if request.region %}{% url 'user_settings' region_slug=request.region.slug %}{% else %}{% url 'user_settings' %}{% endif %}"
                    class="relative block whitespace-nowrap px-4 py-3 text-gray-800 hover:bg-gray-400">
-                    <i data-feather="settings"></i>
+                    <i icon-name="settings"></i>
                     {% trans 'User Settings' %}
                 </a>
                 <a href="{% url 'public:logout' %}"
                    class="relative block whitespace-nowrap px-4 py-3 text-gray-800 hover:bg-gray-400 rounded-b">
-                    <i data-feather="log-out" class="text-red-500"></i>
+                    <i icon-name="log-out" class="text-red-500"></i>
                     {% trans 'Log out' %}
                 </a>
             </div>
@@ -100,7 +100,7 @@
             {% if request.region %}
                 <a href="{% url 'dashboard' region_slug=request.region.slug %}"
                    class="{% if current_menu_item == 'region_dashboard' %} active{% endif %}">
-                    <i data-feather="grid"></i>
+                    <i icon-name="grid"></i>
                     {% trans 'My Dashboard' %}
                 </a>
                 <!-- Analytics Section -->
@@ -112,25 +112,25 @@
                 {% if request.region.statistics_enabled %}
                     <a href="{% url 'statistics' region_slug=request.region.slug %}"
                        class="{% if current_menu_item == 'statistics' %} active{% endif %}">
-                        <i data-feather="trending-up"></i>
+                        <i icon-name="trending-up"></i>
                         {% trans 'Statistics' %}
                     </a>
                 {% endif %}
                 <a href="{% url 'translation_coverage' region_slug=request.region.slug %}"
                 class="{% if current_menu_item == 'translation_coverage' %} active{% endif %}">
-                    <i data-feather="check-circle"></i>
+                    <i icon-name="check-circle"></i>
                     {% trans 'Translation Report' %}
                 </a>
                 {% if perms.cms.view_feedback %}
                 <a href="{% url 'region_feedback' region_slug=request.region.slug %}"
                    class="{% if current_menu_item == 'region_feedback' %} active{% endif %}">
-                    <i data-feather="thumbs-up"></i>
+                    <i icon-name="thumbs-up"></i>
                     {% trans 'Feedback' %}
                 </a>
                 {% endif %}
                 <a href="{% url 'linkcheck_landing' region_slug=request.region.slug %}"
                 class="{% if current_menu_item == 'linkcheck' %} active{% endif %}">
-                    <i data-feather="link"></i>
+                    <i icon-name="link"></i>
                     {% trans 'Broken Links' %}
                 </a>
                 <!-- Content Section -->
@@ -142,14 +142,14 @@
                 {% if perms.cms.view_directory and perms.cms.view_mediafile %}
                     <a href="{% url 'media' region_slug=request.region.slug %}"
                        class="{% if current_menu_item == 'media' %} active{% endif %}">
-                        <i data-feather='file'></i>
+                        <i icon-name='file'></i>
                         {% trans 'Media Library' %}
                     </a>
                 {% endif %}
                 {% if perms.cms.view_page %}
                     <div class="{% if current_menu_item|in_list:'pages,new_page' %} active {% endif %}">
                         <a href="{% url 'pages' region_slug=request.region.slug %}">
-                            <i data-feather="layout"></i>
+                            <i icon-name="layout"></i>
                             {% trans 'Pages' %}
                         </a>
                     </div>
@@ -157,7 +157,7 @@
                 {% if perms.cms.view_event %}
                     <div class="{% if current_menu_item|in_list:'events,events_form' %} active {% endif %}">
                         <a href="{% url 'events' region_slug=request.region.slug %}">
-                            <i data-feather="calendar"></i>
+                            <i icon-name="calendar"></i>
                             {% trans 'Events' %}
                         </a>
                     </div>
@@ -165,7 +165,7 @@
                 {% if perms.cms.view_poi %}
                     <div class="{% if current_menu_item|in_list:'pois,pois_form' %} active {% endif %}">
                         <a href="{% url 'pois' region_slug=request.region.slug %}">
-                            <i data-feather="map-pin"></i>
+                            <i icon-name="map-pin"></i>
                             {% trans 'Locations' %}
                         </a>
                     </div>
@@ -173,7 +173,7 @@
                 {% if FCM_ENABLED and request.region.push_notifications_enabled and perms.cms.view_pushnotification %}
                     <div class="{% if current_menu_item|in_list:'push_notifications,push_notifications_form' %} active {% endif %}">
                         <a href="{% url 'push_notifications' region_slug=request.region.slug %}">
-                            <i data-feather="send"></i>
+                            <i icon-name="send"></i>
                             {% trans 'News' %}
                         </a>
                     </div>
@@ -181,7 +181,7 @@
                 {% if perms.cms.view_imprintpage %}
                     <a href="{% url 'edit_imprint' region_slug=request.region.slug %}"
                        class="{% if current_menu_item == 'imprint' %} active{% endif %}">
-                        <i data-feather="file-text"></i>
+                        <i icon-name="file-text"></i>
                         {% trans 'Imprint' %}
                     </a>
                 {% endif %}
@@ -196,14 +196,14 @@
                 {% if perms.cms.view_organization %}
                 <a href="{% url 'organizations' region_slug=request.region.slug %}"
                    class="{% if current_menu_item == 'organizations' %} active{% endif %}">
-                    <i data-feather="umbrella"></i>
+                    <i icon-name="umbrella"></i>
                     {% trans 'Organizations' %}
                 </a>
                 {% endif %}
                 {% if perms.cms.view_user %}
                     <div class="{% if current_menu_item|in_list:'region_users,region_user_form' %} active {% endif %}">
                         <a href="{% url 'region_users' region_slug=request.region.slug %}">
-                            <i data-feather="users"></i>
+                            <i icon-name="users"></i>
                             {% trans 'Users' %}
                         </a>
                     </div>
@@ -211,41 +211,41 @@
                 {% if perms.cms.view_languagetreenode %}
                     <a href="{% url 'languagetreenodes' region_slug=request.region.slug %}"
                        class="{% if current_menu_item|in_list:'languagetreenodes,language_tree_form' %} active {% endif %}">
-                        <i data-feather="flag"></i>
+                        <i icon-name="flag"></i>
                         {% trans 'Language Tree' %}
                     </a>
                 {% endif %}
             {% else %}
                 <a href="{% url 'admin_dashboard' %}"
                    class="{% if current_menu_item == 'admin_dashboard' %} active{% endif %}">
-                    <i data-feather="grid"></i>
+                    <i icon-name="grid"></i>
                     {% trans 'Admin Dashboard' %}
                 </a>
                 {% if perms.cms.view_region %}
                     <a href="{% url 'regions' %}"
                        class="{% if current_menu_item == 'regions' %} active{% endif %}">
-                        <i data-feather="map"></i>
+                        <i icon-name="map"></i>
                         {% trans 'Regions' %}
                     </a>
                 {% endif %}
                 {% if perms.cms.view_directory and perms.cms.view_mediafile %}
                     <a href="{% url 'media_admin' %}"
                        class="{% if current_menu_item == 'media' %} active{% endif %}">
-                        <i data-feather='file'></i>
+                        <i icon-name='file'></i>
                         {% trans 'Media Library' %}
                     </a>
                 {% endif %}
                 {% if perms.cms.view_language %}
                     <a href="{% url 'languages' %}"
                        class="{% if current_menu_item == 'languages' %} active{% endif %}">
-                        <i data-feather="flag"></i>
+                        <i icon-name="flag"></i>
                         {% trans 'Languages' %}
                     </a>
                 {% endif %}
                 {% if perms.cms.view_user %}
                     <div class="{% if current_menu_item|in_list:'users,user_form' %} active {% endif %}">
                         <a href="{% url 'users' %}">
-                            <i data-feather="users"></i>
+                            <i icon-name="users"></i>
                             {% trans 'Users' %}
                         </a>
                     </div>
@@ -253,28 +253,28 @@
                 {% if perms.auth.view_group %}
                     <a href="{% url 'roles' %}"
                        class="{% if current_menu_item == 'roles' %} active{% endif %}">
-                        <i data-feather="key"></i>
+                        <i icon-name="key"></i>
                         {% trans 'Roles' %}
                     </a>
                 {% endif %}
                 {% if perms.cms.view_offer_template %}
                     <a href="{% url 'offertemplates' %}"
                        class="{% if current_menu_item == 'offertemplates' %} active{% endif %}">
-                        <i data-feather="star"></i>
+                        <i icon-name="star"></i>
                         {% trans 'Offer Templates' %}
                     </a>
                 {% endif %}
                 {% if perms.cms.view_feedback %}
                     <a href="{% url 'admin_feedback' %}"
                        class="{% if current_menu_item == 'admin_feedback' %} active{% endif %}">
-                        <i data-feather="thumbs-up"></i>
+                        <i icon-name="thumbs-up"></i>
                         {% trans 'Feedback' %}
                     </a>
                 {% endif %}
                 {% if perms.cms.view_poicategory %}
                     <a href="{% url 'poicategories' %}"
                        class="{% if current_menu_item == 'poicategories' %} active{% endif %}">
-                        <i data-feather="tag"></i>
+                        <i icon-name="tag"></i>
                         {% trans 'Location Categories' %}
                     </a>
                 {% endif %}

--- a/integreat_cms/cms/templates/_collapsible_box.html
+++ b/integreat_cms/cms/templates/_collapsible_box.html
@@ -2,14 +2,14 @@
 <div class="rounded shadow-2xl border border-blue-500 bg-white mb-3">
     <div class="collapsible cursor-pointer rounded p-4 bg-water-500 text-black font-bold flex justify-between">
         <span>
-            <i data-feather="{% spaceless %}{% block collapsible_box_icon %}{% endblock collapsible_box_icon %}{% endspaceless %}"
+            <i icon-name="{% spaceless %}{% block collapsible_box_icon %}{% endblock collapsible_box_icon %}{% endspaceless %}"
                class="pb-1"></i>
             {% block collapsible_box_title %}
             {% endblock collapsible_box_title %}
         </span>
-        <i data-feather="chevron-up"
+        <i icon-name="chevron-up"
            class="up-arrow {% if collapsed %}hidden{% endif %}"></i>
-        <i data-feather="chevron-down"
+        <i icon-name="chevron-down"
            class="down-arrow {% if not collapsed %}hidden{% endif %}"></i>
     </div>
     <div class="collapsible-content transition-all duration-200 ease-in-out overflow-hidden {% if collapsed %}h-0{% endif %}">

--- a/integreat_cms/cms/templates/_form_language_tabs.html
+++ b/integreat_cms/cms/templates/_form_language_tabs.html
@@ -16,32 +16,32 @@
                         {% endif %}
                         {% if other_status == translation_status.IN_TRANSLATION %}
                             <span {% if other_language == language %} id="currently-in-translation-state" {% endif %} title="{% trans 'Currently in translation' %}">
-                                <i data-feather="clock"></i>
+                                <i icon-name="clock"></i>
                             </span>
                             {# For the current language, provide fallback icons in case translation process is cancelled #}
                             {% if other_language == language %}
                                 <span id="reset-translation-state-{{ translation_status.OUTDATED }}" title="{% trans 'Translation outdated' %}" class="hidden">
-                                    <i data-feather="alert-triangle"></i>
+                                    <i icon-name="alert-triangle"></i>
                                 </span>
                                 <span id="reset-translation-state-{{ translation_status.UP_TO_DATE }}" title="{% trans 'Translation up-to-date' %}" class="hidden">
-                                    <i data-feather="check"></i>
+                                    <i icon-name="check"></i>
                                 </span>
                             {% endif %}
                         {% elif other_status == translation_status.OUTDATED %}
                             <span title="{% trans 'Translation outdated' %}">
-                                <i data-feather="alert-triangle"></i>
+                                <i icon-name="alert-triangle"></i>
                             </span>
                         {% elif other_status == translation_status.UP_TO_DATE  %}
                             <span title="{% trans 'Translation up-to-date' %}">
-                                <i data-feather="check"></i>
+                                <i icon-name="check"></i>
                             </span>
                         {% elif other_status == translation_status.FALLBACK %}
                             <span title="{% trans 'Default language is duplicated' %}">
-                                <i data-feather="copy"></i>
+                                <i icon-name="copy"></i>
                             </span>
                         {% elif other_status == translation_status.MISSING  %}
                             <span title="{% trans 'Translation missing' %}" class="no-trans">
-                                <i data-feather="x"></i>
+                                <i icon-name="x"></i>
                             </span>
                         {% endif %}
                         {{ other_language.translated_name }}
@@ -63,7 +63,7 @@
                 <div id="language-switcher" class="flex flex-col text-black">
                     <div id="language-switcher-current" class="font-bold text-right bg-water-500 py-[calc(0.75rem+2px)] px-4 border-l border-t border-r border-blue-500 rounded-t cursor-default">
                         {% trans 'Other Languages' %}
-                        <i data-feather="chevron-down"></i>
+                        <i icon-name="chevron-down"></i>
                     </div>
                     <div id="language-switcher-list" class="h-0 hidden z-10">
                         {% for other_language, other_status in sorted_translation_states|slice:"4:" %}
@@ -71,19 +71,19 @@
                             <div>
                                 {% if other_status == translation_status.IN_TRANSLATION %}
                                     <span title="{% trans 'Currently in translation' %}">
-                                        <i data-feather="clock"></i>
+                                        <i icon-name="clock"></i>
                                     </span>
                                 {% elif other_status == translation_status.OUTDATED %}
                                     <span title="{% trans 'Translation outdated' %}">
-                                        <i data-feather="alert-triangle"></i>
+                                        <i icon-name="alert-triangle"></i>
                                     </span>
                                 {% elif other_status == translation_status.UP_TO_DATE  %}
                                     <span title="{% trans 'Translation up-to-date' %}">
-                                        <i data-feather="check"></i>
+                                        <i icon-name="check"></i>
                                     </span>
                                 {% elif other_status == translation_status.MISSING  %}
                                     <span title="{% trans 'Translation missing' %}" class="no-trans">
-                                        <i data-feather="x"></i>
+                                        <i icon-name="x"></i>
                                     </span>
                                 {% endif %}
                                 <span class="px-2 max-w-max truncate">

--- a/integreat_cms/cms/templates/_search_input.html
+++ b/integreat_cms/cms/templates/_search_input.html
@@ -25,7 +25,7 @@
             title="{% trans 'Reset search' %}"
             class="bg-gray-200 hover:bg-gray-300 text-gray-800 py-2 px-3"
         >
-            <i data-feather="x" class="w-5"></i>
+            <i icon-name="x" class="w-5"></i>
         </button>
     {% endif %}
     <button
@@ -33,6 +33,6 @@
         title="{% trans 'Search' %}" {% if related_form %}form={{ related_form }}{% endif %}
         class="bg-blue-500 hover:bg-blue-600 text-white rounded-r py-2 px-3"
     >
-        <i data-feather="search" class="w-5"></i>
+        <i icon-name="search" class="w-5"></i>
     </button>
 </div>

--- a/integreat_cms/cms/templates/analytics/_broken_links_widget.html
+++ b/integreat_cms/cms/templates/analytics/_broken_links_widget.html
@@ -20,13 +20,13 @@
     </div>
     <div class="mt-4">
         <div id="stats-network-error" class="text-red-500 px-4 hidden">
-            <i data-feather="alert-triangle"></i> {% trans 'A network error has occurred.' %} {% trans 'Please try again later.' %}
+            <i icon-name="alert-triangle"></i> {% trans 'A network error has occurred.' %} {% trans 'Please try again later.' %}
         </div>
         <div id="stats-server-error" class="text-red-500 px-4 hidden">
-            <i data-feather="alert-triangle"></i> {% trans 'A server error has occurred.' %} {% trans 'Please contact the administrator.' %}
+            <i icon-name="alert-triangle"></i> {% trans 'A server error has occurred.' %} {% trans 'Please contact the administrator.' %}
         </div>
         <div id="stats-loading" class="px-4 hidden">
-            <i data-feather="loader" class="animate-spin"></i> {% trans 'Loading...' %}
+            <i icon-name="loader" class="animate-spin"></i> {% trans 'Loading...' %}
         </div>
         <table id="linkcheck-stats"
                data-linkcheck-stats-url="{% url 'linkcheck_stats' region_slug=request.region.slug %}"

--- a/integreat_cms/cms/templates/analytics/translation_coverage.html
+++ b/integreat_cms/cms/templates/analytics/translation_coverage.html
@@ -13,7 +13,7 @@
     <div class="grid grid-cols-1 2xl:grid-cols-3 gap-4">
         <div class="2xl:col-span-2 rounded border border-blue-500 shadow-2xl">
             <div class="rounded p-4 bg-water-500">
-                <h3 class="heading font-bold text-black"><i data-feather="check-circle" class="pb-1"></i>
+                <h3 class="heading font-bold text-black"><i icon-name="check-circle" class="pb-1"></i>
                     {% trans 'Current translation status' %}
                 </h3>
             </div>
@@ -24,7 +24,7 @@
         <div class="rounded border border-solid border-blue-500 shadow-2xl bg-white">
             <div class="rounded p-4 bg-water-500">
                 <h3 class="heading font-bold text-black">
-                    <i data-feather="shopping-bag" class="pb-1"></i>
+                    <i icon-name="shopping-bag" class="pb-1"></i>
                     {% trans "Outdated and missing Translations" %}
                 </h3>
             </div>

--- a/integreat_cms/cms/templates/authentication/login.html
+++ b/integreat_cms/cms/templates/authentication/login.html
@@ -35,7 +35,7 @@
         </button>
         <div class="text-right mt-4">
             <a href="{% url 'public:password_reset' %}" class="text-right font-bold text-gray-600 hover:text-gray-200 hover:bg-gray-600 py-2 px-4 rounded">
-                <i data-feather="lock" class="align-top"></i> {% trans 'Forgot your password?' %}
+                <i icon-name="lock" class="align-top"></i> {% trans 'Forgot your password?' %}
             </a>
         </div>
     </form>

--- a/integreat_cms/cms/templates/authentication/password_reset_confirm.html
+++ b/integreat_cms/cms/templates/authentication/password_reset_confirm.html
@@ -37,7 +37,7 @@
         </button>
         <div class="text-right mt-4">
             <a href="{% url 'public:login' %}" class="text-gray-600 hover:text-gray-200 hover:bg-gray-600 rounded py-2 px-3 font-bold">
-                <i data-feather="arrow-left-circle" class="align-top"></i> {% trans 'Back to log in' %}
+                <i icon-name="arrow-left-circle" class="align-top"></i> {% trans 'Back to log in' %}
             </a>
         </div>
     </form>

--- a/integreat_cms/cms/templates/authentication/password_reset_form.html
+++ b/integreat_cms/cms/templates/authentication/password_reset_form.html
@@ -28,7 +28,7 @@
     </form>
     <div class="text-right mt-4">
         <a href="{% url 'public:login' %}" class="text-gray-600 hover:text-gray-200 hover:bg-gray-600 rounded py-2 px-3 font-bold">
-            <i data-feather="arrow-left-circle" class="align-top"></i> {% trans 'Back to log in' %}
+            <i icon-name="arrow-left-circle" class="align-top"></i> {% trans 'Back to log in' %}
         </a>
     </div>
 {% endblock %}

--- a/integreat_cms/cms/templates/chat/_chat_messages.html
+++ b/integreat_cms/cms/templates/chat/_chat_messages.html
@@ -25,7 +25,7 @@
                     {% url 'delete_chat_message' message_id=message.id %}
                 {% endif %}
             {% endspaceless %}">
-        <i data-feather="trash-2"></i>
+        <i icon-name="trash-2"></i>
     </button>
     <span class="text-gray-600 float-right">{{ message.sent_datetime }}</span>
     <p class="pt-2 whitespace-pre-line">{{ message.text|urlize }}</p>

--- a/integreat_cms/cms/templates/chat/_chat_widget.html
+++ b/integreat_cms/cms/templates/chat/_chat_widget.html
@@ -23,10 +23,10 @@
         {% render_field chat_form.text rows="2" class="mb-2" %}
 
         <button id="send-chat-message" class="btn">
-            <i data-feather="send"></i> {% trans "Send message" %}
+            <i icon-name="send"></i> {% trans "Send message" %}
         </button>
-        <span id="chat-loading" class="px-4 hidden"><i data-feather="loader" class="animate-spin"></i></span>
-        <span id="chat-network-error" class="text-red-500 px-4 hidden"><i data-feather="alert-triangle"></i> {% trans 'A network error has occurred.' %} {% trans 'Please try again later.' %}</span>
-        <span id="chat-server-error" class="text-red-500 px-4 hidden"><i data-feather="alert-triangle"></i> {% trans 'A server error has occurred.' %} {% trans 'Please contact the administrator.' %}</span>
+        <span id="chat-loading" class="px-4 hidden"><i icon-name="loader" class="animate-spin"></i></span>
+        <span id="chat-network-error" class="text-red-500 px-4 hidden"><i icon-name="alert-triangle"></i> {% trans 'A network error has occurred.' %} {% trans 'Please try again later.' %}</span>
+        <span id="chat-server-error" class="text-red-500 px-4 hidden"><i icon-name="alert-triangle"></i> {% trans 'A server error has occurred.' %} {% trans 'Please contact the administrator.' %}</span>
     </form>
 {% endblock %}

--- a/integreat_cms/cms/templates/dashboard/_news_widget.html
+++ b/integreat_cms/cms/templates/dashboard/_news_widget.html
@@ -14,15 +14,15 @@
 
 {% block collapsible_box_content %}
     <div class="rss-feed " data-feed-url="{{ feed_url }}">
-        <div id="feed-loading" class="px-4 hidden"><i data-feather="loader" class="animate-spin"></i> {% trans 'Loading...' %}</div>
+        <div id="feed-loading" class="px-4 hidden"><i icon-name="loader" class="animate-spin"></i> {% trans 'Loading...' %}</div>
     </div>
     <div id="reload" class="hidden"> 
-        <div class="text-red-500 px-4"><i data-feather="alert-triangle"></i> {% trans "Unfortunately there was a problem and the news feed could not load." %} </div>
+        <div class="text-red-500 px-4"><i icon-name="alert-triangle"></i> {% trans "Unfortunately there was a problem and the news feed could not load." %} </div>
         <button id="reload-button" class="btn">
-            <i data-feather="refresh-ccw"></i> {% trans "Reload page" %}
+            <i icon-name="refresh-ccw"></i> {% trans "Reload page" %}
         </button>
     </div>
     <button id="read-more" class="btn hidden">
-        <i data-feather="book-open"></i> {% trans "Continue reading" %}
+        <i icon-name="book-open"></i> {% trans "Continue reading" %}
     </button>
 {% endblock %}

--- a/integreat_cms/cms/templates/error_handler/http_error.html
+++ b/integreat_cms/cms/templates/error_handler/http_error.html
@@ -12,6 +12,6 @@
         {{ message }}
     </p>
     <a href="/" class="btn w-full text-center">
-        <i data-feather="arrow-left-circle" class="align-top"></i> {% trans 'Return back home' %}
+        <i icon-name="arrow-left-circle" class="align-top"></i> {% trans 'Return back home' %}
     </a>
 {% endblock %}

--- a/integreat_cms/cms/templates/events/_event_filter_form.html
+++ b/integreat_cms/cms/templates/events/_event_filter_form.html
@@ -36,7 +36,7 @@
                 <input id="poi-query-input" type="search" autocomplete="off" class="no-new-poi" placeholder="{% if filter_poi %}{{ filter_poi|poi_translation_title:current_language }}{% else %}{{ search_placeholder }}{% endif %}" data-url="{% url 'search_poi_ajax' region_slug=request.region.slug %}" data-region-slug="{{ request.region.slug }}" data-default-placeholder="{{ search_placeholder }}">
                 <div class="absolute inset-y-0 right-0 flex items-center px-2 text-gray-800">
                     <a id="poi-remove" title="{% trans 'Empty query input' %}">
-                        <i data-feather="trash-2" class="h-5 w-5"></i>
+                        <i icon-name="trash-2" class="h-5 w-5"></i>
                     </a>
                 </div>
             </div>

--- a/integreat_cms/cms/templates/events/_poi_query_result.html
+++ b/integreat_cms/cms/templates/events/_poi_query_result.html
@@ -27,7 +27,7 @@
         <button class="btn w-full option-new-poi mb-2"
                 data-url="{% url 'new_poi' region_slug=request.region.slug language_slug=request.region.default_language.slug %}"
                 data-poi-title="{{ poi_query }}">
-            <i data-feather="map-pin"></i>
+            <i icon-name="map-pin"></i>
             {% blocktrans %}Create location "{{ poi_query }}"{% endblocktrans %}
         </button>
     {% endif %}

--- a/integreat_cms/cms/templates/events/event_form.html
+++ b/integreat_cms/cms/templates/events/event_form.html
@@ -90,22 +90,22 @@
                                href="{{ url_link }}{{ event_translation_form.instance.slug }}"
                                class="text-blue-500 hover:underline">{{ url_link }}{{ event_translation_form.instance.slug }}</a>
                             <a id="edit-slug-btn" title="{% trans 'Edit' %}" class="mx-2 btn-icon">
-                                <i data-feather="edit-3"></i>
+                                <i icon-name="edit-3"></i>
                             </a>
                             <a id="copy-slug-btn"
                                title="{% trans 'Copy to clipboard' %}"
                                class="btn-icon">
-                                <i data-feather="copy"></i>
+                                <i icon-name="copy"></i>
                             </a>
                             <div class="slug-field hidden">
                                 <label for="{{ event_translation_form.slug.id_for_label }}">{{ url_link }}</label>
                                 {% render_field event_translation_form.slug|add_error_class:"slug-error" %}
                             </div>
                             <a id="save-slug-btn" class="mx-2 btn-icon hidden">
-                                <i data-feather="save"></i>
+                                <i icon-name="save"></i>
                             </a>
                             <a id="restore-slug-btn" class="btn-icon hidden">
-                                <i data-feather="x-circle"></i>
+                                <i icon-name="x-circle"></i>
                             </a>
                         </div>
                         <label for="{{ event_translation_form.content.id_for_label }}">{{ event_translation_form.content.label }}</label>
@@ -118,7 +118,7 @@
                 <div class="rounded border border-blue-500 shadow-2xl bg-white">
                     <div class="rounded p-4 bg-water-500">
                         <h3 class="heading font-bold text-black">
-                            <i data-feather="feather" class="pb-1"></i>
+                            <i icon-name="feather" class="pb-1"></i>
                             {% trans "Minor edit" %}
                         </h3>
                     </div>
@@ -136,7 +136,7 @@
                 <div class="rounded border border-blue-500 shadow-2xl bg-white">
                     <div class="rounded p-4 bg-water-500">
                         <h3 class="heading font-bold text-black">
-                            <i data-feather="calendar" class="pb-1"></i>
+                            <i icon-name="calendar" class="pb-1"></i>
                             {% trans 'Date and time' %}
                         </h3>
                     </div>
@@ -240,7 +240,7 @@
                 <div class="rounded border border-solid border-blue-500 shadow-2xl bg-white">
                     <div class="rounded p-4 bg-water-500">
                         <h3 class="heading font-bold text-black">
-                            <i data-feather="map-pin" class="pb-1"></i>
+                            <i icon-name="map-pin" class="pb-1"></i>
                             {% trans 'Venue' %}
                         </h3>
                     </div>
@@ -268,7 +268,7 @@
                                     <button id="poi-remove"
                                             title="{% trans 'Remove location from event' %}"
                                             {% if event_form.disabled %} disabled{% endif %}>
-                                        <i data-feather="trash-2" class="h-5 w-5"></i>
+                                        <i icon-name="trash-2" class="h-5 w-5"></i>
                                     </button>
                                 </div>
                             </div>
@@ -309,7 +309,7 @@
                 <div class="rounded border border-solid border-blue-500 shadow-2xl bg-white">
                     <div class="rounded p-4 bg-water-500">
                         <h3 class="heading font-bold text-black">
-                            <i data-feather="image" class="pb-1"></i>
+                            <i icon-name="image" class="pb-1"></i>
                             {{ event_form.icon.label }}
                         </h3>
                     </div>
@@ -324,7 +324,7 @@
                     <div class="rounded border border-solid border-blue-500 shadow-2xl bg-white">
                         <div class="rounded p-4 bg-water-500">
                             <h3 class="heading font-bold text-black">
-                                <i data-feather="tool" class="pb-1"></i>
+                                <i icon-name="wrench" class="pb-1"></i>
                                 {% trans 'Actions' %}
                             </h3>
                         </div>
@@ -339,7 +339,7 @@
                                             data-confirmation-text="{{ restore_dialog_text }}"
                                             data-confirmation-subject="{{ event_translation_form.instance.title }}"
                                             data-action="{% url 'restore_event' event_id=event_form.instance.id region_slug=request.region.slug language_slug=language.slug %}">
-                                        <i data-feather="refresh-ccw" class="mr-2"></i>
+                                        <i icon-name="refresh-ccw" class="mr-2"></i>
                                         {% trans 'Restore this event' %}
                                     </button>
                                 {% else %}
@@ -351,7 +351,7 @@
                                             data-confirmation-text="{{ archive_dialog_text }}"
                                             data-confirmation-subject="{{ event_translation_form.instance.title }}"
                                             data-action="{% url 'archive_event' event_id=event_form.instance.id region_slug=request.region.slug language_slug=language.slug %}">
-                                        <i data-feather="archive" class="mr-2"></i>
+                                        <i icon-name="archive" class="mr-2"></i>
                                         {% trans 'Archive this event' %}
                                     </button>
                                 {% endif %}
@@ -366,7 +366,7 @@
                                             data-confirmation-text="{{ delete_dialog_text }}"
                                             data-confirmation-subject="{{ event_translation_form.instance.title }}"
                                             data-action="{% url 'delete_event' event_id=event_form.instance.id region_slug=request.region.slug language_slug=language.slug %}">
-                                        <i data-feather="trash-2" class="mr-2"></i>
+                                        <i icon-name="trash-2" class="mr-2"></i>
                                         {% trans 'Delete this event' %}
                                     </button>
                                 </div>

--- a/integreat_cms/cms/templates/events/event_list.html
+++ b/integreat_cms/cms/templates/events/event_list.html
@@ -11,7 +11,7 @@
             <a href="{% url 'events_archived' region_slug=request.region.slug language_slug=language.slug %}"
                class="font-bold text-sm text-gray-800 flex items-center gap-1 pb-2 hover:underline">
                 <span>
-                    <i data-feather="archive" class="align-top h-5"></i>
+                    <i icon-name="archive" class="align-top h-5"></i>
                     {% trans 'Archived events' %}
                     ({{ archived_count }})
                 </span>

--- a/integreat_cms/cms/templates/events/event_list_archived_row.html
+++ b/integreat_cms/cms/templates/events/event_list_archived_row.html
@@ -41,20 +41,20 @@
                     {% if other_translation %}
                         {% if other_translation.currently_in_translation %}
                             <span title="{% trans 'Currently in translation' %}">
-                                <i data-feather="clock" class="{% if other_language == language %}text-blue-500{% endif %}"></i>
+                                <i icon-name="clock" class="{% if other_language == language %}text-blue-500{% endif %}"></i>
                             </span>
                         {% elif other_translation.is_outdated %}
                             <span title="{% trans 'Translation outdated' %}">
-                                <i data-feather="alert-triangle" class="{% if other_language == language %}text-yellow-500{% endif %}"></i>
+                                <i icon-name="alert-triangle" class="{% if other_language == language %}text-yellow-500{% endif %}"></i>
                             </span>
                         {% else %}
                             <span title="{% trans 'Translation up-to-date' %}">
-                                <i data-feather="check" class="{% if other_language == language %}text-green-500{% endif %}"></i>
+                                <i icon-name="check" class="{% if other_language == language %}text-green-500{% endif %}"></i>
                             </span>
                         {% endif %}
                     {% else %}
                         <span title="{% trans 'Translation missing' %}">
-                            <i data-feather="x" class="{% if other_language == language %}text-red-500{% endif %}"></i>
+                            <i icon-name="x" class="{% if other_language == language %}text-red-500{% endif %}"></i>
                         </span>
                     {% endif %}
                 </a>
@@ -73,16 +73,16 @@
         {% endif %}
     </td>
     <td class="py-3 pr-2">
-        <i data-feather="calendar"></i> {{ event.start_date|date:'d.m.Y'}}{% if not event.is_all_day %} <i data-feather="clock" class="ml-2"></i> {{ event.start_time|time:'H:i' }}{% endif %}
+        <i icon-name="calendar"></i> {{ event.start_date|date:'d.m.Y'}}{% if not event.is_all_day %} <i icon-name="clock" class="ml-2"></i> {{ event.start_time|time:'H:i' }}{% endif %}
     </td>
     <td class="py-3 pr-2">
-        <i data-feather="calendar"></i> {{ event.end_date|date:'d.m.Y'}}{% if not event.is_all_day %} <i data-feather="clock" class="ml-2"></i> {{ event.end_time|time:'H:i' }}{% endif %}
+        <i icon-name="calendar"></i> {{ event.end_date|date:'d.m.Y'}}{% if not event.is_all_day %} <i icon-name="clock" class="ml-2"></i> {{ event.end_time|time:'H:i' }}{% endif %}
     </td>
     <td class="py-3 pr-2">
         {% if event.recurrence_rule %}
-        <i data-feather="repeat"></i> {{ event.recurrence_rule.get_frequency_display }}
+        <i icon-name="repeat"></i> {{ event.recurrence_rule.get_frequency_display }}
         {% else %}
-        <i data-feather="calendar"></i> {% trans 'One-time' %}
+        <i icon-name="calendar"></i> {% trans 'One-time' %}
         {% endif %}
     </td>
     <td class="pr-4 py-3 flex flex-nowrap justify-end gap-2">
@@ -93,7 +93,7 @@
                 data-confirmation-text="{{ restore_dialog_text }}"
                 data-confirmation-subject="{{ event_translation.title }}"
                 data-action="{% url 'restore_event' event_id=event.id region_slug=request.region.slug language_slug=language.slug %}">
-                <i data-feather="refresh-ccw"></i>
+                <i icon-name="refresh-ccw"></i>
             </button>
         {% endif %}
         {% if perms.cms.delete_event %}
@@ -102,7 +102,7 @@
                 data-confirmation-text="{{ delete_dialog_text }}"
                 data-confirmation-subject="{{ event_translation.title }}"
                 data-action="{% url 'delete_event' event_id=event.id region_slug=request.region.slug language_slug=language.slug %}">
-                <i data-feather="trash-2"></i>
+                <i icon-name="trash-2"></i>
             </button>
         {% endif %}
     </td>

--- a/integreat_cms/cms/templates/events/event_list_row.html
+++ b/integreat_cms/cms/templates/events/event_list_row.html
@@ -40,29 +40,29 @@
                     <div id="translation-icon">
                         {% if other_status == translation_status.IN_TRANSLATION %}
                             <span title="{% trans 'Currently in translation' %}">
-                                <i data-feather="clock" class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
+                                <i icon-name="clock" class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
                             </span>
                         {% elif other_status == translation_status.OUTDATED %}
                             <span title="{% trans 'Translation outdated' %}">
-                                <i data-feather="alert-triangle" class="{% if other_language.slug == language.slug %}text-yellow-500{% else %}text-gray-800{% endif %}"></i>
+                                <i icon-name="alert-triangle" class="{% if other_language.slug == language.slug %}text-yellow-500{% else %}text-gray-800{% endif %}"></i>
                             </span>
                         {% elif other_status == translation_status.UP_TO_DATE %}
                             <span title="{% trans 'Translation up-to-date' %}">
-                                <i data-feather="check" class="{% if other_language.slug == language.slug %}text-green-500{% else %}text-gray-800{% endif %}"></i>
+                                <i icon-name="check" class="{% if other_language.slug == language.slug %}text-green-500{% else %}text-gray-800{% endif %}"></i>
                             </span>
                         {% elif other_status == translation_status.FALLBACK %}
                             <span title="{% trans 'Default language is duplicated' %}">
-                                <i data-feather="copy" class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
+                                <i icon-name="copy" class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
                             </span>
                         {% elif other_status == translation_status.MISSING %}
                             <span title="{% trans 'Translation missing' %}" class="no-trans">
-                                <i data-feather="x" class="{% if other_language.slug == language.slug %}text-red-500{% else %}text-gray-800{% endif %}"></i>
+                                <i icon-name="x" class="{% if other_language.slug == language.slug %}text-red-500{% else %}text-gray-800{% endif %}"></i>
                             </span>
                         {% endif %}
                     </div>
                     <div id="ajax-icon" class="hidden">
                         <span title="{% trans 'Currently in translation' %}">
-                            <i data-feather="clock" class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
+                            <i icon-name="clock" class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
                         </span>
                     </div>
                 </a>
@@ -75,33 +75,33 @@
     <td class="py-3 pr-2">
         {% if event.location %}
             {% get_language LANGUAGE_CODE as current_language %}
-            <i data-feather="map-pin"></i> {{ event.location|poi_translation_title:current_language }}
+            <i icon-name="map-pin"></i> {{ event.location|poi_translation_title:current_language }}
         {% else %}
             {% trans 'Not specified' %}
         {% endif %}
     </td>
     <td class="py-3 pr-2">
-        <span class="whitespace-nowrap"><i data-feather="calendar"></i> {{ event.start_local|date:'d.m.Y' }}</span>{% if not event.is_all_day %} <span class="whitespace-nowrap"><i data-feather="clock"></i> {{ event.start_local|date:'H:i' }}</span>{% endif %}
+        <span class="whitespace-nowrap"><i icon-name="calendar"></i> {{ event.start_local|date:'d.m.Y' }}</span>{% if not event.is_all_day %} <span class="whitespace-nowrap"><i icon-name="clock"></i> {{ event.start_local|date:'H:i' }}</span>{% endif %}
     </td>
     <td class="py-3 pr-2">
-        <span class="whitespace-nowrap"><i data-feather="calendar"></i> {{ event.end_local|date:'d.m.Y' }}</span>{% if not event.is_all_day %} <span class="whitespace-nowrap"><i data-feather="clock"></i> {{ event.end_local|date:'H:i' }}</span>{% endif %}
+        <span class="whitespace-nowrap"><i icon-name="calendar"></i> {{ event.end_local|date:'d.m.Y' }}</span>{% if not event.is_all_day %} <span class="whitespace-nowrap"><i icon-name="clock"></i> {{ event.end_local|date:'H:i' }}</span>{% endif %}
     </td>
     <td class="py-3 pr-2 whitespace-nowrap">
         {% if event.recurrence_rule %}
-            <i data-feather="repeat"></i> {{ event.recurrence_rule.get_frequency_display }}
+            <i icon-name="repeat"></i> {{ event.recurrence_rule.get_frequency_display }}
         {% else %}
-            <i data-feather="calendar"></i> {% trans 'One-time' %}
+            <i icon-name="calendar"></i> {% trans 'One-time' %}
         {% endif %}
     </td>
     <td class="pr-4 py-3 flex flex-nowrap justify-end gap-2">
         {% if event_translation.status == PUBLIC %}
             <a href="{{ WEBAPP_URL }}{{ event_translation.get_absolute_url }}"
             rel="noopener noreferrer" target="_blank" title="{% trans 'Open event in web app' %}" class="btn-icon">
-                <i data-feather="external-link"></i>
+                <i icon-name="external-link"></i>
             </a>
         {% else %}
             <button title="{% trans 'This event cannot be opened in the web app, because it is not public.' %}" class="btn-icon" disabled>
-                <i data-feather="external-link"></i>
+                <i icon-name="external-link"></i>
             </button>
         {% endif %}
         {% has_perm 'cms.change_event' request.user as can_edit_event %}
@@ -109,7 +109,7 @@
             <form action="{% url 'copy_event' event_id=event.id region_slug=request.region.slug language_slug=language.slug %}" method="post">
                 {% csrf_token %}
                 <button class="btn-icon" title="{% trans 'Copy event' %}">
-                    <i data-feather="copy"></i>
+                    <i icon-name="copy"></i>
                 </button>
             </form>
             <button title="{% trans 'Archive event' %}" class="confirmation-button btn-icon"
@@ -117,7 +117,7 @@
                 data-confirmation-text="{{ archive_dialog_text }}"
                 data-confirmation-subject="{{ event_translation.title }}"
                 data-action="{% url 'archive_event' event_id=event.id region_slug=request.region.slug language_slug=language.slug %}">
-                <i data-feather="archive"></i>
+                <i icon-name="archive"></i>
             </button>
         {% endif %}
         {% if perms.cms.delete_event %}
@@ -126,7 +126,7 @@
                 data-confirmation-text="{{ delete_dialog_text }}"
                 data-confirmation-subject="{{ event_translation.title }}"
                 data-action="{% url 'delete_event' event_id=event.id region_slug=request.region.slug language_slug=language.slug %}">
-                <i data-feather="trash-2"></i>
+                <i icon-name="trash-2"></i>
             </button>
         {% endif %}
     </td>

--- a/integreat_cms/cms/templates/feedback/_feedback_widget.html
+++ b/integreat_cms/cms/templates/feedback/_feedback_widget.html
@@ -36,24 +36,24 @@
                 <td class="pr-2 feedback-comment max-w-[75px] lg:max-w-[300px] xl:max-w-[75px] 3xl:max-w-[300px] 4xl:max-w-[500px]"
                     title="{{ feedback.comment }}">
                     {% if not feedback.comment %}
-                        <i data-feather="minus" class="pr-1"></i>
+                        <i icon-name="minus" class="pr-1"></i>
                     {% else %}
                         <div class="flex">
                             <div class="feedback-comment-preview truncate grow">{{ feedback.comment }}</div>
-                            <i data-feather="chevron-down"
+                            <i icon-name="chevron-down"
                                 class="toggle-feedback-comment transform cursor-pointer hover:scale-125 flex-none"></i>
                         </div>
                         <div class="hidden">
-                            <span class="feedback-comment-full">{{ feedback.comment }}</span> <i data-feather="chevron-up"
+                            <span class="feedback-comment-full">{{ feedback.comment }}</span> <i icon-name="chevron-up"
                             class="toggle-feedback-comment transform cursor-pointer hover:scale-125"></i>
                         </div>
                     {% endif %}
                 </td>
                 <td class="pr-2">
                     {% if feedback.rating == True %}
-                        <i data-feather="thumbs-up"></i>
+                        <i icon-name="thumbs-up"></i>
                     {% elif feedback.rating == False %}
-                        <i data-feather="thumbs-down"></i>
+                        <i icon-name="thumbs-down"></i>
                     {% endif %}
                 </td>
                 <td class="pr-2">

--- a/integreat_cms/cms/templates/feedback/admin_feedback_list.html
+++ b/integreat_cms/cms/templates/feedback/admin_feedback_list.html
@@ -61,34 +61,34 @@
                     <td class="pr-2 feedback-comment max-w-[75px] xl:max-w-[200px] 2xl:max-w-[300px] 3xl:max-w-[500px] 4xl:max-w-[800px]"
                         title="{{ feedback.comment }}">
                         {% if not feedback.comment %}
-                            <i data-feather="minus" class="pr-1"></i>
+                            <i icon-name="minus" class="pr-1"></i>
                         {% else %}
                             <div class="flex">
                                 <div class="feedback-comment-preview truncate grow">{{ feedback.comment }}</div>
-                                <i data-feather="chevron-down"
+                                <i icon-name="chevron-down"
                                     class="toggle-feedback-comment transform cursor-pointer hover:scale-125 flex-none"></i>
                             </div>
                             <div class="hidden">
-                                <span class="feedback-comment-full">{{ feedback.comment }}</span> <i data-feather="chevron-up"
+                                <span class="feedback-comment-full">{{ feedback.comment }}</span> <i icon-name="chevron-up"
                                 class="toggle-feedback-comment transform cursor-pointer hover:scale-125"></i>
                             </div>
                         {% endif %}
                     </td>
                     <td class="pr-2">
                         {% if feedback.rating == True %}
-                            <i data-feather="thumbs-up" class="pr-1"></i>
+                            <i icon-name="thumbs-up" class="pr-1"></i>
                         {% elif feedback.rating == False %}
-                            <i data-feather="thumbs-down" class="pr-1"></i>
+                            <i icon-name="thumbs-down" class="pr-1"></i>
                         {% elif feedback.rating == None %}
-                            <i data-feather="minus" class="pr-1"></i>
+                            <i icon-name="minus" class="pr-1"></i>
                         {% endif %}
                     </td>
                     <td class="pr-2">
                         <span class="{% if not feedback.rating_sum_positive %}invisible{% endif %}">
-                            <i data-feather="thumbs-up" class="pr-1"></i> {{ feedback.rating_sum_positive }}
+                            <i icon-name="thumbs-up" class="pr-1"></i> {{ feedback.rating_sum_positive }}
                     </span>
                     <span class="{% if not feedback.rating_sum_negative %}invisible{% endif %}">
-                        <i data-feather="thumbs-down" class="pl-1"></i> {{ feedback.rating_sum_negative }}
+                        <i icon-name="thumbs-down" class="pl-1"></i> {{ feedback.rating_sum_negative }}
                 </span>
             </td>
             <td class="pr-2">

--- a/integreat_cms/cms/templates/feedback/region_feedback_list.html
+++ b/integreat_cms/cms/templates/feedback/region_feedback_list.html
@@ -60,34 +60,34 @@
                     <td class="pr-2 feedback-comment max-w-[75px] xl:max-w-[280px] 2xl:max-w-[400px] 3xl:max-w-[550px] 4xl:max-w-[900px]"
                         title="{{ feedback.comment }}">
                         {% if not feedback.comment %}
-                            <i data-feather="minus" class="pr-1"></i>
+                            <i icon-name="minus" class="pr-1"></i>
                         {% else %}
                             <div class="flex">
                                 <div class="feedback-comment-preview truncate grow">{{ feedback.comment }}</div>
-                                <i data-feather="chevron-down"
+                                <i icon-name="chevron-down"
                                     class="toggle-feedback-comment transform cursor-pointer hover:scale-125 flex-none"></i>
                             </div>
                             <div class="hidden">
-                                <span class="feedback-comment-full">{{ feedback.comment }}</span> <i data-feather="chevron-up"
+                                <span class="feedback-comment-full">{{ feedback.comment }}</span> <i icon-name="chevron-up"
                                 class="toggle-feedback-comment transform cursor-pointer hover:scale-125"></i>
                             </div>
                         {% endif %}
                     </td>
                     <td class="pr-2">
                         {% if feedback.rating == True %}
-                            <i data-feather="thumbs-up" class="pr-1"></i>
+                            <i icon-name="thumbs-up" class="pr-1"></i>
                         {% elif feedback.rating == False %}
-                            <i data-feather="thumbs-down" class="pr-1"></i>
+                            <i icon-name="thumbs-down" class="pr-1"></i>
                         {% elif feedback.rating == None %}
-                            <i data-feather="minus" class="pr-1"></i>
+                            <i icon-name="minus" class="pr-1"></i>
                         {% endif %}
                     </td>
                     <td class="pr-2">
                         <span class="{% if not feedback.rating_sum_positive %}invisible{% endif %}">
-                            <i data-feather="thumbs-up" class="pr-1"></i> {{ feedback.rating_sum_positive }}
+                            <i icon-name="thumbs-up" class="pr-1"></i> {{ feedback.rating_sum_positive }}
                     </span>
                     <span class="{% if not feedback.rating_sum_negative %}invisible{% endif %}">
-                        <i data-feather="thumbs-down" class="pl-1"></i> {{ feedback.rating_sum_negative }}
+                        <i icon-name="thumbs-down" class="pl-1"></i> {{ feedback.rating_sum_negative }}
                 </span>
             </td>
             <td class="pr-2">

--- a/integreat_cms/cms/templates/generic_confirmation_dialog.html
+++ b/integreat_cms/cms/templates/generic_confirmation_dialog.html
@@ -8,7 +8,7 @@
      class="flex flex-col justify-center max-w-sm fixed inset-0 hidden">
     <div class="content w-full rounded shadow-2xl bg-white">
         <div class="flex items-center font-bold rounded p-4 bg-water-500">
-            <i data-feather="alert-triangle" class="text-red-500"></i>
+            <i icon-name="alert-triangle" class="text-red-500"></i>
             <span class="uppercase pl-2">{% trans 'Warning' %}</span>
         </div>
         <div class="w-full p-4 rounded shadow">

--- a/integreat_cms/cms/templates/generic_language_switcher.html
+++ b/integreat_cms/cms/templates/generic_language_switcher.html
@@ -10,7 +10,7 @@
             {% if language.secondary_country_code %}
                 <span class="fp fp-rounded fp-{{ language.secondary_country_code }}"></span>
             {% endif %}
-            <i id="language-switcher-chevron" class="-mr-2 h-5" data-feather="chevron-down"></i>
+            <i id="language-switcher-chevron" class="-mr-2 h-5" icon-name="chevron-down"></i>
         </span>
     </a>
     <div id="language-switcher-list" class="h-0 hidden">

--- a/integreat_cms/cms/templates/icon_widget.html
+++ b/integreat_cms/cms/templates/icon_widget.html
@@ -11,7 +11,7 @@
     </div>
     <div class="w-full" id="set-icon-button">
         <label for="{{ widget.attrs.id }}" class="block w-full text-center font-bold bg-blue-500 hover:bg-blue-600 focus:bg-blue-500 text-white py-2 px-4 rounded cursor-pointer relative">
-            <i data-feather="image" class="mr-2"></i>
+            <i icon-name="image" class="mr-2"></i>
             <span id="set-icon-label" class="{% if icon %}hidden{% endif %}">{% blocktrans %}Set {{ label }}{% endblocktrans %}</span>
             <span id="change-icon-label" class="{% if not icon %}hidden{% endif %}">{% blocktrans %}Change {{ label }}{% endblocktrans %}</span>
         </label>
@@ -20,13 +20,13 @@
     </div>
     <div id="remove-icon" class="w-full mt-2 {% if not icon %}hidden{% endif %}">
         <div class="block w-full text-center font-bold bg-gray-500 hover:bg-gray-600 focus:bg-gray-600 text-white py-2 px-4 rounded cursor-pointer relative">
-            <i data-feather="trash-2" class="mr-2"></i>
+            <i icon-name="trash-2" class="mr-2"></i>
             {% blocktrans %}Remove {{ label }}{% endblocktrans %}
         </div>
     </div>
     <div id="restore-icon" class="w-full mt-2 hidden">
         <div class="block w-full text-center font-bold bg-gray-500 hover:bg-gray-600 focus:bg-gray-500 text-white py-2 px-4 rounded cursor-pointer relative">
-            <i data-feather="refresh-ccw" class="mr-2"></i>
+            <i icon-name="refresh-ccw" class="mr-2"></i>
             {% blocktrans %}Restore {{ label }}{% endblocktrans %}
         </div>
     </div>

--- a/integreat_cms/cms/templates/imprint/imprint_form.html
+++ b/integreat_cms/cms/templates/imprint/imprint_form.html
@@ -70,7 +70,7 @@
                                        data-copy-to-clipboard="{{ imprint_translation_form.instance.short_url }}"
                                        title="{% trans 'Copy to clipboard' %}"
                                        class="mx-2 text-gray-800 hover:text-blue-500">
-                                        <i data-feather="copy"></i>
+                                        <i icon-name="copy"></i>
                                     </a>
                                 </div>
                             {% endif %}
@@ -85,7 +85,7 @@
                                data-copy-to-clipboard="{{ WEBAPP_URL }}/{{ request.region.slug }}/{{ language.slug }}/{{ IMPRINT_SLUG }}"
                                title="{% trans 'Copy to clipboard' %}"
                                class="px-2 text-gray-800 hover:text-blue-500">
-                                <i data-feather="copy"></i>
+                                <i icon-name="copy"></i>
                             </a>
                         </div>
                         <label for="{{ imprint_translation_form.content.id_for_label }}">{{ imprint_translation_form.content.label }}</label>
@@ -98,7 +98,7 @@
                     <div class="rounded border border-blue-500 shadow-2xl bg-white">
                         <div class="rounded p-4 bg-water-500">
                             <h3 class="heading font-bold">
-                                <i data-feather="feather" class="pb-1"></i>
+                                <i icon-name="feather" class="pb-1"></i>
                                 {% trans "Minor edit" %}
                             </h3>
                         </div>
@@ -116,7 +116,7 @@
                         <div class="rounded border border-blue-500 shadow-2xl bg-white">
                             <div class="rounded p-4 bg-water-500">
                                 <h3 class="heading font-bold text-black">
-                                    <i data-feather="tool" class="pb-1"></i>
+                                    <i icon-name="wrench" class="pb-1"></i>
                                     {% trans "Actions" %}
                                 </h3>
                             </div>
@@ -128,7 +128,7 @@
                                         data-confirmation-text="{% trans 'All translations of the imprint will also be deleted.' %}"
                                         data-confirmation-subject="{{ imprint_translation_form.instance.title }}"
                                         data-action="{% url 'delete_imprint' region_slug=request.region.slug %}">
-                                    <i data-feather="trash-2" class="mr-2"></i>
+                                    <i icon-name="trash-2" class="mr-2"></i>
                                     {% trans 'Delete the imprint' %}
                                 </button>
                             </div>
@@ -137,7 +137,7 @@
                     <div class="rounded border border-blue-500 shadow-2xl bg-white">
                         <div class="rounded p-4 bg-water-500">
                             <h3 class="heading font-bold text-black">
-                                <i data-feather="columns" class="pb-1"></i>
+                                <i icon-name="columns" class="pb-1"></i>
                                 {% trans 'Side-by-Side view' %}
                             </h3>
                         </div>
@@ -155,7 +155,7 @@
                                 {% endfor %}
                             </select>
                             <a id="side-by-side-link" class="btn mt-4" disabled="disabled">
-                                <i data-feather="external-link"></i>
+                                <i icon-name="external-link"></i>
                                 {% trans 'Show translations side by side' %}
                             </a>
                         </div>

--- a/integreat_cms/cms/templates/imprint/imprint_revisions.html
+++ b/integreat_cms/cms/templates/imprint/imprint_revisions.html
@@ -8,7 +8,7 @@
 <div class="mb-6">
     <h1 class="heading">{% trans 'Imprint versions' %}</h1>
     <a href="{% url 'edit_imprint' region_slug=request.region.slug language_slug=language.slug %}" class="btn btn-gray">
-        <i data-feather="arrow-left-circle" class="align-top"></i> {% trans 'Back to the imprint form' %}
+        <i icon-name="arrow-left-circle" class="align-top"></i> {% trans 'Back to the imprint form' %}
     </a>
 </div>
 

--- a/integreat_cms/cms/templates/imprint/imprint_sbs.html
+++ b/integreat_cms/cms/templates/imprint/imprint_sbs.html
@@ -15,7 +15,7 @@
             <div class="flex flex-wrap grow justify-between gap-2 mb-4">
                 <a href="{% url 'edit_imprint' region_slug=request.region.slug language_slug=target_language.slug %}"
                    class="bg-gray-400 hover:bg-gray-500 text-center cursor-pointer text-white font-bold py-3 px-4 rounded">
-                    <i data-feather="arrow-left-circle" class="align-top"></i> {% trans 'Back to the imprint form' %}
+                    <i icon-name="arrow-left-circle" class="align-top"></i> {% trans 'Back to the imprint form' %}
                 </a>
                 {% if perms.cms.change_imprintpage %}
                     <div class="flex flex-wrap gap-2">
@@ -35,15 +35,15 @@
                     <div class="rounded p-4 bg-water-500 font-bold">
                         {% if source_imprint_translation.is_outdated %}
                             <span title="{% trans 'Translation outdated' %}">
-                                <i data-feather="alert-triangle"></i>
+                                <i icon-name="alert-triangle"></i>
                             </span>
                         {% elif source_imprint_translation.currently_in_translation %}
                             <span title="{% trans 'Currently in translation' %}">
-                                <i data-feather="clock"></i>
+                                <i icon-name="clock"></i>
                             </span>
                         {% else %}
                             <span title="{% trans 'Translation up-to-date' %}">
-                                <i data-feather="check"></i>
+                                <i icon-name="check"></i>
                             </span>
                         {% endif %}
                         {{ source_imprint_translation.language.translated_name }}
@@ -64,7 +64,7 @@
                            data-copy-to-clipboard="{{ WEBAPP_URL }}/{{ request.region.slug }}/{{ source_imprint_translation.language.slug }}/{{ IMPRINT_SLUG }}"
                            title="{% trans 'Copy to clipboard' %}"
                            class="px-2 text-gray-800 hover:text-blue-600">
-                            <i data-feather="copy"></i>
+                            <i icon-name="copy"></i>
                         </a>
                         <br>
                         <label>{{ imprint_translation_form.title.label }}</label>
@@ -83,7 +83,7 @@
                             {% with source_language=source_imprint_translation.language.translated_name target_language_name=target_language.translated_name %}
                                 {% blocktrans %}Copy content of {{ source_language }} to {{ target_language_name }}{% endblocktrans %}
                             {% endwith %}
-                            <i data-feather="arrow-right-circle" class="mr-2"></i>
+                            <i icon-name="arrow-right-circle" class="mr-2"></i>
                         </button>
                     </div>
                 </div>
@@ -92,20 +92,20 @@
                         {% if imprint_translation_form.instance.id %}
                             {% if imprint_translation_form.instance.is_outdated %}
                                 <span title="{% trans 'Translation outdated' %}">
-                                    <i data-feather="alert-triangle"></i>
+                                    <i icon-name="alert-triangle"></i>
                                 </span>
                             {% elif imprint_translation_form.instance.currently_in_translation %}
                                 <span title="{% trans 'Currently in translation' %}">
-                                    <i data-feather="clock"></i>
+                                    <i icon-name="clock"></i>
                                 </span>
                             {% else %}
                                 <span title="{% trans 'Translation up-to-date' %}">
-                                    <i data-feather="check"></i>
+                                    <i icon-name="check"></i>
                                 </span>
                             {% endif %}
                         {% else %}
                             <span title="{% trans 'Create Translation' %}">
-                                <i data-feather="plus"></i>
+                                <i icon-name="plus"></i>
                             </span>
                         {% endif %}
                         {{ target_language.translated_name }}
@@ -128,7 +128,7 @@
                                data-copy-to-clipboard="{{ WEBAPP_URL }}/{{ request.region.slug }}/{{ target_language.slug }}/{{ IMPRINT_SLUG }}"
                                title="{% trans 'Copy to clipboard' %}"
                                class="px-2 text-gray-800 hover:text-blue-600">
-                                <i data-feather="copy"></i>
+                                <i icon-name="copy"></i>
                             </a>
                             <br>
                         {% else %}

--- a/integreat_cms/cms/templates/languages/language_form.html
+++ b/integreat_cms/cms/templates/languages/language_form.html
@@ -24,7 +24,7 @@
       <div class="w-full xl:w-1/2">
         <div class="w-full mb-4 rounded border border-solid border-blue-500 shadow-2xl bg-white">
             <div class="w-full p-4 rounded bg-water-500">
-                <h3 class="font-bold text-black"><i data-feather="flag" class="mr-2"></i> {% trans 'Name' %}</h3>
+                <h3 class="font-bold text-black"><i icon-name="flag" class="mr-2"></i> {% trans 'Name' %}</h3>
             </div>
             <div class="w-full p-4">
                 <label for="{{ form.native_name.id_for_label }}" class="block mb-2">{{ form.native_name.label }}</label>
@@ -37,7 +37,7 @@
         </div>
         <div class="w-full mb-4 rounded border border-solid border-blue-500 shadow-2xl bg-white">
             <div class="w-full p-4 rounded bg-water-500">
-                <h3 class="font-bold text-black"><i data-feather="tag" class="mr-2"></i> {% trans 'Identifier' %}</h3>
+                <h3 class="font-bold text-black"><i icon-name="tag" class="mr-2"></i> {% trans 'Identifier' %}</h3>
             </div>
             <div class="w-full p-4">
                 <label for="{{ form.slug.id_for_label }}" class="block mb-2">{{ form.slug.label }}</label>
@@ -52,7 +52,7 @@
     <div class="w-full xl:w-1/2 xl:pl-4">
         <div class="w-full mb-4 rounded border border-solid border-blue-500 shadow-2xl bg-white">
             <div class="w-full p-4 rounded bg-water-500">
-                <h3 class="font-bold text-black"><i data-feather="globe" class="mr-2"></i> {% trans 'Translations' %}</h3>
+                <h3 class="font-bold text-black"><i icon-name="globe" class="mr-2"></i> {% trans 'Translations' %}</h3>
             </div>
             <div class="w-full p-4">
                 <label for="{{ form.table_of_contents.id_for_label }}" class="font-bold block mt-4 mb-2 cursor-pointer">{{ form.table_of_contents.label }}</label>
@@ -71,7 +71,7 @@
         <div class="w-full">
             <div class="w-full mb-4 rounded border border-solid border-blue-500 shadow-2xl bg-white">
                 <div class="w-full p-4 rounded bg-water-500">
-                    <h3 class="font-bold text-black"><i data-feather="settings" class="mr-2"></i> {% trans 'Extended Settings' %}</h3>
+                    <h3 class="font-bold text-black"><i icon-name="settings" class="mr-2"></i> {% trans 'Extended Settings' %}</h3>
                 </div>
                 <div class="w-full p-4">
                     <label for="{{ form.text_direction.id_for_label }}" class="block mb-2">{{ form.text_direction.label }}</label>
@@ -100,7 +100,7 @@
     {% if form.instance.id and perms.cms.delete_language %}
         {% if form.instance.language_tree_nodes.exists %}
             <button title="{% trans 'You cannot delete a language that is used in at least one region.' %}" class="btn" disabled>
-                <i data-feather="trash-2"></i>
+                <i icon-name="trash-2"></i>
                 {% trans 'Delete this language' %}
             </button>
         {% else %}
@@ -109,7 +109,7 @@
                     data-confirmation-text="{{ delete_dialog_text }}"
                     data-confirmation-subject="{{ form.instance.translated_name }}"
                     data-action="{% url 'delete_language' slug=form.instance.slug %}">
-                <i data-feather="trash-2"></i>
+                <i icon-name="trash-2"></i>
                 {% trans 'Delete this language' %}
             </button>
         {% endif %}

--- a/integreat_cms/cms/templates/languages/language_list_row.html
+++ b/integreat_cms/cms/templates/languages/language_list_row.html
@@ -35,7 +35,7 @@
         {% if perms.cms.delete_language %}
             {% if language.language_tree_nodes.exists %}
                 <button title="{% trans 'You cannot delete a language that is used in at least one region.' %}" class="btn-icon" disabled>
-                    <i data-feather="trash-2"></i>
+                    <i icon-name="trash-2"></i>
                 </button>
             {% else %}
                 <button title="{% trans 'Delete language' %}" class="confirmation-button btn-icon"
@@ -43,7 +43,7 @@
                         data-confirmation-text="{{ delete_dialog_text }}"
                         data-confirmation-subject="{{ language.translated_name }}"
                         data-action="{% url 'delete_language' slug=language.slug %}">
-                    <i data-feather="trash-2"></i>
+                    <i icon-name="trash-2"></i>
                 </button>
             {% endif %}
         {% endif %}

--- a/integreat_cms/cms/templates/languagetreenodes/languagetreenode_form.html
+++ b/integreat_cms/cms/templates/languagetreenodes/languagetreenode_form.html
@@ -39,7 +39,7 @@
                         <span class="fp fp-rounded fp-{{ form.instance.language.secondary_country_code }} text-[24px] align-bottom"></span>
                     {% endif %}
                 {% else %}
-                    <i data-feather="flag"></i>
+                    <i icon-name="flag"></i>
                 {% endif %}
                 <span class="ml-2">{% trans 'Language tree node' %}</span>
                 {% if form.instance.id %}

--- a/integreat_cms/cms/templates/languagetreenodes/languagetreenode_list_row.html
+++ b/integreat_cms/cms/templates/languagetreenodes/languagetreenode_list_row.html
@@ -10,7 +10,7 @@
     </td>
     <td class="hierarchy single_icon">
 		<span data-drag-id="{{ node.id }}" data-node-descendants="{{ node|get_descendant_ids }}" class="drag text-gray-800 block py-1.5 px-2 cursor-move" draggable="true">
-            <i data-feather="move" class="text-gray-800"></i>
+            <i icon-name="move" class="text-gray-800"></i>
         </span>
     </td>
 	<td>
@@ -34,18 +34,18 @@
 	<td>
 		<div class="flex justify-center">
 			{% if node.active %}
-				<i data-feather="check" class="text-green-500"></i>
+				<i icon-name="check" class="text-green-500"></i>
 			{% else %}
-				<i data-feather="x" class="text-red-500"></i>
+				<i icon-name="x" class="text-red-500"></i>
 			{% endif %}
 		</div>
 	</td>
 	<td>
 		<div class="flex justify-center">
 			{% if node.visible %}
-				<i data-feather="check" class="text-green-500"></i>
+				<i icon-name="check" class="text-green-500"></i>
 			{% else %}
-				<i data-feather="x" class="text-red-500"></i>
+				<i icon-name="x" class="text-red-500"></i>
 			{% endif %}
 		</div>
 	</td>
@@ -58,7 +58,7 @@
 				data-confirmation-text="{{ delete_dialog_text }}"
 				data-confirmation-subject="{{ node.translated_name }}"
 				data-action="{% url 'delete_languagetreenode' region_slug=request.region.slug pk=node.pk %}">
-				<i data-feather="trash-2" class="{% if not node.is_leaf %}text-gray-400{% else %}text-gray-800{% endif %}"></i>
+				<i icon-name="trash-2" class="{% if not node.is_leaf %}text-gray-400{% else %}text-gray-800{% endif %}"></i>
 			</button>
 		{% endif %}
 	</td>

--- a/integreat_cms/cms/templates/linkcheck/link_list_row.html
+++ b/integreat_cms/cms/templates/linkcheck/link_list_row.html
@@ -52,7 +52,7 @@
         <a title="{% trans 'Replace URL globally' %}"
            href="{% url 'edit_url' url_id=url.id url_filter=view.kwargs.url_filter region_slug=request.region.slug %}{{ pagination_params }}#replace-url"
            class="btn-icon">
-            <i data-feather="edit"></i>
+            <i icon-name="edit"></i>
         </a>
     </td>
 </tr>

--- a/integreat_cms/cms/templates/offertemplates/offertemplate_form.html
+++ b/integreat_cms/cms/templates/offertemplates/offertemplate_form.html
@@ -27,7 +27,7 @@
     <div class="grid xl:grid-cols-2 gap-4">
 		<div class="mb-4 rounded border border-solid border-blue-500 shadow-2xl bg-white">
 			<div class="p-4 rounded bg-water-500">
-				<h3 class="heading font-bold text-black"><i data-feather="star" class="mr-2"></i> {% trans 'General Settings' %}</h3>
+				<h3 class="heading font-bold text-black"><i icon-name="star" class="mr-2"></i> {% trans 'General Settings' %}</h3>
 			</div>
 			<div class="px-4 pb-4 divide-y divide-gray-200 space-y-4">
 				<div>
@@ -54,7 +54,7 @@
 		</div>
 		<div class="mb-4 rounded border border-solid border-blue-500 shadow-2xl bg-white">
 			<div class="p-4 rounded bg-water-500">
-				<h3 class="heading font-bold text-black"><i data-feather="settings" class="mr-2"></i> {% trans 'Extended Settings' %}</h3>
+				<h3 class="heading font-bold text-black"><i icon-name="settings" class="mr-2"></i> {% trans 'Extended Settings' %}</h3>
 			</div>
 			<div class="px-4 pb-4 divide-y divide-gray-200 space-y-4">
 				<div>
@@ -77,7 +77,7 @@
 	{% if form.instance.id and perms.cms.delete_offertemplate %}
 		{% if form.instance.regions.exists %}
 			<button title="{% trans 'This offer template cannot be deleted because it is used in at least one region.' %}" class="btn" disabled>
-				<i data-feather="trash-2"></i>
+				<i icon-name="trash-2"></i>
 				{% trans 'Delete this offer templates' %}
 			</button>
 		{% else %}
@@ -86,7 +86,7 @@
 					data-confirmation-text="{{ delete_dialog_text }}"
 					data-confirmation-subject="{{ form.instance.name }}"
 					data-action="{% url 'delete_offertemplate' slug=form.instance.slug %}">
-				<i data-feather="trash-2"></i>
+				<i icon-name="trash-2"></i>
 				{% trans 'Delete this offer templates' %}
 			</button>
 		{% endif %}

--- a/integreat_cms/cms/templates/offertemplates/offertemplate_list_row.html
+++ b/integreat_cms/cms/templates/offertemplates/offertemplate_list_row.html
@@ -25,7 +25,7 @@
         {% if perms.cms.delete_offertemplate %}
             {% if offer_template.regions.exists %}
                 <button title="{% trans 'This offer template cannot be deleted because it is used in at least one region.' %}" class="btn-icon" disabled>
-                    <i data-feather="trash-2"></i>
+                    <i icon-name="trash-2"></i>
                 </button>
             {% else %}
                 <button title="{% trans 'Delete offer templates' %}" class="confirmation-button btn-icon"
@@ -33,7 +33,7 @@
                         data-confirmation-text="{{ delete_dialog_text }}"
                         data-confirmation-subject="{{ offer_template.name }}"
                         data-action="{% url 'delete_offertemplate' slug=offer_template.slug %}">
-                    <i data-feather="trash-2"></i>
+                    <i icon-name="trash-2"></i>
                 </button>
             {% endif %}
         {% endif %}

--- a/integreat_cms/cms/templates/organizations/organization_form.html
+++ b/integreat_cms/cms/templates/organizations/organization_form.html
@@ -22,7 +22,7 @@
     <div class="grid xl:grid-cols-2 gap-4">
 		<div class="mb-4 rounded border border-solid border-blue-500 shadow-2xl bg-white">
 			<div class="p-4 rounded bg-water-500">
-				<h3 class="heading font-bold text-black"><i data-feather="umbrella" class="mr-2"></i> {% trans 'General Settings' %}</h3>
+				<h3 class="heading font-bold text-black"><i icon-name="umbrella" class="mr-2"></i> {% trans 'General Settings' %}</h3>
 			</div>
 			<div class="px-4 pb-4">
 				<!-- General Options for organization management -->
@@ -35,7 +35,7 @@
 		</div>
 		<div class="mb-4 rounded border border-solid border-blue-500 shadow-2xl bg-white">
 			<div class="p-4 rounded bg-water-500">
-				<h3 class="heading font-bold text-black"><i data-feather="settings" class="mr-2"></i> {% trans 'Extended Settings' %}</h3>
+				<h3 class="heading font-bold text-black"><i icon-name="settings" class="mr-2"></i> {% trans 'Extended Settings' %}</h3>
 			</div>
 			<div class="px-4 pb-4">
 				<label for="{{ form.icon.id_for_label }}">{{ form.icon.label }}</label>
@@ -50,7 +50,7 @@
 				data-confirmation-text="{{ delete_dialog_text }}"
 				data-confirmation-subject="{{ form.name.value }}"
 				data-action="{% url 'delete_organization' region_slug=request.region.slug slug=form.instance.slug %}">
-			<i data-feather="trash-2" class="mr-2"></i>
+			<i icon-name="trash-2" class="mr-2"></i>
 			{% trans 'Delete this organization' %}
 		</button>
 	</div>

--- a/integreat_cms/cms/templates/organizations/organization_list_row.html
+++ b/integreat_cms/cms/templates/organizations/organization_list_row.html
@@ -17,7 +17,7 @@
                 <img src="{{ organization.icon.url }}" alt="{{ organization.icon.url }}" style="max-height:48px">
             </a>
         {% else %}
-            <i data-feather="x" class="text-red-500"></i>
+            <i icon-name="x" class="text-red-500"></i>
         {% endif %}
 	</td>
     <td class="pl-2 pr-4 text-right min">
@@ -27,7 +27,7 @@
                     data-confirmation-text="{{ delete_dialog_text }}"
                     data-confirmation-subject="{{ organization.name }}"
                     data-action="{% url 'delete_organization' region_slug=request.region.slug slug=organization.slug %}">
-                <i data-feather="trash-2"></i>
+                <i icon-name="trash-2"></i>
             </button>
         {% endif %}
     </td>

--- a/integreat_cms/cms/templates/pages/_page_order_table.html
+++ b/integreat_cms/cms/templates/pages/_page_order_table.html
@@ -13,7 +13,7 @@
                                   draggable="true"
                                   title="{% trans 'Change the position of the page with drag & drop.' %}"
                                   {% endif %}>
-                                <i data-feather="move"></i>
+                                <i icon-name="move"></i>
                             </span>
                         </td>
                         <td id="page_title" data-default-title="{{ sibling.best_translation.title }}">{{ sibling.best_translation.title }}</td>
@@ -43,7 +43,7 @@
                     <tr class="border-2 border-blue-500 hover:bg-gray-100">
                         <td class="single_icon min">
                             <span class="drag text-gray-800 block py-3 px-2 cursor-move" draggable="true">
-                                <i data-feather="move"></i>
+                                <i icon-name="move"></i>
                             </span>
                         </td>
                         <td id="page_title" data-default-title="{% trans 'New Page' %}">{% trans 'New Page' %}</td>
@@ -52,7 +52,7 @@
                     <tr class="border-2 border-blue-500 hover:bg-gray-100">
                         <td class="single_icon min">
                             <span class="drag text-gray-800 block py-3 px-2 cursor-move" draggable="true">
-                                <i data-feather="move"></i>
+                                <i icon-name="move"></i>
                             </span>
                         </td>
                         <td id="page_title" data-default-title="{{ page.best_translation.title }}">{{ page.best_translation.title }}</td>

--- a/integreat_cms/cms/templates/pages/_page_permission_table.html
+++ b/integreat_cms/cms/templates/pages/_page_permission_table.html
@@ -33,7 +33,7 @@
                   title="{{ user.username }}">
                 {{ user.full_user_name }}
                 <a class="revoke-page-permission inline-block align-middle hover:text-red-500" href="{% url 'revoke_page_permission_ajax' region_slug=request.region.slug %}" data-user-id="{{ user.id }}" data-page-id="{{ page.id }}" data-permission="edit">
-                    <i data-feather="x-circle"></i>
+                    <i icon-name="x-circle"></i>
                 </a>
             </span>
         {% empty %}
@@ -42,7 +42,7 @@
     <div class="w-full flex flex-wrap mt-2">
             {% render_field page_form.editors %}
             <a class="grant-page-permission bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-4 mt-2 rounded w-full" data-url="{% url 'grant_page_permission_ajax' region_slug=request.region.slug %}" data-page-id="{{ page.id }}" data-permission="edit">
-                <i data-feather="plus-circle" class="mr-2"></i> {% trans 'Add to authors' %}
+                <i icon-name="plus-circle" class="mr-2"></i> {% trans 'Add to authors' %}
             </a>
     </div>
     <label for="{{ page_form.publishers.id_for_label }}" class="secondary">{{ page_form.publishers.label }}</label>
@@ -53,7 +53,7 @@
                   title="{{ user.username }}">
                 {{ user.full_user_name }}
                 <a class="revoke-page-permission inline-block align-middle hover:text-red-500" href="{% url 'revoke_page_permission_ajax' region_slug=request.region.slug %}" data-user-id="{{ user.id }}" data-page-id="{{ page.id }}" data-permission="publish">
-                    <i data-feather="x-circle"></i>
+                    <i icon-name="x-circle"></i>
                 </a>
             </span>
         {% empty %}
@@ -62,6 +62,6 @@
     <div class="w-full flex flex-wrap mt-2">
         {% render_field page_form.publishers %}
         <button class="btn grant-page-permission bg-blue-500 hover:bg-blue-600 text-white font-bold py-3 px-4 mt-2 rounded w-full" data-url="{% url 'grant_page_permission_ajax' region_slug=request.region.slug %}" data-page-id="{{ page.id }}" data-permission="publish">
-            <i data-feather="plus-circle" class="mr-2"></i> {% trans 'Add to editors' %}
+            <i icon-name="plus-circle" class="mr-2"></i> {% trans 'Add to editors' %}
         </button>
     </div>

--- a/integreat_cms/cms/templates/pages/_page_preview_overlay.html
+++ b/integreat_cms/cms/templates/pages/_page_preview_overlay.html
@@ -4,7 +4,7 @@
     <div class="cursor-auto flex flex-col justify-center max-h-fit w-[850px] max-w-full w-auto px-[10px] z-50 m-auto">
         <div class="bg-white opacity-100 content rounded shadow-md w-full">
             <button type="button" id="btn-close-preview" class="float-right m-4 p-1 rounded-full hover:bg-blue-500 hover:text-white">
-                <i data-feather="x-circle" class="h-8 w-8"></i>
+                <i icon-name="x-circle" class="h-8 w-8"></i>
             </button> 
             <div class="p-12 {% if language.slug == 'zh-CN' %} font-content-sc {% elif right_to_left %} font-content-rtl text-right {% else %} font-content {% endif %}">
                 <h1 id="preview-content-header" class="pt-4 mb-4 text-center font-bold text-[32px] font-default"></h1>

--- a/integreat_cms/cms/templates/pages/_page_xliff_export_overlay.html
+++ b/integreat_cms/cms/templates/pages/_page_xliff_export_overlay.html
@@ -6,7 +6,7 @@
             <div class="flex items-center w-full rounded p-4 bg-water-500">
                 <h2 class="font-bold font-default">{% trans 'Multilingual XLIFF export' %}</h2>
                 <button type="button" id="btn-close-xliff-export" class="flex ml-auto rounded-full hover:bg-blue-500 hover:text-white">
-                    <i data-feather="x-circle" class="h-8 w-8"></i>
+                    <i icon-name="x-circle" class="h-8 w-8"></i>
                 </button>
             </div> 
             <div class="w-full p-4 rounded shadow">

--- a/integreat_cms/cms/templates/pages/_page_xliff_import_diff.html
+++ b/integreat_cms/cms/templates/pages/_page_xliff_import_diff.html
@@ -34,12 +34,12 @@
             {% trans 'deleted user' as deleted_user_text %}
             <div>
                 <label class="block font-bold text-lg">{% trans 'Last updated' %}:</label>
-                <i data-feather="calendar"></i> {{ diff.existing.last_updated }} {% trans 'by' %}
-                <i data-feather="user"></i> {% firstof diff.existing.creator deleted_user_text %}
+                <i icon-name="calendar"></i> {{ diff.existing.last_updated }} {% trans 'by' %}
+                <i icon-name="user"></i> {% firstof diff.existing.creator deleted_user_text %}
             </div>
             <div>
                 <label class="block font-bold text-lg">{% trans 'Versions' %}:</label>
-                <i data-feather="clock"></i>
+                <i icon-name="clock"></i>
                 <a href="{% url 'page_revisions' page_id=diff.existing.page.id region_slug=diff.existing.page.region.slug language_slug=diff.existing.language.slug %}"
                    class="text-blue-500 hover:underline" target="_blank" rel="noopener noreferrer">
                     {% trans 'Show previous versions' %} ({{ diff.existing.version }})
@@ -52,7 +52,7 @@
                 <li class="xliff-show-preview-diff mr-1 z-10" style="margin-bottom: -2px">
                     <div class="bg-white text-blue-500 border-l-2 border-t-2 border-r-2 border-blue-500 font-bold rounded-t-lg">
                         <div class="border-b-2 border-white p-4">
-                            <i data-feather="layout"></i>
+                            <i icon-name="layout"></i>
                             {% trans 'Preview' %}
                         </div>
                     </div>
@@ -60,7 +60,7 @@
                 <li class="xliff-show-source-code-diff cursor-pointer mr-1" style="margin-bottom: -2px">
                     <div class="bg-white text-blue-500 hover:bg-blue-500 hover:text-white border-l-2 border-t-2 border-r-2 border-blue-500 font-bold rounded-t-lg">
                         <div class="border-b-2 border-white">
-                            <div class="p-4"><i data-feather="code"></i> {% trans 'Source Code' %}</div>
+                            <div class="p-4"><i icon-name="code"></i> {% trans 'Source Code' %}</div>
                         </div>
                     </div>
                 </li>

--- a/integreat_cms/cms/templates/pages/page_form.html
+++ b/integreat_cms/cms/templates/pages/page_form.html
@@ -79,7 +79,7 @@
                     <div class="flex flex-col flex-auto p-4">
                         {% if page_translation_form.instance.currently_in_translation %}
                             <div id="currently-in-translation-warning">
-                                <i data-feather="alert-triangle" class="text-red-500"></i>
+                                <i icon-name="alert-triangle" class="text-red-500"></i>
                                 <label class="inline-block mb-2 font-bold">{% trans 'Warning' %}:</label>
                                 {% trans 'Translation in progress' %}
                                 (<a href="#"
@@ -129,7 +129,7 @@
                                        data-copy-to-clipboard="{{ page_translation_form.instance.short_url }}"
                                        title="{% trans 'Copy to clipboard' %}"
                                        class="mx-2 text-gray-800 hover:text-blue-500">
-                                        <i data-feather="copy"></i>
+                                        <i icon-name="copy"></i>
                                     </a>
                                 </div>
                             {% endif %}
@@ -143,22 +143,22 @@
                                href="{{ page_translation_form.instance.base_link }}{{ page_translation_form.instance.slug }}"
                                class="text-blue-500 hover:underline">{{ page_translation_form.instance.base_link }}{{ page_translation_form.instance.slug }}</a>
                             <a id="edit-slug-btn" title="{% trans 'Edit' %}" class="mx-2 btn-icon">
-                                <i data-feather="edit-3"></i>
+                                <i icon-name="edit-3"></i>
                             </a>
                             <a id="copy-slug-btn"
                                title="{% trans 'Copy to clipboard' %}"
                                class="btn-icon">
-                                <i data-feather="copy"></i>
+                                <i icon-name="copy"></i>
                             </a>
                             <div class="slug-field hidden">
                                 <label for="{{ page_translation_form.slug.id_for_label }}">{{ page_translation_form.instance.base_link }}</label>
                                 {% render_field page_translation_form.slug|add_error_class:"slug-error" %}
                             </div>
                             <a id="save-slug-btn" class="mx-2 btn-icon hidden">
-                                <i data-feather="save"></i>
+                                <i icon-name="save"></i>
                             </a>
                             <a id="restore-slug-btn" class="btn-icon hidden">
-                                <i data-feather="x-circle"></i>
+                                <i icon-name="x-circle"></i>
                             </a>
                         </div>
                         <label for="{{ page_translation_form.content.id_for_label }}">{{ page_translation_form.content.label }}</label>
@@ -171,7 +171,7 @@
                     <div class="rounded border border-blue-500 shadow-2xl bg-white">
                         <div class="rounded p-4 bg-water-500">
                             <h3 class="heading font-bold text-black">
-                                <i data-feather="feather" class="pb-1"></i>
+                                <i icon-name="feather" class="pb-1"></i>
                                 {% trans "Minor edit" %}
                             </h3>
                         </div>
@@ -189,7 +189,7 @@
                 <div class="rounded border border-solid border-blue-500 shadow-2xl bg-white">
                     <div class="rounded p-4 bg-water-500">
                         <h3 class="heading font-bold text-black">
-                            <i data-feather="settings" class="pb-1"></i>
+                            <i icon-name="settings" class="pb-1"></i>
                             {% trans 'Settings of the page' %}
                         </h3>
                     </div>
@@ -235,13 +235,13 @@
                                         <button id="copy-api-token"
                                                 title="{% trans 'Copy to clipboard' %}"
                                                 class="bg-blue-500 hover:bg-blue-600 text-white px-3 rounded-r">
-                                            <i data-feather="copy" class="w-5 align-bottom"></i>
+                                            <i icon-name="copy" class="w-5 align-bottom"></i>
                                         </button>
                                         <button id="copy-api-token-success"
                                                 title="{% trans 'Access token was successfully copied to clipboard' %}"
                                                 class="bg-green-500 text-white px-3 rounded-r hidden"
                                                 disabled>
-                                            <i data-feather="check-circle" class="w-5 align-middle"></i>
+                                            <i icon-name="check-circle" class="w-5 align-middle"></i>
                                         </button>
                                     </div>
                                     <div class="help-text">
@@ -281,7 +281,7 @@
                         <div class="rounded border border-solid border-blue-500 shadow-2xl bg-white">
                             <div class="rounded p-4 bg-water-500">
                                 <h3 class="heading font-bold text-black">
-                                    <i data-feather="tool" class="pb-1"></i>
+                                    <i icon-name="wrench" class="pb-1"></i>
                                     {% trans 'Actions' %}
                                 </h3>
                             </div>
@@ -295,7 +295,7 @@
                                             name="refresh_page"
                                             class="btn text-center w-full"
                                             >
-                                        <i data-feather="check-circle" class="mr-2"></i>
+                                        <i icon-name="check-circle" class="mr-2"></i>
                                         {% trans 'Mark this page as up-to-date' %}
                                     </button>
                                 {% endif %}
@@ -309,7 +309,7 @@
                                             data-confirmation-text="{{ restore_dialog_text }}"
                                             data-confirmation-subject="{{ page_translation_form.instance.title }}"
                                             data-action="{% url 'restore_page' page_id=page_form.instance.id region_slug=request.region.slug language_slug=language.slug %}">
-                                        <i data-feather="refresh-ccw" class="mr-2"></i> {% trans 'Restore this page' %}
+                                        <i icon-name="refresh-ccw" class="mr-2"></i> {% trans 'Restore this page' %}
                                     </button>
                                 {% elif page.implicitly_archived %}
                                     <label>
@@ -328,7 +328,7 @@
                                     {% for ancestor in page.explicitly_archived_ancestors %}
                                         <a href="{% url 'edit_page' page_id=ancestor.id region_slug=request.region.slug language_slug=language.slug %}"
                                            class="block pt-2 hover:underline">
-                                            <i data-feather="edit" class="mr-2"></i> {{ ancestor.best_translation.title }}
+                                            <i icon-name="edit" class="mr-2"></i> {{ ancestor.best_translation.title }}
                                         </a>
                                     {% endfor %}
                                 {% else %}
@@ -341,7 +341,7 @@
                                             data-confirmation-text="{{ archive_dialog_text }}"
                                             data-confirmation-subject="{{ page_translation_form.instance.title }}"
                                             data-action="{% url 'archive_page' page_id=page_form.instance.id region_slug=request.region.slug language_slug=language.slug %}">
-                                        <i data-feather="archive" class="mr-2"></i>
+                                        <i icon-name="archive" class="mr-2"></i>
                                         {% trans 'Archive this page' %}
                                     </button>
                                 {% endif %}
@@ -366,7 +366,7 @@
                                             {% for descendant in descendants %}
                                                 <a href="{% url 'edit_page' page_id=descendant.id region_slug=request.region.slug language_slug=language.slug %}"
                                                    class="block pt-2 hover:underline">
-                                                    <i data-feather="edit" class="mr-2"></i> {{ descendant.best_translation.title }}
+                                                    <i icon-name="edit" class="mr-2"></i> {{ descendant.best_translation.title }}
                                                 </a>
                                             {% endfor %}
                                         {% endwith %}
@@ -390,7 +390,7 @@
                                                 {% if can_change_page_object %}
                                                     <a href="{% url 'edit_page' page_id=mirroring_page.id region_slug=mirroring_page.region.slug language_slug=language.slug %}"
                                                        class="block pt-2 hover:underline">
-                                                        <i data-feather="edit" class="mr-2"></i>
+                                                        <i icon-name="edit" class="mr-2"></i>
                                                         {{ mirroring_page.best_translation.title }}
                                                         {% if mirroring_page.region != request.region %}
                                                             ({{ mirroring_page.region }})
@@ -401,7 +401,7 @@
                                                        class="block pt-2 hover:underline"
                                                        target="_blank"
                                                        rel="noopener noreferrer">
-                                                        <i data-feather="external-link" class="mr-2"></i>
+                                                        <i icon-name="external-link" class="mr-2"></i>
                                                         {{ mirroring_page.best_translation.title }}
                                                         {% if mirroring_page.region != request.region %}
                                                             ({{ mirroring_page.region }})
@@ -417,7 +417,7 @@
                                                 data-confirmation-text="{{ delete_dialog_text }}"
                                                 data-confirmation-subject="{{ page_translation_form.instance.title }}"
                                                 data-action="{% url 'delete_page' page_id=page_form.instance.id region_slug=request.region.slug language_slug=language.slug %}">
-                                            <i data-feather="trash-2" class="mr-2"></i>
+                                            <i icon-name="trash-2" class="mr-2"></i>
                                             {% trans 'Delete this page' %}
                                         </button>
                                     {% endif %}
@@ -428,7 +428,7 @@
                     <div class="rounded border border-solid border-blue-500 shadow-2xl bg-white">
                         <div class="rounded p-4 bg-water-500">
                             <h3 class="heading font-bold text-black">
-                                <i data-feather="columns" class="pb-1"></i>
+                                <i icon-name="columns" class="pb-1"></i>
                                 {% trans 'Translator view' %}
                             </h3>
                         </div>
@@ -448,7 +448,7 @@
                                 {% endfor %}
                             </select>
                             <a id="side-by-side-link" class="btn mt-4" disabled="disabled">
-                                <i data-feather="external-link"></i>
+                                <i icon-name="external-link"></i>
                                 {% trans 'Show translator view' %}
                             </a>
                         </div>

--- a/integreat_cms/cms/templates/pages/page_revisions.html
+++ b/integreat_cms/cms/templates/pages/page_revisions.html
@@ -12,7 +12,7 @@
         {% endwith %}
     </h1>
     <a href="{% url 'edit_page' page_id=page.id region_slug=request.region.slug language_slug=language.slug %}" class="btn btn-gray">
-        <i data-feather="arrow-left-circle" class="align-top"></i> {% trans 'Back to the page form' %}
+        <i icon-name="arrow-left-circle" class="align-top"></i> {% trans 'Back to the page form' %}
     </a>
 </div>
 

--- a/integreat_cms/cms/templates/pages/page_sbs.html
+++ b/integreat_cms/cms/templates/pages/page_sbs.html
@@ -15,7 +15,7 @@
             <div class="flex flex-wrap grow justify-between gap-2 mb-4">
                 <a href="{% url 'edit_page' page_id=source_page_translation.page.id region_slug=request.region.slug language_slug=target_language.slug %}"
                    class="bg-gray-400 hover:bg-gray-500 text-center cursor-pointer text-white font-bold py-3 px-4 rounded">
-                    <i data-feather="arrow-left-circle" class="align-top"></i> {% trans 'Back to the page form' %}
+                    <i icon-name="arrow-left-circle" class="align-top"></i> {% trans 'Back to the page form' %}
                 </a>
                 <div class="flex flex-wrap gap-2">
                     {% has_perm 'cms.change_page_object' request.user source_page_translation.page as can_edit_page %}
@@ -41,15 +41,15 @@
                     <div class="rounded p-4 bg-water-500 font-bold">
                         {% if source_page_translation.is_outdated %}
                             <span title="{% trans 'Translation outdated' %}">
-                                <i data-feather="alert-triangle"></i>
+                                <i icon-name="alert-triangle"></i>
                             </span>
                         {% elif source_page_translation.currently_in_translation %}
                             <span title="{% trans 'Currently in translation' %}">
-                                <i data-feather="clock"></i>
+                                <i icon-name="clock"></i>
                             </span>
                         {% else %}
                             <span title="{% trans 'Translation up-to-date' %}">
-                                <i data-feather="check"></i>
+                                <i icon-name="check"></i>
                             </span>
                         {% endif %}
                         {{ source_page_translation.language.translated_name }}
@@ -99,7 +99,7 @@
                                 {% with source_language=source_page_translation.language.translated_name target_language_name=target_language.translated_name %}
                                     {% blocktrans %}Copy content of {{ source_language }} to {{ target_language_name }}{% endblocktrans %}
                                 {% endwith %}
-                                <i data-feather="arrow-right-circle" class="mr-2"></i>
+                                <i icon-name="arrow-right-circle" class="mr-2"></i>
                             </button>
                         </div>
                     </div>
@@ -109,20 +109,20 @@
                         {% if page_translation_form.instance.id %}
                             {% if page_translation_form.instance.is_outdated %}
                                 <span title="{% trans 'Translation outdated' %}">
-                                    <i data-feather="alert-triangle"></i>
+                                    <i icon-name="alert-triangle"></i>
                                 </span>
                             {% elif page_translation_form.instance.currently_in_translation %}
                                 <span title="{% trans 'Currently in translation' %}">
-                                    <i data-feather="clock"></i>
+                                    <i icon-name="clock"></i>
                                 </span>
                             {% else %}
                                 <span title="{% trans 'Translation up-to-date' %}">
-                                    <i data-feather="check"></i>
+                                    <i icon-name="check"></i>
                                 </span>
                             {% endif %}
                         {% else %}
                             <span title="{% trans 'Create Translation' %}">
-                                <i data-feather="plus"></i>
+                                <i icon-name="plus"></i>
                             </span>
                         {% endif %}
                         {{ target_language.translated_name }}

--- a/integreat_cms/cms/templates/pages/page_tree.html
+++ b/integreat_cms/cms/templates/pages/page_tree.html
@@ -11,12 +11,12 @@
                 <h1 class="heading">
                     {% trans 'Page Tree' %}
                     <button data-show-tutorial="page-tree" class="hover:text-blue-500">
-                        <i data-feather="help-circle" class="align-baseline"></i>
+                        <i icon-name="help-circle" class="align-baseline"></i>
                     </button>
                 </h1>
                 <a href="{% url 'archived_pages' region_slug=request.region.slug language_slug=language.slug %}"
                    class="font-bold text-sm text-gray-800 flex items-center gap-1 mb-2 hover:underline">
-                    <span><i data-feather="archive" class="align-top h-5"></i> {% trans 'Archived pages' %}</span>
+                    <span><i icon-name="archive" class="align-top h-5"></i> {% trans 'Archived pages' %}</span>
                 </a>
             </div>
             <div class="flex flex-wrap justify-between gap-4">
@@ -125,7 +125,7 @@
                 {% if not filter_form.is_enabled %}
                     <a id="expand-all-pages" class="text-blue-500 !cursor-wait">
                         {% spaceless %}
-                            <i data-feather="chevron-down"
+                            <i icon-name="chevron-down"
                                class="align-sub h-5 rounded-full group-hover:bg-blue-500 group-hover:text-white"></i>
                             {% trans 'Expand all' %}
                         {% endspaceless %}
@@ -133,7 +133,7 @@
                     <span class="text-gray-600 font-default">|</span>
                     <a id="collapse-all-pages" class="text-blue-500 !cursor-wait">
                         {% spaceless %}
-                            <i data-feather="chevron-up"
+                            <i icon-name="chevron-up"
                                class="align-sub h-5 rounded-full group-hover:bg-blue-500 group-hover:text-white"></i>
                             {% trans 'Collapse all' %}
                         {% endspaceless %}
@@ -206,7 +206,7 @@
                     <label id="xliff_file_label"
                            for="xliff_file"
                            class="inline-block cursor-pointer bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 m-0 rounded">
-                        <i data-feather="upload" class="inline-block pr-1"></i>
+                        <i icon-name="upload" class="inline-block pr-1"></i>
                         {% trans 'Select files' %}
                     </label>
                     <span id="xliff_file_label_multiple" class="hidden">{% trans 'and {} other files' %}</span>

--- a/integreat_cms/cms/templates/pages/page_tree_archived.html
+++ b/integreat_cms/cms/templates/pages/page_tree_archived.html
@@ -12,7 +12,7 @@
     <div class="flex flex-wrap justify-between gap-4">
         <h1 class="heading">{% trans 'Archived Pages' %}</h1>
         <a href="{% url 'pages' region_slug=request.region.slug language_slug=language.slug %}" class="font-bold text-sm text-gray-800 flex items-center gap-1 mb-2 hover:underline">
-            <span><i data-feather="layout" class="align-top h-5"></i> {% trans 'Page Tree' %}</span>
+            <span><i icon-name="layout" class="align-top h-5"></i> {% trans 'Page Tree' %}</span>
         </a>
     </div>
     <div class="flex flex-wrap justify-between gap-4">

--- a/integreat_cms/cms/templates/pages/page_tree_archived_node.html
+++ b/integreat_cms/cms/templates/pages/page_tree_archived_node.html
@@ -10,7 +10,7 @@
     {% if not filter_form.is_enabled %}
         <td class="hierarchy single_icon whitespace-nowrap">
             <span class="cursor-move text-gray-800 inline-block align-middle" title="{% trans 'Drag & drop is disabled for archived pages.' %}">
-                <i data-feather="move"></i>
+                <i icon-name="move"></i>
             </span>
             {% if page.cached_children|length > 0 %}
                 <span class="toggle-subpages cursor-pointer inline-block align-middle"
@@ -18,7 +18,7 @@
                   data-alt-title="{% trans 'Collapse all subpages' %}"
                   data-page-id="{{ page.id }}"
                   data-page-children="{{ page|get_children_ids }}">
-                    <i data-feather="chevron-right"></i>
+                    <i icon-name="chevron-right"></i>
                 </span>
             {% endif %}
         </td>
@@ -53,20 +53,20 @@
                             {% if other_translation %}
                                 {% if other_translation.currently_in_translation %}
                                     <span title="{% trans 'Currently in translation' %}">
-                                        <i data-feather="clock" class="text-gray-800"></i>
+                                        <i icon-name="clock" class="text-gray-800"></i>
                                     </span>
                                 {% elif other_translation.is_outdated %}
                                     <span title="{% trans 'Translation outdated' %}">
-                                        <i data-feather="alert-triangle" class="text-gray-800"></i>
+                                        <i icon-name="alert-triangle" class="text-gray-800"></i>
                                     </span>
                                 {% else %}
                                     <span title="{% trans 'Translation up-to-date' %}">
-                                        <i data-feather="check" class="text-gray-800"></i>
+                                        <i icon-name="check" class="text-gray-800"></i>
                                     </span>
                                 {% endif %}
                             {% else %}
                                 <span title="{% trans 'Translation missing' %}">
-                                    <i data-feather="x" class="text-gray-800"></i>
+                                    <i icon-name="x" class="text-gray-800"></i>
                                 </span>
                             {% endif %}
                         </a>
@@ -98,7 +98,7 @@
                 data-preview-page="{% url 'preview_page_ajax' page_id=page.id region_slug=request.region.slug language_slug=language.slug %}"
                 title="{% trans 'View page as preview' %}"
                 class="btn-icon">
-                <i data-feather="eye"></i>
+                <i icon-name="eye"></i>
             </button>
         {% else %}
             <button
@@ -106,7 +106,7 @@
                 title="{% trans 'You cannot preview an empty page.' %}"
                 class="btn-icon"
                 disabled>
-                <i data-feather="eye"></i>
+                <i icon-name="eye"></i>
             </button>
         {% endif %}
         {% if page.explicitly_archived %}
@@ -115,21 +115,21 @@
                     data-confirmation-text="{{ restore_dialog_text }}"
                     data-confirmation-subject="{{ page.best_translation.title }}"
                     data-action="{% url 'restore_page' page_id=page.id region_slug=request.region.slug language_slug=language.slug %}">
-                <i data-feather="refresh-ccw"></i>
+                <i icon-name="refresh-ccw"></i>
             </button>
         {% else %}
             <a title="{% trans 'To restore this page, you have to restore its archived parent page.' %}" class="btn-icon" disabled>
-                <i data-feather="refresh-ccw"></i>
+                <i icon-name="refresh-ccw"></i>
             </a>
         {% endif %}
         {% if perms.cms.delete_page %}
             {% if not page.is_leaf %}
                 <a title="{% trans 'You cannot delete a page which has subpages.' %}&#013;{% trans 'This also involves non-archived subpages.' %}" class="btn-icon" disabled>
-                    <i data-feather="trash-2"></i>
+                    <i icon-name="trash-2"></i>
                 </a>
             {% elif page.mirroring_pages.exists %}
                 <button title="{% trans 'This page cannot be deleted because it was embedded as live content from another page.' %}" class="btn-icon" disabled>
-                    <i data-feather="trash-2"></i>
+                    <i icon-name="trash-2"></i>
                 </button>
             {% else %}
                 <button title="{% trans 'Delete page' %}" class="confirmation-button btn-icon"
@@ -137,7 +137,7 @@
                     data-confirmation-text="{{ delete_dialog_text }}"
                     data-confirmation-subject="{{ page.best_translation.title }}"
                     data-action="{% url 'delete_page' page_id=page.id region_slug=request.region.slug language_slug=language.slug %}">
-                    <i data-feather="trash-2"></i>
+                    <i icon-name="trash-2"></i>
                 </button>
             {% endif %}
         {% endif %}

--- a/integreat_cms/cms/templates/pages/page_tree_node.html
+++ b/integreat_cms/cms/templates/pages/page_tree_node.html
@@ -16,7 +16,7 @@
                   class="drag cursor-move text-gray-800 inline-block pl-4 align-middle"
                   draggable="true"
                   title="{% trans 'Change the order and position of the pages with drag & drop.' %}">
-                <i data-feather="move"></i>
+                <i icon-name="move"></i>
             </span>
             {% if not page.parent_id and not page.is_leaf or page.parent_id and page.cached_children|length > 0 %}
                 <span class="toggle-subpages inline-block align-middle cursor-wait transform"
@@ -25,7 +25,7 @@
                       data-page-id="{{ page.id }}"
                       data-page-children="{{ page|get_children_ids }}"
                       data-page-descendants-url="{% url 'get_page_tree_ajax' region_slug=request.region.slug language_slug=language.slug tree_id=page.tree_id %}">
-                    <i data-feather="chevron-right"></i>
+                    <i icon-name="chevron-right"></i>
                 </span>
             {% endif %}
         </td>
@@ -69,25 +69,25 @@
                             <div id="translation-icon">
                                 {% if other_status == translation_status.IN_TRANSLATION %}
                                     <span title="{% trans 'Currently in translation' %}">
-                                        <i data-feather="clock" class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
+                                        <i icon-name="clock" class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
                                     </span>
                                 {% elif other_status == translation_status.OUTDATED %}
                                     <span title="{% trans 'Translation outdated' %}">
-                                        <i data-feather="alert-triangle" class="{% if other_language.slug == language.slug %}text-yellow-500{% else %}text-gray-800{% endif %}"></i>
+                                        <i icon-name="alert-triangle" class="{% if other_language.slug == language.slug %}text-yellow-500{% else %}text-gray-800{% endif %}"></i>
                                     </span>
                                 {% elif other_status == translation_status.UP_TO_DATE %}
                                     <span title="{% trans 'Translation up-to-date' %}">
-                                        <i data-feather="check" class="{% if other_language.slug == language.slug %}text-green-500{% else %}text-gray-800{% endif %}"></i>
+                                        <i icon-name="check" class="{% if other_language.slug == language.slug %}text-green-500{% else %}text-gray-800{% endif %}"></i>
                                     </span>
                                 {% elif other_status == translation_status.MISSING %}
                                     <span title="{% trans 'Translation missing' %}" class="no-trans">
-                                        <i data-feather="x" class="{% if other_language.slug == language.slug %}text-red-500{% else %}text-gray-800{% endif %}"></i>
+                                        <i icon-name="x" class="{% if other_language.slug == language.slug %}text-red-500{% else %}text-gray-800{% endif %}"></i>
                                     </span>
                                 {% endif %}
                             </div>
                             <div id="ajax-icon" class="hidden">
                                 <span title="{% trans 'Currently in translation' %}">
-                                    <i data-feather="clock" class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
+                                    <i icon-name="clock" class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
                                 </span>
                             </div>
                         </a>
@@ -113,7 +113,7 @@
                 data-preview-page="{% url 'preview_page_ajax' page_id=page.id region_slug=request.region.slug language_slug=language.slug %}"
                 title="{% trans 'View page as preview' %}"
                 class="btn-icon">
-                <i data-feather="eye"></i>
+                <i icon-name="eye"></i>
             </button>
         {% else %}
             <button
@@ -121,21 +121,21 @@
                 title="{% trans 'You cannot preview an empty page.' %}"
                 class="btn-icon"
                 disabled>
-                <i data-feather="eye"></i>
+                <i icon-name="eye"></i>
             </button>
         {% endif %}
         {% if page_translation.status == PUBLIC %}
             <a href="{{ WEBAPP_URL }}{{ page_translation.get_absolute_url }}"
                 rel="noopener noreferrer" target="_blank" title="{% trans 'Open page in web app' %}" class="btn-icon">
-                <i data-feather="external-link"></i>
+                <i icon-name="external-link"></i>
             </a>
         {% else %}
             <button title="{% trans 'This page cannot be opened in the web app, because it is not public.' %}" class="btn-icon" disabled>
-                <i data-feather="external-link"></i>
+                <i icon-name="external-link"></i>
             </button>
         {% endif %}
         <a href="{% url 'edit_page' page_id=page.id region_slug=request.region.slug language_slug=language.slug %}" title="{% trans 'Edit page' %}" class="btn-icon">
-            <i data-feather="edit"></i>
+            <i icon-name="edit"></i>
         </a>
 
         <button title="{% trans 'Archive page' %}" class="confirmation-button btn-icon"
@@ -143,16 +143,16 @@
                 data-confirmation-text="{{ archive_dialog_text }}"
                 data-confirmation-subject="{{ page.best_translation.title }}"
                 data-action="{% url 'archive_page' page_id=page.id region_slug=request.region.slug language_slug=language.slug %}">
-            <i data-feather="archive"></i>
+            <i icon-name="archive"></i>
         </button>
         {% if perms.cms.delete_page %}
             {% if not page.is_leaf %}
                 <button title="{% trans 'You cannot delete a page which has subpages.' %}&#013;{% trans 'This also involves archived subpages.' %}" class="btn-icon" disabled>
-                    <i data-feather="trash-2"></i>
+                    <i icon-name="trash-2"></i>
                 </button>
             {% elif page.mirroring_pages.exists %}
                 <button title="{% trans 'This page cannot be deleted because it was embedded as live content from another page.' %}&#013;{% trans 'You can however archive this page.' %}" class="btn-icon" disabled>
-                    <i data-feather="trash-2"></i>
+                    <i icon-name="trash-2"></i>
                 </button>
             {% else %}
                 <button title="{% trans 'Delete page' %}" class="confirmation-button btn-icon"
@@ -160,18 +160,18 @@
                         data-confirmation-text="{{ delete_dialog_text }}"
                         data-confirmation-subject="{{ page.best_translation.title }}"
                         data-action="{% url 'delete_page' page_id=page.id region_slug=request.region.slug language_slug=language.slug %}">
-                    <i data-feather="trash-2"></i>
+                    <i icon-name="trash-2"></i>
                 </button>
             {% endif %}
         {% endif %}
         {% if request.region.short_urls_enabled and request.user.expert_mode %}
             {% if page_translation %}
             <button data-copy-to-clipboard="{{ page_translation.short_url }}" title="{% trans 'Copy short link' %}" class="btn-icon">
-                <i data-feather="copy"></i>
+                <i icon-name="copy"></i>
             </button>
             {% else %}
             <button title="{% trans 'You cannot copy a short link of a page which has no translation.' %}" class="btn-icon" disabled>
-                <i data-feather="copy"></i>
+                <i icon-name="copy"></i>
             </button>
             {% endif %}
         {% endif %}

--- a/integreat_cms/cms/templates/pagination.html
+++ b/integreat_cms/cms/templates/pagination.html
@@ -24,7 +24,7 @@
         <!-- pagination always contains left and right buttons -->
         <!-- in case the left/right outer bounds are reached these links are disabled -->
         <a href="{% if chunk.has_previous %}{% add_queries url 'page' chunk.previous_page_number %}{% endif %}" class="arrow-link">
-            <i data-feather="chevron-left"></i>
+            <i icon-name="chevron-left"></i>
         </a>
         <!-- pagination always allows to jump to start page -->
         <a href="{% add_queries url 'page' 1 %}" class="{% if chunk.number == 1 %}active{% endif %}">1</a>
@@ -47,7 +47,7 @@
         <!-- pagination always allows to jump to last page -->
         <a href="{% add_queries url 'page' num_pages %}" class="{% if chunk.number == num_pages %}active{% endif %}">{{ num_pages }}</a>
         <a href="{% if chunk.has_next %}{% add_queries url 'page' chunk.next_page_number %}{% else %}#{% endif %}" class="arrow-link">
-            <i data-feather="chevron-right"></i>
+            <i icon-name="chevron-right"></i>
         </a>
     </div>
     {% endif %}

--- a/integreat_cms/cms/templates/poicategories/poicategory_form.html
+++ b/integreat_cms/cms/templates/poicategories/poicategory_form.html
@@ -23,7 +23,7 @@
 	    <div class="w-full">
 		    <div class="w-full mb-4 rounded border border-solid border-blue-500 shadow-2xl bg-white">
 				<div class="w-full p-4 rounded bg-water-500">
-					<h3 class="heading font-bold text-black"><i data-feather="tag" class="mr-2"></i> {% trans 'Category name' %}</h3>
+					<h3 class="heading font-bold text-black"><i icon-name="tag" class="mr-2"></i> {% trans 'Category name' %}</h3>
 				</div>
                 <div class="px-4 pb-4">
                     {% for form in formset %}

--- a/integreat_cms/cms/templates/poicategories/poicategory_list_row.html
+++ b/integreat_cms/cms/templates/poicategories/poicategory_list_row.html
@@ -14,11 +14,11 @@
                     {% get_translation poi_category language.slug as poi_category_translation %}
                             {% if poi_category_translation %}
                                 <span title="{{ poi_category_translation.name }}">
-                                    <i data-feather="check" class="text-green-500"></i>
+                                    <i icon-name="check" class="text-green-500"></i>
                                 </span>
                             {% else %}
                                 <span title="{% trans 'Translation missing' %}" class="no-trans">
-                                    <i data-feather="x" class="text-red-500"></i>
+                                    <i icon-name="x" class="text-red-500"></i>
                                 </span>     
                             {% endif %}
                 {% endfor %}
@@ -32,7 +32,7 @@
         {% if perms.cms.delete_poicategory %}
             {% if poi_category.pois.exists %}
                 <button title="{% trans 'You cannot delete a location category that is used in at least one location.' %}" class="btn-icon" disabled>
-                    <i data-feather="trash-2"></i>
+                    <i icon-name="trash-2"></i>
                 </button>
             {% else %}
                 <button title="{% trans 'Delete location category' %}" class="confirmation-button btn-icon"
@@ -40,7 +40,7 @@
                         data-confirmation-text="{{ delete_dialog_text }}"
                         data-confirmation-subject="{{ language.translated_name }}"
                         data-action="{% url 'delete_poicategory' pk=poi_category.pk %}">
-                    <i data-feather="trash-2"></i>
+                    <i icon-name="trash-2"></i>
                 </button>
             {% endif %}
         {% endif %}

--- a/integreat_cms/cms/templates/pois/poi_form.html
+++ b/integreat_cms/cms/templates/pois/poi_form.html
@@ -83,22 +83,22 @@
                                href="{{ url_link }}{{ poi_translation_form.instance.slug }}/"
                                class="text-blue-500 hover:underline">{{ url_link }}{{ poi_translation_form.instance.slug }}</a>
                             <a id="edit-slug-btn" title="{% trans 'Edit' %}" class="mx-2 btn-icon">
-                                <i data-feather="edit-3"></i>
+                                <i icon-name="edit-3"></i>
                             </a>
                             <a id="copy-slug-btn"
                                title="{% trans 'Copy to clipboard' %}"
                                class="btn-icon">
-                                <i data-feather="copy"></i>
+                                <i icon-name="copy"></i>
                             </a>
                             <div class="slug-field hidden">
                                 <label for="{{ poi_translation_form.slug.id_for_label }}">{{ url_link }}</label>
                                 {% render_field poi_translation_form.slug|add_error_class:"slug-error" %}
                             </div>
                             <a id="save-slug-btn" class="mx-2 btn-icon hidden">
-                                <i data-feather="save"></i>
+                                <i icon-name="save"></i>
                             </a>
                             <a id="restore-slug-btn" class="btn-icon hidden">
-                                <i data-feather="x-circle"></i>
+                                <i icon-name="x-circle"></i>
                             </a>
                         </div>
                         <label for="{{ poi_translation_form.short_description.id_for_label }}">
@@ -115,7 +115,7 @@
                     <div class="rounded border border-blue-500 shadow-2xl bg-white">
                         <div class="rounded p-4 bg-water-500">
                             <h3 class="heading font-bold text-black">
-                                <i data-feather="feather" class="pb-1"></i>
+                                <i icon-name="feather" class="pb-1"></i>
                                 {% trans "Minor edit" %}
                             </h3>
                         </div>
@@ -133,7 +133,7 @@
                 <div class="flex flex-col flex-auto rounded border border-blue-500 shadow-2xl bg-white">
                     <div class="rounded p-4 bg-water-500">
                         <h3 class="heading font-bold text-black">
-                            <i data-feather="map-pin" class="h-5"></i>
+                            <i icon-name="map-pin" class="h-5"></i>
                             {% trans 'Position' %}
                         </h3>
                     </div>
@@ -173,7 +173,7 @@
                 <div class="rounded border border-solid border-blue-500 shadow-2xl bg-white">
                     <div class="rounded p-4 bg-water-500">
                         <h3 class="heading font-bold text-black">
-                            <i data-feather="phone" class="pb-1"></i>
+                            <i icon-name="phone" class="pb-1"></i>
                             {% trans 'Contact details' %}
                         </h3>
                     </div>
@@ -199,7 +199,7 @@
                 <div class="rounded border border-solid border-blue-500 shadow-2xl bg-white">
                     <div class="rounded p-4 bg-water-500">
                         <h3 class="heading font-bold text-black">
-                            <i data-feather="tag" class="pb-1"></i>
+                            <i icon-name="tag" class="pb-1"></i>
                             {{ poi_form.category.label }}
                         </h3>
                     </div>
@@ -214,7 +214,7 @@
                 <div class="rounded border border-solid border-blue-500 shadow-2xl bg-white">
                     <div class="rounded p-4 bg-water-500">
                         <h3 class="heading font-bold text-black">
-                            <i data-feather="image" class="pb-1"></i>
+                            <i icon-name="image" class="pb-1"></i>
                             {{ poi_form.icon.label }}
                         </h3>
                     </div>
@@ -229,7 +229,7 @@
                     <div class="rounded border border-solid border-blue-500 shadow-2xl bg-white">
                         <div class="rounded p-4 bg-water-500">
                             <h3 class="heading font-bold text-black">
-                                <i data-feather="tool" class="pb-1"></i>
+                                <i icon-name="wrench" class="pb-1"></i>
                                 {% trans 'Actions' %}
                             </h3>
                         </div>
@@ -245,7 +245,7 @@
                                             data-confirmation-text="{{ restore_dialog_text }}"
                                             data-confirmation-subject="{{ poi_form.instance|poi_translation_title:language }}"
                                             data-action="{% url 'restore_poi' poi_id=poi_form.instance.id region_slug=request.region.slug language_slug=language.slug %}">
-                                        <i data-feather="refresh-ccw" class="mr-2"></i> {% trans 'Restore this location' %}
+                                        <i icon-name="refresh-ccw" class="mr-2"></i> {% trans 'Restore this location' %}
                                 </button>
                             {% else %}
                                 <label>
@@ -257,7 +257,7 @@
                                         data-confirmation-text="{{ archive_dialog_text }}"
                                         data-confirmation-subject="{{ poi_form.instance|poi_translation_title:language }}"
                                         data-action="{% url 'archive_poi' poi_id=poi_form.instance.id region_slug=request.region.slug language_slug=language.slug %}">
-                                    <i data-feather="archive" class="mr-2"></i> {% trans 'Archive this location' %}
+                                    <i icon-name="archive" class="mr-2"></i> {% trans 'Archive this location' %}
                             </button>
                         {% endif %}
                     </div>
@@ -282,7 +282,7 @@
                                 {% for event in poi_form.instance.events.all %}
                                     <a href="{% url 'edit_event' event_id=event.id region_slug=request.region.slug language_slug=language.slug %}"
                                        class="block pt-2 hover:underline">
-                                        <i data-feather="edit" class="mr-2"></i> {{ event.best_translation.title }}
+                                        <i icon-name="edit" class="mr-2"></i> {{ event.best_translation.title }}
                                 </a>
                             {% endfor %}
                         {% else %}
@@ -292,7 +292,7 @@
                                     data-confirmation-text="{{ delete_dialog_text }}"
                                     data-confirmation-subject="{{ poi_form.instance|poi_translation_title:language }}"
                                     data-action="{% url 'delete_poi' poi_id=poi_form.instance.id region_slug=request.region.slug language_slug=language.slug %}">
-                                <i data-feather="trash-2" class="mr-2"></i> {% trans 'Delete this location' %}
+                                <i icon-name="trash-2" class="mr-2"></i> {% trans 'Delete this location' %}
                         </button>
                     {% endif %}
                 </div>

--- a/integreat_cms/cms/templates/pois/poi_list.html
+++ b/integreat_cms/cms/templates/pois/poi_list.html
@@ -12,7 +12,7 @@
             <a href="{% url 'archived_pois' region_slug=request.region.slug language_slug=language.slug %}"
                class="font-bold text-sm text-gray-800 flex items-center gap-1 pb-2 hover:underline">
                 <span>
-                    <i data-feather="archive" class="align-top h-5"></i>
+                    <i icon-name="archive" class="align-top h-5"></i>
                     {% trans 'Archived locations' %}
                     ({{ archived_count }})
                 </span>

--- a/integreat_cms/cms/templates/pois/poi_list_archived_row.html
+++ b/integreat_cms/cms/templates/pois/poi_list_archived_row.html
@@ -67,12 +67,12 @@
             data-confirmation-text="{{ restore_dialog_text }}"
             data-confirmation-subject="{{ poi_translation.title }}"
             data-action="{% url 'restore_poi' poi_id=poi.id region_slug=request.region.slug language_slug=language.slug %}">
-            <i data-feather="refresh-ccw"></i>
+            <i icon-name="refresh-ccw"></i>
         </button>
         {% if perms.cms.delete_poi %}
             {% if poi.events.exists %}
                 <button title="{% trans 'You cannot delete a location which is used by an event.' %}&#013;{% trans 'This also involves archived events.' %}" class="btn-icon" disabled>
-                    <i data-feather="trash-2"></i>
+                    <i icon-name="trash-2"></i>
                 </button>
             {% else %}
                 <button title="{% trans 'Delete location' %}" class="confirmation-button btn-icon"
@@ -80,7 +80,7 @@
                     data-confirmation-text="{{ delete_dialog_text }}"
                     data-confirmation-subject="{{ poi_translation.title }}"
                     data-action="{% url 'delete_poi' poi_id=poi.id region_slug=request.region.slug language_slug=language.slug %}">
-                    <i data-feather="trash-2"></i>
+                    <i icon-name="trash-2"></i>
                 </button>
             {% endif %}
         {% endif %}

--- a/integreat_cms/cms/templates/pois/poi_list_row.html
+++ b/integreat_cms/cms/templates/pois/poi_list_row.html
@@ -38,29 +38,29 @@
                     <div id="translation-icon">
                         {% if other_status == translation_status.IN_TRANSLATION %}
                             <span title="{% trans 'Currently in translation' %}">
-                                <i data-feather="clock" class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
+                                <i icon-name="clock" class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
                             </span>
                         {% elif other_status == translation_status.OUTDATED %}
                             <span title="{% trans 'Translation outdated' %}">
-                                <i data-feather="alert-triangle" class="{% if other_language.slug == language.slug %}text-yellow-500{% else %}text-gray-800{% endif %}"></i>
+                                <i icon-name="alert-triangle" class="{% if other_language.slug == language.slug %}text-yellow-500{% else %}text-gray-800{% endif %}"></i>
                             </span>
                         {% elif other_status == translation_status.UP_TO_DATE %}
                             <span title="{% trans 'Translation up-to-date' %}">
-                                <i data-feather="check" class="{% if other_language.slug == language.slug %}text-green-500{% else %}text-gray-800{% endif %}"></i>
+                                <i icon-name="check" class="{% if other_language.slug == language.slug %}text-green-500{% else %}text-gray-800{% endif %}"></i>
                             </span>
                         {% elif other_status == translation_status.FALLBACK %}
                             <span title="{% trans 'Default language is duplicated' %}">
-                                <i data-feather="copy" class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
+                                <i icon-name="copy" class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
                             </span>
                         {% elif other_status == translation_status.MISSING %}
                             <span title="{% trans 'Translation missing' %}" class="no-trans">
-                                <i data-feather="x" class="{% if other_language.slug == language.slug %}text-red-500{% else %}text-gray-800{% endif %}"></i>
+                                <i icon-name="x" class="{% if other_language.slug == language.slug %}text-red-500{% else %}text-gray-800{% endif %}"></i>
                             </span>
                         {% endif %}
                     </div>
                     <div id="ajax-icon" class="hidden">
                         <span title="{% trans 'Currently in translation' %}">
-                            <i data-feather="clock" class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
+                            <i icon-name="clock" class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
                         </span>
                     </div>
                 </a>
@@ -102,11 +102,11 @@
         {% if poi_translation.status == PUBLIC %}
             <a href="{{ WEBAPP_URL }}{{ poi_translation.get_absolute_url }}"
             rel="noopener noreferrer" target="_blank" title="{% trans 'Open location in web app' %}" class="btn-icon">
-                <i data-feather="external-link"></i>
+                <i icon-name="external-link"></i>
             </a>
         {% else %}
             <button title="{% trans 'This location cannot be opened in the web app, because it is not public.' %}" class="btn-icon" disabled>
-                <i data-feather="external-link"></i>
+                <i icon-name="external-link"></i>
             </button>
         {% endif %}
         <button title="{% trans 'Archive location' %}" class="confirmation-button btn-icon"
@@ -114,12 +114,12 @@
             data-confirmation-text="{{ archive_dialog_text }}"
             data-confirmation-subject="{{ poi_translation.title }}"
             data-action="{% url 'archive_poi' poi_id=poi.id region_slug=request.region.slug language_slug=language.slug %}">
-            <i data-feather="archive"></i>
+            <i icon-name="archive"></i>
         </button>
         {% if perms.cms.delete_poi %}
             {% if poi.events.exists %}
                 <button title="{% trans 'You cannot delete a location which is used by an event.' %}&#013;{% trans 'This also involves archived events.' %}" class="btn-icon" disabled>
-                    <i data-feather="trash-2"></i>
+                    <i icon-name="trash-2"></i>
                 </button>
             {% else %}
                 <button title="{% trans 'Delete location' %}" class="confirmation-button btn-icon"
@@ -127,7 +127,7 @@
                     data-confirmation-text="{{ delete_dialog_text }}"
                     data-confirmation-subject="{{ poi_translation.title }}"
                     data-action="{% url 'delete_poi' poi_id=poi.id region_slug=request.region.slug language_slug=language.slug %}">
-                    <i data-feather="trash-2"></i>
+                    <i icon-name="trash-2"></i>
                 </button>
             {% endif %}
         {% endif %}

--- a/integreat_cms/cms/templates/push_notifications/push_notification_form.html
+++ b/integreat_cms/cms/templates/push_notifications/push_notification_form.html
@@ -91,7 +91,7 @@
                 <div class="rounded border border-blue-500 shadow-2xl bg-white">
                     <div class="rounded p-4 bg-water-500">
                         <h3 class="heading font-bold text-black">
-                            <i data-feather="settings" class="pb-1"></i>
+                            <i icon-name="settings" class="pb-1"></i>
                             {% trans "Settings" %}
                         </h3>
                     </div>
@@ -106,17 +106,17 @@
                     <div class="rounded border border-blue-500 shadow-2xl bg-white">
                         <div class="rounded p-4 bg-water-500">
                             <h3 class="heading font-bold text-black">
-                                <i data-feather="settings" class="pb-1"></i>
+                                <i icon-name="settings" class="pb-1"></i>
                                 {% trans "Status" %}
                             </h3>
                         </div>
                         <div class="px-4 pb-4 rounded bg-white">
                             <label>{% trans 'Sent' %}</label>
                             {% if push_notification_form.instance.sent_date %}
-                                <i data-feather="check" class="text-green-500 align-text-top"></i>
+                                <i icon-name="check" class="text-green-500 align-text-top"></i>
                                 {{ push_notification_form.instance.sent_date }}
                             {% else %}
-                                <i data-feather="x" class="text-red-500 align-text-top"></i>
+                                <i icon-name="x" class="text-red-500 align-text-top"></i>
                                 {% trans 'Message not sent yet' %}
                             {% endif %}
                         </div>

--- a/integreat_cms/cms/templates/push_notifications/push_notification_list_row.html
+++ b/integreat_cms/cms/templates/push_notifications/push_notification_list_row.html
@@ -24,7 +24,7 @@
                 {% spaceless %}
                     {% for other_language in languages %}
                         <a href="{% url 'edit_push_notification' push_notification_id=push_notification.id region_slug=request.region.slug language_slug=other_language.slug %}">
-                            <i data-feather="{% if other_language in push_notification.languages %}edit-2{% else %}plus{% endif %}" class="text-gray-800"></i>
+                            <i icon-name="{% if other_language in push_notification.languages %}edit-2{% else %}plus{% endif %}" class="text-gray-800"></i>
                         </a>
                     {% endfor %}
                 {% endspaceless %}
@@ -36,9 +36,9 @@
     </td>
     <td class="px-2 whitespace-nowrap">
         {% if push_notification.sent_date %}
-            <i data-feather="check" class="text-green-500 align-text-top"></i> {{ push_notification.sent_date }}
+            <i icon-name="check" class="text-green-500 align-text-top"></i> {{ push_notification.sent_date }}
         {% else %}
-            <i data-feather="x" class="text-red-500 align-text-top"></i> {% trans 'Message not sent yet' %}
+            <i icon-name="x" class="text-red-500 align-text-top"></i> {% trans 'Message not sent yet' %}
         {% endif %}
     </td>
 </tr>

--- a/integreat_cms/cms/templates/regions/region_form.html
+++ b/integreat_cms/cms/templates/regions/region_form.html
@@ -26,7 +26,7 @@
     <div class="grid xl:grid-cols-2 2xl:grid-cols-3 gap-4">
         <div class="rounded border border-solid border-blue-500 shadow-2xl bg-white">
             <div class="p-4 rounded bg-water-500">
-                <h3 class="heading font-bold text-black"><i data-feather="map" class="mr-2"></i> {% trans 'General Settings' %}</h3>
+                <h3 class="heading font-bold text-black"><i icon-name="map" class="mr-2"></i> {% trans 'General Settings' %}</h3>
             </div>
             <div class="px-4 pb-4 divide-y divide-gray-200 space-y-4">
                 <div>
@@ -75,7 +75,7 @@
         </div>
         <div class="rounded border border-solid border-blue-500 shadow-2xl bg-white">
             <div class="p-4 rounded bg-water-500">
-                <h3 class="heading font-bold text-black"><i data-feather="settings" class="mr-2"></i> {% trans 'Extended Settings' %}</h3>
+                <h3 class="heading font-bold text-black"><i icon-name="settings" class="mr-2"></i> {% trans 'Extended Settings' %}</h3>
             </div>
             <div class="px-4 pb-4 divide-y divide-gray-200 space-y-2">
                 <div>
@@ -101,7 +101,7 @@
                                     <a href="https://www.openstreetmap.org/?mlat={{ form.instance.latitude }}&mlon={{ form.instance.longitude }}"
                                     class="text-blue-500 hover:underline"
                                     target="_blank" rel="noopener noreferrer">
-                                        <i data-feather="map" class="mr-2"></i>
+                                        <i icon-name="map" class="mr-2"></i>
                                         {% trans 'Preview on map' %}
                                     </a>
                                 </label>
@@ -127,7 +127,7 @@
                                     <a href="https://www.openstreetmap.org/?minlon={{ form.instance.longitude_min }}&minlat={{ form.instance.latitude_min }}&maxlon={{ form.instance.longitude_max }}&maxlat={{ form.instance.latitude_max }}&box=yes"
                                     class="text-blue-500 hover:underline"
                                     target="_blank" rel="noopener noreferrer">
-                                        <i data-feather="map" class="mr-2"></i>
+                                        <i icon-name="map" class="mr-2"></i>
                                         {% trans 'Preview on map' %}
                                     </a>
                                 </label>
@@ -161,7 +161,7 @@
         <div class="grid gap-4">
             <div class="rounded border border-solid border-blue-500 shadow-2xl bg-white">
                 <div class="p-4 rounded bg-water-500">
-                    <h3 class="heading font-bold text-black"><i data-feather="star" class="mr-2"></i> {% trans 'Features' %}</h3>
+                    <h3 class="heading font-bold text-black"><i icon-name="star" class="mr-2"></i> {% trans 'Features' %}</h3>
                 </div>
                 <div class="px-4 pb-4 divide-y divide-gray-200 space-y-2">
                     <div>
@@ -245,7 +245,7 @@
             </div>
             <div class="rounded border border-solid border-blue-500 shadow-2xl bg-white">
                 <div class="p-4 rounded bg-water-500">
-                    <h3 class="heading font-bold text-black"><i data-feather="image" class="mr-2"></i> {{ form.icon.label }}</h3>
+                    <h3 class="heading font-bold text-black"><i icon-name="image" class="mr-2"></i> {{ form.icon.label }}</h3>
                 </div>
                 <div class="p-4">
                     {% render_field form.icon label=form.icon.label %}
@@ -254,7 +254,7 @@
             {% if not form.instance.id %}
             <div class="rounded border border-solid border-blue-500 shadow-2xl bg-white">
                 <div class="p-4 rounded bg-water-500">
-                    <h3 class="heading font-bold text-black"><i data-feather="copy" class="mr-2"></i> {% trans 'Duplicate content of another region' %}</h3>
+                    <h3 class="heading font-bold text-black"><i icon-name="copy" class="mr-2"></i> {% trans 'Duplicate content of another region' %}</h3>
                 </div>
                 <div class="px-4 pb-4">
                     <label for="{{ form.duplicated_region.id_for_label }}">{% trans 'Copy languages, pages and media from another region' %}</label>
@@ -271,7 +271,7 @@
                     data-confirmation-text="{% trans 'This can not be reversed.' %} {% trans 'All pages, events and locations of this region will also be deleted.' %} {% trans 'Users, who only have access to this region, will be removed as well.' %}"
                     data-confirmation-subject="{{ form.name.value }}"
                     data-action="{% url 'delete_region' slug=form.instance.slug %}">
-                <i data-feather="trash-2"></i>
+                <i icon-name="trash-2"></i>
                 {% trans 'Delete this region' %}
             </button>
         </div>

--- a/integreat_cms/cms/templates/roles/role_form.html
+++ b/integreat_cms/cms/templates/roles/role_form.html
@@ -23,7 +23,7 @@
 	    <div class="w-full">
 		    <div class="w-full mb-4 rounded border border-solid border-blue-500 shadow-2xl bg-white">
 				<div class="w-full p-4 rounded bg-water-500">
-					<h3 class="heading font-bold text-black"><i data-feather="key" class="mr-2"></i> {% trans 'Role settings' %}</h3>
+					<h3 class="heading font-bold text-black"><i icon-name="key" class="mr-2"></i> {% trans 'Role settings' %}</h3>
 				</div>
 				<div class="px-4 pb-4">
 					<label for="{{ role_form.name.id_for_label }}" >{{ role_form.name.label }}</label>

--- a/integreat_cms/cms/templates/roles/role_list_row.html
+++ b/integreat_cms/cms/templates/roles/role_list_row.html
@@ -9,9 +9,9 @@
     <td class="pl-2 pr-2">
         <a href="{% url 'edit_role' role_id=role.id %}" class="block py-3 px-2 text-gray-800">
             {% if role.staff_role %}
-                <i data-feather="check"></i>
+                <i icon-name="check"></i>
             {% else %}
-                <i data-feather="x"></i>
+                <i icon-name="x"></i>
             {% endif %}
         </a>
     </td>
@@ -21,7 +21,7 @@
                 data-confirmation-text="{{ delete_dialog_text }}"
                 data-confirmation-subject="{{ role.name }}"
                 data-action="#" disabled> <!-- TODO: delete roles -->
-            <i data-feather="trash-2"></i>
+            <i icon-name="trash-2"></i>
         </button>
     </td>
 </tr>

--- a/integreat_cms/cms/templates/settings/user_settings.html
+++ b/integreat_cms/cms/templates/settings/user_settings.html
@@ -10,7 +10,7 @@
     <div class="flex flex-wrap w-full xl:w-1/2 xl:pr-4">
         <div class="w-full mb-4 rounded border border-solid border-blue-500 shadow-2xl bg-white">
             <div class="w-full p-4 rounded bg-water-500">
-                <h3 class="font-bold text-black"><i data-feather="flag" class="mr-2"></i> {% trans 'My Language Preference' %}</h3>
+                <h3 class="font-bold text-black"><i icon-name="flag" class="mr-2"></i> {% trans 'My Language Preference' %}</h3>
             </div>
             <div class="px-4 pb-4">
                 <form action="{% url 'i18n:set_language' %}" method="post" class="w-full">
@@ -37,7 +37,7 @@
         </div>
         <div class="w-full mb-4 rounded border border-solid border-blue-500 shadow-2xl bg-white">
             <div class="w-full p-4 rounded bg-water-500">
-                <h3 class="font-bold text-black"><i data-feather="mail" class="mr-2"></i> {% trans 'My E-mail-address' %}</h3>
+                <h3 class="font-bold text-black"><i icon-name="mail" class="mr-2"></i> {% trans 'My E-mail-address' %}</h3>
             </div>
             <div class="px-4 pb-4">
                 <form method="post">
@@ -53,7 +53,7 @@
     <div class="w-full xl:w-1/2">
         <div class="w-full mb-4 rounded border border-solid border-blue-500 shadow-2xl bg-white">
             <div class="w-full p-4 rounded bg-water-500">
-                <h3 class="heading font-bold text-black"><i data-feather="lock" class="mr-2"></i> {% trans 'My Password' %}</h3>
+                <h3 class="heading font-bold text-black"><i icon-name="lock" class="mr-2"></i> {% trans 'My Password' %}</h3>
             </div>
             <div class="px-4 pb-4">
                 <form method="post">
@@ -77,7 +77,7 @@
     </div>
         <div class="w-full mb-4 rounded border border-solid border-blue-500 shadow-xl bg-white flex flex-wrap">
             <div class="w-full p-4 rounded bg-water-500">
-                <h3 class="heading font-bold text-black"><i data-feather="key" class="mr-2"></i> {% trans 'My 2-Factor-Authentication Keys' %}</h3>
+                <h3 class="heading font-bold text-black"><i icon-name="key" class="mr-2"></i> {% trans 'My 2-Factor-Authentication Keys' %}</h3>
             </div>
             <div class="p-4">
                 {% trans "You can use your FIDO2 keys to secure your account. Once you added a key to your account you won't be able to log in without using the key." %}<br>
@@ -107,7 +107,7 @@
                                            {% url 'delete_mfa_key' key_id=key.id %}
                                        {% endif %}
                                    {% endspaceless %}">
-                                    <i data-feather="trash-2" class="text-white"></i>
+                                    <i icon-name="trash-2" class="text-white"></i>
                                 </a>
                             </td>
                         </tr>

--- a/integreat_cms/cms/templates/statistics/_statistics_widget.html
+++ b/integreat_cms/cms/templates/statistics/_statistics_widget.html
@@ -19,9 +19,9 @@
         </a>
     </div>
     <div class="p-3 w-full text-center">
-        <div id="chart-network-error" class="text-red-500 px-4 hidden"><i data-feather="alert-triangle"></i> {% trans 'A network error has occurred.' %} {% trans 'Please try again later.' %}</div>
-        <div id="chart-server-error" class="text-red-500 px-4 hidden"><i data-feather="alert-triangle"></i> {% trans 'A server error has occurred.' %} {% trans 'Please contact the administrator.' %}</div>
-        <div id="chart-loading" class="px-4 hidden"><i data-feather="loader" class="animate-spin"></i> {% trans 'Loading...' %}</div>
+        <div id="chart-network-error" class="text-red-500 px-4 hidden"><i icon-name="alert-triangle"></i> {% trans 'A network error has occurred.' %} {% trans 'Please try again later.' %}</div>
+        <div id="chart-server-error" class="text-red-500 px-4 hidden"><i icon-name="alert-triangle"></i> {% trans 'A server error has occurred.' %} {% trans 'Please contact the administrator.' %}</div>
+        <div id="chart-loading" class="px-4 hidden"><i icon-name="loader" class="animate-spin"></i> {% trans 'Loading...' %}</div>
         <canvas id="statistics" data-statistics-url="{% url 'statistics_total_visits' region_slug=request.region.slug %}"></canvas>
     </div>
 {% endblock %}

--- a/integreat_cms/cms/templates/statistics/statistics_overview.html
+++ b/integreat_cms/cms/templates/statistics/statistics_overview.html
@@ -12,37 +12,37 @@
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-3 2xl:grid-cols-4">
         <div class="lg:col-span-2 2xl:row-span-2 2xl:col-span-3 rounded border border-solid border-blue-500 shadow-2xl bg-white">
             <div class="rounded p-4 bg-water-500">
-                <h3 class="heading font-bold text-black"><i data-feather="trending-up" class="pb-1"></i> {% trans 'Number of online accesses' %}</h3>
+                <h3 class="heading font-bold text-black"><i icon-name="trending-up" class="pb-1"></i> {% trans 'Number of online accesses' %}</h3>
             </div>
             <div class="p-5 bg-white text-center">
-                <div id="chart-network-error" class="text-red-500 px-4 hidden"><i data-feather="alert-triangle"></i> {% trans 'A network error has occurred.' %} {% trans 'Please try again later.' %}</div>
-                <div id="chart-server-error" class="text-red-500 px-4 hidden"><i data-feather="alert-triangle"></i> {% trans 'A server error has occurred.' %} {% trans 'Please contact the administrator.' %}</div>
-                <div id="chart-loading" class="px-4 hidden"><i data-feather="loader" class="animate-spin"></i> {% trans 'Loading...' %}</div>
+                <div id="chart-network-error" class="text-red-500 px-4 hidden"><i icon-name="alert-triangle"></i> {% trans 'A network error has occurred.' %} {% trans 'Please try again later.' %}</div>
+                <div id="chart-server-error" class="text-red-500 px-4 hidden"><i icon-name="alert-triangle"></i> {% trans 'A server error has occurred.' %} {% trans 'Please contact the administrator.' %}</div>
+                <div id="chart-loading" class="px-4 hidden"><i icon-name="loader" class="animate-spin"></i> {% trans 'Loading...' %}</div>
                 <div id="chart-label-help-text" class="my-2 text-s text-gray-600 text-left hidden">{% trans 'Individual languages can be hidden by clicking on the labels.' %}</div>
                 <canvas id="statistics" data-statistics-url="{% url 'statistics_visits_per_language' region_slug=request.region.slug %}"></canvas>
             </div>
         </div>
         <div class="rounded border border-solid border-blue-500 shadow-2xl bg-white">
             <div class="rounded p-4 bg-water-500">
-                <h3 class="heading font-bold text-black"><i data-feather="calendar" class="pb-1"></i> {% trans 'Adjust time period' %}</h3>
+                <h3 class="heading font-bold text-black"><i icon-name="calendar" class="pb-1"></i> {% trans 'Adjust time period' %}</h3>
             </div>
             <form id="statistics-form" class="flex flex-col p-4 pt-2">
                 {% csrf_token %}
                 <label for="{{ form.start_date.id_for_label }}">{{ form.start_date.label }}</label>
                 {% render_field form.start_date|add_error_class:"border-red-500" %}
-                <div id="start_date_error" class="chart-client-error text-red-500 pb-2 hidden"><i data-feather="alert-triangle"></i></div>
+                <div id="start_date_error" class="chart-client-error text-red-500 pb-2 hidden"><i icon-name="alert-triangle"></i></div>
                 <label for="{{ form.end_date.id_for_label }}">{{ form.end_date.label }}</label>
                 {% render_field form.end_date|add_error_class:"border-red-500" %}
-                <div id="end_date_error" class="chart-client-error text-red-500 pb-2 hidden"><i data-feather="alert-triangle"></i></div>
+                <div id="end_date_error" class="chart-client-error text-red-500 pb-2 hidden"><i icon-name="alert-triangle"></i></div>
                 <label for="{{ form.period.id_for_label }}">{{ form.period.label }}</label>
                 {% render_field form.period|add_error_class:"border-red-500" %}
-                <div id="period_error" class="chart-client-error text-red-500 pb-2 hidden"><i data-feather="alert-triangle"></i></div>
+                <div id="period_error" class="chart-client-error text-red-500 pb-2 hidden"><i icon-name="alert-triangle"></i></div>
                 <button class="btn mt-4">{% trans 'Customize view' %}</button>
             </form>
         </div>
         <div class="rounded border border-solid border-blue-500 shadow-2xl bg-white">
             <div class="rounded p-4 bg-water-500">
-                <h3 class="heading font-bold text-black"><i data-feather="download" class="pb-1"></i> {% trans 'Export' %}</h3>
+                <h3 class="heading font-bold text-black"><i icon-name="download" class="pb-1"></i> {% trans 'Export' %}</h3>
             </div>
             <div class="flex flex-col gap-4 p-4 pt-2">
                 <label for="export-format">{% trans 'Choose format' %}</label>

--- a/integreat_cms/cms/templates/tutorials/page_tree.html
+++ b/integreat_cms/cms/templates/tutorials/page_tree.html
@@ -5,7 +5,7 @@
 {% block content %}
 <!-- Pop-Up Header -->
 <div class="flex items-center bg-water-500 w-full rounded h-12">
-    <i data-feather="help-circle" class="text-black ml-2"></i>
+    <i icon-name="help-circle" class="text-black ml-2"></i>
     <h2 class="flex items-center font-semibold leading-normal pl-2 text-black text-xl"> {% trans 'Introduction - Page Tree' %}</h2>
 </div>
 <!-- Pop-Up Content -->

--- a/integreat_cms/cms/templates/users/region_user_form.html
+++ b/integreat_cms/cms/templates/users/region_user_form.html
@@ -26,7 +26,7 @@
     <div class="grid xl:grid-cols-2 2xl:grid-cols-3 gap-4">
         <div class="mb-4 rounded border border-blue-500 shadow-2xl bg-white">
             <div class="p-4 rounded bg-water-500">
-                <h3 class="heading font-bold text-black"><i data-feather="user" class="mr-2"></i> {% trans 'General Settings' %}</h3>
+                <h3 class="heading font-bold text-black"><i icon-name="user" class="mr-2"></i> {% trans 'General Settings' %}</h3>
             </div>
             <div class="px-4 pb-4 divide-y divide-gray-200 space-y-4">
                 <!-- General Options for user management -->
@@ -50,7 +50,7 @@
         </div>
         <div class="mb-4 rounded border border-blue-500 shadow-2xl bg-white">
             <div class="p-4 rounded bg-water-500">
-                <h3 class="heading font-bold text-black"><i data-feather="lock" class="mr-2"></i> {% trans 'Login' %}</h3>
+                <h3 class="heading font-bold text-black"><i icon-name="lock" class="mr-2"></i> {% trans 'Login' %}</h3>
             </div>
             <div class="px-4 pb-4 divide-y divide-gray-200 space-y-4">
                 <div>
@@ -78,7 +78,7 @@
         </div>
         <div class="mb-4 rounded border border-blue-500 shadow-2xl bg-white">
             <div class="p-4 rounded bg-water-500">
-                <h3 class="heading font-bold text-black"><i data-feather="key" class="mr-2"></i> {% trans 'Permissions' %}</h3>
+                <h3 class="heading font-bold text-black"><i icon-name="key" class="mr-2"></i> {% trans 'Permissions' %}</h3>
             </div>
             <div class="px-4 pb-4 divide-y divide-gray-200 space-y-4">
                 <div>
@@ -109,7 +109,7 @@
                         data-confirmation-text="{% trans 'This cannot be reversed.' %}"
                         data-confirmation-subject="{{ user_form.username.value }}"
                         data-action="{% url 'delete_region_user' region_slug=request.region.slug user_id=user_form.instance.id %}">
-                    <i data-feather="trash-2" class="mr-2"></i>
+                    <i icon-name="trash-2" class="mr-2"></i>
                     {% trans 'Delete user' %}
                 </button>
             </div>
@@ -120,7 +120,7 @@
                         data-confirmation-text="{% trans 'The user will keep access to the following regions:' %} {{ user_form.instance|remaining_regions:request.region|join:', ' }}"
                         data-confirmation-subject="{{ user_form.username.value }}"
                         data-action="{% url 'delete_region_user' region_slug=request.region.slug user_id=user_form.instance.id %}">
-                    <i data-feather="trash-2" class="mr-2"></i>
+                    <i icon-name="trash-2" class="mr-2"></i>
                     {% trans 'Remove user from region' %}
                 </button>
             </div>

--- a/integreat_cms/cms/templates/users/region_user_list_row.html
+++ b/integreat_cms/cms/templates/users/region_user_list_row.html
@@ -25,18 +25,18 @@
 			{{ user.last_login }}
 		{% else %}
 			<span title="{% trans 'No login yet' %}">
-				<i data-feather="x" class="text-red-500"></i>
+				<i icon-name="x" class="text-red-500"></i>
 			</span>
 		{% endif %}
 	</td>
 	<td class="pr-4 whitespace-nowrap">
 		{% if user.is_active %}
 			<span title="{% trans 'Active' %}">
-				<i data-feather="check" class="text-green-500"></i>
+				<i icon-name="check" class="text-green-500"></i>
 			</span>
 		{% else %}
 			<span title="{% trans 'Inactive' %}">
-				<i data-feather="x" class="text-red-500 align-text-top"></i>
+				<i icon-name="x" class="text-red-500 align-text-top"></i>
 			</span>
 			<form method="post" action="{% url 'resend_activation_link_region' region_slug=request.region.slug user_id=user.id %}" class="inline">
 				{% csrf_token %}

--- a/integreat_cms/cms/templates/users/user_form.html
+++ b/integreat_cms/cms/templates/users/user_form.html
@@ -23,7 +23,7 @@
     <div class="grid xl:grid-cols-2 2xl:grid-cols-3 gap-4">
         <div class="mb-4 rounded border border-solid border-blue-500 shadow-2xl bg-white">
             <div class="p-4 rounded bg-water-500">
-                <h3 class="heading font-bold text-black"><i data-feather="user" class="mr-2"></i> {% trans 'General Settings' %}</h3>
+                <h3 class="heading font-bold text-black"><i icon-name="user" class="mr-2"></i> {% trans 'General Settings' %}</h3>
             </div>
             <div class="px-4 pb-4 divide-y divide-gray-200 space-y-4">
                 <!-- General Options for user management -->
@@ -47,7 +47,7 @@
 		</div>
         <div class="mb-4 rounded border border-solid border-blue-500 shadow-2xl bg-white">
             <div class="p-4 rounded bg-water-500">
-                <h3 class="heading font-bold text-black"><i data-feather="lock" class="mr-2"></i> {% trans 'Login' %}</h3>
+                <h3 class="heading font-bold text-black"><i icon-name="lock" class="mr-2"></i> {% trans 'Login' %}</h3>
             </div>
             <div class="px-4 pb-4 divide-y divide-gray-200 space-y-4">
                 <div>
@@ -76,7 +76,7 @@
         </div>
         <div class="mb-4 rounded border border-solid border-blue-500 shadow-2xl bg-white">
 			<div class="p-4 rounded bg-water-500">
-				<h3 class="heading font-bold text-black"><i data-feather="key" class="mr-2"></i> {% trans 'Permissions' %}</h3>
+				<h3 class="heading font-bold text-black"><i icon-name="key" class="mr-2"></i> {% trans 'Permissions' %}</h3>
 			</div>
 			<div class="px-4 pb-4 divide-y divide-gray-200 space-y-4">
                 <div class="divide-y divide-gray-200">
@@ -131,7 +131,7 @@
                     data-confirmation-text="{% trans 'This cannot be reversed.' %}"
                     data-confirmation-subject="{{ user_form.username.value }}"
                     data-action="{% url 'delete_user' user_id=user_form.instance.id %}">
-                <i data-feather="trash-2" class="mr-2"></i>
+                <i icon-name="trash-2" class="mr-2"></i>
                 {% trans 'Delete this user' %}
             </button>
         </div>

--- a/integreat_cms/cms/templates/users/user_list_row.html
+++ b/integreat_cms/cms/templates/users/user_list_row.html
@@ -30,18 +30,18 @@
 			{{ user.last_login }}
 		{% else %}
 			<span title="{% trans 'No login yet' %}">
-				<i data-feather="x" class="text-red-500"></i>
+				<i icon-name="x" class="text-red-500"></i>
 			</span>
 		{% endif %}
 	</td>
 	<td class="pr-2 whitespace-nowrap">
 		{% if user.is_active %}
 			<span title="{% trans 'Active' %}">
-				<i data-feather="check" class="text-green-500"></i>
+				<i icon-name="check" class="text-green-500"></i>
 			</span>
 		{% else %}
 			<span title="{% trans 'Inactive' %}">
-				<i data-feather="x" class="text-red-500 align-text-top"></i>
+				<i icon-name="x" class="text-red-500 align-text-top"></i>
 			</span>
 			<form method="post" action="{% url 'resend_activation_link' user_id=user.id %}" class="inline">
 				{% csrf_token %}
@@ -54,22 +54,22 @@
 	<td class="pr-2">
 		{% if user.is_staff %}
 			<span title="{% trans 'Staff member' %}">
-				<i data-feather="check" class="text-green-500"></i>
+				<i icon-name="check" class="text-green-500"></i>
 			</span>
 		{% else %}
 			<span title="{% trans 'No staff member' %}">
-				<i data-feather="x" class="text-red-500"></i>
+				<i icon-name="x" class="text-red-500"></i>
 			</span>
 		{% endif %}
 	</td>
 	<td class="pr-4">
 		{% if user.is_superuser %}
 			<span title="{% trans 'Administrator' %}">
-				<i data-feather="check" class="text-green-500"></i>
+				<i icon-name="check" class="text-green-500"></i>
 			</span>
 		{% else %}
 			<span title="{% trans 'No administrator' %}">
-				<i data-feather="x" class="text-red-500"></i>
+				<i icon-name="x" class="text-red-500"></i>
 			</span>
 		{% endif %}
 	</td>

--- a/integreat_cms/static/src/css/style.scss
+++ b/integreat_cms/static/src/css/style.scss
@@ -86,6 +86,13 @@ nav#primary-navigation {
   }
 }
 
+i[icon-name] {
+  width: 24px;
+  height: 24px;
+  display: inline-block;
+  vertical-align: middle;
+}
+
 h1.heading {
   @apply text-3xl mb-2;
 }

--- a/integreat_cms/static/src/index.ts
+++ b/integreat_cms/static/src/index.ts
@@ -4,7 +4,6 @@ import "regenerator-runtime/runtime";
 import "whatwg-fetch"; // IE11: fetch
 require("element-closest").default(window); // IE11: Element.closest
 
-import feather from 'feather-icons';
 import "./css/style.scss";
 
 import "./js/auto-file-download.ts";
@@ -61,6 +60,8 @@ import "./js/user/user-creation-workflow.ts";
 import "./js/user/user-roles.ts";
 import "./js/user/organization.ts";
 
+import { create_icons_at } from "./js/utils/create-icons";
+
 import "./js/charCounter.ts";
 
 import "./js/media-management/index.tsx";
@@ -73,8 +74,8 @@ import "./js/tutorial-overlay.ts";
 
 import "./js/unsaved-warning";
 
-window.addEventListener('load',() => {
-    feather.replace({ class: 'inline-block' });
-    const event = new Event("icon-load");
-    window.dispatchEvent(event);
+window.addEventListener('DOMContentLoaded', () => {
+  create_icons_at(document.documentElement);
+  const event = new Event("icon-load");
+  window.dispatchEvent(event);
 })

--- a/integreat_cms/static/src/js/chat/send-chat-message.ts
+++ b/integreat_cms/static/src/js/chat/send-chat-message.ts
@@ -1,4 +1,4 @@
-import feather from "feather-icons";
+import { create_icons_at } from "../utils/create-icons";
 import { refreshAjaxConfirmationHandlers } from "../confirmation-popups";
 import { deleteChatMessage } from "./delete-chat-message";
 /**
@@ -53,7 +53,7 @@ async function sendChatMessage(event: Event) {
       // Clear input field
       chatForm.reset();
       // Trigger icon replacement
-      feather.replace({ class: 'inline-block' });
+      create_icons_at(chatHistory);
 
       refreshAjaxConfirmationHandlers(".button-delete-chat-message", deleteChatMessage);
     } else {

--- a/integreat_cms/static/src/js/events/event-query-pois.ts
+++ b/integreat_cms/static/src/js/events/event-query-pois.ts
@@ -1,4 +1,4 @@
-import feather from "feather-icons";
+import { create_icons_at } from "../utils/create-icons"
 import { getCsrfToken } from "../utils/csrf-token";
 
 window.addEventListener("load", () => {
@@ -39,10 +39,10 @@ async function queryPois(
 
   if (data) {
     // Set and display new data
-    document.getElementById("poi-query-result").classList.remove("hidden");
-    document.getElementById("poi-query-result").innerHTML = data;
-    // trigger icon replacement
-    feather.replace({ class: 'inline-block' });
+    const query_result = document.getElementById("poi-query-result");
+    query_result.classList.remove("hidden");
+    query_result.innerHTML = data;
+    create_icons_at(query_result);
   }
 
   document.querySelectorAll(".option-new-poi").forEach((node) => {

--- a/integreat_cms/static/src/js/pages/fetch-subpages.ts
+++ b/integreat_cms/static/src/js/pages/fetch-subpages.ts
@@ -2,8 +2,7 @@
  * The functionality to fetch subpages
  */
 
-import feather from "feather-icons";
-
+import { create_icons_at } from "../utils/create-icons";
 import { setBulkActionEventListeners } from "../bulk-actions";
 import { setToggleSubpagesEventListeners } from "./toggle-subpages";
 import { addDragAndDropListeners } from "../tree-drag-and-drop";
@@ -17,8 +16,6 @@ window.addEventListener("load", () => {
     console.debug("Loading all subpages");
     Promise.all(rootPages.map(fetchSubpages)).then(() => {
       console.debug("Finished loading all subpages");
-      // Render icons for recently added DOM elements
-      feather.replace({ class: 'inline-block' });
       // Set event handlers
       setToggleSubpagesEventListeners();
       setBulkActionEventListeners();
@@ -65,6 +62,8 @@ export async function fetchSubpages(collapseSpan: HTMLElement): Promise<number[]
         directChildrenIds.push(descendantId);
       }
     }
+    // render icons
+    create_icons_at(rowToInsert);
     // Insert child into DOM tree
     currentRow.after(rowToInsert);
     // Update point to insert next child

--- a/integreat_cms/static/src/js/pages/page-order.ts
+++ b/integreat_cms/static/src/js/pages/page-order.ts
@@ -1,4 +1,4 @@
-import feather from "feather-icons";
+import { create_icons_at } from "../utils/create-icons";
 import { off, on } from "../utils/wrapped-events";
 
 let initialPageTitle: string;
@@ -70,7 +70,7 @@ async function getPageOrderTable({ target }: Event) {
     // Update the modified page title
     updatePageTitle();
     // Trigger icon replacement
-    feather.replace({ class: 'inline-block' });
+    create_icons_at(document.getElementById("page_order_table"));
     // Register event handlers
     registerEventHandlers();
   } catch (error: any) {

--- a/integreat_cms/static/src/js/pages/page-permissions.ts
+++ b/integreat_cms/static/src/js/pages/page-permissions.ts
@@ -1,7 +1,7 @@
 /**
  * This file contains all event handlers and functions which are needed for granting and revoking permissions on individual pages.
  */
-import feather from "feather-icons";
+import { create_icons_at } from "../utils/create-icons";
 import {getCsrfToken} from "../utils/csrf-token";
 
 document.addEventListener("DOMContentLoaded", setPagePermissionEventListeners);
@@ -78,6 +78,6 @@ async function updatePagePermission(
     // set new event listeners
     setPagePermissionEventListeners();
     // trigger icon replacement
-    feather.replace({ class: 'inline-block' });
+    create_icons_at(document.getElementById("page_permission_table"));
   }
 }

--- a/integreat_cms/static/src/js/pages/toggle-subpages.ts
+++ b/integreat_cms/static/src/js/pages/toggle-subpages.ts
@@ -1,7 +1,7 @@
 /*
  * The functionality to toggle subpages
  */
-import feather from "feather-icons";
+import { create_icons_at } from "../utils/create-icons";
 
 window.addEventListener("load", () => {
   // On the page tree, the event listeners are set after all subpages have been loaded
@@ -53,15 +53,14 @@ export async function toggleSubpages(event: Event) {
   toggleSubpagesRecursive(children);
   // Change icon and title
   let icon = collapseSpan.querySelector("svg");
-  if (icon.classList.contains("feather-chevron-down")) {
-    collapseSpan.innerHTML = '<i data-feather="chevron-right"></i>';
+  if (icon.classList.contains("lucide-chevron-down")) {
+    collapseSpan.innerHTML = '<i icon-name="chevron-right"></i>';
     collapseSpan.title = collapseSpan.getAttribute("data-expand-title");
   } else {
-    collapseSpan.innerHTML = '<i data-feather="chevron-down"></i>';
+    collapseSpan.innerHTML = '<i icon-name="chevron-down"></i>';
     collapseSpan.title = collapseSpan.getAttribute("data-collapse-title");
   }
-  // Trigger icon replacement
-  feather.replace({ class: 'inline-block' });
+  create_icons_at(collapseSpan);
 }
 
 /**
@@ -90,7 +89,7 @@ function toggleSubpagesRecursive(childrenIds: Array<number>) {
     if (collapseSpan) {
       // The icon will be null if the page is a leaf node
       const icon = collapseSpan.querySelector("svg");
-      if (icon.classList.contains("feather-chevron-down")) {
+      if (icon.classList.contains("lucide-chevron-down")) {
         // This means the children are not yet collapsed and have to be hidden as well
         const grandChildren: number[] = JSON.parse(
           collapseSpan.getAttribute("data-page-children")
@@ -119,13 +118,12 @@ async function collapseAllPages() {
     const span = page.querySelector(".toggle-subpages") as HTMLElement;
     if (span) {
       // Change icon
-      span.innerHTML = '<i data-feather="chevron-right"></i>';
+      span.innerHTML = '<i icon-name="chevron-right"></i>';
       // Toggle title
       span.title = span.getAttribute("data-expand-title");
+      create_icons_at(span);
     }
   });
-  // Trigger icon replacement
-  feather.replace({ class: 'inline-block' });
 }
 
 /**
@@ -143,11 +141,10 @@ async function expandAllPages() {
     const span = page.querySelector(".toggle-subpages") as HTMLElement;
     if (span) {
       // Change icon
-      span.innerHTML = '<i data-feather="chevron-down"></i>';
+      span.innerHTML = '<i icon-name="chevron-down"></i>';
       // Toggle title
       span.title = span.getAttribute("data-collapse-title");
+      create_icons_at(span);
     }
   });
-  // Trigger icon replacement
-  feather.replace({ class: 'inline-block' });
 }

--- a/integreat_cms/static/src/js/utils/create-icons.ts
+++ b/integreat_cms/static/src/js/utils/create-icons.ts
@@ -1,0 +1,74 @@
+import { icons, createElement } from "lucide";
+
+// This function renders all <i icon-name="..."> children of `root`
+export function create_icons_at(root: HTMLElement) {
+  const elementsToReplace = root.querySelectorAll('[icon-name]');
+  Array.from(elementsToReplace).forEach(element => replace_element(element as HTMLElement, 'icon-name', { class: ['inline-block'] }));
+}
+
+// Most of this is taken from https://github.com/lucide-icons/lucide/tree/main/packages/lucide/src
+
+function replace_element(element: HTMLElement, nameAttr: string, attrs: object) {
+  const iconName = element.getAttribute(nameAttr);
+  const ComponentName = toPascalCase(iconName);
+
+  const iconNode = icons[ComponentName];
+
+  if (!iconNode) {
+    return console.warn(
+      `${element.outerHTML} icon name was not found in the provided icons object.`,
+    );
+  }
+
+  const elementAttrs = getAttrs(element);
+  const [tag, iconAttributes, children] = iconNode;
+
+  const iconAttrs = {
+    ...iconAttributes,
+    'icon-name': iconName,
+    ...attrs,
+    ...elementAttrs,
+  };
+
+  const classNames = combineClassNames(['lucide', `lucide-${iconName}`, elementAttrs, attrs]);
+
+  if (classNames) {
+    iconAttrs.class = classNames;
+  }
+
+  const svgElement = createElement([tag, iconAttrs, children]);
+
+  return element.parentNode.replaceChild(svgElement, element);
+
+}
+
+export const getAttrs = (element: HTMLElement) =>
+  Array.from(element.attributes).reduce((attrs: any, attr) => {
+    attrs[attr.name] = attr.value;
+    return attrs;
+  }, {});
+
+export const combineClassNames = (arrayOfClassnames: Array<string>) => {
+  const classNameArray = arrayOfClassnames.flatMap(getClassNames);
+
+  return classNameArray
+    .map(classItem => classItem.trim())
+    .filter(Boolean)
+    .filter((value, index, self) => self.indexOf(value) === index)
+    .join(' ');
+};
+
+export const getClassNames = (attrs: any) => {
+  if (typeof attrs === 'string') return attrs;
+  if (!attrs || !attrs.class) return '';
+  if (attrs.class && typeof attrs.class === 'string') {
+    return attrs.class.split(' ');
+  }
+  if (attrs.class && Array.isArray(attrs.class)) {
+    return attrs.class;
+  }
+  return '';
+};
+
+const toPascalCase = (str: string) =>
+  str.replace(/(\w)(\w*)(_|-|\s*)/g, (g0, g1, g2) => g1.toUpperCase() + g2.toLowerCase());

--- a/integreat_cms/xliff/utils.py
+++ b/integreat_cms/xliff/utils.py
@@ -382,7 +382,7 @@ def xliff_import_confirm(request, xliff_dir):
                     )
                     error_list = "<ul>"
                     for error in errors:
-                        error_list += f"<li><i data-feather='alert-triangle' class='pb-1'></i> {error['message']}</li>"
+                        error_list += f"<li><i icon-name='alert-triangle' class='pb-1'></i> {error['message']}</li>"
                     error_list += "</ul>"
                     messages.error(
                         request,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,10 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "integreat-cms",
-      "dependencies": {
-        "dropzone": "^6.0.0-beta.2"
-      },
       "devDependencies": {
         "@babel/cli": "^7.18.10",
         "@babel/core": "^7.19.0",
@@ -16,7 +12,6 @@
         "@babel/preset-env": "^7.19.0",
         "@tailwindcss/forms": "^0.5.3",
         "@types/dropzone": "^5.7.4",
-        "@types/feather-icons": "^4.7.0",
         "@types/tinymce": "^4.6.5",
         "autoprefixer": "10.4.8",
         "babel-loader": "^8.2.5",
@@ -27,12 +22,13 @@
         "core-js": "^3.25.1",
         "css-loader": "^6.7.1",
         "css-minimizer-webpack-plugin": "^4.1.0",
+        "dropzone": "^6.0.0-beta.2",
         "element-closest": "^3.0.2",
-        "feather-icons": "^4.29.0",
         "file-loader": "^6.2.0",
         "flagpack-dart-sass": "^1.3.0",
         "history": "^5.3.0",
         "htmldiff-js": "1.0.5",
+        "lucide": "^0.91.0",
         "lucide-preact": "^0.88.0",
         "mini-css-extract-plugin": "^2.6.1",
         "postcss-cli": "^10.0.0",
@@ -2147,7 +2143,8 @@
     "node_modules/@swc/helpers": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.2.14.tgz",
-      "integrity": "sha512-wpCQMhf5p5GhNg2MmGKXzUNwxe7zRiCsmqYsamez2beP7mKPCSiu+BjZcdN95yYSzO857kr0VfQewmGpS77nqA=="
+      "integrity": "sha512-wpCQMhf5p5GhNg2MmGKXzUNwxe7zRiCsmqYsamez2beP7mKPCSiu+BjZcdN95yYSzO857kr0VfQewmGpS77nqA==",
+      "dev": true
     },
     "node_modules/@tailwindcss/forms": {
       "version": "0.5.3",
@@ -2203,12 +2200,6 @@
       "version": "0.0.51",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-      "dev": true
-    },
-    "node_modules/@types/feather-icons": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@types/feather-icons/-/feather-icons-4.7.0.tgz",
-      "integrity": "sha512-vflOrmlHMGIGVN4AEl6ErPCNKBLcP1ehEpLqnJkTgf69r5QmJzy7BF1WzbBc8Hqs9KffROPT/JqlSKH4o5vB/w==",
       "dev": true
     },
     "node_modules/@types/jquery": {
@@ -2523,6 +2514,8 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
       "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -2538,7 +2531,9 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "node_modules/ajv-keywords": {
       "version": "3.5.2",
@@ -3681,6 +3676,7 @@
       "version": "6.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/dropzone/-/dropzone-6.0.0-beta.2.tgz",
       "integrity": "sha512-k44yLuFFhRk53M8zP71FaaNzJYIzr99SKmpbO/oZKNslDjNXQsBTdfLs+iONd0U0L94zzlFzRnFdqbLcs7h9fQ==",
+      "dev": true,
       "dependencies": {
         "@swc/helpers": "^0.2.13",
         "just-extend": "^5.0.0"
@@ -3918,16 +3914,6 @@
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
-      }
-    },
-    "node_modules/feather-icons": {
-      "version": "4.29.0",
-      "resolved": "https://registry.npmjs.org/feather-icons/-/feather-icons-4.29.0.tgz",
-      "integrity": "sha512-Y7VqN9FYb8KdaSF0qD1081HCkm0v4Eq/fpfQYQnubpqi0hXx14k+gF9iqtRys1SIcTEi97xDi/fmsPFZ8xo0GQ==",
-      "dev": true,
-      "dependencies": {
-        "classnames": "^2.2.5",
-        "core-js": "^3.1.3"
       }
     },
     "node_modules/file-loader": {
@@ -4622,7 +4608,8 @@
     "node_modules/just-extend": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-5.1.1.tgz",
-      "integrity": "sha512-b+z6yF1d4EOyDgylzQo5IminlUmzSeqR1hs/bzjBNjuGras4FXq/6TrzjxfN0j+TmI0ltJzTNlqXUMCniciwKQ=="
+      "integrity": "sha512-b+z6yF1d4EOyDgylzQo5IminlUmzSeqR1hs/bzjBNjuGras4FXq/6TrzjxfN0j+TmI0ltJzTNlqXUMCniciwKQ==",
+      "dev": true
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
@@ -4743,6 +4730,12 @@
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
+    },
+    "node_modules/lucide": {
+      "version": "0.91.0",
+      "resolved": "https://registry.npmjs.org/lucide/-/lucide-0.91.0.tgz",
+      "integrity": "sha512-Ynd2KJjNIP/H/YJnKusvLazgR5RYpCqBJ3Fe0E1D7Ml+MudIxCfPG2l2Bm/HCxPxnXarWypdowbuy6dkeH8d/w==",
+      "dev": true
     },
     "node_modules/lucide-preact": {
       "version": "0.88.0",
@@ -9309,7 +9302,8 @@
     "@swc/helpers": {
       "version": "0.2.14",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.2.14.tgz",
-      "integrity": "sha512-wpCQMhf5p5GhNg2MmGKXzUNwxe7zRiCsmqYsamez2beP7mKPCSiu+BjZcdN95yYSzO857kr0VfQewmGpS77nqA=="
+      "integrity": "sha512-wpCQMhf5p5GhNg2MmGKXzUNwxe7zRiCsmqYsamez2beP7mKPCSiu+BjZcdN95yYSzO857kr0VfQewmGpS77nqA==",
+      "dev": true
     },
     "@tailwindcss/forms": {
       "version": "0.5.3",
@@ -9359,12 +9353,6 @@
       "version": "0.0.51",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz",
       "integrity": "sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==",
-      "dev": true
-    },
-    "@types/feather-icons": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@types/feather-icons/-/feather-icons-4.7.0.tgz",
-      "integrity": "sha512-vflOrmlHMGIGVN4AEl6ErPCNKBLcP1ehEpLqnJkTgf69r5QmJzy7BF1WzbBc8Hqs9KffROPT/JqlSKH4o5vB/w==",
       "dev": true
     },
     "@types/jquery": {
@@ -9636,15 +9624,14 @@
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
       "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dev": true,
-      "requires": {
-        "ajv": "^8.0.0"
-      },
+      "requires": {},
       "dependencies": {
         "ajv": {
-          "version": "8.11.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "version": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
           "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
           "dev": true,
+          "optional": true,
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -9656,7 +9643,9 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
           "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-          "dev": true
+          "dev": true,
+          "optional": true,
+          "peer": true
         }
       }
     },
@@ -10453,6 +10442,7 @@
       "version": "6.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/dropzone/-/dropzone-6.0.0-beta.2.tgz",
       "integrity": "sha512-k44yLuFFhRk53M8zP71FaaNzJYIzr99SKmpbO/oZKNslDjNXQsBTdfLs+iONd0U0L94zzlFzRnFdqbLcs7h9fQ==",
+      "dev": true,
       "requires": {
         "@swc/helpers": "^0.2.13",
         "just-extend": "^5.0.0"
@@ -10640,16 +10630,6 @@
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
-      }
-    },
-    "feather-icons": {
-      "version": "4.29.0",
-      "resolved": "https://registry.npmjs.org/feather-icons/-/feather-icons-4.29.0.tgz",
-      "integrity": "sha512-Y7VqN9FYb8KdaSF0qD1081HCkm0v4Eq/fpfQYQnubpqi0hXx14k+gF9iqtRys1SIcTEi97xDi/fmsPFZ8xo0GQ==",
-      "dev": true,
-      "requires": {
-        "classnames": "^2.2.5",
-        "core-js": "^3.1.3"
       }
     },
     "file-loader": {
@@ -11155,7 +11135,8 @@
     "just-extend": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-5.1.1.tgz",
-      "integrity": "sha512-b+z6yF1d4EOyDgylzQo5IminlUmzSeqR1hs/bzjBNjuGras4FXq/6TrzjxfN0j+TmI0ltJzTNlqXUMCniciwKQ=="
+      "integrity": "sha512-b+z6yF1d4EOyDgylzQo5IminlUmzSeqR1hs/bzjBNjuGras4FXq/6TrzjxfN0j+TmI0ltJzTNlqXUMCniciwKQ==",
+      "dev": true
     },
     "kind-of": {
       "version": "6.0.3",
@@ -11258,6 +11239,12 @@
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
       }
+    },
+    "lucide": {
+      "version": "0.91.0",
+      "resolved": "https://registry.npmjs.org/lucide/-/lucide-0.91.0.tgz",
+      "integrity": "sha512-Ynd2KJjNIP/H/YJnKusvLazgR5RYpCqBJ3Fe0E1D7Ml+MudIxCfPG2l2Bm/HCxPxnXarWypdowbuy6dkeH8d/w==",
+      "dev": true
     },
     "lucide-preact": {
       "version": "0.88.0",
@@ -12762,7 +12749,6 @@
         "normalize-path": "^3.0.0",
         "object-hash": "^3.0.0",
         "picocolors": "^1.0.0",
-        "postcss": "^8.4.14",
         "postcss-import": "^14.1.0",
         "postcss-js": "^4.0.0",
         "postcss-load-config": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@babel/preset-env": "^7.19.0",
     "@tailwindcss/forms": "^0.5.3",
     "@types/dropzone": "^5.7.4",
-    "@types/feather-icons": "^4.7.0",
     "@types/tinymce": "^4.6.5",
     "autoprefixer": "10.4.8",
     "babel-loader": "^8.2.5",
@@ -23,19 +22,20 @@
     "core-js": "^3.25.1",
     "css-loader": "^6.7.1",
     "css-minimizer-webpack-plugin": "^4.1.0",
+    "dropzone": "^6.0.0-beta.2",
     "element-closest": "^3.0.2",
-    "feather-icons": "^4.29.0",
     "file-loader": "^6.2.0",
     "flagpack-dart-sass": "^1.3.0",
     "history": "^5.3.0",
     "htmldiff-js": "1.0.5",
+    "lucide": "^0.91.0",
+    "lucide-preact": "^0.88.0",
     "mini-css-extract-plugin": "^2.6.1",
     "postcss-cli": "^10.0.0",
     "postcss-import": "^15.0.0",
     "postcss-loader": "^7.0.1",
     "postcss-preset-env": "^7.8.1",
     "preact": "^10.10.6",
-    "lucide-preact": "^0.88.0",
     "preact-router": "^4.1.0",
     "promise-polyfill": "^8.2.3",
     "regenerator-runtime": "^0.13.9",
@@ -53,8 +53,5 @@
     "webpack-bundle-tracker": "^1.6.0",
     "webpack-cli": "^4.10.0",
     "whatwg-fetch": "^3.6.2"
-  },
-  "dependencies": {
-    "dropzone": "^6.0.0-beta.2"
   }
 }


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr uses lucide instead of feather for rendering icons in the browser, further improving the performance of https://github.com/digitalfabrik/integreat-cms/pull/1379 to make it hopefully usable for large page trees.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Switch to lucide
- Don't query every icon on the document when dynamically rendering an image after an ajax call
- rename the `data-feather` attribute to `icon-name`

### Unresolved questions:
- ~Should this pr include the current implementation of `create-icons.ts` or should I create a pr to lucide?~
- ~Why are most dependencies dev-dependencies? And should lucide be added to the dev-dependency section too?~


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- New image icons must use `icon-name="..."` instead of `data-feather="..."`


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->
Fixes: #1672 

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
