### PR TITLE
Fix bulk archive/restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ UNRELEASED
 ----------
 
 * [ [#1832](https://github.com/digitalfabrik/integreat-cms/issues/1832) ] Add opening hours for locations
+* [ [#1502](https://github.com/digitalfabrik/integreat-cms/issues/1502) ] Hide links on archived pages in broken link checker
 
 
 2022.11.3

--- a/integreat_cms/cms/urls/protected.py
+++ b/integreat_cms/cms/urls/protected.py
@@ -767,7 +767,6 @@ urlpatterns = [
                                             "bulk-archive/",
                                             bulk_action_views.BulkArchiveView.as_view(
                                                 model=Page,
-                                                field_name="explicitly_archived",
                                             ),
                                             name="bulk_archive_pages",
                                         ),
@@ -775,7 +774,6 @@ urlpatterns = [
                                             "bulk-restore/",
                                             bulk_action_views.BulkRestoreView.as_view(
                                                 model=Page,
-                                                field_name="explicitly_archived",
                                             ),
                                             name="bulk_restore_pages",
                                         ),

--- a/integreat_cms/cms/views/events/event_actions.py
+++ b/integreat_cms/cms/views/events/event_actions.py
@@ -10,8 +10,6 @@ from django.shortcuts import render, redirect, get_object_or_404
 from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
 
-from linkcheck.models import Link
-
 from ...constants import status
 from ...decorators import permission_required
 from ...models import Region, POITranslation
@@ -43,11 +41,7 @@ def archive(request, event_id, region_slug, language_slug):
     region = request.region
     event = get_object_or_404(region.events, id=event_id)
 
-    event.archived = True
-    event.save()
-
-    # Delete related link objects as they are no longer required
-    Link.objects.filter(event_translation__event=event).delete()
+    event.archive()
 
     logger.debug("%r archived by %r", event, request.user)
     messages.success(request, _("Event was successfully archived"))
@@ -119,13 +113,7 @@ def restore(request, event_id, region_slug, language_slug):
     region = request.region
     event = get_object_or_404(region.events, id=event_id)
 
-    event.archived = False
-    event.save()
-
-    # Restore related link objects
-    for translation in event.translations.distinct("event__pk", "language__pk"):
-        # The post_save signal will create link objects from the content
-        translation.save(update_timestamp=False)
+    event.restore()
 
     logger.debug("%r restored by %r", event, request.user)
     messages.success(request, _("Event was successfully restored"))

--- a/integreat_cms/cms/views/pois/poi_actions.py
+++ b/integreat_cms/cms/views/pois/poi_actions.py
@@ -11,8 +11,6 @@ from django.shortcuts import render, redirect
 from django.utils.translation import ugettext as _
 from django.views.decorators.http import require_POST
 
-from linkcheck.models import Link
-
 from ....api.decorators import json_response
 from ...decorators import permission_required
 from ...models import POI
@@ -45,11 +43,7 @@ def archive_poi(request, poi_id, region_slug, language_slug):
     """
     poi = POI.objects.get(id=poi_id)
 
-    poi.archived = True
-    poi.save()
-
-    # Delete related link objects as they are no longer required
-    Link.objects.filter(poi_translation__poi=poi).delete()
+    poi.archive()
 
     logger.debug("%r archived by %r", poi, request.user)
     messages.success(request, _("Location was successfully archived"))
@@ -86,13 +80,7 @@ def restore_poi(request, poi_id, region_slug, language_slug):
     """
     poi = POI.objects.get(id=poi_id)
 
-    poi.archived = False
-    poi.save()
-
-    # Restore related link objects
-    for translation in poi.translations.distinct("poi__pk", "language__pk"):
-        # The post_save signal will create link objects from the content
-        translation.save(update_timestamp=False)
+    poi.restore()
 
     logger.debug("%r restored by %r", poi, request.user)
     messages.success(request, _("Location was successfully restored"))

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 1.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-11-17 18:02+0000\n"
+"POT-Creation-Date: 2022-11-18 09:19+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: Integreat <info@integreat-app.de>\n"
 "Language-Team: Integreat <info@integreat-app.de>\n"
@@ -2187,7 +2187,6 @@ msgid "icon"
 msgstr "Icon"
 
 #: cms/models/events/event.py cms/models/pois/poi.py
-#: cms/views/bulk_action_views.py
 msgid "archived"
 msgstr "archiviert"
 
@@ -6493,8 +6492,12 @@ msgid "The selected {} were successfully {}"
 msgstr "Die ausgewählten {} wurden erfolgreich {}"
 
 #: cms/views/bulk_action_views.py
-msgid "restored"
-msgstr "wiederhergestellt"
+msgid "The selected {} were successfully archived"
+msgstr "Die ausgewählten {} wurden erfolgreich archiviert"
+
+#: cms/views/bulk_action_views.py
+msgid "The selected {} were successfully restored"
+msgstr "Die ausgewählten {} wurden erfolgreich wiederhergestellt"
 
 #: cms/views/delete_views.py
 msgid "{} \"{}\" was successfully deleted"
@@ -7689,6 +7692,9 @@ msgstr ""
 "Diese Seite konnte nicht importiert werden, da sie zu einer anderen Region "
 "gehört ({})."
 
+#~ msgid "restored"
+#~ msgstr "wiederhergestellt"
+
 #~ msgid "short description"
 #~ msgstr "Kurzbeschreibung"
 
@@ -7800,9 +7806,6 @@ msgstr ""
 #~ msgid "The automatic translation into Easy German has been started."
 #~ msgstr "Die automatische Übersetzung ins Leichte Deutsch wurde gestartet."
 
-#~ msgid "The selected {} were successfully archived"
-#~ msgstr "Die ausgewählten {} wurden erfolgreich archiviert"
-
 #~ msgid "Number of Members"
 #~ msgstr "Mitgliederanzahl"
 
@@ -7811,9 +7814,6 @@ msgstr ""
 
 #~ msgid "Currently no users belong to this organization"
 #~ msgstr "Aktuell gehören dieser Organisation keine Benutzer:innen an"
-
-#~ msgid "The selected {} were successfully restored"
-#~ msgstr "Die ausgewählten {} wurden erfolgreich wiederhergestellt"
 
 #~ msgid "Edit language tree node"
 #~ msgstr "Sprach-Knoten bearbeiten"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr updates the bulk archive/restore actions to mimic the exact behavior of the per-object archive/restore actions.
That should fix archived pages showing up in the linkchecker.
This pr also fixes a related issue where links of an archived page, that is not a root-page, would not show up in the linkchecker after restoring the page.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add archive/restore methods to the page, event and poi models
- Use these methods from both bulk-actions and per-object actions
- When restoring pages, manually restore links if the page is not a root page


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
/


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes partially: #1502


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
