### PR TITLE
Fix autocompleting POI address for non-staff users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ UNRELEASED
 ----------
 
 * [ [#1350](https://github.com/digitalfabrik/integreat-cms/issues/1350) ] Various small PDF export improvements
+* [ [#1777](https://github.com/digitalfabrik/integreat-cms/issues/1777) ] Fix autocompleting POI address for non-staff users
 
 
 2022.10.1

--- a/integreat_cms/cms/templates/pois/poi_form.html
+++ b/integreat_cms/cms/templates/pois/poi_form.html
@@ -158,7 +158,7 @@
                         <div>
                             <label>{% trans 'Position' %}</label>
                             <div>
-                                <input type="checkbox" id="auto-fill-coordinates" data-url="{% url 'auto_complete_poi_address' %}" checked>
+                                <input type="checkbox" id="auto-fill-coordinates" data-url="{% url 'auto_complete_poi_address' region_slug=request.region.slug %}" checked>
                                 <label for="auto-fill-coordinates" class="secondary !inline">
                                     {% trans 'Derive coordinates automatically from address' %}
                                 </label>

--- a/integreat_cms/cms/urls/protected.py
+++ b/integreat_cms/cms/urls/protected.py
@@ -429,11 +429,6 @@ urlpatterns = [
             [
                 path("", include(media_ajax_urlpatterns)),
                 path(
-                    "locations/auto-complete-address/",
-                    pois.auto_complete_address,
-                    name="auto_complete_poi_address",
-                ),
-                path(
                     "chat/",
                     include(
                         [
@@ -637,6 +632,11 @@ urlpatterns = [
                                 "dismiss-tutorial/<slug:slug>/",
                                 settings.DismissTutorial.as_view(),
                                 name="dismiss_tutorial",
+                            ),
+                            path(
+                                "locations/auto-complete-address/",
+                                pois.auto_complete_address,
+                                name="auto_complete_poi_address",
                             ),
                         ]
                     ),

--- a/integreat_cms/cms/views/pois/poi_actions.py
+++ b/integreat_cms/cms/views/pois/poi_actions.py
@@ -180,12 +180,16 @@ def view_poi(request, poi_id, region_slug, language_slug):
 @json_response
 @require_POST
 @permission_required("cms.view_poi")
-def auto_complete_address(request):
+# pylint: disable=unused-argument
+def auto_complete_address(request, region_slug):
     """
     Autocomplete location address and coordinates
 
     :param request: The current request
     :type request: ~django.http.HttpRequest
+
+    :param region_slug: The slug of the current region
+    :type region_slug: str
 
     :raises ~django.http.Http404: If no location was found for the given address
 

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -7337,11 +7337,11 @@ msgstr "Ort wurde erfolgreich wiederhergestellt"
 msgid "Location was successfully deleted"
 msgstr "Ort wurde erfolgreich gelöscht"
 
-#: cms/views/pois/poi_actions.py:198
+#: cms/views/pois/poi_actions.py:202
 msgid "Location service is disabled"
 msgstr "Ortung ist deaktiviert"
 
-#: cms/views/pois/poi_actions.py:214
+#: cms/views/pois/poi_actions.py:218
 msgid "Address could not be found"
 msgstr "Adresse konnte nicht gefunden werden"
 


### PR DESCRIPTION
### Short description
At the moment, the auto completion feature introduced in https://github.com/digitalfabrik/integreat-cms/pull/1744 does only work for staff users.

### Proposed changes
Pass region_slug parameter into the view.
(Because our [access control](https://github.com/digitalfabrik/integreat-cms/blob/15ce171cc8041bac2d24823e271632db56eaebf1/integreat_cms/core/middleware/access_control_middleware.py#L59-L69) treats all views without the region_slug parameter as "staff area" and denies region users to access them.)

### Side effects
Didn't find any

### Resolved issues
Fixes: #1777


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
