### PR TITLE
Make sure translations are never a minor version after XLIFF import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ UNRELEASED
 * [ [#1889](https://github.com/digitalfabrik/integreat-cms/issues/1889) ] Make translation status independent from publishing status
 * [ [#1494](https://github.com/digitalfabrik/integreat-cms/issues/1494) ] Add a role without page editing permissions
 * [ [#1914](https://github.com/digitalfabrik/integreat-cms/issues/1914) ] Always uncheck minor edit field by default
+* [ [#1934](https://github.com/digitalfabrik/integreat-cms/issues/1934) ] Make sure translations are never a minor version after XLIFF import
 
 
 2022.11.4

--- a/integreat_cms/cms/forms/custom_content_model_form.py
+++ b/integreat_cms/cms/forms/custom_content_model_form.py
@@ -39,7 +39,7 @@ class CustomContentModelForm(CustomModelForm):
         # Instantiate CustomModelForm
         super().__init__(**kwargs)
 
-        # Always set the minor edit to unchecked to make sure it does ot influence future versions
+        # Always set the minor edit to unchecked to make sure it does not influence future versions
         # (unless manually enabled)
         self.initial["minor_edit"] = False
 

--- a/integreat_cms/xliff/base_serializer.py
+++ b/integreat_cms/xliff/base_serializer.py
@@ -230,6 +230,8 @@ class Deserializer(xml_serializer.Deserializer):
         page_translation.version = page_translation.version + 1
         # Make sure object is not in translation anymore if it was before
         page_translation.currently_in_translation = False
+        # Make sure object is not a minor edit anymore if it was before
+        page_translation.minor_edit = False
         # Set the id to None to make sure a new object is stored in the database when save() is called
         page_translation.id = None
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Make sure translations are never a minor version after XLIFF import

### Proposed changes
<!-- Describe this PR in more detail. -->

- When deserializing XLIFF files, always reset the minor edit field to `False`, independently of whether the existing database object is a minor or major edit.



### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1934


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
