### PR TITLE
Dynamically create POIs from within event form 

### DIFF
--- a/integreat_cms/cms/templates/events/_poi_form_widget.html
+++ b/integreat_cms/cms/templates/events/_poi_form_widget.html
@@ -1,0 +1,22 @@
+{% load i18n %}
+{% load widget_tweaks %}
+<div>
+    <label for="{{ poi_translation_form.title.id_for_label }}">{{ poi_translation_form.title.label }}</label>
+    {% render_field poi_translation_form.title|append_attr:"form:ajax_poi_form" %}
+    <label for="{{ poi_form.address.id_for_label }}">{{ poi_form.address.label }}</label>
+    {% render_field poi_form.address|append_attr:"form:ajax_poi_form" %}
+    <label for="{{ poi_form.postcode.id_for_label }}">{{ poi_form.postcode.label }}</label>
+    {% render_field poi_form.postcode|append_attr:"form:ajax_poi_form" %}
+    <label for="{{ poi_form.city.id_for_label }}">{{ poi_form.city.label }}</label>
+    {% render_field poi_form.city|append_attr:"form:ajax_poi_form" %}
+    <label for="{{ poi_form.country.id_for_label }}">{{ poi_form.country.label }}</label>
+    {% render_field poi_form.country|append_attr:"form:ajax_poi_form" %}
+    <button name="status"
+            value="{{ PUBLIC }}"
+            form="ajax_poi_form"
+            data-btn-save-poi-form
+            class="btn w-full mt-4 mb-2"
+            data-url="{% url 'create_poi_ajax' region_slug=request.region.slug language_slug=request.region.default_language.slug %}">
+        {% translate "Publish" %}
+    </button>
+</div>

--- a/integreat_cms/cms/templates/events/_poi_query_result.html
+++ b/integreat_cms/cms/templates/events/_poi_query_result.html
@@ -23,9 +23,10 @@
         </select>
     {% endif %}
     {% if create_poi_option %}
-        <button class="btn w-full option-new-poi mb-2"
-                data-url="{% url 'new_poi' region_slug=request.region.slug language_slug=request.region.default_language.slug %}"
-                data-poi-title="{{ poi_query }}">
+        <button id="show-poi-form-button"
+                class="btn w-full option-new-poi mb-2"
+                data-poi-title="{{ poi_query }}"
+                data-url="{% url 'show_poi_form_ajax' region_slug=request.region.slug language_slug=request.region.default_language.slug poi_title=poi_query %}">
             <i icon-name="map-pin"></i>
             {% blocktrans %}Create location "{{ poi_query }}"{% endblocktrans %}
         </button>

--- a/integreat_cms/cms/templates/events/event_form.html
+++ b/integreat_cms/cms/templates/events/event_form.html
@@ -139,6 +139,12 @@
             </div>
         </div>
     </form>
+    <form id="ajax_poi_form"
+          name="ajax_poi_form"
+          method="post"
+          enctype="multipart/form-data"
+          data-unsaved-warning>
+    </form>
     {{ media_config_data|json_script:"media_config_data" }}
     {% if not perms.cms.change_event or event_form.instance.id and event_form.instance.archived %}
         {% include "../_tinymce_config.html" with readonly=1 %}

--- a/integreat_cms/cms/templates/events/event_form_sidebar/venue_box.html
+++ b/integreat_cms/cms/templates/events/event_form_sidebar/venue_box.html
@@ -39,7 +39,7 @@
             </div>
         </div>
         <p class="text-sm italic block mt-2 mb-2">
-            {% translate "Create an event location or start typing the name of an existing location" %}.
+            {% translate "Create an event location or start typing the name of an existing location. Only published locations can be set as event venues" %}.
         </p>
         <div class="relative" id="poi-query-result">{% include "events/_poi_query_result.html" %}</div>
         <div id="poi-address-container" class="{% if not poi %} hidden{% endif %}">
@@ -65,5 +65,14 @@
                 {% translate "Open on Google Maps" %}
             </a>
         </div>
+        <div id="poi-ajax-success-message"
+             class="bg-green-100 border-l-4 border-green-500 text-green-500 px-4 py-3 hidden">
+            {% trans "The new location was successfully created." %}
+        </div>
+        <div id="poi-ajax-error-message"
+             class="bg-red-100 border-l-4 border-red-500 text-red-500 px-4 py-3 hidden">
+            {% trans "An error occured." %}
+        </div>
+        <div id="poi-form-widget"></div>
     </div>
 {% endblock collapsible_box_content %}

--- a/integreat_cms/cms/urls/protected.py
+++ b/integreat_cms/cms/urls/protected.py
@@ -1153,6 +1153,16 @@ urlpatterns = [
                                             name="bulk_restore_pois",
                                         ),
                                         path(
+                                            "show-poi-form-ajax/<str:poi_title>/",
+                                            pois.POIFormAjaxView.as_view(),
+                                            name="show_poi_form_ajax",
+                                        ),
+                                        path(
+                                            "create-poi-ajax/",
+                                            pois.POIFormAjaxView.as_view(),
+                                            name="create_poi_ajax",
+                                        ),
+                                        path(
                                             "<int:poi_id>/",
                                             include(
                                                 [

--- a/integreat_cms/cms/views/pois/__init__.py
+++ b/integreat_cms/cms/views/pois/__init__.py
@@ -9,5 +9,6 @@ from .poi_actions import (
     restore_poi,
     view_poi,
 )
+from .poi_form_ajax_view import POIFormAjaxView
 from .poi_form_view import POIFormView
 from .poi_list_view import POIListView

--- a/integreat_cms/cms/views/pois/poi_form_ajax_view.py
+++ b/integreat_cms/cms/views/pois/poi_form_ajax_view.py
@@ -1,0 +1,116 @@
+from django.http import JsonResponse
+from django.shortcuts import get_object_or_404, render
+from django.views.generic import TemplateView
+
+from ...forms import POIForm, POITranslationForm
+from ...models import Language, POITranslation
+from ...models.pois.poi import get_default_opening_hours, POI
+from .poi_context_mixin import POIContextMixin
+
+
+class POIFormAjaxView(TemplateView, POIContextMixin):
+    """
+    View for the ajax POI widget
+    """
+
+    #: Template for ajax POI widget
+    template = "events/_poi_form_widget.html"
+
+    def get(self, request, *args, **kwargs):
+        r"""Render a POI form widget template
+
+        :param request: The current request
+        :type request: ~django.http.HttpRequest
+
+        :param \*args: The supplied arguments
+        :type \*args: list
+
+        :param \**kwargs: The supplied keyword arguments
+        :type \**kwargs: dict
+
+        :return: The html template of a POI form
+        :rtype: ~django.http.HttpResponse
+        """
+        poi_form = POIForm()
+        poi_title = kwargs.get("poi_title")
+        poi_translation_form = POITranslationForm(data={"title": poi_title})
+
+        return render(
+            request,
+            "events/_poi_form_widget.html",
+            {
+                **self.get_context_data(**kwargs),
+                "poi_form": poi_form,
+                "poi_translation_form": poi_translation_form,
+            },
+        )
+
+    # pylint: disable=unused-argument
+    def post(self, request, *args, **kwargs):
+        r"""Add a new POI to the database
+
+        :param request: The current request
+        :type request: ~django.http.HttpRequest
+
+        :param \*args: The supplied arguments
+        :type \*args: list
+
+        :param \**kwargs: The supplied keyword arguments
+        :type \**kwargs: dict
+
+        :raises ~django.http.Http404: If no language for the given language slug was found
+
+        :return: A status message, either a success or an error message
+        :rtype: ~django.http.JsonResponse
+        """
+
+        region = request.region
+        language_slug = kwargs.get("language_slug")
+        language = get_object_or_404(Language, slug=language_slug)
+
+        poi_instance = POI.objects.filter(id=None).first()
+        poi_translation_instance = POITranslation.objects.filter(
+            poi=poi_instance,
+            language=language,
+        ).first()
+
+        data = request.POST.dict()
+        data["opening_hours"] = get_default_opening_hours()
+
+        poi_form = POIForm(
+            data=data,
+            files=request.FILES,
+            instance=poi_instance,
+            additional_instance_attributes={
+                "region": region,
+            },
+        )
+
+        poi_translation_form = POITranslationForm(
+            data=request.POST,
+            instance=poi_translation_instance,
+            additional_instance_attributes={
+                "creator": request.user,
+                "language": language,
+                "poi": poi_form.instance,
+            },
+            changed_by_user=request.user,
+        )
+
+        if not poi_form.is_valid() or not poi_translation_form.is_valid():
+            return JsonResponse(
+                data={
+                    "poi_form": poi_form.get_error_messages(),
+                    "poit_ranslation_form": poi_translation_form.get_error_messages(),
+                }
+            )
+
+        poi_translation_form.instance.poi = poi_form.save()
+        poi_translation_form.save()
+
+        return JsonResponse(
+            data={
+                "success": "Successfully created location",
+                "id": poi_form.instance.id,
+            }
+        )

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -4477,6 +4477,13 @@ msgstr "Filter zurücksetzen"
 msgid "Apply filter"
 msgstr "Filter anwenden"
 
+#: cms/templates/events/_poi_form_widget.html
+#: cms/templates/events/event_form.html cms/templates/imprint/imprint_form.html
+#: cms/templates/imprint/imprint_sbs.html cms/templates/pages/page_form.html
+#: cms/templates/pages/page_sbs.html cms/templates/pois/poi_form.html
+msgid "Publish"
+msgstr "Veröffentlichen"
+
 #: cms/templates/events/_poi_query_result.html
 msgid "Select existing location"
 msgstr "Bestehenden Ort auswählen"
@@ -4504,12 +4511,6 @@ msgstr "Veranstaltung erstellen"
 #: cms/templates/pages/page_sbs.html cms/templates/pois/poi_form.html
 msgid "Save as draft"
 msgstr "Als Entwurf speichern"
-
-#: cms/templates/events/event_form.html cms/templates/imprint/imprint_form.html
-#: cms/templates/imprint/imprint_sbs.html cms/templates/pages/page_form.html
-#: cms/templates/pages/page_sbs.html cms/templates/pois/poi_form.html
-msgid "Publish"
-msgstr "Veröffentlichen"
 
 #: cms/templates/events/event_form.html cms/templates/pages/page_form.html
 #: cms/templates/pages/page_sbs.html
@@ -4590,10 +4591,12 @@ msgstr "Veranstaltungsort von Veranstaltung entfernen"
 
 #: cms/templates/events/event_form_sidebar/venue_box.html
 msgid ""
-"Create an event location or start typing the name of an existing location"
+"Create an event location or start typing the name of an existing location. "
+"Only published locations can be set as event venues"
 msgstr ""
 "Erstellen Sie einen Veranstaltungsort oder beginnen Sie den Namen eines "
-"bestehenden Veranstaltungsortes einzutippen"
+"bestehenden Veranstaltungsortes einzutippen. Nur öffentliche Orte können als "
+"Veranstaltungsorte verwendet werden"
 
 #: cms/templates/events/event_form_sidebar/venue_box.html
 #: cms/templates/pois/poi_form_sidebar/position_box.html
@@ -4603,6 +4606,14 @@ msgstr "Adresse"
 #: cms/templates/events/event_form_sidebar/venue_box.html
 msgid "Open on Google Maps"
 msgstr "Auf Google Maps öffnen"
+
+#: cms/templates/events/event_form_sidebar/venue_box.html
+msgid "The new location was successfully created."
+msgstr "Ein neuer Ort wurde erfolgreich erstellt"
+
+#: cms/templates/events/event_form_sidebar/venue_box.html
+msgid "An error occured."
+msgstr "Es ist ein Fehler aufgetreten."
 
 #: cms/templates/events/event_list.html
 #: cms/templates/events/event_list_archived.html
@@ -8729,11 +8740,6 @@ msgstr ""
 #~ msgid "Opened"
 #~ msgstr "Geöffnet"
 
-#~ msgid "Map preview will be available when coordinates are given."
-#~ msgstr ""
-#~ "Die Karten-Vorschau wird verfügbar, sobald die Koordinaten eingetragen "
-#~ "wurden."
-
 #~ msgid "New position found:"
 #~ msgstr "Neue Position gefunden:"
 
@@ -9285,9 +9291,6 @@ msgstr ""
 #~ msgid "Translation was successfully created and published"
 #~ msgstr "Übersetzung wurde erfolgreich erstellt und veröffentlicht"
 
-#~ msgid "Translation was successfully created"
-#~ msgstr "Übersetzung wurde erfolgreich erstellt"
-
 #~ msgid "Translation was successfully published"
 #~ msgstr "Übersetzung wurde erfolgreich veröffentlicht"
 
@@ -9371,9 +9374,6 @@ msgstr ""
 
 #~ msgid "Location was successfully created and published"
 #~ msgstr "Ort wurde erfolgreich erstellt und veröffentlicht"
-
-#~ msgid "Location was successfully created"
-#~ msgstr "Ort wurde erfolgreich erstellt"
 
 #~ msgid "Location was successfully published"
 #~ msgstr "Ort wurde erfolgreich veröffentlicht"

--- a/integreat_cms/release_notes/current/unreleased/1171.yml
+++ b/integreat_cms/release_notes/current/unreleased/1171.yml
@@ -1,0 +1,2 @@
+en: Allow dynamic POI creation within event form
+de: Erlaube das dynamische Erzeugen von Orten innerhalb des Veranstaltungsformulars

--- a/integreat_cms/static/src/js/events/event-query-pois.ts
+++ b/integreat_cms/static/src/js/events/event-query-pois.ts
@@ -1,14 +1,6 @@
 import { createIconsAt } from "../utils/create-icons";
 import { getCsrfToken } from "../utils/csrf-token";
 
-const newPoiWindow = ({ target }: Event) => {
-    const option = (target as HTMLElement).closest(".option-new-poi");
-    const newWindow = window.open(option.getAttribute("data-url"), "_blank");
-    newWindow.onload = () => {
-        newWindow.document.getElementById("id_title").setAttribute("value", option.getAttribute("data-poi-title"));
-    };
-};
-
 const renderPoiData = (
     queryPlaceholder: string,
     id: string,
@@ -33,6 +25,11 @@ const renderPoiData = (
     (document.getElementById("poi-query-input") as HTMLInputElement).value = "";
 };
 
+const hidePoiFormWidget = () => {
+    const widget = document.getElementById("poi-form-widget") as HTMLElement;
+    widget.textContent = "";
+};
+
 const setPoi = ({ target }: Event) => {
     const option = (target as HTMLElement).closest(".option-existing-poi");
     renderPoiData(
@@ -46,6 +43,74 @@ const setPoi = ({ target }: Event) => {
     // Show the address container
     document.getElementById("poi-address-container")?.classList.remove("hidden");
     console.debug("Rendered POI data");
+};
+
+const showMessage = (response: any) => {
+    const timeoutDuration = 10000;
+    if (response.success) {
+        hidePoiFormWidget();
+        const successMessageField = document.getElementById("poi-ajax-success-message");
+        successMessageField.classList.remove("hidden");
+        setTimeout(() => {
+            successMessageField.classList.add("hidden");
+        }, timeoutDuration);
+    } else {
+        const errorMessageField = document.getElementById("poi-ajax-error-message");
+        errorMessageField.classList.remove("hidden");
+        setTimeout(() => {
+            errorMessageField.classList.add("hidden");
+        }, timeoutDuration);
+    }
+};
+
+const showPoiFormWidget = async ({ target }: Event) => {
+    const option = (target as HTMLElement).closest(".option-new-poi");
+    const response = await fetch(document.getElementById("show-poi-form-button").getAttribute("data-url"));
+
+    document.getElementById("poi-form-widget").innerHTML = await response.text();
+    document.querySelector("[data-poi-title]").setAttribute("value", option.getAttribute("data-poi-title"));
+    document.getElementById("show-poi-form-button").classList.add("hidden");
+
+    // Add listeners for save and draft-save buttons
+    document.querySelectorAll("[data-btn-save-poi-form]").forEach((el) => {
+        el.addEventListener("click", async (event) => {
+            event.preventDefault();
+            const btn = event.target as HTMLInputElement;
+            const form = btn.form as HTMLFormElement;
+            const formData: FormData = new FormData(form);
+            formData.append(btn.name, btn.value);
+            if (!form.reportValidity()) {
+                return;
+            }
+            const response = await fetch(btn.getAttribute("data-url"), {
+                method: "POST",
+                headers: {
+                    "X-CSRFToken": getCsrfToken(),
+                },
+                body: formData,
+            });
+            // Handle messages
+            const messages = await response.json();
+            console.debug(messages);
+            showMessage(messages);
+            // If POI was created successful, show it as selected option
+            if (messages.success) {
+                console.debug(messages);
+                renderPoiData(
+                    formData.get("title").toString(),
+                    messages.id,
+                    formData.get("address").toString(),
+                    formData.get("postcode").toString(),
+                    formData.get("city").toString(),
+                    formData.get("country").toString()
+                );
+                document.getElementById("poi-address-container")?.classList.remove("hidden");
+                // Add the POI to the actual django form field
+                (document.getElementById("id_location") as HTMLInputElement).value = messages.id.toString();
+            }
+            hidePoiFormWidget();
+        });
+    });
 };
 
 const queryPois = async (url: string, queryString: string, regionSlug: string, createPoiOption: boolean) => {
@@ -80,7 +145,7 @@ const queryPois = async (url: string, queryString: string, regionSlug: string, c
     document.querySelectorAll(".option-new-poi").forEach((node) => {
         node.addEventListener("click", (event) => {
             event.preventDefault();
-            newPoiWindow(event);
+            showPoiFormWidget(event);
         });
     });
 
@@ -106,6 +171,8 @@ const removePoi = () => {
     );
     // Hide the address container
     document.getElementById("poi-address-container")?.classList.add("hidden");
+    // Clear the poi form
+    hidePoiFormWidget();
     console.debug("Removed POI data");
 };
 
@@ -113,6 +180,7 @@ let scheduledFunction: number | null = null;
 const setPoiQueryEventListeners = () => {
     // AJAX search
     document.getElementById("poi-query-input").addEventListener("keyup", (event) => {
+        hidePoiFormWidget();
         event.preventDefault();
         const inputField = (event.target as HTMLElement).closest("input");
 

--- a/integreat_cms/static/src/js/pois/opening-hours/index.tsx
+++ b/integreat_cms/static/src/js/pois/opening-hours/index.tsx
@@ -73,7 +73,7 @@ const OpeningHoursWidget = ({ translations, days, initial, canChangeLocation }: 
 };
 export default OpeningHoursWidget;
 
-document.addEventListener("DOMContentLoaded", () => {
+export const addOpeningHoursListener = () => {
     document.querySelectorAll("opening-hours-widget").forEach((el) => {
         const openingHourConfigData = JSON.parse(document.getElementById("openingHourConfigData").textContent);
         const openingHourInitialData = JSON.parse(
@@ -88,7 +88,9 @@ document.addEventListener("DOMContentLoaded", () => {
             el
         );
     });
-});
+};
+
+document.addEventListener("DOMContentLoaded", addOpeningHoursListener);
 
 (window as any).IntegreatOpeningHoursWidget = OpeningHoursWidget;
 (window as any).preactRender = render;


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
With this PR a feature should be introduced, where POIs can be created from within the event form. ~However there are still a few important things to do~: 
- [x]  Proper form validation
- [x] Success/ error messages
- [x] ~The media library on the event form level breaks~
- [ ] ~The media library on the POI overlay form does not work~

#### Edit: 
We decided to reduce the scope of this PR significantly as the solution of a pop-up overlay does bring various design decisions that are questionable (in terms of system design as well as UX design). The solution now is a minimal POI form that is shown inside the event venue box.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add a POI form ~overlay~ widget to the ~event form~ event venue box
- Create and save POI form via AJAX
- ~Add new widgets for opening hours and maps to the AJAX POI form~

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- ~I think there might be clashes between namings from the input fields of the POI and the event form (due to Django's render_field). Therefore JavaScript Searches through the DOM might give unexpected results.~



### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1171


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
