### PR TITLE
Make Multi-language-XLIFF export popup scrollable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 UNRELEASED
 ----------
 
+* [ [#1827](https://github.com/digitalfabrik/integreat-cms/issues/1827) ] Make Multi-language-XLIFF export popup scrollable
+
 
 2022.11.1
 ---------

--- a/integreat_cms/cms/templates/pages/_page_xliff_export_overlay.html
+++ b/integreat_cms/cms/templates/pages/_page_xliff_export_overlay.html
@@ -11,7 +11,7 @@
                     <i icon-name="x-circle" class="h-8 w-8"></i>
                 </button>
             </div>
-            <div class="w-full p-4 rounded shadow">
+            <div class="w-full p-4 rounded shadow overflow-scroll max-h-[80vh]">
                 <h3>{% trans "Please select languages for multilingual export." %}</h3>
                 <table class="mt-4">
                     <tbody>


### PR DESCRIPTION
### Short description
Make multi language popup scrollable so that even on smaller screens the end doesn't get cut off

### Proposed changes
- Add view height to popups, set to 80vh
- Add overflow scroll
- Change only for this popup. Couldn't find a popup that has the same issue. All other popups I considered had less height and therefore didn't have this issue
- Add custom height class for 80vh


### Side effects
There are some screens which would have just a minimal scroll which can be a bit ugly and/or annoying, but I hope that's okay

### Resolved issues

Fixes: #1827

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
