### PR TITLE
Fix sending feedback for recurring events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ UNRELEASED
 ----------
 
 * [ [#1718](https://github.com/digitalfabrik/integreat-cms/issues/1718) ] Enable submitting feedback about fallback translations of events and pois
+* [ [#1793](https://github.com/digitalfabrik/integreat-cms/issues/1793) ] Fix sending feedback for recurring events
 
 
 2022.10.2

--- a/integreat_cms/api/v3/feedback/event_feedback.py
+++ b/integreat_cms/api/v3/feedback/event_feedback.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from django.http import JsonResponse, Http404
 
@@ -67,10 +68,11 @@ def event_feedback_internal(data, region, language, comment, rating, is_technica
     :return: JSON object according to APIv3 single page feedback endpoint definition
     :rtype: ~django.http.JsonResponse
     """
-    event_translation_slug = data.get("slug")
+    # Remove date from the slug for recurrung events
+    event_translation_slug = re.sub(r"\$\d{4}-\d{2}-\d{2}$", "", data.get("slug"))
 
     events = region.events.filter(
-        translations__slug=data.get("slug"),
+        translations__slug=event_translation_slug,
         translations__language=language,
     ).distinct()
 


### PR DESCRIPTION
### Short description
Slugs for recurring events contain date (in format: base-slug$yyyy-mm-dd).
As a result, when we receive a feedback for recurring event, event can't found by slug in DB and response 404 is returned.

### Proposed changes
Remove the date from the slug during feedback processing

### Side effects
- If someone manually creates event with the slug ending with the date in format $yyyy-mm-dd, feedback for such event won't be processed (upd: actually not possible, symbol $ is not allowed in the slug)
- There is no validation of the date in slug. If we receive feedback for an existing event but with an nonexistent date, it will be processed successfully.
- We lose information about which date the feedback belongs to.

### Resolved issues
Fixes: #1793

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
