### PR TITLE
Fix formatting error in slug error message

### DIFF
--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -7128,7 +7128,7 @@ msgid ""
 "is already used by <a>{translation}</a> or one of its previous versions."
 msgstr ""
 "Der URL-Parameter wurde von '{user_slug}' zu '{slug}' geändert, da "
-"'{user_slug}' bereits von <a{translation}</a> oder einer vorherigen Version "
+"'{user_slug}' bereits von <a>{translation}</a> oder einer vorherigen Version "
 "davon verwendet wird."
 
 #: cms/views/events/event_form_view.py


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This fixes a small bug when submitting a form with a duplicate slug which is already used in another object:
```
ValueError at /augsburg/pois/de/61/edit/

not enough values to unpack (expected 3, got 1)
```

### Proposed changes
<!-- Describe this PR in more detail. -->

- Fix formatting error in slug error message translation



__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
