### PR TITLE
Mark POI category as not visible in app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ UNRELEASED
 * [ [#1746](https://github.com/digitalfabrik/integreat-cms/issues/1746) ] Hide analytics section (partially) for author, editor and event manager
 * [ [#1035](https://github.com/digitalfabrik/integreat-cms/issues/1035) ] Enable setting POI position via drag & drop on map
 * [ [#1456](https://github.com/digitalfabrik/integreat-cms/issues/1456) ] Use gender sensitive language
+* [ [#1806](https://github.com/digitalfabrik/integreat-cms/issues/1806) ] Mark POI category as not visible in app
 
 
 2022.10.2

--- a/integreat_cms/cms/templates/pois/poi_form.html
+++ b/integreat_cms/cms/templates/pois/poi_form.html
@@ -306,6 +306,7 @@
                             <i icon-name="tag" class="pb-1"></i>
                             {{ poi_form.category.label }}
                         </h3>
+                        ({% trans "Currently not visible in apps" %})
                     </div>
                     <div class="px-4 pb-4 divide-y divide-gray-200 space-y-2">
                         <div>

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-08 09:49+0000\n"
+"POT-Creation-Date: 2022-11-08 15:35+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -5622,6 +5622,10 @@ msgid "Contact details"
 msgstr "Kontaktdaten"
 
 #: cms/templates/pois/poi_form.html
+msgid "Currently not visible in apps"
+msgstr "Wird noch nicht in den Apps angezeigt"
+
+#: cms/templates/pois/poi_form.html
 #: cms/templates/pois/poi_list_archived_row.html
 msgid "Restore location"
 msgstr "Ort wiederherstellen"
@@ -7695,9 +7699,6 @@ msgstr ""
 #~ "Hier finden Sie eine Reihe von Werkzeugen, um den Erfolg und die "
 #~ "Korrektheit Ihrer App zu überprüfen. Klicken Sie auf Details um weitere "
 #~ "Informationen zu erhalten."
-
-#~ msgid "currently not publicly visible"
-#~ msgstr "aktuell nicht öffentlich sichtbar"
 
 #~ msgid "Overview of the current translation status"
 #~ msgstr "Hier können Sie den Status der Übersetzungen sehen."


### PR DESCRIPTION
### Short description
As the app is not using our POI categories right now, we should inform our users about it.


### Proposed changes
Add text 'currently not publicly visible' into Category section of POI form


### Side effects
Didn't find any


### Resolved issues
Fixes: #1806


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
