### PR TITLE
Fix ongoing page translation not cancellable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ UNRELEASED
 * [ [#1914](https://github.com/digitalfabrik/integreat-cms/issues/1914) ] Always uncheck minor edit field by default
 * [ [#1934](https://github.com/digitalfabrik/integreat-cms/issues/1934) ] Make sure translations are never a minor version after XLIFF import
 * [ [#1864](https://github.com/digitalfabrik/integreat-cms/issues/1864) ] Fix possibility to mark page as up-to-date without performing changes
+* [ [#1885](https://github.com/digitalfabrik/integreat-cms/issues/1885) ] Fix ongoing translation cancel button
 
 
 2022.11.4

--- a/integreat_cms/cms/models/abstract_content_model.py
+++ b/integreat_cms/cms/models/abstract_content_model.py
@@ -394,7 +394,7 @@ class AbstractContentModel(AbstractBaseModel):
         :return: A string describing the state of the translation, one of :data:`~integreat_cms.cms.constants.translation_status.CHOICES`
         :rtype: str
         """
-        translation = self.get_major_translation(language_slug)
+        translation = self.get_translation(language_slug)
         if not translation:
             if self.fallback_translations_enabled:
                 fallback_translation = self.get_translation(

--- a/integreat_cms/cms/models/abstract_content_translation.py
+++ b/integreat_cms/cms/models/abstract_content_translation.py
@@ -431,7 +431,8 @@ class AbstractContentTranslation(AbstractBaseModel):
             # If the page does not have a major public version, it is considered "missing" (keep in mind that it might
             # have draft versions or public versions that are marked as "minor edit")
             return translation_status.MISSING
-        if translation.currently_in_translation:
+        # For "currently in translation", we consider the latest version instead of the latest major version
+        if self.currently_in_translation:
             return translation_status.IN_TRANSLATION
         if not self.source_language:
             # If the language of this translation is the root of this region's language tree, it is always "up to date"

--- a/integreat_cms/cms/views/pages/page_actions.py
+++ b/integreat_cms/cms/views/pages/page_actions.py
@@ -323,7 +323,7 @@ def cancel_translation_process_ajax(request, region_slug, language_slug, page_id
             status=404,
         )
     page_translation.currently_in_translation = False
-    page_translation.save()
+    page_translation.save(update_timestamp=False)
     # Get new (respectively old) translation state
     translation_state = page.get_translation_state(language_slug)
     return JsonResponse(

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -7696,12 +7696,12 @@ msgid "Page {} could not be imported successfully because of the errors: {}"
 msgstr "Die Seite {} konnte nicht importiert werden aufgrund der Fehler: {}"
 
 #: xliff/utils.py
-msgid "Page {} was imported without changes."
-msgstr "Seite {} wurde ohne Änderungen importiert."
-
-#: xliff/utils.py
 msgid "Page {} was imported successfully."
 msgstr "Seite {} wurde erfolgreich importiert."
+
+#: xliff/utils.py
+msgid "Page {} was imported without changes."
+msgstr "Seite {} wurde ohne Änderungen importiert."
 
 #: xliff/utils.py
 msgid "You don't have the permission to import this page."

--- a/integreat_cms/xliff/utils.py
+++ b/integreat_cms/xliff/utils.py
@@ -206,9 +206,14 @@ def page_to_xliff(page, target_language, dir_name, only_public=False):
     logger.debug("Created XLIFF file %r", actual_filename)
 
     # Set "currently in translation" status for existing target translation
-    if target_page_translation.id:
-        target_page_translation.currently_in_translation = True
-        target_page_translation.save()
+    if latest_version := page.get_translation(target_language.slug):
+        latest_version.currently_in_translation = True
+        latest_version.save(update_timestamp=False)
+        logger.debug(
+            "Updated translation status of %r to %r",
+            latest_version,
+            latest_version.translation_state,
+        )
 
     return download_storage.path(actual_filename)
 
@@ -391,23 +396,6 @@ def xliff_import_confirm(request, xliff_dir):
                         ).format(page_translation.readable_title, error_list),
                     )
                     success = False
-                elif not has_changed:
-                    # Update existing translation
-                    existing_translation = page_translation.latest_version
-                    existing_translation.currently_in_translation = False
-                    existing_translation.save()
-                    logger.info(
-                        "%r of XLIFF file %r was imported without changes by %r",
-                        existing_translation,
-                        xliff_file,
-                        request.user,
-                    )
-                    messages.info(
-                        request,
-                        _("Page {} was imported without changes.").format(
-                            page_translation.readable_title
-                        ),
-                    )
                 else:
                     # Check if previous version already exists
                     existing_translation = page_translation.latest_version
@@ -416,18 +404,34 @@ def xliff_import_confirm(request, xliff_dir):
                         existing_translation.links.all().delete()
                     # Confirm import and write changes to the database
                     page_translation.save()
-                    logger.info(
-                        "%r of XLIFF file %r was imported successfully by %r",
-                        page_translation,
-                        xliff_file,
-                        request.user,
-                    )
-                    messages.success(
-                        request,
-                        _("Page {} was imported successfully.").format(
-                            page_translation.readable_title
-                        ),
-                    )
+
+                    if has_changed:
+                        logger.info(
+                            "%r of XLIFF file %r was imported successfully by %r",
+                            page_translation,
+                            xliff_file,
+                            request.user,
+                        )
+                        messages.success(
+                            request,
+                            _("Page {} was imported successfully.").format(
+                                page_translation.readable_title
+                            ),
+                        )
+                    else:
+                        logger.info(
+                            "%r of XLIFF file %r was imported without changes by %r",
+                            existing_translation,
+                            xliff_file,
+                            request.user,
+                        )
+                        messages.info(
+                            request,
+                            _("Page {} was imported without changes.").format(
+                                page_translation.readable_title
+                            ),
+                        )
+
     return success
 
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr fixes a bug where an ongoing translation was not cancellable if the latest version is a minor edit.
It also fixes two related bugs I noticed, where the status was always set to `up-to-date` after cancelling an ongoing translation, and a bug where the the translation status would not update after an xliff import/export if the latest version is a minor edit.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Store the translation status in the latest version (as opposed to the latest major version previously)
- Don't update the objects timestamp after changing the translation state


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
/


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1885


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
