### PR TITLE
Process test_path argument in test.sh

### DIFF
--- a/dev-tools/_functions.sh
+++ b/dev-tools/_functions.sh
@@ -185,7 +185,7 @@ function ensure_not_root {
 function ensure_root {
     # Check if script is not running as root
     if ! [[ $(id -u) == 0 ]]; then
-        echo "The script ${SCRIPT_NAME} needs root privileges to connect to the docker deamon. It is be automatically restarted with sudo." | print_warning
+        echo "The script ${SCRIPT_NAME} needs root privileges to connect to the docker daemon. It will automatically be restarted with sudo." | print_warning
         # Call this script again as root (pass -E because we want the user's environment, not root's)
         sudo --preserve-env=HOME,PATH env "${SCRIPT_PATH}" "${SCRIPT_ARGS[@]}"
         # Exit with code of subprocess

--- a/dev-tools/test.sh
+++ b/dev-tools/test.sh
@@ -6,8 +6,9 @@
 # shellcheck source=./dev-tools/_functions.sh
 source "$(dirname "${BASH_SOURCE[0]}")/_functions.sh"
 
-# Delete outdated code coverage
-rm -rf "${BASE_DIR:?}/htmlcov/"
+# Delete outdated code coverage report
+CODE_COVERAGE_DIR="${BASE_DIR:?}/htmlcov"
+rm -rf "${CODE_COVERAGE_DIR}"
 
 require_installed
 require_database
@@ -15,8 +16,23 @@ require_database
 # Set dummy key to enable SUMM.AI during testing
 export INTEGREAT_CMS_SUMM_AI_API_KEY="dummy"
 
-deescalate_privileges pipenv run pytest --disable-warnings --quiet --numprocesses=auto --cov=integreat_cms --cov-report html
+# If only particular tests should be run, test path can be passed as CLI argument
+TEST_PATH=$1;
+
+if [[ -z "$TEST_PATH" ]]; then
+    echo -e "Running all tests..." | print_info
+    deescalate_privileges pipenv run pytest --disable-warnings --quiet --numprocesses=auto --cov=integreat_cms --cov-report html
+elif [[ -e "$TEST_PATH" ]]; then
+    echo -e "Running tests in ${TEST_PATH}..." | print_info
+    deescalate_privileges pipenv run pytest "$TEST_PATH" --quiet --disable-warnings --numprocesses=auto
+else
+    echo -e "${TEST_PATH}: No such file or directory" | print_error
+    exit 1
+fi
+
 echo "✔ Tests successfully completed " | print_success
 
-echo -e "Open the following file in your browser to view the test coverage:\n" | print_info
-echo -e "\tfile://${BASE_DIR}/htmlcov/index.html\n" | print_bold
+if [ -d "$CODE_COVERAGE_DIR" ]; then
+    echo -e "Open the following file in your browser to view the test coverage:\n" | print_info
+    echo -e "\tfile://${CODE_COVERAGE_DIR}/index.html\n" | print_bold
+fi

--- a/sphinx/dev-tools.rst
+++ b/sphinx/dev-tools.rst
@@ -84,7 +84,11 @@ Testing
 
 Run tests and generate coverage report with :github-source:`dev-tools/test.sh`::
 
-    ./dev-tools/test.sh
+    ./dev-tools/test.sh [TEST_PATH]
+
+**Arguments:**
+
+* ``TEST_PATH``: Run only tests in ``TEST_PATH``
 
 
 Code Quality


### PR DESCRIPTION
### Short description
To make it easier to maintain/develop new tests, I suggest adding the ability to pass test_path as an argument to test.sh script.
So that only particular tests can be run like this:
./test.sh tests/api/test_api_feedback.py


### Proposed changes
* Pass TEST_PATH argument to "pipenv run pytest" command
* Generate code coverage report only when all tests are run. Not sure, if it makes sense otherwise.


### Side effects
Didn't find any


### Resolved issues
N/A


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
