### PR TITLE
Add contributor list to GitHub releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,15 +427,23 @@ jobs:
           name: Request installation access token to authorize as Deliverino app
           command: echo "export DELIVERINO_ACCESS_TOKEN=$(pipenv run ./.circleci/scripts/get_access_token.py)" >> $BASH_ENV
       - run:
-          name: Assemble release body
+          name: Get previous version tag
           command: |
             PREV_TAG=$(git describe --abbrev=0 --tags "${CIRCLE_TAG}^") || true
-            CHANGELOG+=$(awk -v RS='\n\n\n' 'NR==2 {print $0}' CHANGELOG.md | tail -n +4)
             echo "export PREV_TAG=\"${PREV_TAG}\"" >> $BASH_ENV
+      - run:
+          name: Get changelog
+          command: |
+            CHANGELOG=$(awk -v RS='\n\n\n' 'NR==2 {print $0}' CHANGELOG.md | tail -n +4)
             echo "export CHANGELOG=\"${CHANGELOG}\"" >> $BASH_ENV
       - run:
+          name: Get contributors
+          command: |
+            CONTRIBUTORS=$(pipenv run ./.circleci/scripts/get_contributors.py "${DELIVERINO_ACCESS_TOKEN}" "${PREV_TAG}" "${CIRCLE_TAG}" -v)
+            echo "export CONTRIBUTORS=\"${CONTRIBUTORS}\"" >> $BASH_ENV
+      - run:
           name: Create release as Deliverino app
-          command: pipenv run ./.circleci/scripts/create_release.py "${DELIVERINO_ACCESS_TOKEN}" "${CIRCLE_TAG}" "${PREV_TAG}" "${CHANGELOG}" ./dist/integreat-cms-*.tar.gz
+          command: pipenv run ./.circleci/scripts/create_release.py "${DELIVERINO_ACCESS_TOKEN}" "${CIRCLE_TAG}" "${PREV_TAG}" "${CHANGELOG}" "${CONTRIBUTORS}" ./dist/integreat-cms-*.tar.gz
   notify-mattermost:
     docker:
       - image: cimg/base:stable

--- a/.circleci/scripts/create_release.py
+++ b/.circleci/scripts/create_release.py
@@ -25,6 +25,9 @@ def main():
         "changelog", metavar="CHANGELOG", help="changelog of the release"
     )
     parser.add_argument(
+        "contributors", metavar="CONTRIBUTORS", help="contributors of the release"
+    )
+    parser.add_argument(
         "assets", metavar="ASSET", help="uploadable asset file", nargs="*"
     )
     args = parser.parse_args()
@@ -36,6 +39,7 @@ def main():
         f"### ![]({logo_url}) integreat-cms `{args.tag}`"
         f"\n\n### Changelog\n\n{args.changelog}\n\n"
         f"Compare changes: [{args.prev_tag} → {args.tag}]({compare_url}/{args.prev_tag}...{args.tag})"
+        f"\n\n### Contributors\n\n{args.contributors}"
     )
 
     # Create release

--- a/.circleci/scripts/get_contributors.py
+++ b/.circleci/scripts/get_contributors.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import logging
+import requests
+
+# Init logging config
+logging.basicConfig(format="%(message)s")
+logger = logging.getLogger(__name__)
+
+
+def parse_args():
+    """
+    Parse the given command line arguments
+
+    :returns: The command line arguments
+    :rtype: str
+    """
+
+    # Parse command line arguments
+    parser = argparse.ArgumentParser(
+        description="Get contributors between two given git references"
+    )
+    parser.add_argument("token", metavar="TOKEN", help="GitHub API token")
+    parser.add_argument("base", metavar="BASE", help="the base branch/tag/commit")
+    parser.add_argument("head", metavar="HEAD", help="the head branch/tag/commit")
+    parser.add_argument(
+        "-v", "--verbose", action="count", default=0, help="increase logging verbosity"
+    )
+    args = parser.parse_args()
+
+    # Set logging verbosity
+    if args.verbose == 1:
+        logger.setLevel(logging.INFO)
+    elif args.verbose == 2:
+        logger.setLevel(logging.DEBUG)
+
+    return args
+
+
+def get_commits(token, base, head):
+    """
+    Get the commits between the to references ``base`` and ``head``
+
+    :param token: The access token for the GitHub API
+    :type token: str
+
+    :param base: The base git reference
+    :type base: str
+
+    :param head: The head git reference
+    :type head: str
+
+    :raises SystemExit: When the API returns an error
+
+    :returns: The list of commits
+    :rtype: list
+    """
+    # Get the commits since the last tag
+    another_page = True
+    endpoint = f"https://api.github.com/repos/digitalfabrik/integreat-cms/compare/{base}...{head}?per_page=100"
+    commits = []
+
+    # Retrieve commits as long as other pages exist
+    while another_page:
+        # Request GitHub API
+        logger.info("Retrieving endpoint: %r", endpoint)
+        response = requests.get(
+            endpoint,
+            headers={"Authorization": f"token {token}"},
+            timeout=60,
+        )
+        if not response.ok:
+            logger.error(
+                "Fetching commits failed with status %r and content %s",
+                response.status_code,
+                json.dumps(response.json(), indent=2),
+            )
+            raise SystemExit(1)
+        logger.debug("Response: %s", json.dumps(response.json(), indent=2))
+        # Append to commit list
+        commits.extend(response.json()["commits"])
+        # Check if there is another page of commits
+        if "next" in response.links:
+            endpoint = response.links["next"]["url"]
+        else:
+            another_page = False
+
+    if not commits:
+        logger.error("No commits found")
+        raise SystemExit(1)
+
+    logger.debug("Commits: %s", json.dumps(commits, indent=2))
+    return commits
+
+
+def get_authors(commits):
+    """
+    Get a list of authors of a list of commits
+
+    :param commits: The list of commits
+    :type commits: list
+
+    :raises SystemExit: When the commits do not contain a valid author
+
+    :returns: The list of authors
+    :rtype: list
+    """
+    authors = []
+    for commit in commits:
+        # Skip anonymous authors
+        if not commit["author"]:
+            continue
+        username = commit["author"]["login"]
+        # Skip the bot
+        if username == "deliverino[bot]":
+            continue
+        # Once is enough
+        if username in authors:
+            continue
+        # Append author
+        authors.append(username)
+
+    if not authors:
+        logger.error("No authors found")
+        raise SystemExit(1)
+
+    logger.info("Authors: %r", authors)
+    return authors
+
+
+def main():
+    """
+    Get the contributors between two given git references
+
+    :raises SystemExit: When something went wrong
+    """
+    # Parse command line arguments
+    args = parse_args()
+
+    # Get list of commits between the given git references
+    commits = get_commits(token=args.token, base=args.base, head=args.head)
+
+    # Get list of authors in the given commits
+    authors = get_authors(commits)
+
+    # Print out the usernames of all contributors
+    print("@" + " @".join(authors))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This mentions all contributors of a given release in the release body which automatically adds a contribution footer similar to e.g.:

![Screenshot 2022-11-04 at 00-19-44 Build software better together](https://user-images.githubusercontent.com/16021269/199853304-47c06f4c-14fa-4320-b8a9-21c8c9b5c2f4.png)

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add new script to fetch contributors between two given git references
- Add new contributors section in GitHub release body


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- We cannot really test the new workflow until the next release, so it's not unlikely that I screwed something up and the notification won't work next time :see_no_evil:  (this shouldn't affect the PyPI release however, just the GitHub release and the Mattermost notification)


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
