### PR TITLE
Make slugfield scrollable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ UNRELEASED
 * [ [#1769](https://github.com/digitalfabrik/integreat-cms/issues/1769) ] Evenly distribute page, event and poi form sidebar boxes
 * [ [#1876](https://github.com/digitalfabrik/integreat-cms/issues/1876) ] Make items in the sidebar of poi and event form toggleable
 * [ [#2023](https://github.com/digitalfabrik/integreat-cms/issues/2023) ] Rephrase texts in text understandability-box
+* [ [#1552](https://github.com/digitalfabrik/integreat-cms/issues/1552) ] Make slugfield scrollable
 
 
 2023.1.1

--- a/integreat_cms/static/src/css/style.scss
+++ b/integreat_cms/static/src/css/style.scss
@@ -203,17 +203,20 @@ select,
 
 .slug-field {
     @apply flex px-3 py-2 whitespace-nowrap;
+    overflow: auto;
     &:focus-within {
         @apply bg-white border-blue-500 ring-1 ring-blue-500 outline-none;
     }
     > [type="text"] {
         @apply flex-grow p-0 border-none;
+        width: fit-content;
         &:focus {
             box-shadow: none;
         }
     }
     > label {
         @apply font-normal cursor-auto m-0;
+        opacity: 0.66;
     }
     &.hidden {
         display: none;


### PR DESCRIPTION
### Short description

Make slugfield usable, even if URI prefix is very long.

### Proposed changes
<!-- Describe this PR in more detail. -->

- make slugfield scrollable by setting `overflow: auto` on the container
- ensure `input` is never at 0 width
- reduce label opacity to $\frac{2}{3}$ for better distinction from input


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Other places using `.slug-field` will be affected. We estimate this to be fine.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1552 (Slug field layout broken when permalink is too long)


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
