### PR TITLE
Show Link Checker status codes to all users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ UNRELEASED
 ----------
 
 * [ [#2037](https://github.com/digitalfabrik/integreat-cms/issues/2037) ] Add organization and barrier-free fields to POI
+* [ [#2064](https://github.com/digitalfabrik/integreat-cms/issues/2064) ] Show Linkcheck status codes to all users
 
 
 2023.1.2

--- a/integreat_cms/cms/templates/linkcheck/link_list_row.html
+++ b/integreat_cms/cms/templates/linkcheck/link_list_row.html
@@ -19,12 +19,10 @@
            rel="noopener noreferrer"
            class="text-blue-500 hover:underline">{{ url.url }}</a>
     </td>
-    {% if request.user.expert_mode %}
-        <td class="pr-2 {% if view.kwargs.url_filter == 'invalid' %} text-red-500 {% elif view.kwargs.url_filter == 'valid' %} text-green-500 {% endif %} max-w-[75px] sm:max-w-[100px] md:max-w-[150px] lg:max-w-[200px] xl:max-w-[250px] 2xl:max-w-[300px] 3xl:max-w-[350px] 4xl:max-w-[400px]"
-            title="{{ url.message }}">
-            <div class="max-h-12 overflow-hidden text-ellipsis">{{ url.message|linkcheck_status_filter }}</div>
-        </td>
-    {% endif %}
+    <td class="pr-2 {% if view.kwargs.url_filter == 'invalid' %} text-red-500 {% elif view.kwargs.url_filter == 'valid' %} text-green-500 {% endif %} max-w-[75px] sm:max-w-[100px] md:max-w-[150px] lg:max-w-[200px] xl:max-w-[250px] 2xl:max-w-[300px] 3xl:max-w-[350px] 4xl:max-w-[400px]"
+        title="{{ url.message }}">
+        <div class="max-h-12 overflow-hidden text-ellipsis">{{ url.message|linkcheck_status_filter }}</div>
+    </td>
     <td class="pr-2 max-w-[75px] sm:max-w-[100px] md:max-w-[100px] lg:max-w-[150px] xl:max-w-[200px] 2xl:max-w-[300px] 3xl:max-w-[350px] 4xl:max-w-[400px]"
         title="{{ url.region_links.0.text }}">
         <div class="max-h-12 overflow-hidden text-ellipsis">{{ url.region_links.0.text }}</div>

--- a/integreat_cms/cms/templates/linkcheck/links_by_filter.html
+++ b/integreat_cms/cms/templates/linkcheck/links_by_filter.html
@@ -60,9 +60,7 @@
                         <input type="checkbox" id="bulk-select-all"/>
                     </th>
                     <th class="text-sm text-left uppercase py-3 pr-2">{% translate "URL" %}</th>
-                    {% if request.user.expert_mode %}
-                        <th class="text-sm text-left uppercase py-3 pr-2">{% translate "Status" %}</th>
-                    {% endif %}
+                    <th class="text-sm text-left uppercase py-3 pr-2">{% translate "Status" %}</th>
                     <th class="text-sm text-left uppercase py-3 pr-2">{% translate "Link text" %}</th>
                     <th class="text-sm text-left uppercase py-3 pr-2">{% translate "Source" %}</th>
                     <th class="text-sm text-right uppercase py-3 pr-2">{% translate "Usages" %}</th>

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8329,6 +8329,12 @@ msgstr ""
 "Diese Seite konnte nicht importiert werden, da sie zu einer anderen Region "
 "gehört ({})."
 
+#~ msgid "Edit language tree node"
+#~ msgstr "Sprach-Knoten bearbeiten"
+
+#~ msgid "Add language"
+#~ msgstr "Sprache hinzufügen"
+
 #~ msgid "Barrier free"
 #~ msgstr "Barrierefrei"
 
@@ -8554,12 +8560,6 @@ msgstr ""
 
 #~ msgid "Currently no users belong to this organization"
 #~ msgstr "Aktuell gehören dieser Organisation keine Benutzer:innen an"
-
-#~ msgid "Edit language tree node"
-#~ msgstr "Sprach-Knoten bearbeiten"
-
-#~ msgid "Add language"
-#~ msgstr "Sprache hinzufügen"
 
 #~ msgid "Publish changes"
 #~ msgstr "Änderungen veröffentlichen"


### PR DESCRIPTION
### Short description
* For the time being the HTTP status codes for broken links should be shown to all users.
* Revert cf6d5d9d7ea63caaac3456e149817b4ffab33f97

### Proposed changes
- Remove the condition that shows the code only to expert users.

### Side effects
- None a.t.m.

### Resolved issues
Fixes: https://chat.tuerantuer.org/digitalfabrik/threads/n31dzqkz4bnguecz8kw4ed9ndy


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
