### PR TITLE
Remove gap between sidebar boxes (for POIs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ UNRELEASED
 ----------
 
 * [ [#2056](https://github.com/digitalfabrik/integreat-cms/issues/2056) ] Change restriction of event duration to 28 days
+* [ [#2032](https://github.com/digitalfabrik/integreat-cms/issues/2032) ] Remove gap between sidebar boxes in location form
 
 
 2023.2.0

--- a/integreat_cms/cms/templates/_collapsible_box.html
+++ b/integreat_cms/cms/templates/_collapsible_box.html
@@ -1,5 +1,5 @@
 {# Set collapsed=True when including this template to show the box collapsed in the beginning #}
-<div class="rounded shadow-2xl border border-blue-500 bg-white mb-3">
+<div class="rounded shadow-2xl border border-blue-500 bg-white mb-4">
     <div {% if box_id %}id="{{ box_id }}"{% endif %}
          class="collapsible cursor-pointer rounded p-4 bg-water-500 text-black font-bold flex justify-between"
          {% if collapsed %}data-collapsed{% endif %}>

--- a/integreat_cms/cms/templates/pois/poi_form.html
+++ b/integreat_cms/cms/templates/pois/poi_form.html
@@ -43,10 +43,10 @@
                 </div>
             {% endif %}
         </div>
-        <div class="pt-4 lg:pt-0 md:grid grid-cols-2 3xl:grid-cols-[minmax(0px,_1fr)_400px] 4xl:grid-cols-[minmax(0px,_1fr)_400px_400px] gap-4">
+        <div class="pt-4 lg:pt-0 3xl:grid grid-cols-2 3xl:grid-cols-[minmax(0px,_1fr)_400px] 4xl:grid-cols-[minmax(0px,_1fr)_816px] gap-4">
             <div class="col-span-2 3xl:col-span-1 flex flex-wrap flex-col">
                 {% include "_form_language_tabs.html" with target="edit_poi" instance=poi_form.instance content_field="poi_id" %}
-                <div class="flex flex-wrap flex-col flex-auto gap-4">
+                <div class="flex flex-wrap flex-col gap-4">
                     <div class="flex flex-col flex-auto w-full rounded border border-blue-500 bg-white shadow-2xl">
                         <div class="flex flex-col w-full p-4 flex-auto">
                             <div class="flex justify-between">
@@ -136,25 +136,25 @@
                     {% endif %}
                 </div>
             </div>
-            <div id="left-sidebar-column"
-                 class="flex flex-col flex-auto mt-3 md:mt-0 md:gap-2"
-                 {% if request.user.distribute_sidebar_boxes %} data-enable-automatic-sidebar-distribution{% endif %}>
-                {% if poi_form.instance.id and perms.cms.change_poi %}
-                    {% include "./poi_form_sidebar/minor_edit_box.html" with box_id="poi-minor-edit" %}
-                {% endif %}
-                {% include "./poi_form_sidebar/position_box.html" with box_id="poi-position" %}
-            </div>
-            <div id="right-sidebar-column"
-                 class="3xl:col-end-3 4xl:col-end-auto flex flex-wrap flex-col md:gap-2">
-                {% include "./poi_form_sidebar/contact_box.html" with box_id="poi-contact" %}
-                {% include "./poi_form_sidebar/opening_hours_box.html" with box_id="poi-opening-hours" no_padding=True %}
-                {% include "./poi_form_sidebar/category_box.html" with box_id="poi-category" %}
-                {% include "./poi_form_sidebar/icon_box.html" with box_id="poi-icon" %}
-                {% include "./poi_form_sidebar/organization_box.html" with box_id="poi-organization" %}
-                {% include "./poi_form_sidebar/barrier_free_box.html" with box_id="poi-barrier-free" %}
-                {% if poi_form.instance.id and perms.cms.change_poi %}
-                    {% include "./poi_form_sidebar/action_box.html" with box_id="poi-action" %}
-                {% endif %}
+            <div class="sm:block md:flex sm:mt-4 3xl:mt-0 3xl:block 4xl:flex">
+                <div id="left-sidebar-column"
+                     class="flex flex-col flex-auto mt-4 md:mt-0 md:mr-4 3xl:mr-0 md:w-full 4xl:mr-4"
+                     {% if request.user.distribute_sidebar_boxes %} data-enable-automatic-sidebar-distribution{% endif %}>
+                    {% if poi_form.instance.id and perms.cms.change_poi %}
+                        {% include "./poi_form_sidebar/minor_edit_box.html" with box_id="poi-minor-edit" %}
+                    {% endif %}
+                    {% include "./poi_form_sidebar/position_box.html" with box_id="poi-position" %}
+                </div>
+                <div id="right-sidebar-column"
+                     class="3xl:col-end-3 4xl:col-end-auto flex flex-wrap flex-col md:w-full">
+                    {% include "./poi_form_sidebar/contact_box.html" with box_id="poi-contact" %}
+                    {% include "./poi_form_sidebar/opening_hours_box.html" with box_id="poi-opening-hours" no_padding=True %}
+                    {% include "./poi_form_sidebar/category_box.html" with box_id="poi-category" %}
+                    {% include "./poi_form_sidebar/icon_box.html" with box_id="poi-icon" %}
+                    {% if poi_form.instance.id and perms.cms.change_poi %}
+                        {% include "./poi_form_sidebar/action_box.html" with box_id="poi-action" %}
+                    {% endif %}
+                </div>
             </div>
         </div>
     </form>


### PR DESCRIPTION
### Short description
With introducing the collapsible boxes to the page, event and POI form we created a gap between the boxes when certain boxes are collapsed. This is mainly due to two factors: a. using grid instead of flex, b. the two sidebars for medium and 4xl screens aren't wrapped inside one parent div. These changes are going to be relevant for all post types, however in this PR (at least up until now) I focused on POIs only. If we fixed everything for POI I will extend these changes to events and pages one by one.

For a graphical summary on what I tried to fix see the screenshots here: 
Before: 
![grafik](https://user-images.githubusercontent.com/72705147/215739220-9de88b88-74f1-493b-8eae-21cdadc15322.png)

After: 
![grafik](https://user-images.githubusercontent.com/72705147/215739581-325686dd-1697-4098-b505-16aad08d6f24.png)


### Proposed changes

- Using grid only for 3xl screens
- Add parent div for two sidebars (for medium and 4xl screens)
- Remove flex-auto for the editor so it doesn't create blank space
- Adjust spacing between the boxes


### Side effects
While testing this, I didn't run into any. However I can't imagine that there are now, since this is a major change. So I would ask you to test this PR thoroughly :blush: 
Please also check if you can find classes, that aren't used anymore, so I can remove them :) 


### Resolved issues
Fixes: Parts of #2032 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
