### PR TITLE
Specify protected pages when trying to delete regions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@ UNRELEASED
 * [ [#1502](https://github.com/digitalfabrik/integreat-cms/issues/1502) ] Hide links on archived pages in broken link checker
 * [ [#1791](https://github.com/digitalfabrik/integreat-cms/issues/1791) ] Render live content in pdfs
 * [ [#1869](https://github.com/digitalfabrik/integreat-cms/issues/1869) ] Fix error in imprint side by side view
-* [ [#1786](https://github.com/digitalfabrik/integreat-cms/issues/1786) ] Remove texblock option in editor, add button to clear all formatting
+* [ [#1786](https://github.com/digitalfabrik/integreat-cms/issues/1786) ] Remove textblock option in editor, add button to clear all formatting
 * [ [#1788](https://github.com/digitalfabrik/integreat-cms/issues/1788) ] Fix broken translation status of events & locations if only minor public versions exists
+* [ [#1688](https://github.com/digitalfabrik/integreat-cms/issues/1688) ] Specify protected pages when trying to delete regions
 
 
 2022.11.3

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -7458,6 +7458,18 @@ msgstr ""
 "Benachrichtigungen verwalten."
 
 #: cms/views/regions/region_actions.py
+msgid ""
+"Region could not be deleted, because the following pages are mirrored in "
+"other regions:"
+msgstr ""
+"Die Region konnte nicht gelöscht werden, weil die folgenden Seiten in "
+"anderen Region gespiegelt werden:"
+
+#: cms/views/regions/region_actions.py
+msgid "is mirrored here:"
+msgstr "wird hier gespiegelt:"
+
+#: cms/views/regions/region_actions.py
 msgid "Region was successfully deleted"
 msgstr "Region wurde erfolgreich gelöscht"
 


### PR DESCRIPTION
### Short description
It's not possible to delete a region of which pages are mirrored in other regions. However, up until now there was only a Django default error and there wasn't an informative output to the user

### Proposed changes

- Give warning to user why deleting the region didn't work 
- Output which pages are causing the issue

- I thought maybe it would also be interesting to know in which region the page is mirrored to. But since this wasn't in the issue I didn't do that yet. What do you think? Do I need to implement this? 


### Side effects

- I mean there has to be a simpler way to do this than what I did. I don't know why but I really struggled to make this more simple. I would be very interested to hear your ideas on how to refactor this

### Resolved issues
Fixes: #1688


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
