### PR TITLE
Hide link edit icon for observers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ UNRELEASED
 * [ [#1876](https://github.com/digitalfabrik/integreat-cms/issues/1876) ] Make sidebar boxes on page form collapsible and save status as cookie
 * [ [#1345](https://github.com/digitalfabrik/integreat-cms/issues/1345) ] Track DeepL API usage by regions
 * [ [#1695](https://github.com/digitalfabrik/integreat-cms/issues/1695) ] Treat URLs with broken hash anchors as valid in link checker
+* [ [#1969](https://github.com/digitalfabrik/integreat-cms/issues/1969) ] Hide edit link button in content forms for users without edit permission
 
 
 2022.12.3

--- a/integreat_cms/cms/templates/events/event_form.html
+++ b/integreat_cms/cms/templates/events/event_form.html
@@ -89,15 +89,17 @@
                             <a id="slug-link"
                                href="{{ url_link }}{{ event_translation_form.instance.slug }}"
                                class="text-blue-500 hover:underline">{{ url_link }}{{ event_translation_form.instance.slug }}</a>
-                            <a id="edit-slug-btn"
-                               title="{% translate "Edit" %}"
-                               class="mx-2 btn-icon">
-                                <i icon-name="edit-3"></i>
-                            </a>
+                            {% if perms.cms.change_event %}
+                                <a id="edit-slug-btn"
+                                   title="{% translate "Edit" %}"
+                                   class="ml-2 btn-icon">
+                                    <i icon-name="edit-3"></i>
+                                </a>
+                            {% endif %}
                             <a id="copy-slug-btn"
                                data-copy-to-clipboard="{{ event_translation_form.instance.base_link }}{{ event_translation_form.instance.slug }}"
                                title="{% translate "Copy to clipboard" %}"
-                               class="btn-icon">
+                               class="ml-2 btn-icon">
                                 <i icon-name="copy"></i>
                                 <i icon-name="check" class="hidden text-green-500"></i>
                             </a>
@@ -105,10 +107,10 @@
                                 <label for="{{ event_translation_form.slug.id_for_label }}">{{ url_link }}</label>
                                 {% render_field event_translation_form.slug|add_error_class:"slug-error" %}
                             </div>
-                            <a id="save-slug-btn" class="mx-2 btn-icon hidden">
+                            <a id="save-slug-btn" class="ml-2 btn-icon hidden">
                                 <i icon-name="save"></i>
                             </a>
-                            <a id="restore-slug-btn" class="btn-icon hidden">
+                            <a id="restore-slug-btn" class="ml-2 btn-icon hidden">
                                 <i icon-name="x-circle"></i>
                             </a>
                         </div>

--- a/integreat_cms/cms/templates/pages/page_form.html
+++ b/integreat_cms/cms/templates/pages/page_form.html
@@ -119,7 +119,7 @@
                                     <a href="#"
                                        data-copy-to-clipboard="{{ page_translation_form.instance.short_url }}"
                                        title="{% translate "Copy to clipboard" %}"
-                                       class="mx-2 text-gray-800 hover:text-blue-500">
+                                       class="ml-2 text-gray-800 hover:text-blue-500">
                                         <i icon-name="copy"></i>
                                         <i icon-name="check" class="hidden text-green-500"></i>
                                     </a>
@@ -134,15 +134,17 @@
                             <a id="slug-link"
                                href="{{ page_translation_form.instance.base_link }}{{ page_translation_form.instance.slug }}"
                                class="text-blue-500 hover:underline">{{ page_translation_form.instance.base_link }}{{ page_translation_form.instance.slug }}</a>
-                            <a id="edit-slug-btn"
-                               title="{% translate "Edit" %}"
-                               class="mx-2 btn-icon">
-                                <i icon-name="edit-3"></i>
-                            </a>
+                            {% if can_publish_page or can_edit_page %}
+                                <a id="edit-slug-btn"
+                                   title="{% translate "Edit" %}"
+                                   class="ml-2 btn-icon">
+                                    <i icon-name="edit-3"></i>
+                                </a>
+                            {% endif %}
                             <a id="copy-slug-btn"
                                data-copy-to-clipboard="{{ page_translation_form.instance.base_link }}{{ page_translation_form.instance.slug }}"
                                title="{% translate "Copy to clipboard" %}"
-                               class="btn-icon">
+                               class="ml-2 btn-icon">
                                 <i icon-name="copy"></i>
                                 <i icon-name="check" class="hidden text-green-500"></i>
                             </a>
@@ -150,10 +152,10 @@
                                 <label for="{{ page_translation_form.slug.id_for_label }}">{{ page_translation_form.instance.base_link }}</label>
                                 {% render_field page_translation_form.slug|add_error_class:"slug-error" %}
                             </div>
-                            <a id="save-slug-btn" class="mx-2 btn-icon hidden">
+                            <a id="save-slug-btn" class="ml-2 btn-icon hidden">
                                 <i icon-name="save"></i>
                             </a>
-                            <a id="restore-slug-btn" class="btn-icon hidden">
+                            <a id="restore-slug-btn" class="ml-2 btn-icon hidden">
                                 <i icon-name="x-circle"></i>
                             </a>
                         </div>

--- a/integreat_cms/cms/templates/pois/poi_form.html
+++ b/integreat_cms/cms/templates/pois/poi_form.html
@@ -83,15 +83,17 @@
                                 <a id="slug-link"
                                    href="{{ url_link }}{{ poi_translation_form.instance.slug }}/"
                                    class="text-blue-500 hover:underline">{{ url_link }}{{ poi_translation_form.instance.slug }}</a>
-                                <a id="edit-slug-btn"
-                                   title="{% translate "Edit" %}"
-                                   class="mx-2 btn-icon">
-                                    <i icon-name="edit-3"></i>
-                                </a>
+                                {% if perms.cms.change_poi %}
+                                    <a id="edit-slug-btn"
+                                       title="{% translate "Edit" %}"
+                                       class="ml-2 btn-icon">
+                                        <i icon-name="edit-3"></i>
+                                    </a>
+                                {% endif %}
                                 <a id="copy-slug-btn"
                                    data-copy-to-clipboard="{{ poi_translation_form.instance.base_link }}{{ poi_translation_form.instance.slug }}"
                                    title="{% translate "Copy to clipboard" %}"
-                                   class="btn-icon">
+                                   class="ml-2 btn-icon">
                                     <i icon-name="copy"></i>
                                     <i icon-name="check" class="hidden text-green-500"></i>
                                 </a>
@@ -99,10 +101,10 @@
                                     <label for="{{ poi_translation_form.slug.id_for_label }}">{{ url_link }}</label>
                                     {% render_field poi_translation_form.slug|add_error_class:"slug-error" %}
                                 </div>
-                                <a id="save-slug-btn" class="mx-2 btn-icon hidden">
+                                <a id="save-slug-btn" class="ml-2 btn-icon hidden">
                                     <i icon-name="save"></i>
                                 </a>
-                                <a id="restore-slug-btn" class="btn-icon hidden">
+                                <a id="restore-slug-btn" class="ml-2 btn-icon hidden">
                                     <i icon-name="x-circle"></i>
                                 </a>
                             </div>


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR hides the link edit icon in page/event/location form for observer users, except for pages they are allowed to publish or edit (per page-specific permission, for example).

### Proposed changes
<!-- Describe this PR in more detail. -->
- Check the permission of the user and decide to show or hide the icon.
- Though only page form is mentioned in the issue description, the requested change is applied also in event and location form, since observer users have no permission to change anything there too.

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- I hope none.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1969 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
