### PR TITLE
Fix region deletion error if media library has nested structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ UNRELEASED
 
 * [ [#1350](https://github.com/digitalfabrik/integreat-cms/issues/1350) ] Various small PDF export improvements
 * [ [#1777](https://github.com/digitalfabrik/integreat-cms/issues/1777) ] Fix autocompleting POI address for non-staff users
+* [ [#1749](https://github.com/digitalfabrik/integreat-cms/issues/1749) ] Fix region deletion error if media library has nested structure
 
 
 2022.10.1

--- a/integreat_cms/cms/views/regions/region_actions.py
+++ b/integreat_cms/cms/views/regions/region_actions.py
@@ -40,6 +40,8 @@ def delete_region(request, *args, **kwargs):
     # Remove hierarchy to prevent ProtectedError when children get deleted before their parents
     region.pages.update(parent=None)
     region.language_tree_nodes.update(parent=None)
+    region.media_directories.update(parent=None)
+    region.files.update(parent_directory=None)
     # Prevent ProtectedError when location gets deleted before their events
     region.events.update(location=None)
     # Delete region and cascade delete all contents

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -7453,7 +7453,7 @@ msgstr ""
 "Bitte erstellen Sie mindestens einen Sprach-Knoten, bevor Sie Push-"
 "Benachrichtigungen verwalten."
 
-#: cms/views/regions/region_actions.py:65
+#: cms/views/regions/region_actions.py:67
 msgid "Region was successfully deleted"
 msgstr "Region wurde erfolgreich gelöscht"
 


### PR DESCRIPTION
### Short description
When region has nested directory structure with media elements in subfolders, attempt to delete such region produces an error:
```
django.db.models.deletion.ProtectedError: ("Cannot delete some instances of model 'Region' because they are referenced through protected foreign keys: 'Director
y.region'.", {<MediaFile (id: 66048, name: arriving.png, path: /var/www/integreat-cms/media/regions/252/2022/06/arriving.png, Landeshauptstadt Saarbrücken (alt)
(&#9888; Versteckt))>})
```

### Proposed changes
Protected relationship is removed by setting parent = None on all directories and parent_directory = None on all media files before deleting the region


### Side effects
Didn't find any


### Resolved issues
Fixes: #1749


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
