### PR TITLE
Fix: .testmondata-journal should be in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ coverage.xml
 htmlcov/
 .coverage.*
 *.cover
-.testmondata
+.testmondata*
 
 # Compiled translations
 integreat_cms/locale/*/LC_MESSAGES/django.mo


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
 `.testmondata-journal` should be in gitignore

### Proposed changes
<!-- Describe this PR in more detail. -->

- change `.gitignore` to include all files starting with `.testmondata` 


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none
__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
