### PR TITLE
Disable upload-test-coverage CircleCI job for PRs of forks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -445,6 +445,9 @@ workflows:
           context: codeclimate
           requires:
             - test
+          filters:
+            branches:
+              only: /^(?!pull\/).*$/ 
       - check-translations:
           requires:
             - pipenv-install


### PR DESCRIPTION
### Short description
The [upload-test-coverage](https://github.com/digitalfabrik/integreat-cms/blob/8c1b48ffb325560ceff1bd77edf1dbf071b35f19/.circleci/config.yml#L191-L205) job on CircleCI doesn't work for external PRs since we don't pass our secrets to builds in other forks of this repository, see e.g. [this workflow run](https://app.circleci.com/pipelines/github/digitalfabrik/integreat-cms/5700/workflows/9aa77ab3-2c58-4d5b-802f-17cf49eab20b).

### Proposed changes
Add job filter by branch name: match branches where CircleCI doesn’t include pull/ at the beginning.
(CircleCI automatically names external branches as pull/XXX)

Tested on external PR:
https://github.com/digitalfabrik/integreat-cms/pull/1789

### Side effects
We shouldn't name our branches as pull/XXX, otherwise upload-test-coverage job won't run.

### Resolved issues
Fixes: #1762

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
