### PR TITLE
Combine recurring events and add rrule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ UNRELEASED
 * [ [#1989](https://github.com/digitalfabrik/integreat-cms/issues/1989) ] Improve load time of locations endpoint
 * [ [#1578](https://github.com/digitalfabrik/integreat-cms/issues/1578) ] Add option to hide files in global media library
 * [ [#1752](https://github.com/digitalfabrik/integreat-cms/issues/1752) ] Show chapter for internal link suggestions
+* [ [#1965](https://github.com/digitalfabrik/integreat-cms/issues/1965) ] Add ical rrule for recurring events
 
 
 2023.2.0

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -67,6 +67,7 @@ extensions = [
 #: Enable cross-references to other documentations
 intersphinx_mapping = {
     "aiohttp": ("https://docs.aiohttp.org/en/stable/", None),
+    "dateutil": ("https://dateutil.readthedocs.io/en/stable/", None),
     "geopy": ("https://geopy.readthedocs.io/en/stable/", None),
     "lxml": ("https://lxml.de/apidoc/", None),
     "python": (

--- a/tests/api/api_config.py
+++ b/tests/api/api_config.py
@@ -107,6 +107,12 @@ API_ENDPOINTS = [
         200,
     ),
     (
+        "/api/augsburg/de/events/?combine_recurring=True",
+        None,
+        "tests/api/expected-outputs/augsburg_de_events_combine_recurring.json",
+        200,
+    ),
+    (
         "/api/augsburg/en/events/",
         "/augsburg/en/wp-json/extensions/v3/events/",
         "tests/api/expected-outputs/augsburg_en_events.json",

--- a/tests/api/expected-outputs/augsburg_ar_events.json
+++ b/tests/api/expected-outputs/augsburg_ar_events.json
@@ -50,7 +50,8 @@
       "recurrence_id": 1,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
   },
   {
     "id": null,
@@ -103,7 +104,8 @@
       "recurrence_id": 1,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
   },
   {
     "id": null,
@@ -156,7 +158,8 @@
       "recurrence_id": 1,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
   },
   {
     "id": null,
@@ -209,7 +212,8 @@
       "recurrence_id": 1,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
   },
   {
     "id": null,
@@ -262,7 +266,8 @@
       "recurrence_id": 1,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
   },
   {
     "id": null,
@@ -315,6 +320,7 @@
       "recurrence_id": 1,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
   }
 ]

--- a/tests/api/expected-outputs/augsburg_de_events.json
+++ b/tests/api/expected-outputs/augsburg_de_events.json
@@ -50,7 +50,8 @@
       "recurrence_id": 1,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
   },
   {
     "id": null,
@@ -103,7 +104,8 @@
       "recurrence_id": 1,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
   },
   {
     "id": null,
@@ -156,7 +158,8 @@
       "recurrence_id": 1,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
   },
   {
     "id": null,
@@ -209,7 +212,8 @@
       "recurrence_id": 1,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
   },
   {
     "id": null,
@@ -262,7 +266,8 @@
       "recurrence_id": 1,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
   },
   {
     "id": null,
@@ -315,6 +320,7 @@
       "recurrence_id": 1,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
   }
 ]

--- a/tests/api/expected-outputs/augsburg_de_events_combine_recurring.json
+++ b/tests/api/expected-outputs/augsburg_de_events_combine_recurring.json
@@ -1,0 +1,56 @@
+[
+  {
+    "id": 2,
+    "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung/",
+    "path": "/augsburg/de/events/test-veranstaltung/",
+    "title": "Test-Veranstaltung",
+    "modified_gmt": "2020-01-22T12:46:33.967Z",
+    "last_updated": "2020-01-22T13:46:33.967+01:00",
+    "excerpt": "Dies ist die Beschreibung einer Test-Veranstaltung.",
+    "content": "<p>Dies ist die Beschreibung einer Test-Veranstaltung.</p>",
+    "available_languages": {
+      "en": {
+        "id": 3,
+        "url": "http://localhost:8000/augsburg/en/events/test-event/",
+        "path": "/augsburg/en/events/test-event/"
+      },
+      "ar": {
+        "id": null,
+        "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung/",
+        "path": "/augsburg/ar/events/test-veranstaltung/"
+      },
+      "fa": {
+        "id": null,
+        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung/",
+        "path": "/augsburg/fa/events/test-veranstaltung/"
+      }
+    },
+    "thumbnail": null,
+    "location": {
+      "id": null,
+      "name": null,
+      "address": null,
+      "town": null,
+      "state": null,
+      "postcode": null,
+      "region": null,
+      "country": null,
+      "latitude": null,
+      "longitude": null
+    },
+    "event": {
+      "id": 1,
+      "start": "2030-01-01T13:00:00+01:00",
+      "start_date": "2030-01-01",
+      "start_time": "13:00:00",
+      "end": "2030-01-01T15:00:00+01:00",
+      "end_date": "2030-01-01",
+      "end_time": "15:00:00",
+      "all_day": false,
+      "recurrence_id": 1,
+      "timezone": "Europe/Berlin"
+    },
+    "hash": null,
+    "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
+  }
+]

--- a/tests/api/expected-outputs/augsburg_en_events.json
+++ b/tests/api/expected-outputs/augsburg_en_events.json
@@ -50,7 +50,8 @@
       "recurrence_id": 1,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
   },
   {
     "id": null,
@@ -103,7 +104,8 @@
       "recurrence_id": 1,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
   },
   {
     "id": null,
@@ -156,7 +158,8 @@
       "recurrence_id": 1,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
   },
   {
     "id": null,
@@ -209,7 +212,8 @@
       "recurrence_id": 1,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
   },
   {
     "id": null,
@@ -262,7 +266,8 @@
       "recurrence_id": 1,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
   },
   {
     "id": null,
@@ -315,6 +320,7 @@
       "recurrence_id": 1,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
   }
 ]

--- a/tests/api/expected-outputs/nurnberg_de_events.json
+++ b/tests/api/expected-outputs/nurnberg_de_events.json
@@ -40,7 +40,8 @@
       "recurrence_id": 2,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20310101T140000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20320101T235959;BYDAY=WE,FR"
   },
   {
     "id": null,
@@ -83,7 +84,8 @@
       "recurrence_id": 2,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20310101T140000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20320101T235959;BYDAY=WE,FR"
   },
   {
     "id": null,
@@ -126,7 +128,8 @@
       "recurrence_id": 2,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20310101T140000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20320101T235959;BYDAY=WE,FR"
   },
   {
     "id": null,
@@ -169,7 +172,8 @@
       "recurrence_id": 2,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20310101T140000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20320101T235959;BYDAY=WE,FR"
   },
   {
     "id": null,
@@ -212,7 +216,8 @@
       "recurrence_id": 2,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20310101T140000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20320101T235959;BYDAY=WE,FR"
   },
   {
     "id": null,
@@ -255,6 +260,7 @@
       "recurrence_id": 2,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20310101T140000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20320101T235959;BYDAY=WE,FR"
   }
 ]

--- a/tests/api/expected-outputs/nurnberg_en_events.json
+++ b/tests/api/expected-outputs/nurnberg_en_events.json
@@ -40,7 +40,8 @@
       "recurrence_id": 2,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20310101T140000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20320101T235959;BYDAY=WE,FR"
   },
   {
     "id": null,
@@ -83,7 +84,8 @@
       "recurrence_id": 2,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20310101T140000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20320101T235959;BYDAY=WE,FR"
   },
   {
     "id": null,
@@ -126,7 +128,8 @@
       "recurrence_id": 2,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20310101T140000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20320101T235959;BYDAY=WE,FR"
   },
   {
     "id": null,
@@ -169,7 +172,8 @@
       "recurrence_id": 2,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20310101T140000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20320101T235959;BYDAY=WE,FR"
   },
   {
     "id": null,
@@ -212,7 +216,8 @@
       "recurrence_id": 2,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20310101T140000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20320101T235959;BYDAY=WE,FR"
   },
   {
     "id": null,
@@ -255,6 +260,7 @@
       "recurrence_id": 2,
       "timezone": "Europe/Berlin"
     },
-    "hash": null
+    "hash": null,
+    "recurrence_rule": "DTSTART:20310101T140000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20320101T235959;BYDAY=WE,FR"
   }
 ]

--- a/tests/api/test_api_result.py
+++ b/tests/api/test_api_result.py
@@ -38,10 +38,12 @@ def test_api_result(
     response = client.get(endpoint, format="json")
     print(response.headers)
     assert response.status_code == expected_code
-    response_wp = client.get(wp_endpoint, format="json")
-    print(response_wp.headers)
-    assert response_wp.status_code == expected_code
+    if wp_endpoint:
+        response_wp = client.get(wp_endpoint, format="json")
+        print(response_wp.headers)
+        assert response_wp.status_code == expected_code
     with open(expected_result, encoding="utf-8") as f:
         result = json.load(f)
         assert result == response.json()
-        assert result == response_wp.json()
+        if wp_endpoint:
+            assert result == response_wp.json()

--- a/tests/cms/models/events/test_recurrence_rule.py
+++ b/tests/cms/models/events/test_recurrence_rule.py
@@ -1,0 +1,107 @@
+"""
+Test module for RecurrenceRule class
+"""
+import datetime
+import pytz
+
+from integreat_cms.cms.models import RecurrenceRule, Event
+
+
+# pylint: disable=missing-docstring
+
+
+class TestCreatingIcalRule:
+    """
+    Test whether to_ical_rrule_string function is calculating the rrule correctly
+    """
+
+    test_event = Event(
+        start=datetime.datetime(2030, 1, 1, 11, 30, 0, 0, pytz.UTC),
+        end=datetime.datetime(2030, 1, 1, 12, 30, 0, 0, pytz.UTC),
+    )
+
+    def test_api_rrule_every_year_start_date_in_the_past(self):
+        recurrence_rule = RecurrenceRule(
+            frequency="YEARLY",
+            interval=1,
+            weekdays_for_weekly=None,
+            weekday_for_monthly=None,
+            week_for_monthly=None,
+            recurrence_end_date=None,
+        )
+        test_event = Event(
+            start=datetime.datetime(2020, 1, 1, 11, 30, 0, 0, pytz.UTC),
+            end=datetime.datetime(2030, 1, 1, 12, 30, 0, 0, pytz.UTC),
+        )
+        test_event.recurrence_rule = recurrence_rule
+        ical_rrule = recurrence_rule.to_ical_rrule_string()
+        assert ical_rrule == "DTSTART:20200101T113000\nRRULE:FREQ=YEARLY"
+
+    def check_rrule(self, recurrence_rule, expected):
+        self.test_event.recurrence_rule = recurrence_rule
+        ical_rrule = recurrence_rule.to_ical_rrule_string()
+        assert ical_rrule == expected
+
+    def test_api_rrule_every_three_days(self):
+        recurrence_rule = RecurrenceRule(
+            frequency="DAILY",
+            interval=3,
+            weekdays_for_weekly=None,
+            weekday_for_monthly=None,
+            week_for_monthly=None,
+            recurrence_end_date=None,
+        )
+        self.check_rrule(
+            recurrence_rule, "DTSTART:20300101T113000\nRRULE:FREQ=DAILY;INTERVAL=3"
+        )
+
+    def test_api_rrule_weekly(self):
+        recurrence_rule = RecurrenceRule(
+            frequency="WEEKLY",
+            interval=1,
+            weekdays_for_weekly=[0, 1],
+            weekday_for_monthly=None,
+            week_for_monthly=None,
+            recurrence_end_date=None,
+        )
+        self.check_rrule(
+            recurrence_rule, "DTSTART:20300101T113000\nRRULE:FREQ=WEEKLY;BYDAY=MO,TU"
+        )
+
+    def test_api_rrule_monthly(self):
+        recurrence_rule = RecurrenceRule(
+            frequency="MONTHLY",
+            interval=1,
+            weekdays_for_weekly=None,
+            weekday_for_monthly=4,
+            week_for_monthly=1,
+            recurrence_end_date=None,
+        )
+        self.check_rrule(
+            recurrence_rule, "DTSTART:20300101T113000\nRRULE:FREQ=MONTHLY;BYDAY=+1FR"
+        )
+
+    def test_api_rrule_bimonthly_until(self):
+        recurrence_rule = RecurrenceRule(
+            frequency="MONTHLY",
+            interval=2,
+            weekdays_for_weekly=None,
+            weekday_for_monthly=6,
+            week_for_monthly=1,
+            recurrence_end_date=datetime.date(2030, 10, 19),
+        )
+        self.check_rrule(
+            recurrence_rule,
+            "DTSTART:20300101T113000\nRRULE:FREQ=MONTHLY;INTERVAL=2;UNTIL=20301019T235959;BYDAY=+1SU",
+        )
+
+    def test_api_rrule_yearly(self):
+        recurrence_rule = RecurrenceRule(
+            frequency="YEARLY",
+            interval=1,
+            weekdays_for_weekly=None,
+            weekday_for_monthly=None,
+            week_for_monthly=None,
+            recurrence_end_date=None,
+        )
+        self.check_rrule(recurrence_rule, "DTSTART:20300101T113000\nRRULE:FREQ=YEARLY")


### PR DESCRIPTION
### Short description
For the new endpoint /events/?combine_recurring=True only one event object is returned. This object contains an rrule, which defines how the element is repeated.


### Proposed changes
Added this new endpoint, we need to keep the old one for backwards compatibility.
If we want to remove the old endpoint in the future (we should wait at least 6 months), i can open a ticket, i think this would be nice to remove the legacy code.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1965 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
