### PR TITLE
Fix observer permissions in media library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 UNRELEASED
 ----------
 
+* [ [#1968](https://github.com/digitalfabrik/integreat-cms/issues/1968) ] Fix media library permissions for observer
+
 
 2023.1.0
 --------

--- a/integreat_cms/cms/constants/roles.py
+++ b/integreat_cms/cms/constants/roles.py
@@ -66,7 +66,6 @@ OBSERVER_PERMISSIONS = [
     "change_directory",
     "view_directory",
     "change_mediafile",
-    "replace_mediafile",
     "upload_mediafile",
     "view_mediafile",
     "view_page",

--- a/integreat_cms/cms/migrations/0056_update_observer_permissions.py
+++ b/integreat_cms/cms/migrations/0056_update_observer_permissions.py
@@ -1,0 +1,43 @@
+from django.db import migrations
+from ..constants import roles
+
+
+# pylint: disable=unused-argument
+def update_roles(apps, schema_editor):
+    """
+    Update the role definitions
+
+    :param apps: The configuration of installed applications
+    :type apps: ~django.apps.registry.Apps
+
+    :param schema_editor: The database abstraction layer that creates actual SQL code
+    :type schema_editor: ~django.db.backends.base.schema.BaseDatabaseSchemaEditor
+    """
+    # We can't import the Person model directly as it may be a newer
+    # version than this migration expects. We use the historical version.
+    Group = apps.get_model("auth", "Group")
+    Permission = apps.get_model("auth", "Permission")
+
+    # Assign the correct permissions
+    for role_name in dict(roles.CHOICES):
+        group, _ = Group.objects.get_or_create(name=role_name)
+        # Clear permissions
+        group.permissions.clear()
+        # Set permissions
+        group.permissions.add(
+            *Permission.objects.filter(codename__in=roles.PERMISSIONS[role_name])
+        )
+
+
+class Migration(migrations.Migration):
+    """
+    Migration file to update permissions of observer
+    """
+
+    dependencies = [
+        ("cms", "0055_track_region_deepl_api_usage"),
+    ]
+
+    operations = [
+        migrations.RunPython(update_roles, migrations.RunPython.noop),
+    ]

--- a/integreat_cms/cms/views/media/media_context_mixin.py
+++ b/integreat_cms/cms/views/media/media_context_mixin.py
@@ -92,6 +92,9 @@ class MediaContextMixin(ContextMixin):
             },
             "expertMode": self.request.user.expert_mode,
             "allowedMediaTypes": ", ".join(dict(allowed_media.UPLOAD_CHOICES)),
+            "canDeleteFile": self.request.user.has_perm("cms.delete_mediafile"),
+            "canReplaceFile": self.request.user.has_perm("cms.replace_mediafile"),
+            "canDeleteDirectory": self.request.user.has_perm("cms.delete_directory"),
         }
         kwargs = (
             {"region_slug": self.request.region.slug} if self.request.region else {}

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8019,6 +8019,14 @@ msgstr ""
 "Diese Seite konnte nicht importiert werden, da sie zu einer anderen Region "
 "gehört ({})."
 
+#~ msgid "You don't have the permission to replace media files."
+#~ msgstr ""
+#~ "Sie haben nicht die nötige Berechtigung, um Mediadateien zu ersetzen."
+
+#~ msgid "You don't have the permission to delete media files."
+#~ msgstr ""
+#~ "Sie haben nicht die nötige Berechtigung, um Mediadateien zu löschen."
+
 #~ msgid ""
 #~ "To further protect your account you can add additional authentication "
 #~ "methods (2-factor authentication). The system currently supports the "

--- a/integreat_cms/static/src/js/media-management/component/edit-directory-sidebar.tsx
+++ b/integreat_cms/static/src/js/media-management/component/edit-directory-sidebar.tsx
@@ -18,6 +18,7 @@ type Props = {
     globalEdit?: boolean;
     submitForm: (event: Event, successCallback?: (data: any) => void) => void;
     isLoading: boolean;
+    canDeleteDirectory: boolean;
 };
 const EditDirectorySidebar = ({
     directory,
@@ -26,6 +27,7 @@ const EditDirectorySidebar = ({
     globalEdit,
     submitForm,
     isLoading,
+    canDeleteDirectory,
 }: Props) => {
     // This state is a buffer for the currently changed directory
     const [changedDirectory, setChangedDirectory] = useState<Directory>(directory);
@@ -116,23 +118,25 @@ const EditDirectorySidebar = ({
                                         {mediaTranslations.btn_rename_directory}
                                     </button>
                                 )}
-                                <button
-                                    title={`${
-                                        directory.numberOfEntries === 0
-                                            ? mediaTranslations.btn_delete_directory
-                                            : mediaTranslations.btn_delete_empty_directory
-                                    }`}
-                                    className={cn("btn", {
-                                        "btn-red": !isLoading && directory.numberOfEntries === 0,
-                                    })}
-                                    data-confirmation-title={mediaTranslations.text_dir_delete_confirm}
-                                    data-confirmation-subject={directory.name}
-                                    disabled={isLoading || directory.numberOfEntries !== 0}
-                                    onClick={showConfirmationPopupAjax}
-                                    onaction-confirmed={() => document.getElementById("delete-directory").click()}>
-                                    <Trash2 class="mr-2 inline-block h-5" />
-                                    {mediaTranslations.btn_delete_directory}
-                                </button>
+                                {canDeleteDirectory && (
+                                    <button
+                                        title={`${
+                                            directory.numberOfEntries === 0
+                                                ? mediaTranslations.btn_delete_directory
+                                                : mediaTranslations.btn_delete_empty_directory
+                                        }`}
+                                        className={cn("btn", {
+                                            "btn-red": !isLoading && directory.numberOfEntries === 0,
+                                        })}
+                                        data-confirmation-title={mediaTranslations.text_dir_delete_confirm}
+                                        data-confirmation-subject={directory.name}
+                                        disabled={isLoading || directory.numberOfEntries !== 0}
+                                        onClick={showConfirmationPopupAjax}
+                                        onaction-confirmed={() => document.getElementById("delete-directory").click()}>
+                                        <Trash2 class="mr-2 inline-block h-5" />
+                                        {mediaTranslations.btn_delete_directory}
+                                    </button>
+                                )}
                             </div>
                         ) : (
                             <p class="italic">

--- a/integreat_cms/static/src/js/media-management/component/edit-sidebar.tsx
+++ b/integreat_cms/static/src/js/media-management/component/edit-sidebar.tsx
@@ -46,6 +46,8 @@ type Props = {
     selectMedia?: (file: File) => any;
     submitForm: (event: Event) => void;
     isLoading: boolean;
+    canDeleteFile: boolean;
+    canReplaceFile: boolean;
 };
 
 const EditSidebar = ({
@@ -60,6 +62,8 @@ const EditSidebar = ({
     onlyImage,
     submitForm,
     isLoading,
+    canDeleteFile,
+    canReplaceFile,
 }: Props) => {
     // The file index contains the index of the file which is currently opened in the sidebar
     const [fileIndex, setFileIndex] = fileIndexState;
@@ -240,7 +244,7 @@ const EditSidebar = ({
                                         {mediaTranslations.btn_save_file}
                                     </button>
                                 )}
-                                {!selectionMode && (
+                                {!selectionMode && canReplaceFile && (
                                     <label
                                         for="replace-file-input"
                                         title={mediaTranslations.btn_replace_file}
@@ -254,17 +258,19 @@ const EditSidebar = ({
                                         {mediaTranslations.btn_replace_file}
                                     </label>
                                 )}
-                                <button
-                                    title={mediaTranslations.btn_delete_file}
-                                    className={cn("btn", { "btn-red": !isLoading })}
-                                    data-confirmation-title={mediaTranslations.text_file_delete_confirm}
-                                    data-confirmation-subject={file.name}
-                                    disabled={isLoading}
-                                    onClick={showConfirmationPopupAjax}
-                                    onaction-confirmed={() => document.getElementById("delete-file").click()}>
-                                    <Trash2 class="inline-block" />
-                                    {mediaTranslations.btn_delete_file}
-                                </button>
+                                {canDeleteFile && (
+                                    <button
+                                        title={mediaTranslations.btn_delete_file}
+                                        className={cn("btn", { "btn-red": !isLoading })}
+                                        data-confirmation-title={mediaTranslations.text_file_delete_confirm}
+                                        data-confirmation-subject={file.name}
+                                        disabled={isLoading}
+                                        onClick={showConfirmationPopupAjax}
+                                        onaction-confirmed={() => document.getElementById("delete-file").click()}>
+                                        <Trash2 class="inline-block" />
+                                        {mediaTranslations.btn_delete_file}
+                                    </button>
+                                )}
                             </>
                         ) : (
                             <p class="italic">

--- a/integreat_cms/static/src/js/media-management/index.tsx
+++ b/integreat_cms/static/src/js/media-management/index.tsx
@@ -67,6 +67,9 @@ type Props = {
     allowedMediaTypes?: string;
     selectionMode?: boolean;
     selectMedia?: (file: File) => any;
+    canDeleteFile: boolean;
+    canReplaceFile: boolean;
+    canDeleteDirectory: boolean;
 };
 
 const MediaManagement = (props: Props) => {

--- a/integreat_cms/static/src/js/media-management/library.tsx
+++ b/integreat_cms/static/src/js/media-management/library.tsx
@@ -44,6 +44,9 @@ export type LibraryProps = {
         successCallback: (data: any) => void,
         errorCallback?: (data: any) => void
     ) => void;
+    canDeleteFile: boolean;
+    canReplaceFile: boolean;
+    canDeleteDirectory: boolean;
 };
 
 const Library = ({
@@ -64,6 +67,9 @@ const Library = ({
     onlyImage,
     showMessage,
     selectMedia,
+    canDeleteFile,
+    canReplaceFile,
+    canDeleteDirectory,
 }: LibraryProps) => {
     // The directory path contains the current directory and all its parents
     const [directoryPath, _setDirectoryPath] = directoryPathState;
@@ -318,6 +324,8 @@ const Library = ({
                             globalEdit={globalEdit}
                             expertMode={expertMode}
                             isLoading={isLoading}
+                            canDeleteFile={canDeleteFile}
+                            canReplaceFile={canReplaceFile}
                         />
                     </div>
                 ) : (
@@ -330,6 +338,7 @@ const Library = ({
                                 submitForm={submitForm}
                                 globalEdit={globalEdit}
                                 isLoading={isLoading}
+                                canDeleteDirectory={canDeleteDirectory}
                             />
                         </div>
                     )

--- a/integreat_cms/static/src/js/media-management/select-media.tsx
+++ b/integreat_cms/static/src/js/media-management/select-media.tsx
@@ -13,9 +13,21 @@ type Props = {
     selectMedia: (file: File) => any;
     apiEndpoints: MediaApiPaths;
     mediaTranslations: any;
+    canDeleteFile: boolean;
+    canReplaceFile: boolean;
+    canDeleteDirectory: boolean;
 };
 
-const SelectMedia = ({ cancel, onlyImage, selectMedia, apiEndpoints, mediaTranslations }: Props) => (
+const SelectMedia = ({
+    cancel,
+    onlyImage,
+    selectMedia,
+    apiEndpoints,
+    mediaTranslations,
+    canDeleteFile,
+    canReplaceFile,
+    canDeleteDirectory,
+}: Props) => (
     <div
         className="flex flex-col items-center justify-center w-full h-full fixed inset-0 z-50 m-auto"
         style="z-index: 2000;">
@@ -27,6 +39,9 @@ const SelectMedia = ({ cancel, onlyImage, selectMedia, apiEndpoints, mediaTransl
                     selectMedia={selectMedia}
                     apiEndpoints={apiEndpoints}
                     mediaTranslations={mediaTranslations}
+                    canDeleteFile={canDeleteFile}
+                    canReplaceFile={canReplaceFile}
+                    canDeleteDirectory={canDeleteDirectory}
                 />
             </div>
             <button


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adjusts the permission of observer role so observers can neither delete nor replace media files.

### Proposed changes
<!-- Describe this PR in more detail. -->
- remove the permission replace_mediafile from observer role (delete_media_file was not listed).
- save whether the user is allowed to replace/delete media files <s>in the attribute "value" in the template media_list(_admin)</s> as canReplaceFile and canDeleteFile in MediaContextMixin.
- hide the replace and delete buttons depend on <s>the "value" attribute</s> canReplaceFile and canDeleteFile.
- check permission before replacing/deleting the file and show an warning message if an observer user manages to send a delete/replace request.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- I hope none.
- There is probably a better way to check the permission to hide the buttons......


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1968


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
