### PR TITLE
Make Matomo filters compatible to WP URLs

### DIFF
--- a/integreat_cms/api/v3/pages.py
+++ b/integreat_cms/api/v3/pages.py
@@ -178,7 +178,6 @@ def get_single_page(request, language_slug):
     return page
 
 
-@matomo_tracking
 @json_response
 # pylint: disable=unused-argument
 def single_page(request, region_slug, language_slug):

--- a/integreat_cms/matomo_api/matomo_api_client.py
+++ b/integreat_cms/matomo_api/matomo_api_client.py
@@ -261,7 +261,7 @@ class MatomoApiClient:
                     self.fetch(
                         session,
                         **query_params,
-                        segment="pageUrl=@/wp-json/extensions/v3/pages/",
+                        segment="pageUrl=@/wp-json/extensions/v3/pages",
                     ),
                 )
             )
@@ -271,7 +271,7 @@ class MatomoApiClient:
                     self.fetch(
                         session,
                         **query_params,
-                        segment="pageUrl=@/wp-json/extensions/v3/children/",
+                        segment="pageUrl=@/wp-json/extensions/v3/children",
                     ),
                 )
             )


### PR DESCRIPTION
### Short description
Make our statistics filters compatible to the old WP URL pattern (w/o slashes behind endpoints). This should not interfere with the Django pattern.


### Proposed changes
- Filter URLs without the ending slash.
- Disable tracking for the single page endpoint. This should have no consequences at all as the end point is not being used (and I did not find any relevant results for it in the Matomo database).

### Side effects
- None.


### Resolved issues
Fixes: None


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
