### PR TITLE
Render live content in pdfs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ UNRELEASED
 
 * [ [#1832](https://github.com/digitalfabrik/integreat-cms/issues/1832) ] Add opening hours for locations
 * [ [#1502](https://github.com/digitalfabrik/integreat-cms/issues/1502) ] Hide links on archived pages in broken link checker
+* [ [#1791](https://github.com/digitalfabrik/integreat-cms/issues/1791) ] Render live content in pdfs
 
 
 2022.11.3

--- a/integreat_cms/cms/models/pages/page_translation.py
+++ b/integreat_cms/cms/models/pages/page_translation.py
@@ -103,6 +103,22 @@ class PageTranslation(AbstractBasePageTranslation):
     @cached_property
     def mirrored_translation_text(self):
         """
+        This method returns the text of the mirrored translation or an empty string,
+        if it is not available in this language
+
+        :return: The text
+        :rtype: str
+        """
+        if self.page.mirrored_page:
+            if translation := self.page.get_mirrored_page_translation(
+                self.language.slug
+            ):
+                return translation.content
+        return ""
+
+    @cached_property
+    def mirrored_translation_text_or_fallback_message(self):
+        """
         This method returns the text of the mirrored translation.
         If there is no mirrored translation, it returns an empty string.
         If there is a mirrored page but no translation, a html error message will be returned with languages that are translated as options.
@@ -113,9 +129,8 @@ class PageTranslation(AbstractBasePageTranslation):
         if not self.page.mirrored_page:
             return ""
 
-        translation = self.page.get_mirrored_page_translation(self.language.slug)
-        if translation and translation.content:
-            return translation.content
+        if content := self.mirrored_translation_text:
+            return content
 
         error_message = (
             self.language.message_partial_live_content_not_available
@@ -179,8 +194,11 @@ class PageTranslation(AbstractBasePageTranslation):
         :rtype: str
         """
         if self.page.mirrored_page_first:
-            return self.mirrored_translation_text + self.display_content
-        return self.display_content + self.mirrored_translation_text
+            return (
+                self.mirrored_translation_text_or_fallback_message
+                + self.display_content
+            )
+        return self.display_content + self.mirrored_translation_text_or_fallback_message
 
     @cached_property
     def combined_last_updated(self):

--- a/integreat_cms/cms/templates/pages/page_pdf.html
+++ b/integreat_cms/cms/templates/pages/page_pdf.html
@@ -87,7 +87,13 @@
                         {% endif %}
                         {% get_public_translation page language.slug as page_translation %}
                         <h1 class="level-{{ page.depth|add:"-1" }}">{{ page_translation.title }}</h1>
-                        <div class="content" style="padding-bottom: 30px;">{{ page_translation.content|pdf_strip_fontstyles|safe }}</div>
+                        <div class="content" style="padding-bottom: 30px;">
+                            {% if page.mirrored_page_first %}{{ page_translation.mirrored_translation_text|pdf_strip_fontstyles|safe }}{% endif %}
+                            {{ page_translation.content|pdf_strip_fontstyles|safe }}
+                            {% if not page.mirrored_page_first %}
+                                {{ page_translation.mirrored_translation_text|pdf_strip_fontstyles|safe }}
+                            {% endif %}
+                        </div>
                         {% for close in info.close %}
                         </li>
                     </ul>


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr fixes a bug that live content does not get rendered in pdfs


### Proposed changes
<!-- Describe this PR in more detail. -->
- Include the live content when rendering the pdf
- If no matching translation of the live content exists, render the default error message which lists alternative languages which work


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
/ 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1791


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
