### PR TITLE
Reduce CircleCI resource classes to save credits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
   black:
     docker:
       - image: cimg/python:3.9
+    resource_class: small
     steps:
       - checkout
       - attach_workspace:
@@ -50,7 +51,6 @@ jobs:
   pylint:
     docker:
       - image: cimg/python:3.9
-    resource_class: xlarge
     steps:
       - checkout
       - attach_workspace:
@@ -61,6 +61,7 @@ jobs:
   check-translations:
     docker:
       - image: cimg/python:3.9
+    resource_class: small
     steps:
       - checkout
       - attach_workspace:
@@ -131,6 +132,7 @@ jobs:
           POSTGRES_USER: integreat
           POSTGRES_DB: integreat
           POSTGRES_PASSWORD: password
+    resource_class: small
     steps:
       - checkout
       - attach_workspace:
@@ -141,6 +143,7 @@ jobs:
   setup-test-reporter:
     docker:
       - image: cimg/base:stable
+    resource_class: small
     steps:
       - attach_workspace:
           at: .
@@ -165,7 +168,6 @@ jobs:
           POSTGRES_DB: integreat
           POSTGRES_PASSWORD: password
     parallelism: 16
-    resource_class: large
     steps:
       - checkout
       - attach_workspace:
@@ -191,6 +193,7 @@ jobs:
   upload-test-coverage:
     docker:
       - image: cimg/base:stable
+    resource_class: small
     steps:
       - attach_workspace:
           at: .
@@ -251,6 +254,7 @@ jobs:
   deploy-documentation:
     docker:
       - image: cimg/python:3.9
+    resource_class: small
     environment:
       BRANCH: gh-pages
       DOC_DIR: docs
@@ -294,6 +298,7 @@ jobs:
   bump-dev-version:
     docker:
       - image: cimg/python:3.9
+    resource_class: small
     steps:
       - checkout
       - attach_workspace:
@@ -325,6 +330,7 @@ jobs:
   bump-version:
     docker:
       - image: cimg/python:3.9
+    resource_class: small
     steps:
       - checkout
       - attach_workspace:
@@ -372,6 +378,7 @@ jobs:
   create-release:
     docker:
       - image: cimg/python:3.9
+    resource_class: small
     steps:
       - checkout
       - attach_workspace:
@@ -392,6 +399,7 @@ jobs:
   notify-mattermost:
     docker:
       - image: cimg/base:stable
+    resource_class: small
     steps:
       - checkout
       - run:


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

Our credit usage has nearly doubled in the current month:

![Screenshot 2022-10-25 at 12-56-22 Insights](https://user-images.githubusercontent.com/16021269/197755561-4d351dd8-0a5e-4594-bed2-69d77231f017.png)

So maybe it's time to reduce CircleCI resource classed to save credits

Reducing the `resource_class` of the `build-documentation` did not work:

```
Exception occurred:
  File "/home/circleci/.pyenv/versions/3.9.14/lib/python3.9/multiprocessing/connection.py", line 388, in _recv
    raise EOFError
```
... so somehow the job needs the cores?

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
Increased workflow duration, not sure how much, maybe 1-2 mins?

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
