### PR TITLE
Improve Documentation of Project Architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,25 @@ For detailed instructions, tutorials and the source code reference have a look a
 
 <p align="center">:notebook: https://digitalfabrik.github.io/integreat-cms/</p>
 
+Alternatively, you can generate it yourself using the `dev-tools/generate_documentation.sh` script.
+
+
+## Project Architecture / Reference
+
+- [Integreat CMS](integreat_cms): The main package of the integreat-cms with the following sub-packages:
+	- [API](integreat_cms/api): This app provides wrapper functions around all API routes and classes mapping the cms models to API JSON responses.
+	- [CMS](integreat_cms/cms): This app contains all database models, views, forms and templates forming the content management system for backend users.
+	- [Core](integreat_cms/core): This is the project’s main app which contains all configuration files.
+	- [Firebase API](firebase_api): This app provides wrapper functions around the Firebase API to send push notifications.
+	- [GVZ API](integreat_cms/gvz_api): This app provides wrapper functions around our Gemeindeverzeichnis API to automatically import coordinates and region aliases.
+	- [Nominatim API](nominatim_api): This app provides wrapper functions around our Nominatim API to automatically import region bounding boxes.
+	- [Sitemap](integreat_cms/sitemap): This app dynamically generates a sitemap.xml for the webapp.
+	- [SUMM.AI API](integreat_cms/summ_ai_api): This app provides wrapper functions around the SUMM.AI API for automatic translations into Easy German.
+	- [XLIFF](integreat_cms/xliff): This app allows (de-)serialization of translations from/to XLIFF (XML Localization Interchange File Format) for standardised exchange with translation agencies.
+- [Tests](tests): This app contains all tests to verify integreat-cms works as intended
+
+To better understand the overall intention it might also be helpful to look at the [wiki for municipalities (GER)](https://wiki.integreat-app.de/) that teaches how to use our CMS.
+
 
 ## License
 

--- a/sphinx/index.rst
+++ b/sphinx/index.rst
@@ -27,6 +27,41 @@ First Steps
 * :doc:`troubleshooting`: General problem solving guide
 
 
+Project Architecture / Reference
+================================
+
+.. toctree::
+    :caption: Reference
+    :hidden:
+
+    ref/integreat_cms
+    ref/tests
+
+* :doc:`ref/integreat_cms`: The main package of the integreat-cms with the following sub-packages:
+
+  - :doc:`ref/integreat_cms.api`: This app provides wrapper functions around all API routes and classes mapping the cms models to API JSON responses.
+  - :doc:`ref/integreat_cms.cms`: This app contains all database models, views, forms and templates forming the content management system for backend users.
+  - :doc:`ref/integreat_cms.core`: This is the project’s main app which contains all configuration files.
+  - :doc:`ref/integreat_cms.firebase_api`: This app provides wrapper functions around the Firebase API to send push notifications.
+  - :doc:`ref/integreat_cms.gvz_api`: This app provides wrapper functions around our Gemeindeverzeichnis API to automatically import coordinates and region aliases.
+  - :doc:`ref/integreat_cms.nominatim_api`: This app provides wrapper functions around our Nominatim API to automatically import region bounding boxes.
+  - :doc:`ref/integreat_cms.sitemap`: This app dynamically generates a sitemap.xml for the webapp.
+  - :doc:`ref/integreat_cms.summ_ai_api`: This app provides wrapper functions around the SUMM.AI API for automatic translations into Easy German.
+  - :doc:`ref/integreat_cms.xliff`: This app allows (de-)serialization of translations from/to XLIFF (XML Localization Interchange File Format) for standardised exchange with translation agencies.
+
+* :doc:`ref/tests`: This app contains all tests to verify integreat-cms works as intended
+
+To better understand the overall intention it might also be helpful to look at the `wiki for municipalities (GER) <https://wiki.integreat-app.de/>`_ that teaches how to use our CMS.
+
+
+.. toctree::
+    :caption: Extended Reference
+    :hidden:
+
+    ref-ext/integreat_cms
+    ref-ext/tests
+
+
 Basic Concepts
 ==============
 
@@ -83,39 +118,6 @@ Contributing
 * :doc:`code-style`: Coding Conventions
 * :doc:`git-flow`: GitHub Workflow model
 * :doc:`code-of-conduct`: Contributor Covenant Code of Conduct
-
-
-Reference
-=========
-
-.. toctree::
-    :caption: Reference
-    :hidden:
-
-    ref/integreat_cms
-    ref/tests
-
-* :doc:`ref/integreat_cms`: The main package of the integreat-cms with the following sub-packages:
-
-  - :doc:`ref/integreat_cms.api`: This is the app which contains all API routes and Classes which maps the cms models to API JSON responses. This is not the API documentation itself, but the Django developer documentation. A link to the API documentation will follow soon.
-  - :doc:`ref/integreat_cms.cms`: This is the content management system for backend users which contains all database models, views, forms and templates.
-  - :doc:`ref/integreat_cms.core`: This is the project's main app which contains all configuration files.
-  - :doc:`ref/integreat_cms.firebase_api`: This is the app to communicate with the Firebase API to send push notifications
-  - :doc:`ref/integreat_cms.gvz_api`: This is the app to communicate with our Gemeindeverzeichnis API to automatically import coordinates and region aliases
-  - :doc:`ref/integreat_cms.nominatim_api`: This is the app to communicate with our Nominatim API to automatically import region bounding boxes
-  - :doc:`ref/integreat_cms.sitemap`: This is the app to dynamically generate a sitemap.xml for the webapp
-  - :doc:`ref/integreat_cms.summ_ai_api`: This is the app to interact with the SUMM.AI API for automatic translations into Easy German
-  - :doc:`ref/integreat_cms.xliff`: The XLIFF serializer module
-
-* :doc:`ref/tests`: The tests for integreat-cms
-
-
-.. toctree::
-    :caption: Extended Reference
-    :hidden:
-
-    ref-ext/integreat_cms
-    ref-ext/tests
 
 
 Indices


### PR DESCRIPTION
### Short description
This PR aims to allow new-hires like myself and new volunteers to quickly get a sufficient understanding of the project architecture.


### Proposed changes
<!-- Describe this PR in more detail. -->

- The *Reference* section in the documentation index is moved up to be after *First Steps* and before *Basic Concepts* and the following sections, which describe the technical requirements of the project.
- The *Reference* section is being renamed to *Project Architecture / Reference* to better signal it as the starting point for understanding the project.
- The descriptions of each django app have been rewritten to have more concise wording and provide sufficient explanation to get a good first idea about what each app does.
- The [wiki for the municipalities](https://wiki.integreat-app.de/) is linked to allow the reader to further familiarise themselves with the perspective of the backend user and get a better understanding where each component fits into.
- The *Reference* is now also in the README.md
- The README.md now includes a hint on how to generate the documentation yourself.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

Since this only affects content in the documentation and README, no side effects are expected.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

*None*


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
