### PR TITLE
Respect settings of machine translation management section

### DIFF
--- a/integreat_cms/cms/templates/events/event_list.html
+++ b/integreat_cms/cms/templates/events/event_list.html
@@ -120,27 +120,23 @@
                 <option data-bulk-action="{% url 'bulk_archive_events' region_slug=request.region.slug language_slug=language.slug %}">
                     {% translate "Archive events" %}
                 </option>
-                {% if DEEPL_ENABLED %}
-                    {% if language == request.region.default_language %}
-                        <option disabled
-                                title="{% translate "You cannot translate into the default language" %}">
-                            {% translate "Create missing translations automatically" %}
+                {% if MT_PERMITTED %}
+                    {% if SUMM_AI_ENABLED %}
+                        <option data-bulk-action="{% url 'auto_translate_easy_german_events' region_slug=request.region.slug language_slug=language.slug %}">
+                            {% translate "Automatically translate this event into Easy German" %}
                         </option>
-                    {% elif DEEPL_AVAILABLE %}
-                        <option data-bulk-action="{% url 'automatic_translation_events' region_slug=request.region.slug language_slug=language.slug %}">
-                            {% translate "Create missing translations automatically" %}
-                        </option>
-                    {% else %}
-                        <option disabled
-                                title="{% translate "This language is not supported by DeepL" %}">
-                            {% translate "Create missing translations automatically" %}
-                        </option>
+                    {% elif DEEPL_ENABLED %}
+                        {% if DEEPL_AVAILABLE %}
+                            <option data-bulk-action="{% url 'automatic_translation_events' region_slug=request.region.slug language_slug=language.slug %}">
+                                {% translate "Create missing translations automatically" %}
+                            </option>
+                        {% else %}
+                            <option disabled
+                                    title="{% translate "This language is not supported by any available machine translation provider." %}">
+                                {% translate "Create missing translations automatically" %}
+                            </option>
+                        {% endif %}
                     {% endif %}
-                {% endif %}
-                {% if SUMM_AI_ENABLED %}
-                    <option data-bulk-action="{% url 'auto_translate_easy_german_events' region_slug=request.region.slug language_slug=language.slug %}">
-                        {% translate "Automatically translate this event into Easy German" %}
-                    </option>
                 {% endif %}
             </select>
             <button form="bulk-action-form" id="bulk-action-execute" class="btn" disabled>{% translate "Execute" %}</button>

--- a/integreat_cms/cms/templates/pages/page_tree.html
+++ b/integreat_cms/cms/templates/pages/page_tree.html
@@ -158,7 +158,7 @@
                         {% translate "Archive pages" %}
                     </option>
                 {% endif %}
-                {% if SUMM_AI_ENABLED and request.user.is_staff %}
+                {% if MT_PERMITTED and SUMM_AI_ENABLED and request.user.is_staff %}
                     <option data-bulk-action="{% url 'auto_translate_easy_german_pages' region_slug=request.region.slug language_slug=language.slug %}">
                         {% translate "Automatically translate this page into Easy German" %}
                     </option>

--- a/integreat_cms/cms/templates/pois/poi_list.html
+++ b/integreat_cms/cms/templates/pois/poi_list.html
@@ -107,27 +107,23 @@
                 <option data-bulk-action="{% url 'bulk_archive_pois' region_slug=request.region.slug language_slug=language.slug %}">
                     {% translate "Archive locations" %}
                 </option>
-                {% if DEEPL_ENABLED %}
-                    {% if language == request.region.default_language %}
-                        <option disabled
-                                title="{% translate "You cannot translate into the default language" %}">
-                            {% translate "Create missing translations automatically" %}
+                {% if MT_PERMITTED %}
+                    {% if SUMM_AI_ENABLED %}
+                        <option data-bulk-action="{% url 'auto_translate_easy_german_pois' region_slug=request.region.slug language_slug=language.slug %}">
+                            {% translate "Automatically translate this location into Easy German" %}
                         </option>
-                    {% elif DEEPL_AVAILABLE %}
-                        <option data-bulk-action="{% url 'automatic_translation_pois' region_slug=request.region.slug language_slug=language.slug %}">
-                            {% translate "Create missing translations automatically" %}
-                        </option>
-                    {% else %}
-                        <option disabled
-                                title="{% translate "This language is not supported by DeepL" %}">
-                            {% translate "Create missing translations automatically" %}
-                        </option>
+                    {% elif DEEPL_ENABLED %}
+                        {% if DEEPL_AVAILABLE %}
+                            <option data-bulk-action="{% url 'automatic_translation_pois' region_slug=request.region.slug language_slug=language.slug %}">
+                                {% translate "Create missing translations automatically" %}
+                            </option>
+                        {% else %}
+                            <option disabled
+                                    title="{% translate "This language is not supported by any available machine translation provider." %}">
+                                {% translate "Create missing translations automatically" %}
+                            </option>
+                        {% endif %}
                     {% endif %}
-                {% endif %}
-                {% if SUMM_AI_ENABLED %}
-                    <option data-bulk-action="{% url 'auto_translate_easy_german_pois' region_slug=request.region.slug language_slug=language.slug %}">
-                        {% translate "Automatically translate this location into Easy German" %}
-                    </option>
                 {% endif %}
             </select>
             <button form="bulk-action-form" id="bulk-action-execute" class="btn" disabled>{% translate "Execute" %}</button>

--- a/integreat_cms/cms/utils/translation_utils.py
+++ b/integreat_cms/cms/utils/translation_utils.py
@@ -1,10 +1,15 @@
 """
 This module contains helpers for the translation process.
 """
+import logging
 import re
 
 from django.utils.html import format_html, format_html_join
 from django.utils.text import format_lazy
+
+from ..constants import machine_translation_permissions as mt_perms
+
+logger = logging.getLogger(__name__)
 
 
 def gettext_many_lazy(*strings):
@@ -46,3 +51,78 @@ def translate_link(message, attributes):
         link_text,
         after,
     )
+
+
+def mt_is_permitted(region, user, content_type, target_lang_slug):
+    """
+    Checks if a machine translation is permitted, i.e. if for the
+    given region, MT of the given content type is allowed and
+    MT into the target language is enabled for the requesting user.
+
+    :param region: the region attempting to machine translate
+    :type region: ~integreat_cms.cms.models.regions.region.Region
+
+    :param user: the user requesting the translation
+    :type user: ~django.contrib.auth.models.User
+
+    :param content_type: type of content which would be translated
+    :type content_type: ~integreat_cms.cms.models.abstract_content_model.AbstractContentModel
+
+    :param target_lang_slug: slug of the MT target language
+    :type target_lang_slug: str
+
+    :return: if the translation is permitted
+    :rtype: bool
+    """
+    permission_settings = {
+        "events": (region.machine_translate_events, "cms.change_event"),
+        "pages": (region.machine_translate_pages, "cms.change_page"),
+        "pois": (region.machine_translate_pois, "cms.change_poi"),
+    }
+
+    mt_perms_setting, required_perm = permission_settings[content_type]
+
+    if mt_perms_setting == mt_perms.NO_ONE:
+        logger.debug(
+            "Machine translations are disabled for content type %r in %r.",
+            content_type,
+            region,
+        )
+        return False
+
+    mt_perm = "cms.manage_translations"
+    if mt_perms_setting == mt_perms.MANAGERS and not user.has_perm(mt_perm):
+        logger.debug(
+            "Machine translations are only enabled for content type %r in %r for users with the permission %r.",
+            content_type,
+            region,
+            mt_perm,
+        )
+        return False
+
+    if not user.has_perm(required_perm):
+        logger.debug(
+            "Machine translations are only enabled for content type %r in %r for users with the permission %r.",
+            content_type,
+            region,
+            required_perm,
+        )
+        return False
+
+    target_lang = region.language_node_by_slug[target_lang_slug]
+
+    if target_lang.is_root():
+        logger.debug(
+            "Machine translations are disabled for the default language %r in %r.",
+            target_lang,
+            region,
+        )
+        return False
+
+    if not target_lang.machine_translation_enabled:
+        logger.debug(
+            "Machine translations are disabled for %r in %r.", target_lang, region
+        )
+        return False
+
+    return True

--- a/integreat_cms/cms/views/events/event_list_view.py
+++ b/integreat_cms/cms/views/events/event_list_view.py
@@ -15,6 +15,8 @@ from ..mixins import SummAiContextMixin
 from .event_context_mixin import EventContextMixin
 
 from ....deepl_api.utils import DeepLApi
+from ...utils.translation_utils import mt_is_permitted
+from ...models.events.event import Event
 
 logger = logging.getLogger(__name__)
 
@@ -112,6 +114,9 @@ class EventListView(TemplateView, EventContextMixin, SummAiContextMixin):
             DEEPL_AVAILABLE = deepl.check_availability(request, language_slug)
         else:
             DEEPL_AVAILABLE = False
+        MT_PERMITTED = mt_is_permitted(
+            region, request.user, Event._meta.default_related_name, language_slug
+        )
 
         return render(
             request,
@@ -127,5 +132,6 @@ class EventListView(TemplateView, EventContextMixin, SummAiContextMixin):
                 "translation_status": translation_status,
                 "search_query": query,
                 "DEEPL_AVAILABLE": DEEPL_AVAILABLE,
+                "MT_PERMITTED": MT_PERMITTED,
             },
         )

--- a/integreat_cms/cms/views/mixins.py
+++ b/integreat_cms/cms/views/mixins.py
@@ -131,9 +131,6 @@ class SummAiContextMixin(ContextMixin):
             settings.SUMM_AI_ENABLED
             and self.request.region.summ_ai_enabled
             and kwargs.get("language_slug")
-            in [
-                settings.SUMM_AI_GERMAN_LANGUAGE_SLUG,
-                settings.SUMM_AI_EASY_GERMAN_LANGUAGE_SLUG,
-            ]
+            == settings.SUMM_AI_EASY_GERMAN_LANGUAGE_SLUG
         )
         return context

--- a/integreat_cms/cms/views/pages/page_tree_view.py
+++ b/integreat_cms/cms/views/pages/page_tree_view.py
@@ -14,6 +14,7 @@ from ...forms import PageFilterForm
 from ..mixins import SummAiContextMixin
 from .page_context_mixin import PageContextMixin
 from ...models import Page
+from ...utils.translation_utils import mt_is_permitted
 
 logger = logging.getLogger(__name__)
 
@@ -139,6 +140,11 @@ class PageTreeView(TemplateView, PageContextMixin, SummAiContextMixin):
         # Filter pages according to given filters, if any
         pages = filter_form.apply(pages, language_slug)
 
+        # Determine if MT is permitted
+        MT_PERMITTED = mt_is_permitted(
+            region, request.user, Page._meta.default_related_name, language_slug
+        )
+
         return render(
             request,
             self.template_name,
@@ -149,5 +155,6 @@ class PageTreeView(TemplateView, PageContextMixin, SummAiContextMixin):
                 "languages": region.active_languages,
                 "filter_form": filter_form,
                 "XLIFF_EXPORT_VERSION": settings.XLIFF_EXPORT_VERSION,
+                "MT_PERMITTED": MT_PERMITTED,
             },
         )

--- a/integreat_cms/cms/views/pois/poi_list_view.py
+++ b/integreat_cms/cms/views/pois/poi_list_view.py
@@ -15,6 +15,8 @@ from ..mixins import SummAiContextMixin
 from .poi_context_mixin import POIContextMixin
 
 from ....deepl_api.utils import DeepLApi
+from ...utils.translation_utils import mt_is_permitted
+from ...models.pois.poi import POI
 
 logger = logging.getLogger(__name__)
 
@@ -123,6 +125,9 @@ class POIListView(TemplateView, POIContextMixin, SummAiContextMixin):
             DEEPL_AVAILABLE = deepl.check_availability(request, language_slug)
         else:
             DEEPL_AVAILABLE = False
+        MT_PERMITTED = mt_is_permitted(
+            region, request.user, POI._meta.default_related_name, language_slug
+        )
 
         return render(
             request,
@@ -135,6 +140,7 @@ class POIListView(TemplateView, POIContextMixin, SummAiContextMixin):
                 "languages": region.active_languages,
                 "search_query": query,
                 "DEEPL_AVAILABLE": DEEPL_AVAILABLE,
+                "MT_PERMITTED": MT_PERMITTED,
             },
         )
 

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -4680,21 +4680,20 @@ msgstr "Mehrfachaktion auswählen"
 msgid "Archive events"
 msgstr "Veranstaltungen archivieren"
 
-#: cms/templates/events/event_list.html cms/templates/pois/poi_list.html
-msgid "You cannot translate into the default language"
-msgstr "Sie können nicht in die Standard-Sprache übersetzen"
+#: cms/templates/events/event_list.html
+msgid "Automatically translate this event into Easy German"
+msgstr "Diese Veranstaltung automatisch in Leichte Sprache übersetzen"
 
 #: cms/templates/events/event_list.html cms/templates/pois/poi_list.html
 msgid "Create missing translations automatically"
 msgstr "Fehlende Übersetzungen automatisch erstellen"
 
 #: cms/templates/events/event_list.html cms/templates/pois/poi_list.html
-msgid "This language is not supported by DeepL"
-msgstr "Diese Sprache wird von DeepL nicht unterstützt"
-
-#: cms/templates/events/event_list.html
-msgid "Automatically translate this event into Easy German"
-msgstr "Diese Veranstaltung automatisch in Leichte Sprache übersetzen"
+msgid ""
+"This language is not supported by any available machine translation provider."
+msgstr ""
+"Diese Sprache wird von keinem verfügbaren Anbieter maschineller "
+"Übersetzungen unterstützt."
 
 #: cms/templates/events/event_list.html
 #: cms/templates/events/event_list_archived.html
@@ -8221,6 +8220,14 @@ msgstr "Niederländisch"
 msgid "DeepL API"
 msgstr "DeepL API"
 
+#: deepl_api/utils.py summ_ai_api/summ_ai_api_client.py
+msgid ""
+"Machine translations are disabled for content type \"{}\", language \"{}\" "
+"or the current user."
+msgstr ""
+"Machinelle Übersetzungen sind für Inhaltsart \"{}\", Sprache \"{}\" oder den "
+"aktuellen Benutzer deaktiviert."
+
 #: deepl_api/utils.py
 msgid "No source translation could be found for {} \"{}\"."
 msgstr "Es konnte kein Quelltext für {} \"{}\" gefunden werden."
@@ -8409,11 +8416,21 @@ msgstr ""
 #~ msgid "No icon is set"
 #~ msgstr "Kein Icon ist ausgewählt"
 
+#~ msgid "This language is not supported by DeepL"
+#~ msgstr "Diese Sprache wird von DeepL nicht unterstützt"
+
 #~ msgid "Currently not visible in apps"
 #~ msgstr "Wird noch nicht in den Apps angezeigt"
 
 #~ msgid "Integreat CMS core"
 #~ msgstr "Integreat CMS core"
+
+#~ msgid ""
+#~ "Machine translations have been disabled for this content type or for this "
+#~ "language"
+#~ msgstr ""
+#~ "Machinelle Übersetzungen sind für diese Inhaltsart oder diese Sprache "
+#~ "deaktiviert"
 
 #~ msgid "Edit language tree node"
 #~ msgstr "Sprach-Knoten bearbeiten"
@@ -8423,6 +8440,9 @@ msgstr ""
 
 #~ msgid "File is hidden:"
 #~ msgstr "Datei ist verborgen:"
+
+#~ msgid "You cannot translate into the default language"
+#~ msgstr "Sie können nicht in die Standard-Sprache übersetzen"
 
 #~ msgid "Barrier free"
 #~ msgstr "Barrierefrei"

--- a/integreat_cms/summ_ai_api/summ_ai_api_client.py
+++ b/integreat_cms/summ_ai_api/summ_ai_api_client.py
@@ -8,8 +8,11 @@ import itertools
 import aiohttp
 
 from django.conf import settings
+from django.contrib import messages
+from django.utils.translation import gettext as _
 
 from .utils import TranslationHelper
+from ..cms.utils.translation_utils import mt_is_permitted
 
 logger = logging.getLogger(__name__)
 
@@ -153,6 +156,23 @@ class SummAiApiClient:
         easy_german = self.request.region.get_language_or_404(
             settings.SUMM_AI_EASY_GERMAN_LANGUAGE_SLUG
         )
+
+        if queryset and not mt_is_permitted(
+            self.request.region,
+            self.request.user,
+            type(queryset[0])._meta.default_related_name,
+            settings.SUMM_AI_EASY_GERMAN_LANGUAGE_SLUG,
+        ):
+            messages.error(
+                self.request,
+                _(
+                    'Machine translations are disabled for content type "{}", language "{}" or the current user.'
+                ).format(
+                    type(queryset[0])._meta.verbose_name.title(),
+                    easy_german,
+                ),
+            )
+            return
 
         # Initialize translation helpers for each object instance
         translation_helpers = [


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
In #1831 / #1994 and #1927 / #2036 settings were added to control who is allowed to machine translate which content, and into which languages MTs are allowed. This PR implements the necessary backend logic to ensure only permitted requests are being passed on to SUMM.AI/DeepL.

### Proposed changes
<!-- Describe this PR in more detail. -->

- add a utility function responsible for determining whether or not a request should be permitted
- call this function in (page/event/poi)_list_views to be able to disable the bulk action option
- also call it within the DeepL and SUMM.AI translation functions to prevent malicious circumvention of those rules


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none that I could find


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2031 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
