### PR TITLE
Make events, pois and pages uniform for observer users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 UNRELEASED
 ----------
 
+* [ [#1945](https://github.com/digitalfabrik/integreat-cms/issues/1945) ] Make message and button in list and form of page/event/poi uniform for observer users
+
 
 2022.12.2
 ---------

--- a/integreat_cms/cms/templates/events/event_list.html
+++ b/integreat_cms/cms/templates/events/event_list.html
@@ -31,10 +31,10 @@
                            class="btn">
                             {% translate "Create event" %}
                         </a>
-                    {% else %}
+                    {% elif perms.cms.change_event %}
                         {% blocktrans trimmed asvar disabled_button_title with request.region.default_language.translated_name as default_language %}
-                        You can only create events in the default language ({{ default_language }}).
-                    {% endblocktrans %}
+                            You can only create events in the default language ({{ default_language }}).
+                        {% endblocktrans %}
                         <button title="{{ disabled_button_title }}" class="btn" disabled>{% translate "Create event" %}</button>
                     {% endif %}
                 </div>

--- a/integreat_cms/cms/templates/pois/poi_form.html
+++ b/integreat_cms/cms/templates/pois/poi_form.html
@@ -467,7 +467,7 @@
         </div>
     </form>
     {{ media_config_data|json_script:"media_config_data" }}
-    {% if poi_form.instance.id and poi_form.instance.archived %}
+    {% if not perms.cms.change_poi or poi_form.instance.id and poi_form.instance.archived %}
         {% include "../_tinymce_config.html" with readonly=1 %}
     {% else %}
         {% include "../_tinymce_config.html" %}

--- a/integreat_cms/cms/templates/pois/poi_list.html
+++ b/integreat_cms/cms/templates/pois/poi_list.html
@@ -28,7 +28,7 @@
                    class="btn">
                     {% translate "Create location" %}
                 </a>
-            {% else %}
+            {% elif perms.cms.change_poi %}
                 {% blocktrans trimmed asvar disabled_button_title with request.region.default_language.translated_name as default_language %}
                     You can only create locations in the default language ({{ default_language }}).
                 {% endblocktrans %}

--- a/integreat_cms/cms/views/events/event_form_view.py
+++ b/integreat_cms/cms/views/events/event_form_view.py
@@ -82,16 +82,16 @@ class EventFormView(
             messages.warning(
                 request, _("You don't have the permission to edit events.")
             )
-        else:
+        elif not request.user.has_perm("cms.publish_event"):
             disabled = False
-
-        if not request.user.has_perm("cms.publish_event"):
             messages.warning(
                 request,
                 _(
                     "You don't have the permission to publish events, but you can propose changes and submit them for review instead."
                 ),
             )
+        else:
+            disabled = False
 
         event_form = EventForm(
             instance=event_instance,

--- a/integreat_cms/cms/views/pois/poi_form_view.py
+++ b/integreat_cms/cms/views/pois/poi_form_view.py
@@ -70,6 +70,11 @@ class POIFormView(
             messages.warning(
                 request, _("You cannot edit this location because it is archived.")
             )
+        elif not request.user.has_perm("cms.change_poi"):
+            disabled = True
+            messages.warning(
+                request, _("You don't have the permission to edit locations.")
+            )
         else:
             disabled = False
 

--- a/integreat_cms/cms/views/pois/poi_list_view.py
+++ b/integreat_cms/cms/views/pois/poi_list_view.py
@@ -92,6 +92,11 @@ class POIListView(TemplateView, POIContextMixin, SummAiContextMixin):
                 }
             )
 
+        if not request.user.has_perm("cms.change_poi"):
+            messages.warning(
+                request, _("You don't have the permission to edit or create locations.")
+            )
+
         pois = region.pois.filter(archived=self.archived)
         query = None
 

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -7582,6 +7582,10 @@ msgid "You cannot edit this location because it is archived."
 msgstr "Sie können diesen Ort nicht bearbeiten, da er archiviert ist."
 
 #: cms/views/pois/poi_form_view.py
+msgid "You don't have the permission to edit locations."
+msgstr "Sie haben nicht die nötige Berechtigung, um Orte zu bearbeiten."
+
+#: cms/views/pois/poi_form_view.py
 msgid "Location \"{}\" was successfully created"
 msgstr "Ort \"{}\" wurde erfolgreich erstellt"
 
@@ -7601,6 +7605,12 @@ msgstr "Bitte vergewissern Sie sich, dass die eingegebenen Werte korrekt sind."
 msgid "Please create at least one language node before creating locations."
 msgstr ""
 "Bitte erstellen Sie mindestens einen Sprach-Knoten, bevor Sie Orte verwalten."
+
+#: cms/views/pois/poi_list_view.py
+msgid "You don't have the permission to edit or create locations."
+msgstr ""
+"Sie haben nicht die nötige Berechtigung, um Orte zu bearbeiten oder zu "
+"erstellen."
 
 #: cms/views/push_notifications/push_notification_form_view.py
 #: cms/views/push_notifications/push_notification_list_view.py
@@ -8095,10 +8105,6 @@ msgstr ""
 
 #~ msgid "deleted"
 #~ msgstr "Löschen"
-
-#~ msgid "You don't have the permission to edit or create organizations."
-#~ msgstr ""
-#~ "Sie haben nicht die nötige Berechtigung, um Veranstaltungen zu bearbeiten."
 
 #~ msgid "You don't have the permission to edit an organization."
 #~ msgstr ""
@@ -9597,10 +9603,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Sie haben nicht die nötige Berechtigung, um POIs zu bearbeiten oder zu "
 #~ "erstellen."
-
-#~ msgid "You don't have the permission to edit this POI."
-#~ msgstr ""
-#~ "Sie haben nicht die nötige Berechtigung, um diesen POI zu bearbeiten."
 
 #~ msgid "POI Translation was successfully created and published."
 #~ msgstr "POI Übersetzung wurde erfolgreich erstellt und veröffentlicht."


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
There are some inconsistencies regarding the poi/event/page forms and list views for observer users.
This pr tries to fix that.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add no editing permission message to the location list view
- Disable the location form for users without editing permission
- Hide the create new poi/event buttons for users without the create object permission
- Don't show invalid warning in the event form for users without publishing and editing permissions


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
/


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1945 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
