### PR TITLE
Add database checks into feedback API tests

### DIFF
--- a/tests/api/api_config.py
+++ b/tests/api/api_config.py
@@ -262,7 +262,11 @@ API_FEEDBACK_VIEWS = [
     ),
     (
         "api:region_feedback",
-        {"comment": "Cool region!", "rating": "up", "category": "Inhalte"},
+        {"rating": "up", "category": "Inhalte"},
+    ),
+    (
+        "api:region_feedback",
+        {"comment": "Feedback ohne Bewertung", "category": "Inhalte"},
     ),
     (
         "api:region_feedback",
@@ -320,7 +324,7 @@ API_FEEDBACK_VIEWS = [
     (
         "api:event_feedback",
         {
-            "slug": "test-veranstaltung",
+            "slug": "test-veranstaltung$2030-01-01",
             "comment": "Strange bug!",
             "rating": "down",
             "category": "Technisches Feedback",
@@ -409,5 +413,59 @@ API_FEEDBACK_VIEWS = [
             "rating": "down",
             "category": "Technisches Feedback",
         },
+    ),
+]
+
+API_FEEDBACK_ERRORS = [
+    (
+        "api:region_feedback",
+        {"region_slug": "augsburg", "language_slug": "ch"},
+        {"rating": "up"},
+        {"code": 404, "error": 'No language found with slug "ch"'},
+    ),
+    (
+        "api:region_feedback",
+        {"region_slug": "augsburg", "language_slug": "de"},
+        {"rating": "neutral"},
+        {"code": 400, "error": "Invalid rating."},
+    ),
+    (
+        "api:region_feedback",
+        {"region_slug": "augsburg", "language_slug": "de"},
+        {"category": "Inhalte"},
+        {"code": 400, "error": "Either comment or rating is required."},
+    ),
+    (
+        "api:event_feedback",
+        {"region_slug": "augsburg", "language_slug": "de"},
+        {"slug": "not-exist", "rating": "down"},
+        {"code": 404, "error": "No matching event found for slug."},
+    ),
+    (
+        "api:page_feedback",
+        {"region_slug": "augsburg", "language_slug": "de"},
+        {"slug": "not-exist", "rating": "down"},
+        {"code": 404, "error": "No matching page found for slug."},
+    ),
+    (
+        "api:poi_feedback",
+        {"region_slug": "augsburg", "language_slug": "de"},
+        {"slug": "not-exist", "rating": "down"},
+        {"code": 404, "error": "No matching location found for slug."},
+    ),
+    (
+        "api:imprint_page_feedbacks",
+        {"region_slug": "nurnberg", "language_slug": "de"},
+        {"rating": "down"},
+        {
+            "code": 404,
+            "error": "The imprint does not exist in this region for the selected language.",
+        },
+    ),
+    (
+        "api:search_result_feedback",
+        {"region_slug": "augsburg", "language_slug": "de"},
+        {"rating": "down"},
+        {"code": 400, "error": "Search query is required."},
     ),
 ]

--- a/tests/api/test_api_feedback.py
+++ b/tests/api/test_api_feedback.py
@@ -1,17 +1,47 @@
+from datetime import datetime
+
 import pytest
 
 from django.test.client import Client
 from django.urls import reverse
 
-from .api_config import API_FEEDBACK_VIEWS
+from integreat_cms.cms.models import (
+    Feedback,
+    RegionFeedback,
+    PageFeedback,
+    POIFeedback,
+    EventFeedback,
+    EventListFeedback,
+    ImprintPageFeedback,
+    MapFeedback,
+    SearchResultFeedback,
+    OfferListFeedback,
+    OfferFeedback,
+)
+
+from .api_config import API_FEEDBACK_VIEWS, API_FEEDBACK_ERRORS
+
+
+feedback_type_dict = {
+    "api:region_feedback": RegionFeedback,
+    "api:page_feedback": PageFeedback,
+    "api:poi_feedback": POIFeedback,
+    "api:event_feedback": EventFeedback,
+    "api:event_list_feedback": EventListFeedback,
+    "api:imprint_page_feedbacks": ImprintPageFeedback,
+    "api:map_feedback": MapFeedback,
+    "api:search_result_feedback": SearchResultFeedback,
+    "api:offer_list_feedback": OfferListFeedback,
+    "api:offer_feedback": OfferFeedback,
+}
 
 
 # pylint: disable=unused-argument
 @pytest.mark.django_db
 @pytest.mark.parametrize("view_name,post_data", API_FEEDBACK_VIEWS)
-def test_api_feedback(load_test_data, view_name, post_data):
+def test_api_feedback_success(load_test_data, view_name, post_data):
     """
-    This test checks whether the feedback submission returns the correct result
+    Check successful feedback submission for different feedback types
 
     :param load_test_data: The fixture providing the test data (see :meth:`~tests.conftest.load_test_data`)
     :type load_test_data: NoneType
@@ -25,6 +55,87 @@ def test_api_feedback(load_test_data, view_name, post_data):
     client = Client()
     url = reverse(view_name, kwargs={"region_slug": "augsburg", "language_slug": "de"})
     response = client.post(url, data=post_data)
-    print(response.headers)
     assert response.status_code == 201
     assert response.json() == {"success": "Feedback successfully submitted"}
+
+    # database checks
+    assert Feedback.objects.count() == 1
+    feedback = Feedback.objects.first()
+
+    if view_name != "api:legacy_feedback_endpoint":
+        assert isinstance(feedback, feedback_type_dict[view_name])
+
+    if "rating" in post_data:
+        rating = post_data["rating"] == "up"
+        assert feedback.rating == rating
+    else:
+        assert feedback.rating is None
+
+    if "comment" in post_data:
+        assert feedback.comment == post_data["comment"]
+    else:
+        assert feedback.comment == ""
+
+    is_technical = post_data["category"] == "Technisches Feedback"
+    assert feedback.is_technical == is_technical
+    assert feedback.created_date.date() == datetime.today().date()
+    assert feedback.language_id == 1
+    assert feedback.read_by_id is None
+    assert feedback.region_id == 1
+
+
+# pylint: disable=unused-argument
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "view_name,kwargs,post_data,response_data", API_FEEDBACK_ERRORS
+)
+def test_api_feedback_errors(
+    load_test_data, view_name, kwargs, post_data, response_data
+):
+    """
+    Check different errors during feedback processing
+
+    :param load_test_data: The fixture providing the test data (see :meth:`~tests.conftest.load_test_data`)
+    :type load_test_data: NoneType
+
+    :param view_name: The identifier of the view
+    :type view_name: str
+
+    :param kwargs: The keyword argument passed to the view
+    :type kwargs: dict
+
+    :param post_data: The post data for this view
+    :type post_data: dict
+
+    :param response_data: The expected response data
+    :type response_data: dict
+    """
+    client = Client()
+    url = reverse(view_name, kwargs=kwargs)
+    response = client.post(url, data=post_data)
+    assert response.status_code == response_data["code"]
+    assert response.json() == {"error": f"{response_data['error']}"}
+
+    # database checks
+    assert not Feedback.objects.exists()
+
+
+# pylint: disable=unused-argument
+@pytest.mark.django_db
+def test_api_feedback_invalid_method(load_test_data):
+    """
+    Check error when request method is not POST
+
+    :param load_test_data: The fixture providing the test data (see :meth:`~tests.conftest.load_test_data`)
+    :type load_test_data: NoneType
+    """
+    client = Client()
+    url = reverse(
+        "api:region_feedback", kwargs={"region_slug": "augsburg", "language_slug": "de"}
+    )
+    response = client.get(url)
+    assert response.status_code == 405
+    assert response.json() == {"error": "Invalid request."}
+
+    # database checks
+    assert not Feedback.objects.exists()


### PR DESCRIPTION
### Short description
In feedback API tests we currently only check the API response.
We don't validate that feedback was actually processed correctly.


### Proposed changes
- Check feedback in database
- Add more cases to increase test coverage


### Side effects
No side effects, but only cms_feedback table is checked.
Also need to cover tables for different feedback types, like cms_pagefeedback, cms_poifeedback etc.
I will implement it separately.


### Resolved issues
Partially fixes: #1880


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
