### PR TITLE
add line break between images in PDF exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 UNRELEASED
 ----------
 
+* [ [#1759](https://github.com/digitalfabrik/integreat-cms/issues/1759) ] Add line break between images in PDF exports
 * [ [#951](https://github.com/digitalfabrik/integreat-cms/issues/951) ] Add possibility to create categories for POIs
 * [ [#1742](https://github.com/digitalfabrik/integreat-cms/issues/1742) ] Add last modified date to media sidebar
 * [ [#1703](https://github.com/digitalfabrik/integreat-cms/issues/1703) ] Remove pending account activation warning when user form is submitted with errors

--- a/integreat_cms/static/src/css/pdf_page_export.css
+++ b/integreat_cms/static/src/css/pdf_page_export.css
@@ -137,3 +137,11 @@ li {
     text-align: right;
     background-color: white;
 }
+
+/* force linebreak between images wrapped in links */
+p a img {
+    display: block;
+}
+p a:first-child img {
+    display: inline-block;
+}


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Putting large images next to each other without a wrapping `<p>` or '<div>`  resulted in all images appearing next to each other and overflowing offpage

### Proposed changes
<!-- Describe this PR in more detail. -->

- starting from the second image inside a wrapping `<p>`, images are displayed as `block`


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- having two or more links, each including at least one image, on the same line (inside one shared `<p>`) breaks the styling of all but the first links. See discusion in #1499 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1759 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
