### PR TITLE
Fix changelog and migrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ UNRELEASED
 ----------
 
 * [ [#1968](https://github.com/digitalfabrik/integreat-cms/issues/1968) ] Fix media library permissions for observer
+* [ [#1883](https://github.com/digitalfabrik/integreat-cms/issues/1883) ] Introduce new status for automatic translations
 
 
 2023.1.1
@@ -64,7 +65,6 @@ UNRELEASED
 * [ [#1885](https://github.com/digitalfabrik/integreat-cms/issues/1885) ] Fix ongoing translation cancel button
 * [ [#1942](https://github.com/digitalfabrik/integreat-cms/issues/1942) ] Fix auto save functionality
 * [ [#1922](https://github.com/digitalfabrik/integreat-cms/issues/1922) ] Fix html escape in xliff import error message
-* [ [#1883](https://github.com/digitalfabrik/integreat-cms/issues/1883) ] Introduce new status for automatic translations
 
 
 2022.11.4

--- a/integreat_cms/cms/migrations/0055_track_region_deepl_api_usage.py
+++ b/integreat_cms/cms/migrations/0055_track_region_deepl_api_usage.py
@@ -9,7 +9,7 @@ class Migration(migrations.Migration):
     """
 
     dependencies = [
-        ("cms", "0055_add_machine_translated_flag"),
+        ("cms", "0054_user_totp_key"),
     ]
 
     operations = [

--- a/integreat_cms/cms/migrations/0056_update_observer_permissions.py
+++ b/integreat_cms/cms/migrations/0056_update_observer_permissions.py
@@ -35,7 +35,7 @@ class Migration(migrations.Migration):
     """
 
     dependencies = [
-        ("cms", "0056_track_region_deepl_api_usage"),
+        ("cms", "0055_track_region_deepl_api_usage"),
     ]
 
     operations = [

--- a/integreat_cms/cms/migrations/0057_add_machine_translated_flag.py
+++ b/integreat_cms/cms/migrations/0057_add_machine_translated_flag.py
@@ -9,7 +9,7 @@ class Migration(migrations.Migration):
     """
 
     dependencies = [
-        ("cms", "0054_user_totp_key"),
+        ("cms", "0056_update_observer_permissions"),
     ]
 
     operations = [


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Two problems occurred during conflict resolution of #1941:
- The changelog entry was inserted at the wrong position
- The previous migrations were renamed and re-ordered, which does not work on production systems which already have them applied. Migrations depend on each other in a specific order to produce a deterministic state.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Move changelog entry
- Reorder migrations to their previous position


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
