### PR TITLE
Unescape text sent to Textlab API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 UNRELEASED
 ----------
 
+* [ [#1808](https://github.com/digitalfabrik/integreat-cms/issues/1808) ] Improve calculation of HIX values via Textlab
 * [ [#1800](https://github.com/digitalfabrik/integreat-cms/issues/1800) ] Exclude archived pages from PDF exports
 * [ [#1802](https://github.com/digitalfabrik/integreat-cms/issues/1802) ] Reenable table of contents and page numbers in PDFs
 * [ [#1350](https://github.com/digitalfabrik/integreat-cms/issues/1350) ] Various small PDF export improvements

--- a/integreat_cms/textlab_api/textlab_api_client.py
+++ b/integreat_cms/textlab_api/textlab_api_client.py
@@ -3,6 +3,8 @@ import logging
 from urllib.error import HTTPError
 from urllib.request import Request, urlopen
 
+from html import unescape
+
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
@@ -48,7 +50,7 @@ class TextlabClient:
 
         :raises urllib.error.HTTPError: if an http error occurred
         """
-        data = {"text": text, "locale_name": "de_DE"}
+        data = {"text": unescape(text), "locale_name": "de_DE"}
         path = "/benchmark/5"
         try:
             response = self.post_request(path, data, self.token)
@@ -76,7 +78,9 @@ class TextlabClient:
         :raises urllib.error.HTTPError: If the request failed
         """
         data = json.dumps(data).encode("utf-8")
-        request = Request(f"{settings.TEXTLAB_API_URL}{path}", data=data, method="POST")
+        request = Request(
+            f"{settings.TEXTLAB_API_URL.rstrip('/')}{path}", data=data, method="POST"
+        )
         if auth_token:
             request.add_header("authorization", f"Bearer {auth_token}")
         request.add_header("Content-Type", "application/json")


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Unescape text sent to Textlab API

### Proposed changes
<!-- Describe this PR in more detail. -->
- Call `unescape()` on the text before sending it to the textlab api
- Make trailing slash of API setting optional


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
