### PR TITLE
Provide fallback translations for imprint feedbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ UNRELEASED
 
 * [ [#1718](https://github.com/digitalfabrik/integreat-cms/issues/1718) ] Enable submitting feedback about fallback translations of events and pois
 * [ [#1793](https://github.com/digitalfabrik/integreat-cms/issues/1793) ] Fix sending feedback for recurring events
+* [ [#1717](https://github.com/digitalfabrik/integreat-cms/issues/1717) ] Provide fallback translations for imprint feedbacks
 
 
 2022.10.2

--- a/integreat_cms/api/v3/feedback/imprint_page_feedback.py
+++ b/integreat_cms/api/v3/feedback/imprint_page_feedback.py
@@ -73,7 +73,7 @@ def imprint_page_feedback_internal(
     :return: JSON object according to APIv3 imprint feedback endpoint definition
     :rtype: ~django.http.JsonResponse
     """
-    if region.imprint:
+    if region.imprint and language in region.visible_languages:
         ImprintPageFeedback.objects.create(
             region=region,
             language=language,
@@ -88,4 +88,6 @@ def imprint_page_feedback_internal(
         region,
         language,
     )
-    raise Http404("The imprint does not exist in this region")
+    raise Http404(
+        "The imprint does not exist in this region for the selected language."
+    )

--- a/integreat_cms/cms/models/feedback/imprint_page_feedback.py
+++ b/integreat_cms/cms/models/feedback/imprint_page_feedback.py
@@ -20,7 +20,11 @@ class ImprintPageFeedback(Feedback):
         :rtype: str
         """
         try:
-            return self.region.imprint.get_translation(self.language.slug).title
+            translation = (
+                self.region.imprint.get_translation(self.language.slug)
+                or self.region.imprint.default_translation
+            )
+            return translation
         except ImprintPage.DoesNotExist:
             return _("Imprint")
 

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-27 09:09+0000\n"
+"POT-Creation-Date: 2022-10-31 15:38+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -2387,12 +2387,12 @@ msgstr "Wenn das Feedback ungelesen ist, ist dieses Feld leer."
 msgid "feedback"
 msgstr "Feedback"
 
-#: cms/models/feedback/imprint_page_feedback.py:25 cms/templates/_base.html:182
+#: cms/models/feedback/imprint_page_feedback.py:29 cms/templates/_base.html:182
 msgid "Imprint"
 msgstr "Impressum"
 
-#: cms/models/feedback/imprint_page_feedback.py:57
-#: cms/models/feedback/imprint_page_feedback.py:59
+#: cms/models/feedback/imprint_page_feedback.py:61
+#: cms/models/feedback/imprint_page_feedback.py:63
 msgid "imprint feedback"
 msgstr "Impressums-Feedback"
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR should fix the feedback view error, that was shown, when imprint feedback was submitted in a language, that does not exist for this regions feedback.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Use fallback translation for the title of an imprint feedback, if the language exists in this region
- Use default backend language, otherwise


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes:  #1717

There was a previous PR, where I used a different solution which did not work out. When I dropped the changes, the PR was closed automatically. However, for full discussion also see #1730.


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
