### PR TITLE
Suggest to make two reviews for every PR opened

### DIFF
--- a/sphinx/pull-request-review-guide.rst
+++ b/sphinx/pull-request-review-guide.rst
@@ -23,7 +23,7 @@ Goals and purpose
 
 .. tip::
 
-    Have a personal goal of a minimum of reviews. You should aim to make a review for every own PR that you open.
+    Have a personal goal of a minimum of reviews. You should aim to make two reviews for every own PR that you open.
 
 
 Checklist


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
We require two reviews per PR, so the math only works out when everybody makes two reviews for each of their own PRs they open. Otherwise, the pile of open PRs gets bigger and bigger until someone reviews more than twice as many PRs as they open.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Suggest to make two reviews for every PR opened

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
