### PR TITLE
Correctly escape success/error messages

### DIFF
--- a/integreat_cms/cms/templates/messages.html
+++ b/integreat_cms/cms/templates/messages.html
@@ -4,25 +4,25 @@
             {% if msg.level_tag == 'info' %}
                 <div class="bg-blue-100 border-l-4 border-blue-500 text-blue-500 px-4 py-3 mb-5"
                      role="alert">
-                    <p>{{ msg.message|safe }}</p>
+                    <p>{{ msg.message }}</p>
                 </div>
             {% endif %}
             {% if msg.level_tag == 'success' %}
                 <div class="bg-green-100 border-l-4 border-green-500 text-green-500 px-4 py-3 mb-5"
                      role="alert">
-                    <p>{{ msg.message|safe }}</p>
+                    <p>{{ msg.message }}</p>
                 </div>
             {% endif %}
             {% if msg.level_tag == 'warning' %}
                 <div class="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-600 px-4 py-3 mb-5"
                      role="alert">
-                    <p>{{ msg.message|safe }}</p>
+                    <p>{{ msg.message }}</p>
                 </div>
             {% endif %}
             {% if msg.level_tag == 'error' %}
                 <div class="bg-red-100 border-l-4 border-red-500 text-red-500 px-4 py-3 mb-5"
                      role="alert">
-                    <p>{{ msg.message|safe }}</p>
+                    <p>{{ msg.message }}</p>
                 </div>
             {% endif %}
         {% endfor %}

--- a/integreat_cms/cms/utils/translation_utils.py
+++ b/integreat_cms/cms/utils/translation_utils.py
@@ -1,6 +1,9 @@
 """
 This module contains helpers for the translation process.
 """
+import re
+
+from django.utils.html import format_html, format_html_join
 from django.utils.text import format_lazy
 
 
@@ -18,3 +21,28 @@ def ugettext_many_lazy(*strings):
     """
     fstring = ("{} " * len(strings)).strip()
     return format_lazy(fstring, *strings)
+
+
+def translate_link(message, attributes):
+    """
+    Translate a link with keeping the HTML tags and still escaping all unknown parts of the message
+
+    :param message: The translated message that contains the link placeholder ``<a>{link_text}</a>``
+    :type message: str
+
+    :param attributes: A dictionary of attributes for the link
+    :type attributes: dict
+
+    :return: A correctly escaped formatted string with the translated message and the HTML link
+    :rtype: str
+    """
+    # Split the message at the link text
+    before, link_text, after = re.split(r"<a>(.+)</a>", str(message))
+    # Format the HTML
+    return format_html(
+        "{}<a {}>{}</a>{}",
+        before,
+        format_html_join(" ", "{}='{}'", attributes.items()),
+        link_text,
+        after,
+    )

--- a/integreat_cms/cms/views/events/event_form_view.py
+++ b/integreat_cms/cms/views/events/event_form_view.py
@@ -1,4 +1,5 @@
 import logging
+
 from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
@@ -12,6 +13,7 @@ from ...constants import status, translation_status
 from ...decorators import permission_required
 from ...forms import EventForm, EventTranslationForm, RecurrenceRuleForm
 from ...models import Language, Event, EventTranslation, RecurrenceRule, POI
+from ...utils.translation_utils import translate_link
 from .event_context_mixin import EventContextMixin
 from ..media.media_context_mixin import MediaContextMixin
 from ..mixins import ContentEditLockMixin
@@ -242,15 +244,22 @@ class EventFormView(
                     event__region=region, slug=user_slug, language=language
                 ).first()
                 other_translation_link = other_translation.backend_edit_link
+                message = _(
+                    "The slug was changed from '{user_slug}' to '{slug}', "
+                    "because '{user_slug}' is already used by <a>{translation}</a> or one of its previous versions.",
+                ).format(
+                    user_slug=user_slug,
+                    slug=event_translation_form.cleaned_data["slug"],
+                    translation=other_translation,
+                )
                 messages.warning(
                     request,
-                    _(
-                        "The slug was changed from '{user_slug}' to '{slug}', because '{user_slug}' is already used by <a href='{link}' class='underline hover:no-underline'>{translation}</a> or one of its previous versions"
-                    ).format(
-                        user_slug=user_slug,
-                        slug=event_translation_form.cleaned_data["slug"],
-                        link=other_translation_link,
-                        translation=other_translation,
+                    translate_link(
+                        message,
+                        attributes={
+                            "href": other_translation_link,
+                            "class": "underline hover:no-underline",
+                        },
                     ),
                 )
 

--- a/integreat_cms/cms/views/pages/page_bulk_actions.py
+++ b/integreat_cms/cms/views/pages/page_bulk_actions.py
@@ -8,7 +8,7 @@ from django.views.generic.list import MultipleObjectMixin
 from ....xliff.utils import pages_to_xliff_file
 from ...models import Page
 from ...utils.pdf_utils import generate_pdf
-from ...utils.translation_utils import ugettext_many_lazy as __
+from ...utils.translation_utils import translate_link, ugettext_many_lazy as __
 from ..bulk_action_views import BulkActionView
 
 logger = logging.getLogger(__name__)
@@ -100,22 +100,30 @@ class ExportXliffView(PageBulkActionMixin, BulkActionView):
         )
         if xliff_file_url:
             # Insert link with automatic download into success message
-            messages.success(
-                request,
-                __(
+            message = __(
+                (
                     _(
                         "XLIFF file with published pages only for translation to {} successfully created."
-                    ).format(target_language)
+                    )
                     if self.only_public
                     else _(
                         "XLIFF file with unpublished and published pages for translation to {} successfully created."
-                    ).format(target_language),
-                    _(
-                        "If the download does not start automatically, please click {}here{}."
-                    ).format(
-                        f"<a data-auto-download href='{xliff_file_url}' class='font-bold underline hover:no-underline' download>",
-                        "</a>",
-                    ),
+                    )
+                ).format(target_language),
+                _(
+                    "If the download does not start automatically, please click <a>here</a>.",
+                ),
+            )
+            messages.success(
+                request,
+                translate_link(
+                    message,
+                    attributes={
+                        "href": xliff_file_url,
+                        "class": "font-bold underline hover:no-underline",
+                        "data-auto-download": "",
+                        "download": "",
+                    },
                 ),
             )
 
@@ -160,18 +168,24 @@ class ExportMultiLanguageXliffView(PageBulkActionMixin, BulkActionView):
         )
         if xliff_file_url:
             # Insert link with automatic download into success message
+            message = __(
+                _(
+                    "XLIFF file for translation to selected languages successfully created."
+                ),
+                _(
+                    "If the download does not start automatically, please click <a>here</a>.",
+                ),
+            )
             messages.success(
                 request,
-                __(
-                    _(
-                        "XLIFF file for translation to selected languages successfully created."
-                    ),
-                    _(
-                        "If the download does not start automatically, please click {}here{}."
-                    ).format(
-                        f"<a data-auto-download href='{xliff_file_url}' class='font-bold underline hover:no-underline' download>",
-                        "</a>",
-                    ),
+                translate_link(
+                    message,
+                    attributes={
+                        "href": xliff_file_url,
+                        "class": "font-bold underline hover:no-underline",
+                        "data-auto-download": "",
+                        "download": "",
+                    },
                 ),
             )
 

--- a/integreat_cms/cms/views/pages/page_form_view.py
+++ b/integreat_cms/cms/views/pages/page_form_view.py
@@ -13,7 +13,7 @@ from ...constants import status, text_directions
 from ...decorators import permission_required
 from ...forms import PageForm, PageTranslationForm
 from ...models import PageTranslation
-from ...utils.translation_utils import ugettext_many_lazy as __
+from ...utils.translation_utils import translate_link, ugettext_many_lazy as __
 from ..media.media_context_mixin import MediaContextMixin
 from ..mixins import ContentEditLockMixin
 from .page_context_mixin import PageContextMixin
@@ -108,15 +108,18 @@ class PageFormView(
                         action = _("reject")
                     # If the user has the permission to reject/discard, show another message
                     if request.user.has_perm("cms.publish_page_object", page):
-                        status_message = __(
+                        message = __(
                             status_message,
                             _(
-                                "You can {action} these changes in the {link_start}version overview{link_end}."
-                            ).format(
-                                action=action,
-                                link_start=f"<a href='{revision_url}' class='underline hover:no-underline'>",
-                                link_end="</a>",
-                            ),
+                                "You can {action} these changes in the <a>version overview</a>."
+                            ).format(action=action),
+                        )
+                        status_message = translate_link(
+                            message,
+                            attributes={
+                                "href": revision_url,
+                                "class": "underline hover:no-underline",
+                            },
                         )
                     messages.warning(request, status_message)
                 # Show information if a public translation exists even if the latest version is not public
@@ -136,14 +139,17 @@ class PageFormView(
                             "selected_revision": public_translation.version,
                         },
                     )
+                    message = _(
+                        "Currently, <a>version {}</a> of this page is displayed in the app."
+                    ).format(public_translation.version)
                     messages.info(
                         request,
-                        _(
-                            "Currently, {link_start}version {version}{link_end} of this page is displayed in the app."
-                        ).format(
-                            link_start=f" <a href='{revision_url}' class='underline hover:no-underline'>",
-                            version=public_translation.version,
-                            link_end="</a>",
+                        translate_link(
+                            message,
+                            attributes={
+                                "href": revision_url,
+                                "class": "underline hover:no-underline",
+                            },
                         ),
                     )
 
@@ -333,15 +339,22 @@ class PageFormView(
                         "selected_revision": other_translation.version,
                     },
                 )
+                message = _(
+                    "The slug was changed from '{user_slug}' to '{slug}', "
+                    "because '{user_slug}' is already used by <a>{translation}</a>.",
+                ).format(
+                    user_slug=user_slug,
+                    slug=page_translation_form.cleaned_data["slug"],
+                    translation=other_translation,
+                )
                 messages.warning(
                     request,
-                    _(
-                        "The slug was changed from '{user_slug}' to '{slug}', because '{user_slug}' is already used by <a href='{link}' class='underline hover:no-underline'>{translation}</a>"
-                    ).format(
-                        user_slug=user_slug,
-                        slug=page_translation_form.cleaned_data["slug"],
-                        link=other_translation_link,
-                        translation=other_translation,
+                    translate_link(
+                        message,
+                        attributes={
+                            "href": other_translation_link,
+                            "class": "underline hover:no-underline",
+                        },
                     ),
                 )
 

--- a/integreat_cms/cms/views/pois/poi_form_view.py
+++ b/integreat_cms/cms/views/pois/poi_form_view.py
@@ -14,7 +14,7 @@ from ...constants import status
 from ...decorators import permission_required
 from ...forms import POIForm, POITranslationForm
 from ...models import POI, POITranslation, Language
-from ...utils.translation_utils import ugettext_many_lazy as __
+from ...utils.translation_utils import translate_link, ugettext_many_lazy as __
 from ..media.media_context_mixin import MediaContextMixin
 from ..mixins import ContentEditLockMixin
 from .poi_context_mixin import POIContextMixin
@@ -184,15 +184,22 @@ class POIFormView(
                     poi__region=region, slug=user_slug, language=language
                 ).first()
                 other_translation_link = other_translation.backend_edit_link
+                message = _(
+                    "The slug was changed from '{user_slug}' to '{slug}', "
+                    "because '{user_slug}' is already used by <a>{translation}</a> or one of its previous versions.",
+                ).format(
+                    user_slug=user_slug,
+                    slug=poi_translation_form.cleaned_data["slug"],
+                    translation=other_translation,
+                )
                 messages.warning(
                     request,
-                    _(
-                        "The slug was changed from '{user_slug}' to '{slug}', because '{user_slug}' is already used by <a href='{link}' class='underline hover:no-underline'>{translation}</a> or one of its previous versions"
-                    ).format(
-                        user_slug=user_slug,
-                        slug=poi_translation_form.cleaned_data["slug"],
-                        link=other_translation_link,
-                        translation=other_translation,
+                    translate_link(
+                        message,
+                        attributes={
+                            "href": other_translation_link,
+                            "class": "underline hover:no-underline",
+                        },
                     ),
                 )
 

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -6612,13 +6612,11 @@ msgstr "Keine Änderungen vorgenommen, automatisches Speichern übersprungen"
 #, python-brace-format
 msgid ""
 "The slug was changed from '{user_slug}' to '{slug}', because '{user_slug}' "
-"is already used by <a href='{link}' class='underline hover:no-"
-"underline'>{translation}</a> or one of its previous versions"
+"is already used by <a>{translation}</a> or one of its previous versions."
 msgstr ""
 "Der URL-Parameter wurde von '{user_slug}' zu '{slug}' geändert, da "
-"'{user_slug}' bereits von <a href='{link}' class='underline hover:no-"
-"underline'>{translation}</a> oder einer vorherigen Version davon verwendet "
-"wird"
+"'{user_slug}' bereits von <a{translation}</a> oder einer vorherigen Version "
+"davon verwendet wird."
 
 #: cms/views/events/event_form_view.py
 msgid "Event \"{}\" was successfully created"
@@ -7102,9 +7100,9 @@ msgstr ""
 "Übersetzung nach {} wurde erfolgreich erstellt."
 
 #: cms/views/pages/page_bulk_actions.py
-msgid "If the download does not start automatically, please click {}here{}."
+msgid "If the download does not start automatically, please click <a>here</a>."
 msgstr ""
-"Wenn der Download nicht automatisch startet, klicken Sie bitte {}hier{}."
+"Wenn der Download nicht automatisch startet, klicken Sie bitte <a>hier</a>."
 
 #: cms/views/pages/page_bulk_actions.py
 msgid "XLIFF file for translation to selected languages successfully created."
@@ -7179,24 +7177,16 @@ msgstr "ablehnen"
 
 #: cms/views/pages/page_form_view.py
 #, python-brace-format
-msgid ""
-"You can {action} these changes in the {link_start}version overview{link_end}."
-msgstr ""
-"Sie können diese Änderungen in der {link_start}Versionsübersicht{link_end} "
-"{action}."
+msgid "You can {action} these changes in the <a>version overview</a>."
+msgstr "Sie können diese Änderungen in der <a>Versionsübersicht</a> {action}."
 
 #: cms/views/pages/page_form_view.py
 msgid "The latest changes have only been saved as a draft."
 msgstr "Die letzten Änderungen wurden nur als Entwurf gespeichert."
 
 #: cms/views/pages/page_form_view.py
-#, python-brace-format
-msgid ""
-"Currently, {link_start}version {version}{link_end} of this page is displayed "
-"in the app."
-msgstr ""
-"Aktuell wird {link_start}Version {version}{link_end} dieser Seite in der App "
-"angezeigt."
+msgid "Currently, <a>version {}</a> of this page is displayed in the app."
+msgstr "Aktuell wird <a>Version {}</a> dieser Seite in der App angezeigt."
 
 #: cms/views/pages/page_form_view.py cms/views/pages/page_sbs_view.py
 msgid "You don't have the permission to edit this page."
@@ -7214,12 +7204,10 @@ msgstr ""
 #, python-brace-format
 msgid ""
 "The slug was changed from '{user_slug}' to '{slug}', because '{user_slug}' "
-"is already used by <a href='{link}' class='underline hover:no-"
-"underline'>{translation}</a>"
+"is already used by <a>{translation}</a>."
 msgstr ""
 "Der URL-Parameter wurde von '{user_slug}' zu '{slug}' geändert, da "
-"'{user_slug}' bereits von <a href='{link}' class='underline hover:no-"
-"underline'>{translation}</a> verwendet wird"
+"'{user_slug}' bereits von <a>{translation}</a> verwendet wird."
 
 #: cms/views/pages/page_form_view.py
 msgid ""

--- a/tests/cms/utils/__init__.py
+++ b/tests/cms/utils/__init__.py
@@ -1,0 +1,3 @@
+"""
+This package contains tests for the :mod:`integreat_cms.cms.utils` package.
+"""

--- a/tests/cms/utils/test_translation_utils.py
+++ b/tests/cms/utils/test_translation_utils.py
@@ -1,0 +1,19 @@
+from integreat_cms.cms.utils.translation_utils import translate_link
+
+
+def test_translate_link():
+    """
+    Test whether the :meth:`~integreat_cms.cms.utils.translation_utils.translate_link` function correctly escapes message
+    text while preserving the link tags
+    """
+    assert (
+        translate_link(
+            "<script>alert('dangerous message!')</script>\"<broken>'\" <a>and <asasd>link</a>",
+            attributes={
+                "href": "=da&nge'rous <link>",
+                "class": "<danger>ous '\"class>",
+            },
+        )
+        == "&lt;script&gt;alert(&#x27;dangerous message!&#x27;)&lt;/script&gt;&quot;&lt;broken&gt;&#x27;&quot; <a href="
+        "'=da&amp;nge&#x27;rous &lt;link&gt;' class='&lt;danger&gt;ous &#x27;&quot;class&gt;'>and &lt;asasd&gt;link</a>"
+    )

--- a/tests/summ_ai_api/summ_ai_test.py
+++ b/tests/summ_ai_api/summ_ai_test.py
@@ -132,7 +132,7 @@ async def test_auto_translate_easy_german(
         for page in changed_pages:
             # Check that the success message are present
             assert (
-                f'Page "{page[settings.SUMM_AI_GERMAN_LANGUAGE_SLUG]}" has been successfully translated into Easy German.'
+                f"Page &quot;{page[settings.SUMM_AI_GERMAN_LANGUAGE_SLUG]}&quot; has been successfully translated into Easy German."
                 in response.content.decode("utf-8")
             )
             # Check that the page translation exists and really has the correct content

--- a/tests/xliff/xliff_test.py
+++ b/tests/xliff/xliff_test.py
@@ -192,7 +192,7 @@ def test_xliff_import(login_role_user, settings):
                 assert translation.content == "<p>Updated content</p>"
                 assert not translation.currently_in_translation
                 assert (
-                    f'Page "{translation.title}" was imported {msg}.'
+                    f"Page &quot;{translation.title}&quot; was imported {msg}."
                     in response.content.decode("utf-8")
                 )
                 if translation.version > 1:


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
The assumption that our messages were `safe` was incorrect, since they also contain user input (e.g. when the title/name of an object is contained in the message).

### Proposed changes
<!-- Describe this PR in more detail. -->
- Escape the message per default by removing the [safe](https://docs.djangoproject.com/en/4.1/ref/templates/builtins/#std-templatefilter-safe) template filter
- Provide a util function `translate_link()` which can be used to render links in messages correct (even if they are escaped)


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- Not sure if I forgot any messages which used HTML syntax... if so, the messages would now contain the escaped tags and the HTML code would be literally printed out.



__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
