### PR TITLE
Distribute sidebar boxes evenly also for pois and events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ UNRELEASED
 * [ [#1968](https://github.com/digitalfabrik/integreat-cms/issues/1968) ] Fix media library permissions for observer
 * [ [#1883](https://github.com/digitalfabrik/integreat-cms/issues/1883) ] Introduce new status for automatic translations
 * [ [#1993](https://github.com/digitalfabrik/integreat-cms/issues/1993) ] Skip duplicate page translations in XLIFF file
-* [ [#1769](https://github.com/digitalfabrik/integreat-cms/issues/1769) ] Evenly distribute page form sidebar boxes
+* [ [#1769](https://github.com/digitalfabrik/integreat-cms/issues/1769) ] Evenly distribute page, event and poi form sidebar boxes
 * [ [#1876](https://github.com/digitalfabrik/integreat-cms/issues/1876) ] Make items in the sidebar of poi and event form toggleable
 
 

--- a/integreat_cms/cms/templates/events/event_form.html
+++ b/integreat_cms/cms/templates/events/event_form.html
@@ -119,13 +119,15 @@
                     </div>
                 </div>
             </div>
-            <div class="3xl:col-end-3 4xl:col-end-auto flex flex-wrap flex-col gap-2">
+            <div id="left-sidebar-column"
+                 class="3xl:col-end-3 4xl:col-end-auto flex flex-wrap flex-col gap-2">
                 {% if event_form.instance.id and perms.cms.change_event %}
                     {% include "./event_form_sidebar/minor_edit_box.html" with box_id="event-minor-edit" %}
                 {% endif %}
                 {% include "./event_form_sidebar/date_and_time_box.html" with box_id="event-date-time" %}
             </div>
-            <div class="3xl:col-end-3 4xl:col-end-auto flex flex-wrap flex-col gap-2">
+            <div id="right-sidebar-column"
+                 class="3xl:col-end-3 4xl:col-end-auto flex flex-wrap flex-col gap-2">
                 {% include "./event_form_sidebar/venue_box.html" with box_id="event-venue" %}
                 {% include "./event_form_sidebar/icon_box.html" with box_id="event-icon" %}
                 {% if event_form.instance.id and perms.cms.change_event %}

--- a/integreat_cms/cms/templates/pois/poi_form.html
+++ b/integreat_cms/cms/templates/pois/poi_form.html
@@ -136,13 +136,14 @@
                     {% endif %}
                 </div>
             </div>
-            <div class="flex flex-col flex-auto gap-2">
+            <div id="left-sidebar-column" class="flex flex-col flex-auto gap-2">
                 {% if poi_form.instance.id and perms.cms.change_poi %}
                     {% include "./poi_form_sidebar/minor_edit_box.html" with box_id="poi-minor-edit" %}
                 {% endif %}
                 {% include "./poi_form_sidebar/position_box.html" with box_id="poi-position" %}
             </div>
-            <div class="3xl:col-end-3 4xl:col-end-auto flex flex-wrap flex-col gap-2">
+            <div id="right-sidebar-column"
+                 class="3xl:col-end-3 4xl:col-end-auto flex flex-wrap flex-col gap-2">
                 {% include "./poi_form_sidebar/contact_box.html" with box_id="poi-contact" %}
                 {% include "./poi_form_sidebar/opening_hours_box.html" with box_id="poi-opening-hours" no_padding=True %}
                 {% include "./poi_form_sidebar/category_box.html" with box_id="poi-category" %}


### PR DESCRIPTION
### Short description
This PR extends the function to evenly distribute the sidebar boxes for POIs and events


### Proposed changes
<!-- Describe this PR in more detail. -->

- Add the required ids (left-sidebar-column and right-sidebar-column), so that the boxes are evenly distributed between the sidebars 


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
I think none


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: Rest of  #1769


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
