### PR TITLE
Fix: 'prefer-template' should be a linter error

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -115,6 +115,7 @@ module.exports = {
         "prefer-destructuring": ["error", { array: false }],
         "prefer-arrow/prefer-arrow-functions": "error",
         "prefer-object-spread": "error",
+        "prefer-template": "error",
         "react/function-component-definition": ["error", { namedComponents: "arrow-function" }],
         "react-hooks/exhaustive-deps": "error",
         "vars-on-top": "error",


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Change `prefer-template` linter severity level from warning to error.  

### Proposed changes
<!-- Describe this PR in more detail. -->

- See above


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- code changes won't pass the circleCI linter checks anymore if `prefer-template` isn't satisfied

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
