### PR TITLE
Remove `--quiet` option for djlint CircleCI check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
           at: .
       - run:
           name: Check formatting of Django templates
-          command: pipenv run djlint --check --quiet --profile django --lint integreat_cms
+          command: pipenv run djlint --check --profile django --lint integreat_cms
   pylint:
     docker:
       - image: cimg/python:3.9.14


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
I'm not sure why I added this option in the first place, I think it makes sense to output the diff in the circleci job to see at the first glance which files and lines should be reformatted.
Just failing with:
```
100% 119/119 [00:00<?, ?it/s]


Exited with code exit status 1
```
like e.g. [here](https://app.circleci.com/pipelines/github/digitalfabrik/integreat-cms/6005/workflows/9cbc491f-a327-4689-8039-1089f68171cd/jobs/53914/parallel-runs/0/steps/0-103) isn't that helpful I guess.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Remove `--quiet` option for djlint CircleCI check


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
