### PR TITLE
Fix newline in chat deletion confirmation box

### DIFF
--- a/integreat_cms/cms/templates/chat/_chat_messages.html
+++ b/integreat_cms/cms/templates/chat/_chat_messages.html
@@ -9,9 +9,12 @@
         <span class="font-bold">{{ message.sender.full_user_name }}</span>
         {% if message.sender.email %}({{ message.sender.email|urlize }}){% endif %}
         {% has_perm 'cms.delete_chat_message_object' request.user message as can_delete_message %}
-        <button title="{% trans "Delete chat message" %}" class="{% if not can_delete_message %} invisible{% endif %} button-delete-chat-message btn-icon float-right ml-2" data-confirmation-title="{% trans "Please confirm that you really want to delete this chat message:" %}" data-confirmation-text='{% trans "Sender:" %} {{ message.sender.full_user_name }}
-            <br />
-            {% trans "Sent on:" %} {{ message.sent_datetime }}' data-confirmation-subject="{{ message.text }}" data-action="{% spaceless %} {% if request.region %} {% url "delete_chat_message" region_slug=request.region.slug message_id=message.id %} {% else %} {% url "delete_chat_message" message_id=message.id %} {% endif %} {% endspaceless %}">
+        <button title="{% trans "Delete chat message" %}"
+                class="{% if not can_delete_message %} invisible{% endif %} button-delete-chat-message btn-icon float-right ml-2"
+                data-confirmation-title="{% trans "Please confirm that you really want to delete this chat message:" %}"
+                data-confirmation-text='{% trans "Sender:" %} {{ message.sender.full_user_name }} &#010 {% trans "Sent on:" %} {{ message.sent_datetime }}'
+                data-confirmation-subject="{{ message.text }}"
+                data-action="{% spaceless %} {% if request.region %} {% url "delete_chat_message" region_slug=request.region.slug message_id=message.id %} {% else %} {% url "delete_chat_message" message_id=message.id %} {% endif %} {% endspaceless %}">
             <i icon-name="trash-2"></i>
         </button>
         <span class="text-gray-600 float-right">{{ message.sent_datetime }}</span>

--- a/integreat_cms/cms/templates/generic_confirmation_dialog.html
+++ b/integreat_cms/cms/templates/generic_confirmation_dialog.html
@@ -14,7 +14,7 @@
         <div class="w-full p-4 rounded shadow">
             <h2 id="confirmation-title"></h2>
             <h3 id="confirmation-subject" class="text-center mt-4 mb-6 break-words"></h3>
-            <p id="confirmation-text" class="mt-4 mb-6"></p>
+            <p id="confirmation-text" class="mt-4 mb-6 whitespace-pre-line"></p>
             <form method="post" action="#">
                 {% csrf_token %}
                 <div class="flex justify-end gap-2">

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-10-26 22:39+0000\n"
+"POT-Creation-Date: 2022-10-27 09:09+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -3939,15 +3939,15 @@ msgstr "Ihre E-Mail-Adresse hier eingeben"
 msgid "Delete chat message"
 msgstr "Chat-Nachricht löschen"
 
-#: cms/templates/chat/_chat_messages.html:12
+#: cms/templates/chat/_chat_messages.html:14
 msgid "Please confirm that you really want to delete this chat message:"
 msgstr "Bitte bestätigen Sie, dass diese Chat-Nachricht gelöscht werden soll:"
 
-#: cms/templates/chat/_chat_messages.html:12
+#: cms/templates/chat/_chat_messages.html:15
 msgid "Sender:"
 msgstr "Absender:"
 
-#: cms/templates/chat/_chat_messages.html:14
+#: cms/templates/chat/_chat_messages.html:15
 msgid "Sent on:"
 msgstr "Gesendet am:"
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
In the confirmation of deleting a chat message, a new line was not working and it was showing br tag.

### Proposed changes
<!-- Describe this PR in more detail. -->
Added style to p tag for accepting new line
Instead of <br> tag used space unicode character 



### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
Not found any yet



### Resolved issues

Fixes: #1694


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)

