### PR TITLE
Fix possibility to mark page as up-to-date without performing changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ UNRELEASED
 * [ [#1494](https://github.com/digitalfabrik/integreat-cms/issues/1494) ] Add a role without page editing permissions
 * [ [#1914](https://github.com/digitalfabrik/integreat-cms/issues/1914) ] Always uncheck minor edit field by default
 * [ [#1934](https://github.com/digitalfabrik/integreat-cms/issues/1934) ] Make sure translations are never a minor version after XLIFF import
+* [ [#1864](https://github.com/digitalfabrik/integreat-cms/issues/1864) ] Fix possibility to mark page as up-to-date without performing changes
 
 
 2022.11.4

--- a/integreat_cms/cms/forms/custom_content_model_form.py
+++ b/integreat_cms/cms/forms/custom_content_model_form.py
@@ -155,13 +155,16 @@ class CustomContentModelForm(CustomModelForm):
         return unique_slug
 
     # pylint: disable=arguments-differ
-    def save(self, commit=True):
+    def save(self, commit=True, foreign_form_changed=False):
         """
         This method extends the default ``save()``-method of the base :class:`~django.forms.ModelForm` to set attributes
         which are not directly determined by input fields.
 
         :param commit: Whether or not the changes should be written to the database
         :type commit: bool
+
+        :param foreign_form_changed: Whether or not the foreign form of this translation form was changed
+        :type foreign_form_changed: bool
 
         :return: The saved page translation object
         :rtype: ~integreat_cms.cms.models.pages.page_translation.PageTranslation
@@ -170,8 +173,8 @@ class CustomContentModelForm(CustomModelForm):
         # Delete now outdated link objects
         self.instance.links.all().delete()
 
-        # If none of the text content fields changed, treat as minor edit (even if checkbox isn't clicked)
-        if {"title", "content"}.isdisjoint(self.changed_data):
+        # If none of the text content fields were changed, but the foreign form was, treat as minor edit (even if checkbox isn't clicked)
+        if {"title", "content"}.isdisjoint(self.changed_data) and foreign_form_changed:
             self.logger.debug("Set 'minor_edit=True' since the content did not change")
             self.instance.minor_edit = True
 

--- a/integreat_cms/cms/forms/custom_model_form.py
+++ b/integreat_cms/cms/forms/custom_model_form.py
@@ -50,6 +50,8 @@ class CustomModelForm(forms.ModelForm):
             attributes.append("data")
         if self.files:
             attributes.append("files")
+        if self.initial:
+            attributes.append("initial")
         if self.instance.id:
             attributes.append("instance")
 

--- a/integreat_cms/cms/forms/events/event_form.py
+++ b/integreat_cms/cms/forms/events/event_form.py
@@ -95,7 +95,11 @@ class EventForm(CustomModelForm):
         self.fields["start"].required = False
         self.fields["end"].required = False
         if self.instance.id:
-            # Initialize BooleanFields based on Event properties
+            # Initialize non-model fields based on event
+            self.fields["start_date"].initial = self.instance.start_local.date()
+            self.fields["start_time"].initial = self.instance.start_local.time()
+            self.fields["end_date"].initial = self.instance.end_local.date()
+            self.fields["end_time"].initial = self.instance.end_local.time()
             self.fields["is_all_day"].initial = self.instance.is_all_day
             self.fields["is_recurring"].initial = self.instance.is_recurring
             self.fields["has_not_location"].initial = not self.instance.has_location
@@ -188,5 +192,9 @@ class EventForm(CustomModelForm):
                 cleaned_data["end_date"],
                 cleaned_data["end_time"],
             ).replace(tzinfo=tzinfo)
+            # Also update data to fix the change detection
+            self.data = self.data.copy()
+            self.data["start"] = cleaned_data["start"]
+            self.data["end"] = cleaned_data["end"]
         logger.debug("EventForm validated [2] with cleaned data %r", cleaned_data)
         return cleaned_data

--- a/integreat_cms/cms/templates/pois/poi_form.html
+++ b/integreat_cms/cms/templates/pois/poi_form.html
@@ -338,6 +338,11 @@
                         <opening-hours-widget></opening-hours-widget>
                         {{ opening_hour_config_data|json_script:"openingHourConfigData" }}
                         {{ poi_form.opening_hours.value|json_script:"openingHourInitialData" }}
+                        {# This hidden input is required for the change detection of the opening hours field #}
+                        <input type="hidden"
+                               id="initial-id_opening_hours"
+                               name="initial-opening_hours"
+                               value="{{ poi_form.opening_hours.value }}"/>
                         <div class="py-2 px-4">
                             {% render_field poi_form.temporarily_closed %}
                             <label for="{{ poi_form.temporarily_closed.id_for_label }}">

--- a/integreat_cms/cms/views/events/event_form_view.py
+++ b/integreat_cms/cms/views/events/event_form_view.py
@@ -71,17 +71,6 @@ class EventFormView(
         recurrence_rule_instance = RecurrenceRule.objects.filter(
             event=event_instance
         ).first()
-        if event_instance:
-            poi_instance = event_instance.location
-            initial = {
-                "start_date": event_instance.start_local.date(),
-                "start_time": event_instance.start_local.time(),
-                "end_date": event_instance.end_local.date(),
-                "end_time": event_instance.end_local.time(),
-            }
-        else:
-            poi_instance = None
-            initial = {}
         # Make form disabled if event is archived or user doesn't have the permission to edit the event
         if event_instance and event_instance.archived:
             disabled = True
@@ -105,7 +94,6 @@ class EventFormView(
             )
 
         event_form = EventForm(
-            initial=initial,
             instance=event_instance,
             disabled=disabled,
         )
@@ -124,7 +112,7 @@ class EventFormView(
                 "event_form": event_form,
                 "event_translation_form": event_translation_form,
                 "recurrence_rule_form": recurrence_rule_form,
-                "poi": poi_instance,
+                "poi": event_instance.location if event_instance else None,
                 "language": language,
                 "languages": region.active_languages if event_instance else [language],
                 "url_link": url_link,

--- a/integreat_cms/cms/views/events/event_form_view.py
+++ b/integreat_cms/cms/views/events/event_form_view.py
@@ -227,7 +227,11 @@ class EventFormView(
             # Save event from event form
             event = event_form.save()
             event_translation_form.instance.event = event
-            event_translation_form.save()
+            event_translation_form.save(
+                foreign_form_changed=(
+                    event_form.has_changed() or recurrence_rule_form.has_changed()
+                )
+            )
             # If any source translation changes to draft, set all depending translations/versions to draft
             if event_translation_form.instance.status == status.DRAFT:
                 language_tree_node = region.language_node_by_slug.get(language.slug)

--- a/integreat_cms/cms/views/pages/page_form_view.py
+++ b/integreat_cms/cms/views/pages/page_form_view.py
@@ -323,7 +323,7 @@ class PageFormView(
             ):
                 page_translation_form.instance.page = page_form.save()
             # Save page translation form
-            page_translation_form.save()
+            page_translation_form.save(foreign_form_changed=page_form.has_changed())
 
             # Show a message that the slug was changed if it was not unique
             if user_slug and user_slug != page_translation_form.cleaned_data["slug"]:

--- a/integreat_cms/cms/views/pois/poi_form_view.py
+++ b/integreat_cms/cms/views/pois/poi_form_view.py
@@ -167,7 +167,7 @@ class POIFormView(
         else:
             # Save forms
             poi_translation_form.instance.poi = poi_form.save()
-            poi_translation_form.save()
+            poi_translation_form.save(foreign_form_changed=poi_form.has_changed())
             # If any source translation changes to draft, set all depending translations/versions to draft
             if poi_translation_form.instance.status == status.DRAFT:
                 language_tree_node = region.language_node_by_slug.get(language.slug)


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fix possibility to mark page as up-to-date without performing changes

### Proposed changes
<!-- Describe this PR in more detail. -->

- Fix possibility to mark page as up-to-date without performing changes
- Fix change detection in event form
- Fix change detection in location form


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1864


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
