### PR TITLE
Fix link scanning when cloning regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ UNRELEASED
 * [ [#1718](https://github.com/digitalfabrik/integreat-cms/issues/1718) ] Enable submitting feedback about fallback translations of events and pois
 * [ [#1793](https://github.com/digitalfabrik/integreat-cms/issues/1793) ] Fix sending feedback for recurring events
 * [ [#1717](https://github.com/digitalfabrik/integreat-cms/issues/1717) ] Provide fallback translations for imprint feedbacks
+* [ [#1513](https://github.com/digitalfabrik/integreat-cms/issues/1513) ] Fix link scanning when cloning regions
 
 
 2022.10.2


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fix link scanning when cloning regions

### Proposed changes
<!-- Describe this PR in more detail. -->
- Disable the link listeners during the normal page cloning
- After cloning is finished, only query the latest versions of all translations and save them again to trigger the scan


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1513


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
