### PR TITLE
Limit log message filepath length

### DIFF
--- a/integreat_cms/cms/utils/pdf_utils.py
+++ b/integreat_cms/cms/utils/pdf_utils.py
@@ -169,7 +169,7 @@ def link_callback(uri, rel):
         # make sure that file exists
         if not os.path.isfile(path):
             logger.exception(
-                "The file %r was not found in the media directories.", path
+                "The file %r was not found in the media directories.", path[:1024]
             )
             return None
         return path
@@ -182,7 +182,7 @@ def link_callback(uri, rel):
     elif not uri.startswith("assets/"):
         logger.warning(
             "The file %r is not inside the static directories %r and %r.",
-            uri,
+            uri[:1024],
             settings.STATIC_URL,
             settings.MEDIA_URL,
         )
@@ -191,7 +191,7 @@ def link_callback(uri, rel):
     if not result:
         logger.exception(
             "The file %r was not found in the static directories %r.",
-            uri,
+            uri[:1024],
             finders.searched_locations,
         )
     return result


### PR DESCRIPTION
### Short description
We sometimes get multiple MB of base64 coded files in the log file. This is not helping. I guess we need a deeper fix, but the output should be limited anyways.


### Proposed changes
Just in case limit the path length to 1024 characters in log messages.

### Side effects
If the path is longer then it would be cut. Should not happen too often though.


### Resolved issues
None, this is it.

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
