### PR TITLE
Improve loading time of page tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ UNRELEASED
 
 * [ [#1756](https://github.com/digitalfabrik/integreat-cms/issues/1756) ] Add media library, content-edit-lock and diff-view to imprint sbs-view
 * [ [#1870](https://github.com/digitalfabrik/integreat-cms/issues/1870) ] Fix copy source content in imprint sbs-view
+* [ [#1950](https://github.com/digitalfabrik/integreat-cms/issues/1950) ] Fix long loading time of page tree
 
 
 2022.12.0

--- a/integreat_cms/cms/views/pages/partial_page_tree_view.py
+++ b/integreat_cms/cms/views/pages/partial_page_tree_view.py
@@ -41,8 +41,9 @@ class PartialPageTreeView(TemplateView, PageContextMixin):
         # Get the tree of the given id
         pages = (
             region.pages.filter(tree_id=tree_id)
-            .prefetch_major_public_translations()
-            .cache_tree(False)
+            .prefetch_major_translations()
+            .prefetch_related("mirroring_pages")
+            .cache_tree(archived=False)
         )
         # The first element must be the root node
         parent = pages[0]


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Improve loading time of page tree

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add `prefetch_major_translations` method to be able to prefetch all major versions of a queryset at once
- Prefetch major translations when building page tree



### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1950


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
