### PR TITLE
Fix wrong parameter type in page order, fix #1983

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ UNRELEASED
 * [ [#1900](https://github.com/digitalfabrik/integreat-cms/issues/1900) ] Exclude users without view_page permission from page-specific permissions
 * [ [#1956](https://github.com/digitalfabrik/integreat-cms/issues/1956) ] Add Amharic fonts and fix PDF export in Amharic
 * [ [#1906](https://github.com/digitalfabrik/integreat-cms/issues/1906) ] Fix link escape in message in imprint form
+* [ [#1983](https://github.com/digitalfabrik/integreat-cms/issues/1983) ] Fix broken page form ordering box
 
 
 2022.12.2

--- a/integreat_cms/static/src/js/pages/page-order.ts
+++ b/integreat_cms/static/src/js/pages/page-order.ts
@@ -120,7 +120,12 @@ const registerEventHandlers = () => {
     });
 };
 
-const escapeMeta = (raw: string) => raw.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/"/g, "&quot;");
+const escapeMeta = (raw: any) => {
+    if (typeof raw !== "string") {
+        return "";
+    }
+    return raw.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/"/g, "&quot;");
+};
 
 // This function updates the page order table each time the parent select changes
 const getPageOrderTable = async ({ target }: Event) => {


### PR DESCRIPTION
### Short description
Fix #1983 where an unexpected parameter type was passed to the `escapeMeta` function.


### Proposed changes
Allow the escapeMeta function to handle any parameter type and always return a valid (String) result.

### Side effects
I thought about splitting the nested function calls in https://github.com/digitalfabrik/integreat-cms/pull/1984/files#diff-12d9bde41ce20ae100fac96355585b5bd8415aeb05cc981c8bbb3b9f1e30f8e6R146 and only pass it to escapeMeta if there is a element. However, this made `getPageOrderTable()` even longer and the result seems to be mostly the same - except for the "unclean" parameter type.

### Resolved issues
Fixes: #1983 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
