### PR TITLE
Show chapter for internal link suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ UNRELEASED
 * [ [#2008](https://github.com/digitalfabrik/integreat-cms/issues/2008) ] Fix end date of recurring events in API
 * [ [#1954](https://github.com/digitalfabrik/integreat-cms/issues/1954) ] Fix RTL text direction in PDF export
 * [ [#1883](https://github.com/digitalfabrik/integreat-cms/issues/1883) ] Add icon and color to POI Category
+* [ [#1752](https://github.com/digitalfabrik/integreat-cms/issues/1752) ] Show chapter for internal link suggestions
 
 
 2023.1.1

--- a/integreat_cms/cms/models/abstract_content_translation.py
+++ b/integreat_cms/cms/models/abstract_content_translation.py
@@ -479,6 +479,16 @@ class AbstractContentTranslation(AbstractBaseModel):
             .distinct(cls.foreign_field())
         )
 
+    def path(self):
+        """
+        This method returns a human-readable path that should uniquely identify this object within a given region
+        If this content object does not have a hierarchy, just `str(obj)` should suffice
+
+        :return: The path
+        :rtype: str
+        """
+        return str(self)
+
     def __str__(self):
         """
         This overwrites the default Django :meth:`~django.db.models.Model.__str__` method.

--- a/integreat_cms/cms/models/pages/page.py
+++ b/integreat_cms/cms/models/pages/page.py
@@ -1,11 +1,8 @@
 import logging
 
-from html import escape
-
 from django.conf import settings
 from django.db import models
 from django.utils.functional import cached_property
-from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 
 from cacheops import invalidate_model
@@ -360,18 +357,7 @@ class Page(AbstractTreeNode, AbstractBasePage):
         :return: A readable string representation of the page
         :rtype: str
         """
-        label = " &rarr; ".join(
-            [
-                # escape page title because string is marked as safe afterwards
-                escape(ancestor.best_translation.title)
-                for ancestor in self.get_cached_ancestors(include_self=True)
-            ]
-        )
-        # Add warning if page is archived
-        if self.archived:
-            label += " (&#9888; " + _("Archived") + ")"
-        # mark as safe so that the arrow and the warning triangle are not escaped
-        return mark_safe(label)
+        return self.best_translation.path()
 
     def get_repr(self):
         """

--- a/integreat_cms/cms/views/utils/search_content_ajax.py
+++ b/integreat_cms/cms/views/utils/search_content_ajax.py
@@ -31,11 +31,12 @@ def format_object_translation(object_translation, typ):
     :type object_translation: ~integreat_cms.cms.models.events.event.Event or ~integreat_cms.cms.models.pages.page.Page or ~integreat_cms.cms.models.pois.poi.POI
     :param typ: The type of this object
     :type typ: str
-    :return: A dictionary with the title, url and type of the translation object
+    :return: A dictionary with the title, path, url and type of the translation object
     :rtype: dict
     """
     return {
         "title": object_translation.title,
+        "path": object_translation.path(),
         "url": f"{settings.WEBAPP_URL}{object_translation.get_absolute_url()}",
         "type": typ,
     }

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -1501,7 +1501,7 @@ msgstr "Aktiv"
 msgid "Hidden"
 msgstr "Versteckt"
 
-#: cms/constants/region_status.py cms/models/pages/page.py
+#: cms/constants/region_status.py cms/models/pages/page_translation.py
 #: cms/models/regions/region.py cms/templates/events/event_form.html
 #: cms/templates/pages/page_form.html
 #: cms/templates/pages/page_tree_archived_node.html

--- a/integreat_cms/static/src/js/tinymce-plugins/custom_link_input/plugin.js
+++ b/integreat_cms/static/src/js/tinymce-plugins/custom_link_input/plugin.js
@@ -78,6 +78,7 @@ import { getCsrfToken } from "../../utils/csrf-token";
             let ajaxRequestId = 0;
             const defaultCompletionItem = {
                 text: tinymceConfig.getAttribute("data-link-no-results-text"),
+                title: "",
                 value: "",
             };
             const completionItems = [defaultCompletionItem];
@@ -96,7 +97,7 @@ import { getCsrfToken } from "../../utils/csrf-token";
                         );
                         // Don't set the completion text to `- no results -`
                         if (currentCompletion.value !== "") {
-                            currentCompletionText = currentCompletion.text;
+                            currentCompletionText = currentCompletion.title;
                         } else {
                             currentCompletionText = "";
                         }
@@ -156,7 +157,8 @@ import { getCsrfToken } from "../../utils/csrf-token";
                         completionItems.length = 0;
                         for (const completion of newCompletions) {
                             completionItems.push({
-                                text: completion.title,
+                                text: completion.path,
+                                title: completion.title,
                                 value: completion.url,
                             });
                         }


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr changes the internal link suggestions to show the full path to an object translation instead of just its title.
As a sideeffect, the title will be shown in the backend language instead of the object translation's language.
I did not change the general search input feature, because there it is not ambiguous which object is which after performing the search.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add  a `path` to the JSON objects returned by `search_content_ajax`
- Display the path instead of the title in the internal link suggestions


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
/

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1752


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
