### PR TITLE
Exclde users without page view permission from page specific permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ UNRELEASED
 
 * [ [#1945](https://github.com/digitalfabrik/integreat-cms/issues/1945) ] Make message and button in list and form of page/event/poi uniform for observer users
 * [ [#1957](https://github.com/digitalfabrik/integreat-cms/issues/1957) ] Add keyboard shortcuts for icons in the editor
+* [ [#1900](https://github.com/digitalfabrik/integreat-cms/issues/1900) ] Exclude users without view_page permission from page-specific permissions
 
 
 2022.12.2

--- a/integreat_cms/cms/fixtures/test_data.json
+++ b/integreat_cms/cms/fixtures/test_data.json
@@ -2005,7 +2005,7 @@
       "mirrored_page": null,
       "mirrored_page_first": true,
       "organization": null,
-      "editors": [],
+      "editors": [10],
       "publishers": []
     }
   },
@@ -2026,7 +2026,7 @@
       "mirrored_page_first": true,
       "organization": null,
       "editors": [],
-      "publishers": []
+      "publishers": [10]
     }
   },
   {

--- a/integreat_cms/cms/forms/pages/page_form.py
+++ b/integreat_cms/cms/forms/pages/page_form.py
@@ -182,7 +182,7 @@ class PageForm(CustomModelForm, CustomTreeNodeForm):
     def get_editor_queryset(self):
         """
         This method retrieves all users, who are eligible to be defined as page editors because they don't yet have the
-        permission to edit this page.
+        permission to edit this page but the permission to view pages.
 
         :return: All potential page editors
         :rtype: ~django.db.models.query.QuerySet [ ~django.contrib.auth.models.User ]
@@ -191,7 +191,10 @@ class PageForm(CustomModelForm, CustomTreeNodeForm):
         users_without_permissions = (
             get_user_model()
             .objects.filter(
-                regions=self.instance.region, is_superuser=False, is_staff=False
+                regions=self.instance.region,
+                is_superuser=False,
+                is_staff=False,
+                groups__permissions__codename="view_page",
             )
             .exclude(
                 Q(groups__permissions__codename="change_page")
@@ -209,7 +212,7 @@ class PageForm(CustomModelForm, CustomTreeNodeForm):
     def get_publisher_queryset(self):
         """
         This method retrieves all users, who are eligible to be defined as page publishers because they don't yet have
-        the permission to publish this page.
+        the permission to publish this page but the permission to view pages.
 
         :return: All potential page publishers
         :rtype: ~django.db.models.query.QuerySet [ ~django.contrib.auth.models.User ]
@@ -218,7 +221,10 @@ class PageForm(CustomModelForm, CustomTreeNodeForm):
         users_without_permissions = (
             get_user_model()
             .objects.filter(
-                regions=self.instance.region, is_superuser=False, is_staff=False
+                regions=self.instance.region,
+                is_superuser=False,
+                is_staff=False,
+                groups__permissions__codename="view_page",
             )
             .exclude(
                 Q(groups__permissions__codename="publish_page")

--- a/integreat_cms/cms/views/pages/page_actions.py
+++ b/integreat_cms/cms/views/pages/page_actions.py
@@ -563,7 +563,14 @@ def grant_page_permission_ajax(request, region_slug):
                 )
                 raise PermissionDenied
 
-        if permission == "edit":
+        if not user.has_perm("cms.view_page"):
+            # check if the selected user has the permission to view pages (e.g. exclude users with role Event Manager)
+            message = _(
+                "Page-specific permissions cannot be granted to users who do not have permission to view pages (e.g event managers)."
+            )
+            level_tag = "warning"
+
+        elif permission == "edit":
             # check, if the user already has this permission
             if user.has_perm("cms.change_page_object", page):
                 message = _(

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -7221,6 +7221,14 @@ msgid "The page \"{page}\" was successfully moved."
 msgstr "Die Seite \"{page}\" wurde erfolgreich verschoben."
 
 #: cms/views/pages/page_actions.py
+msgid ""
+"Page-specific permissions cannot be granted to users who do not have "
+"permission to view pages (e.g event managers)."
+msgstr ""
+"Seitenspezifische Berechtigungen können nicht an Benutzer:innen vergeben "
+"werden, die keine Seiten sehen dürfen (z.B. Terminplaner:innen)."
+
+#: cms/views/pages/page_actions.py
 msgid "Information: The user \"{}\" has this permission already."
 msgstr "Information: \"{}\" hat diese Berechtigung bereits"
 

--- a/tests/cms/test_duplicate_regions.py
+++ b/tests/cms/test_duplicate_regions.py
@@ -45,10 +45,28 @@ def test_duplicate_regions(load_test_data, admin_client):
     assert len(source_pages) == len(target_pages)
     for source_page, target_page in zip(source_pages, target_pages):
         source_page_dict = model_to_dict(
-            source_page, exclude=["id", "tree_id", "region", "parent", "api_token"]
+            source_page,
+            exclude=[
+                "id",
+                "tree_id",
+                "region",
+                "parent",
+                "api_token",
+                "editors",
+                "publishers",
+            ],
         )
         target_page_dict = model_to_dict(
-            target_page, exclude=["id", "tree_id", "region", "parent", "api_token"]
+            target_page,
+            exclude=[
+                "id",
+                "tree_id",
+                "region",
+                "parent",
+                "api_token",
+                "editors",
+                "publishers",
+            ],
         )
         assert source_page_dict == target_page_dict
 

--- a/tests/cms/views/view_config.py
+++ b/tests/cms/views/view_config.py
@@ -264,6 +264,54 @@ VIEWS = [
     ),
     (
         [
+            (
+                "edit_page",
+                PRIV_STAFF_ROLES + [MANAGEMENT, EDITOR],
+                {
+                    "title": "new page",
+                    "mirrored_page_region": "",
+                    "_ref_node_id": 1,
+                    "_position": "first-child",
+                    "status": status.PUBLIC,
+                },
+            ),
+        ],
+        {"region_slug": "augsburg", "language_slug": "de", "page_id": 4},
+    ),
+    (
+        [
+            (
+                "edit_page",
+                PRIV_STAFF_ROLES + [MANAGEMENT, EDITOR, AUTHOR, OBSERVER],
+                {
+                    "title": "new page",
+                    "mirrored_page_region": "",
+                    "_ref_node_id": 1,
+                    "_position": "first-child",
+                    "status": status.REVIEW,
+                },
+            ),
+        ],
+        {"region_slug": "augsburg", "language_slug": "de", "page_id": 5},
+    ),
+    (
+        [
+            (
+                "edit_page",
+                PRIV_STAFF_ROLES + [MANAGEMENT, EDITOR, OBSERVER],
+                {
+                    "title": "new page",
+                    "mirrored_page_region": "",
+                    "_ref_node_id": 1,
+                    "_position": "first-child",
+                    "status": status.PUBLIC,
+                },
+            ),
+        ],
+        {"region_slug": "augsburg", "language_slug": "de", "page_id": 6},
+    ),
+    (
+        [
             ("archived_pages", STAFF_ROLES),
             ("archived_pois", STAFF_ROLES),
             ("edit_imprint", STAFF_ROLES),


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR excludes users wihout the page view permission from the candidates list for page-specific permission grant and prevent such cases that pege-specific permissions are given to users who do not have the page view permission and therefore cannot access the pages. 

### Proposed changes
<!-- Describe this PR in more detail. -->
- Show in the candidates list only the users who have the permission to view pages.
- Check if the selected user has the permission to view pages before granting them a page specific edit permission. If not, show a message.
- Test for page-specific permission: the observer in the test data is added to the editor and publisher list respectively for the pages with id=5, 6, and view test for "edit_page" will be run for those pages to check whether the observer can change the pages. The page with id=4 is used to check false positiv.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
Not really a side effect but one notice.
- If an user with role Event Manager is added to an organisation and some pages are shared with their organisation, this means they are allowed to edit those pages but cannot see (access) the pages.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1900 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
