### PR TITLE
Update SSH key used for deployment of the documentation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,7 +325,7 @@ jobs:
       - attach_workspace:
           at: .
       - add_ssh_keys:
-          fingerprints: 8f:d7:a2:cb:47:e2:cf:9b:78:44:86:6d:4e:44:11:54
+          fingerprints: aa:6c:35:24:8a:80:d8:6a:f3:d7:b1:b3:49:42:a2:b3
       - run:
           name: Add GitHub's Public SSH Key to known hosts
           command: echo 'github.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==' >> ~/.ssh/known_hosts


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
The SSH key of the Digitalfabrikmember GitHub user was changed due to the recent incident at CircleCI


### Proposed changes
<!-- Describe this PR in more detail. -->

-  Update fingerprint of SSH key used in documentation deployment job


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

I hope this fixes our docs deployment:

https://app.circleci.com/pipelines/github/digitalfabrik/integreat-cms/7014/workflows/9a241d5c-af1b-4328-afb2-4f700ee45420/jobs/68201
```
Cloning into '.gh-pages'...
Warning: Permanently added the RSA host key for IP address '140.82.113.3' to the list of known hosts.
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository
```


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
