### PR TITLE
Fix broken translation status if only minor public versions exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ UNRELEASED
 * [ [#1791](https://github.com/digitalfabrik/integreat-cms/issues/1791) ] Render live content in pdfs
 * [ [#1869](https://github.com/digitalfabrik/integreat-cms/issues/1869) ] Fix error in imprint side by side view
 * [ [#1786](https://github.com/digitalfabrik/integreat-cms/issues/1786) ] Remove texblock option in editor, add button to clear all formatting
+* [ [#1788](https://github.com/digitalfabrik/integreat-cms/issues/1788) ] Fix broken translation status of events & locations if only minor public versions exists
 
 
 2022.11.3

--- a/integreat_cms/cms/views/events/event_form_view.py
+++ b/integreat_cms/cms/views/events/event_form_view.py
@@ -236,6 +236,13 @@ class EventFormView(
                     language__in=languages
                 ).update(status=status.DRAFT)
 
+            elif (
+                event_translation_form.instance.status == status.PUBLIC
+                and event_translation_form.instance.minor_edit
+            ):
+                event_translation_form.instance.event.translations.filter(
+                    language=language
+                ).update(status=status.PUBLIC)
             # Show a message that the slug was changed if it was not unique
             if user_slug and user_slug != event_translation_form.cleaned_data["slug"]:
                 other_translation = EventTranslation.objects.filter(

--- a/integreat_cms/cms/views/pois/poi_form_view.py
+++ b/integreat_cms/cms/views/pois/poi_form_view.py
@@ -177,6 +177,13 @@ class POIFormView(
                 poi_translation_form.instance.poi.translations.filter(
                     language__in=languages
                 ).update(status=status.DRAFT)
+            elif (
+                poi_translation_form.instance.status == status.PUBLIC
+                and poi_translation_form.instance.minor_edit
+            ):
+                poi_translation_form.instance.poi.translations.filter(
+                    language=language
+                ).update(status=status.PUBLIC)
 
             # Show a message that the slug was changed if it was not unique
             if user_slug and user_slug != poi_translation_form.cleaned_data["slug"]:


### PR DESCRIPTION
### Short description
Fixes the issue with the broken translation status if only minor public versions exists for POI and event


### Proposed changes
- Add extra if-condition to ensure the correct translation status is set

### Side effects
I don't think there are any.  


### Resolved issues
Fixes: #1788


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
