### PR TITLE
Fix indentation in git tag message

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -410,7 +410,7 @@ jobs:
           command: |
             # Get most recent changelog (split by 3 sequential new lines and print the second record except the first three lines)
             CHANGELOG=$(awk -v RS='\n\n\n' 'NR==2 {print $0}' CHANGELOG.md | tail -n +4 | sed --regexp-extended 's|\[#([0-9]+)\]\(https://github\.com/digitalfabrik/integreat-cms/issues/([0-9]+)\)|#\1|')
-            git tag --annotate "${CURRENT_VERSION}" --message "${CHANGELOG}"
+            git tag --annotate "${CURRENT_VERSION}" --message "Changelog:" --message "${CHANGELOG}"
             git push origin --follow-tags "${CURRENT_VERSION}" HEAD
       - run:
           name: Merge version bump into develop


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
I noticed that the indentation of out git [tag](https://github.com/digitalfabrik/integreat-cms/tags) messages is a bit broken:

![Screenshot 2022-11-03 at 21-21-18 Tags · digitalfabrik_integreat-cms](https://user-images.githubusercontent.com/16021269/199826069-13a12c24-45cb-4aa4-a8d7-e5401025f90d.png)

I assume this is because it somehow treats the first line special and expects it to be the heading or something...

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add the heading "Changelog" to the git tag message 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
