### PR TITLE
Fix link escape in message in imprint form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ UNRELEASED
 * [ [#1957](https://github.com/digitalfabrik/integreat-cms/issues/1957) ] Add keyboard shortcuts for icons in the editor
 * [ [#1900](https://github.com/digitalfabrik/integreat-cms/issues/1900) ] Exclude users without view_page permission from page-specific permissions
 * [ [#1956](https://github.com/digitalfabrik/integreat-cms/issues/1956) ] Add Amharic fonts and fix PDF export in Amharic
+* [ [#1906](https://github.com/digitalfabrik/integreat-cms/issues/1906) ] Fix link escape in message in imprint form
 
 
 2022.12.2

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -6865,15 +6865,12 @@ msgstr ""
 "verwalten."
 
 #: cms/views/imprint/imprint_form_view.py
-#, python-format
-msgid ""
-"This is <b>not</b> the most recent public revision of this translation. "
-"Instead, <a href='%(revision_url)s' class='underline hover:no-"
-"underline'>revision %(revision)s</a> is shown in the apps."
-msgstr ""
-"Dies ist <b>nicht</b> die neueste öffentliche Revision dieser Übersetzung. "
-"Stattdessen wird die <a href='%(revision_url)s' class='underline hover:no-"
-"underline'>Revision %(revision)s</a> in den Apps angezeigt."
+msgid "This is not the most recent public revision of this translation."
+msgstr "Dies ist nicht die neueste öffentliche Revision dieser Übersetzung."
+
+#: cms/views/imprint/imprint_form_view.py
+msgid "Instead, <a>revision {}</a> is shown in the apps."
+msgstr "Stattdessen wird die <a>Revision {}</a> in den Apps angezeigt."
 
 #: cms/views/imprint/imprint_form_view.py cms/views/imprint/imprint_sbs_view.py
 msgid "You don't have the permission to edit the imprint."


### PR DESCRIPTION
### Short description
Link is displayed as HTML tags in imprint form:
https://user-images.githubusercontent.com/82345046/204389202-d3e95ff6-7d71-4c38-8a36-a386df4a2089.png
Also link itself is incorrect, when there is no public version for the translation (it routes to Revision 1, but this revision is in draft state)


### Proposed changes
- Use format_html function to display link as a link
- Don't show the message, when there is no public version of the translation in the requested language.
I added condition by 'public_translation.id' for that. When it is 'None', it means that fallback translation is used.


### Side effects
Didn't find any


### Resolved issues
Fixes: #1906


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
