### PR TITLE
Increase request timeout for Nominatim calls

### DIFF
--- a/integreat_cms/nominatim_api/nominatim_api_client.py
+++ b/integreat_cms/nominatim_api/nominatim_api_client.py
@@ -37,6 +37,7 @@ class NominatimApiClient:
                 domain=nominatim_url.netloc + nominatim_url.path,
                 scheme=nominatim_url.scheme,
                 user_agent=f"integreat-cms/{__version__} ({settings.HOSTNAME})",
+                timeout=settings.DEFAULT_REQUEST_TIMEOUT,
             )
         except GeopyError as e:
             logger.exception(e)


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Previous default timeout was [1 second](https://geopy.readthedocs.io/en/latest/index.html?highlight=timeout#geopy.geocoders.options.default_timeout), now it is [10 seconds](https://github.com/digitalfabrik/integreat-cms/blob/1e20cd659b2dd287912b211272bf3bd41b90f5be/integreat_cms/core/settings.py#L113-L115).

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
