### PR TITLE
Fix eslint pre-commit-hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
             files: \.[jt]sx?$
             types: [file]
             additional_dependencies:
+                - eslint@8.27.0
                 - "@typescript-eslint/eslint-plugin@5.42.1"
                 - "eslint-plugin-prefer-arrow@1.2.3"
     - repo: local


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
I noticed a small problem with the pre-commit hook failing due to eslint not being installed.
According to [this](https://github.com/pre-commit/mirrors-eslint/issues/10#issuecomment-344977736) comment, as a fix eslint should be listed as an additional dependency of itself...


### Proposed changes
<!-- Describe this PR in more detail. -->


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
/


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->
/

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
