### PR TITLE
Disable linkcheck listeners during tests

### DIFF
--- a/dev-tools/test.sh
+++ b/dev-tools/test.sh
@@ -16,6 +16,9 @@ require_database
 # Set dummy key to enable SUMM.AI during testing
 export INTEGREAT_CMS_SUMM_AI_API_KEY="dummy"
 
+# Disable linkcheck listeners during testing
+export INTEGREAT_CMS_LINKCHECK_DISABLE_LISTENERS=1
+
 # Parse given command line arguments
 while [[ $# -gt 0 ]]; do
     case $1 in

--- a/integreat_cms/core/circleci_settings.py
+++ b/integreat_cms/core/circleci_settings.py
@@ -21,6 +21,8 @@ SUMM_AI_API_KEY = "dummy"
 SUMM_AI_ENABLED = True
 #: Use debug logging on CircleCI
 LOG_LEVEL = "DEBUG"
+#: Disable linkcheck listeners on CircleCI
+LINKCHECK_DISABLE_LISTENERS = True
 
 # Use simple non-colored logging in circleci
 for logger in LOGGING["loggers"].values():


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
The linkcheck listeners do not have access to the database, which leads to very verbose errors during testing.
And since #1977, these errors get now logged to the console.
Since I don't know how to enable access for these asynchronous tasks (I mean there is no place I could add the `@django_db` etc), I thought it might be easier to just disable the listeners during testing.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Disable linkcheck listeners during local tests
- Disable linkcheck listeners on CircleCI


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- If we would have proper tests of the linkchecker, this would probably break our tests. But since we don't, it apparently makes no difference to disable the listeners...


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->
This fixes a lot of verbose error messages during tests:
```
RuntimeError: Database access not allowed, use the "django_db" mark, or the "db" or "transactional_db" fixtures to enable it.
RuntimeError while running do_check_instance_links with args=(<class 'integreat_cms.cms.models.pages.page_translation.PageTranslation'>, <PageTranslation (id: 233, page_id: 47, language: ar, slug: الترجمة-الشفهية-والتحريرية)>, True) and kwargs={}: Database access not allowed, use the "django_db" mark, or the "db" or "transactional_db" fixtures to enable it.
```

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
