### PR TITLE
Deactivate page order drag and drop for observers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ UNRELEASED
 * [ [#1322](https://github.com/digitalfabrik/integreat-cms/issues/1322) ] Add organization name & logo to the page API response
 * [ [#2105](https://github.com/digitalfabrik/integreat-cms/issues/2105) ] Indicate that categories are now shown in the apps
 * [ [#2065](https://github.com/digitalfabrik/integreat-cms/issues/2065) ] Only allow staff members to use SUMM.AI bulk action
+* [ [#1970](https://github.com/digitalfabrik/integreat-cms/issues/1970) ] Disable drag & drop in page order for users without editing permission
+* [ [#2112](https://github.com/digitalfabrik/integreat-cms/issues/2112) ] Hide form buttons and bulk actions for users without editing permissions
 
 
 2023.2.2

--- a/integreat_cms/cms/templates/events/event_list.html
+++ b/integreat_cms/cms/templates/events/event_list.html
@@ -111,39 +111,41 @@
             </div>
         </div>
     {% endif %}
-    <div class="flex flex-wrap gap-2 mt-4">
-        <select id="bulk-action" class="w-auto max-w-full">
-            <option>
-                {% translate "Select bulk action" %}
-            </option>
-            <option data-bulk-action="{% url 'bulk_archive_events' region_slug=request.region.slug language_slug=language.slug %}">
-                {% translate "Archive events" %}
-            </option>
-            {% if DEEPL_ENABLED %}
-                {% if language == request.region.default_language %}
-                    <option disabled
-                            title="{% translate "You cannot translate into the default language" %}">
-                        {% translate "Create missing translations automatically" %}
-                    </option>
-                {% elif DEEPL_AVAILABLE %}
-                    <option data-bulk-action="{% url 'automatic_translation_events' region_slug=request.region.slug language_slug=language.slug %}">
-                        {% translate "Create missing translations automatically" %}
-                    </option>
-                {% else %}
-                    <option disabled
-                            title="{% translate "This language is not supported by DeepL" %}">
-                        {% translate "Create missing translations automatically" %}
+    {% if perms.cms.change_event %}
+        <div class="flex flex-wrap gap-2 mt-4">
+            <select id="bulk-action" class="w-auto max-w-full">
+                <option>
+                    {% translate "Select bulk action" %}
+                </option>
+                <option data-bulk-action="{% url 'bulk_archive_events' region_slug=request.region.slug language_slug=language.slug %}">
+                    {% translate "Archive events" %}
+                </option>
+                {% if DEEPL_ENABLED %}
+                    {% if language == request.region.default_language %}
+                        <option disabled
+                                title="{% translate "You cannot translate into the default language" %}">
+                            {% translate "Create missing translations automatically" %}
+                        </option>
+                    {% elif DEEPL_AVAILABLE %}
+                        <option data-bulk-action="{% url 'automatic_translation_events' region_slug=request.region.slug language_slug=language.slug %}">
+                            {% translate "Create missing translations automatically" %}
+                        </option>
+                    {% else %}
+                        <option disabled
+                                title="{% translate "This language is not supported by DeepL" %}">
+                            {% translate "Create missing translations automatically" %}
+                        </option>
+                    {% endif %}
+                {% endif %}
+                {% if SUMM_AI_ENABLED %}
+                    <option data-bulk-action="{% url 'auto_translate_easy_german_events' region_slug=request.region.slug language_slug=language.slug %}">
+                        {% translate "Automatically translate this event into Easy German" %}
                     </option>
                 {% endif %}
-            {% endif %}
-            {% if SUMM_AI_ENABLED %}
-                <option data-bulk-action="{% url 'auto_translate_easy_german_events' region_slug=request.region.slug language_slug=language.slug %}">
-                    {% translate "Automatically translate this event into Easy German" %}
-                </option>
-            {% endif %}
-        </select>
-        <button form="bulk-action-form" id="bulk-action-execute" class="btn" disabled>{% translate "Execute" %}</button>
-    </div>
+            </select>
+            <button form="bulk-action-form" id="bulk-action-execute" class="btn" disabled>{% translate "Execute" %}</button>
+        </div>
+    {% endif %}
     {% include "../generic_confirmation_dialog.html" %}
     {% url "events" as url %}
     {% include "pagination.html" with chunk=events %}

--- a/integreat_cms/cms/templates/events/event_list_archived.html
+++ b/integreat_cms/cms/templates/events/event_list_archived.html
@@ -81,17 +81,19 @@
             </tbody>
         </table>
     </div>
-    <div class="flex flex-wrap gap-2 mt-4">
-        <select id="bulk-action" class="w-auto max-w-full">
-            <option>
-                {% translate "Select bulk action" %}
-            </option>
-            <option data-bulk-action="{% url 'bulk_restore_events' region_slug=request.region.slug language_slug=language.slug %}">
-                {% translate "Restore events" %}
-            </option>
-        </select>
-        <button form="bulk-action-form" id="bulk-action-execute" class="btn" disabled>{% translate "Execute" %}</button>
-    </div>
+    {% if perms.cms.change_event %}
+        <div class="flex flex-wrap gap-2 mt-4">
+            <select id="bulk-action" class="w-auto max-w-full">
+                <option>
+                    {% translate "Select bulk action" %}
+                </option>
+                <option data-bulk-action="{% url 'bulk_restore_events' region_slug=request.region.slug language_slug=language.slug %}">
+                    {% translate "Restore events" %}
+                </option>
+            </select>
+            <button form="bulk-action-form" id="bulk-action-execute" class="btn" disabled>{% translate "Execute" %}</button>
+        </div>
+    {% endif %}
     {% include "../generic_confirmation_dialog.html" %}
     {% url "events" as url %}
     {% include "pagination.html" with chunk=events %}

--- a/integreat_cms/cms/templates/icon_widget.html
+++ b/integreat_cms/cms/templates/icon_widget.html
@@ -14,34 +14,36 @@
                 {{ widget.document.name }}
             </div>
         </div>
-        <div class="w-full" id="set-icon-button">
-            <label for="{{ widget.attrs.id }}"
-                   class="block w-full text-center font-bold bg-blue-500 hover:bg-blue-600 focus:bg-blue-500 text-white py-2 px-4 rounded cursor-pointer relative">
-                <i icon-name="image" class="mr-2"></i>
-                <span id="set-icon-label" class="{% if icon %}hidden{% endif %}">{% blocktrans %}Set {{ label }}{% endblocktrans %}</span>
-                <span id="change-icon-label" class="{% if not icon %}hidden{% endif %}">{% blocktrans %}Change {{ label }}{% endblocktrans %}</span>
-            </label>
-            <input name="{{ widget.name }}"
-                   id="{{ widget.attrs.id }}"
-                   type="hidden"
-                   value="{{ widget.value|default_if_none:'' }}"/>
-            <input type="checkbox"
-                   name="{{ widget.checkbox_name }}"
-                   id="{{ widget.checkbox_id }}"
-                   class="hidden"/>
-        </div>
-        <div id="remove-icon"
-             class="w-full mt-2 {% if not icon %}hidden{% endif %}">
-            <div class="block w-full text-center font-bold bg-gray-500 hover:bg-gray-600 focus:bg-gray-600 text-white py-2 px-4 rounded cursor-pointer relative">
-                <i icon-name="trash-2" class="mr-2"></i>
-                {% blocktrans %}Remove {{ label }}{% endblocktrans %}
+        {% if not widget.attrs.disabled %}
+            <div class="w-full" id="set-icon-button">
+                <label for="{{ widget.attrs.id }}"
+                       class="block w-full text-center font-bold bg-blue-500 hover:bg-blue-600 focus:bg-blue-500 text-white py-2 px-4 rounded cursor-pointer relative">
+                    <i icon-name="image" class="mr-2"></i>
+                    <span id="set-icon-label" class="{% if icon %}hidden{% endif %}">{% blocktrans %}Set {{ label }}{% endblocktrans %}</span>
+                    <span id="change-icon-label" class="{% if not icon %}hidden{% endif %}">{% blocktrans %}Change {{ label }}{% endblocktrans %}</span>
+                </label>
+                <input name="{{ widget.name }}"
+                       id="{{ widget.attrs.id }}"
+                       type="hidden"
+                       value="{{ widget.value|default_if_none:'' }}"/>
+                <input type="checkbox"
+                       name="{{ widget.checkbox_name }}"
+                       id="{{ widget.checkbox_id }}"
+                       class="hidden"/>
             </div>
-        </div>
-        <div id="restore-icon" class="w-full mt-2 hidden">
-            <div class="block w-full text-center font-bold bg-gray-500 hover:bg-gray-600 focus:bg-gray-500 text-white py-2 px-4 rounded cursor-pointer relative">
-                <i icon-name="refresh-ccw" class="mr-2"></i>
-                {% blocktrans %}Restore {{ label }}{% endblocktrans %}
+            <div id="remove-icon"
+                 class="w-full mt-2 {% if not icon %}hidden{% endif %}">
+                <div class="block w-full text-center font-bold bg-gray-500 hover:bg-gray-600 focus:bg-gray-600 text-white py-2 px-4 rounded cursor-pointer relative">
+                    <i icon-name="trash-2" class="mr-2"></i>
+                    {% blocktrans %}Remove {{ label }}{% endblocktrans %}
+                </div>
             </div>
-        </div>
+            <div id="restore-icon" class="w-full mt-2 hidden">
+                <div class="block w-full text-center font-bold bg-gray-500 hover:bg-gray-600 focus:bg-gray-500 text-white py-2 px-4 rounded cursor-pointer relative">
+                    <i icon-name="refresh-ccw" class="mr-2"></i>
+                    {% blocktrans %}Restore {{ label }}{% endblocktrans %}
+                </div>
+            </div>
+        {% endif %}
     {% endwith %}
 </div>

--- a/integreat_cms/cms/templates/pages/_page_order_table.html
+++ b/integreat_cms/cms/templates/pages/_page_order_table.html
@@ -2,7 +2,7 @@
 {% load content_filters %}
 {% load page_filters %}
 <div class="table-listing">
-    <table data-activate-page-order
+    <table {% if can_edit_page %}data-activate-page-order{% endif %}
            class="w-full mt-4 rounded border border-solid border-gray-200 shadow bg-white table-auto cursor-default break-all">
         <tbody>
             {# djlint:off H020 #}
@@ -12,8 +12,9 @@
                         <td class="single_icon min">
                             <span data-contained-in-siblings="true"
                                   class="drag text-gray-800 block py-3 px-2 cursor-move"
-                                  {% if not page.archived %} draggable="true" title="{% translate "Change the position of the page with drag & drop." %}" {% endif %}>
-                                <i icon-name="move"></i>
+                                  draggable="{% if not page.archived and can_edit_page %}true{% else %}false{% endif %}"
+                                  title="{% translate "Change the position of the page with drag & drop." %}">
+                                {% if can_edit_page %}<i icon-name="move"></i>{% endif %}
                             </span>
                         </td>
                         <td id="page_title"
@@ -77,8 +78,8 @@
                     <tr class="border-2 border-blue-500 hover:bg-gray-100">
                         <td class="single_icon min">
                             <span class="drag text-gray-800 block py-3 px-2 cursor-move"
-                                  draggable="true">
-                                <i icon-name="move"></i>
+                                  draggable="{% if can_edit_page %}true{% else %}false{% endif %}">
+                                {% if can_edit_page %}<i icon-name="move"></i>{% endif %}
                             </span>
                         </td>
                         <td id="page_title" data-default-title="{% translate "New Page" %}">{% translate "New Page" %}</td>
@@ -87,8 +88,8 @@
                     <tr class="border-2 border-blue-500 hover:bg-gray-100">
                         <td class="single_icon min">
                             <span class="drag text-gray-800 block py-3 px-2 cursor-move"
-                                  draggable="true">
-                                <i icon-name="move"></i>
+                                  draggable="{% if can_edit_page %}true{% else %}false{% endif %}">
+                                {% if can_edit_page %}<i icon-name="move"></i>{% endif %}
                             </span>
                         </td>
                         <td id="page_title"

--- a/integreat_cms/cms/templates/pages/page_sbs.html
+++ b/integreat_cms/cms/templates/pages/page_sbs.html
@@ -87,6 +87,7 @@
                             </button>
                             <button id="copy-translation-content"
                                     title="{% translate "Copy content" %}"
+                                    {% if not can_edit_page %}disabled{% endif %}
                                     class="btn grow bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded">
                                 {% with source_language=source_page_translation.language.translated_name target_language_name=target_language.translated_name %}
                                     {% blocktrans %}Copy content of {{ source_language }} to {{ target_language_name }}{% endblocktrans %}

--- a/integreat_cms/cms/templates/pages/page_tree.html
+++ b/integreat_cms/cms/templates/pages/page_tree.html
@@ -5,6 +5,7 @@
 {% load page_filters %}
 {% load rules %}
 {% block content %}
+    {% has_perm 'cms.change_page_object' request.user as can_edit_pages %}
     {% with filter_form.filters_visible as filters_visible %}
         <div class="table-header">
             <div class="flex flex-wrap justify-between gap-4">
@@ -31,7 +32,6 @@
                             <span class="filter-toggle-text {% if not filters_visible %}hidden{% endif %}">{% translate "Hide filters" %}</span>
                         </button>
                     {% endif %}
-                    {% has_perm 'cms.change_page_object' request.user as can_edit_pages %}
                     {% if can_edit_pages %}
                         {% if request.region.default_language == language %}
                             <a href="{% url 'new_page' region_slug=request.region.slug language_slug=language.slug %}"
@@ -153,9 +153,11 @@
                 <option>
                     {% translate "Select bulk action" %}
                 </option>
-                <option data-bulk-action="{% url 'bulk_archive_pages' region_slug=request.region.slug language_slug=language.slug %}">
-                    {% translate "Archive pages" %}
-                </option>
+                {% if can_edit_pages %}
+                    <option data-bulk-action="{% url 'bulk_archive_pages' region_slug=request.region.slug language_slug=language.slug %}">
+                        {% translate "Archive pages" %}
+                    </option>
+                {% endif %}
                 {% if SUMM_AI_ENABLED and request.user.is_staff %}
                     <option data-bulk-action="{% url 'auto_translate_easy_german_pages' region_slug=request.region.slug language_slug=language.slug %}">
                         {% translate "Automatically translate this page into Easy German" %}
@@ -200,7 +202,7 @@
             <button id="bulk-action-execute" class="btn" disabled>{% translate "Execute" %}</button>
         </div>
     </form>
-    {% if request.user.expert_mode %}
+    {% if request.user.expert_mode and can_edit_pages %}
         <div class="flex-wrap relative w-auto mt-12">
             <h3 class="font-bold text-xl">{% translate "Import XLIFF files" %}</h3>
             <div class="my-2 text-s text-gray-600">{% translate "Supported file extensions" %}: .zip, .xlf, .xliff</div>

--- a/integreat_cms/cms/templates/pages/page_tree_archived.html
+++ b/integreat_cms/cms/templates/pages/page_tree_archived.html
@@ -5,6 +5,7 @@
 {% load page_filters %}
 {% load rules %}
 {% block content %}
+    {% has_perm 'cms.change_page_object' request.user as can_edit_pages %}
     {% with filter_form.filters_visible as filters_visible %}
         <div class="table-header">
             <div class="flex flex-wrap justify-between gap-4">
@@ -89,17 +90,19 @@
                     {% endfor %}
                 </tbody>
             </table>
-            <div class="flex flex-wrap gap-2 mt-4">
-                <select id="bulk-action" class="w-auto max-w-full">
-                    <option>
-                        {% translate "Select bulk action" %}
-                    </option>
-                    <option data-bulk-action="{% url 'bulk_restore_pages' region_slug=request.region.slug language_slug=language.slug %}">
-                        {% translate "Restore pages" %}
-                    </option>
-                </select>
-                <button form="bulk-action-form" id="bulk-action-execute" class="btn" disabled>{% translate "Execute" %}</button>
-            </div>
+            {% if can_edit_pages %}
+                <div class="flex flex-wrap gap-2 mt-4">
+                    <select id="bulk-action" class="w-auto max-w-full">
+                        <option>
+                            {% translate "Select bulk action" %}
+                        </option>
+                        <option data-bulk-action="{% url 'bulk_restore_pages' region_slug=request.region.slug language_slug=language.slug %}">
+                            {% translate "Restore pages" %}
+                        </option>
+                    </select>
+                    <button form="bulk-action-form" id="bulk-action-execute" class="btn" disabled>{% translate "Execute" %}</button>
+                </div>
+            {% endif %}
         </div>
     </div>
     {% include "../generic_confirmation_dialog.html" %}

--- a/integreat_cms/cms/templates/pages/page_tree_archived_node.html
+++ b/integreat_cms/cms/templates/pages/page_tree_archived_node.html
@@ -120,21 +120,23 @@
                 <i icon-name="eye"></i>
             </button>
         {% endif %}
-        {% if page.explicitly_archived %}
-            <button title="{% translate "Restore page" %}"
-                    class="confirmation-button btn-icon"
-                    data-confirmation-title="{{ restore_dialog_title }}"
-                    data-confirmation-text="{{ restore_dialog_text }}"
-                    data-confirmation-subject="{{ page.best_translation.title }}"
-                    data-action="{% url 'restore_page' page_id=page.id region_slug=request.region.slug language_slug=language.slug %}">
-                <i icon-name="refresh-ccw"></i>
-            </button>
-        {% else %}
-            <a title="{% translate "To restore this page, you have to restore its archived parent page." %}"
-               class="btn-icon"
-               disabled>
-                <i icon-name="refresh-ccw"></i>
-            </a>
+        {% if can_edit_pages %}
+            {% if page.explicitly_archived %}
+                <button title="{% translate "Restore page" %}"
+                        class="confirmation-button btn-icon"
+                        data-confirmation-title="{{ restore_dialog_title }}"
+                        data-confirmation-text="{{ restore_dialog_text }}"
+                        data-confirmation-subject="{{ page.best_translation.title }}"
+                        data-action="{% url 'restore_page' page_id=page.id region_slug=request.region.slug language_slug=language.slug %}">
+                    <i icon-name="refresh-ccw"></i>
+                </button>
+            {% else %}
+                <a title="{% translate "To restore this page, you have to restore its archived parent page." %}"
+                   class="btn-icon"
+                   disabled>
+                    <i icon-name="refresh-ccw"></i>
+                </a>
+            {% endif %}
         {% endif %}
         {% if perms.cms.delete_page %}
             {% if not page.is_leaf %}

--- a/integreat_cms/cms/templates/pages/page_tree_node.html
+++ b/integreat_cms/cms/templates/pages/page_tree_node.html
@@ -2,6 +2,7 @@
 {% load content_filters %}
 {% load page_filters %}
 {% load tree_filters %}
+{% load rules %}
 {% get_translation page language.slug as page_translation %}
 <tr id="page-{{ page.id }}-drop-left"
     data-drop-id="{{ page.id }}"
@@ -26,13 +27,14 @@
                class="bulk-select-item cursor-wait"/>
     </td>
     {% if not filter_form.is_enabled %}
+        {% has_perm 'cms.change_page_object' request.user as can_edit_pages %}
         <td class="hierarchy single_icon whitespace-nowrap">
             <span data-drag-id="{{ page.id }}"
                   data-node-descendants="{{ page|get_descendant_ids }}"
                   class="drag cursor-move text-gray-800 inline-block pl-4 align-middle"
-                  draggable="true"
+                  draggable="{% if can_edit_pages %}true{% else %}false{% endif %}"
                   title="{% translate "Change the order and position of the pages with drag & drop." %}">
-                <i icon-name="move"></i>
+                {% if can_edit_pages %}<i icon-name="move"></i>{% endif %}
             </span>
             {% if not page.parent_id and not page.is_leaf or page.parent_id and page.cached_children|length > 0 %}
                 <span class="toggle-subpages inline-block align-middle cursor-wait transform"
@@ -170,14 +172,16 @@
            class="btn-icon">
             <i icon-name="edit"></i>
         </a>
-        <button title="{% translate "Archive page" %}"
-                class="confirmation-button btn-icon"
-                data-confirmation-title="{{ archive_dialog_title }}"
-                data-confirmation-text="{{ archive_dialog_text }}"
-                data-confirmation-subject="{{ page.best_translation.title }}"
-                data-action="{% url 'archive_page' page_id=page.id region_slug=request.region.slug language_slug=language.slug %}">
-            <i icon-name="archive"></i>
-        </button>
+        {% if can_edit_pages %}
+            <button title="{% translate "Archive page" %}"
+                    class="confirmation-button btn-icon"
+                    data-confirmation-title="{{ archive_dialog_title }}"
+                    data-confirmation-text="{{ archive_dialog_text }}"
+                    data-confirmation-subject="{{ page.best_translation.title }}"
+                    data-action="{% url 'archive_page' page_id=page.id region_slug=request.region.slug language_slug=language.slug %}">
+                <i icon-name="archive"></i>
+            </button>
+        {% endif %}
         {% if perms.cms.delete_page %}
             {# djlint:off H023 #}
             {% if not page.is_leaf %}

--- a/integreat_cms/cms/templates/pois/poi_form_sidebar/position_box.html
+++ b/integreat_cms/cms/templates/pois/poi_form_sidebar/position_box.html
@@ -53,13 +53,16 @@
         <div id="map"
              class="aspect-video"
              data-url="{% url "get_address_from_coordinates" region_slug=request.region.slug %}"
-             data-bounding-box="{{ request.region.bounding_box.api_representation }}">
+             data-bounding-box="{{ request.region.bounding_box.api_representation }}"
+             data-change-permission="{{ perms.cms.change_poi }}">
         </div>
         <div id="set_map_position_text" class="help-text hidden">
             {% translate "You can set the position by clicking on the map" %}
         </div>
         <div id="change_map_position_text" class="help-text hidden">
-            {% translate "You can change the position via drag & drop" %}
+            {% if perms.cms.change_poi %}
+                {% translate "You can change the position via drag & drop" %}
+            {% endif %}
         </div>
         <div id="update_position_from_map_marker" class="hidden">
             <p class="mb-3">

--- a/integreat_cms/cms/templates/pois/poi_list.html
+++ b/integreat_cms/cms/templates/pois/poi_list.html
@@ -98,39 +98,41 @@
             </div>
         </div>
     {% endif %}
-    <div class="flex flex-wrap gap-2 mt-4">
-        <select id="bulk-action" class="w-auto max-w-full">
-            <option>
-                {% translate "Select bulk action" %}
-            </option>
-            <option data-bulk-action="{% url 'bulk_archive_pois' region_slug=request.region.slug language_slug=language.slug %}">
-                {% translate "Archive locations" %}
-            </option>
-            {% if DEEPL_ENABLED %}
-                {% if language == request.region.default_language %}
-                    <option disabled
-                            title="{% translate "You cannot translate into the default language" %}">
-                        {% translate "Create missing translations automatically" %}
-                    </option>
-                {% elif DEEPL_AVAILABLE %}
-                    <option data-bulk-action="{% url 'automatic_translation_pois' region_slug=request.region.slug language_slug=language.slug %}">
-                        {% translate "Create missing translations automatically" %}
-                    </option>
-                {% else %}
-                    <option disabled
-                            title="{% translate "This language is not supported by DeepL" %}">
-                        {% translate "Create missing translations automatically" %}
+    {% if perms.cms.change_poi %}
+        <div class="flex flex-wrap gap-2 mt-4">
+            <select id="bulk-action" class="w-auto max-w-full">
+                <option>
+                    {% translate "Select bulk action" %}
+                </option>
+                <option data-bulk-action="{% url 'bulk_archive_pois' region_slug=request.region.slug language_slug=language.slug %}">
+                    {% translate "Archive locations" %}
+                </option>
+                {% if DEEPL_ENABLED %}
+                    {% if language == request.region.default_language %}
+                        <option disabled
+                                title="{% translate "You cannot translate into the default language" %}">
+                            {% translate "Create missing translations automatically" %}
+                        </option>
+                    {% elif DEEPL_AVAILABLE %}
+                        <option data-bulk-action="{% url 'automatic_translation_pois' region_slug=request.region.slug language_slug=language.slug %}">
+                            {% translate "Create missing translations automatically" %}
+                        </option>
+                    {% else %}
+                        <option disabled
+                                title="{% translate "This language is not supported by DeepL" %}">
+                            {% translate "Create missing translations automatically" %}
+                        </option>
+                    {% endif %}
+                {% endif %}
+                {% if SUMM_AI_ENABLED %}
+                    <option data-bulk-action="{% url 'auto_translate_easy_german_pois' region_slug=request.region.slug language_slug=language.slug %}">
+                        {% translate "Automatically translate this location into Easy German" %}
                     </option>
                 {% endif %}
-            {% endif %}
-            {% if SUMM_AI_ENABLED %}
-                <option data-bulk-action="{% url 'auto_translate_easy_german_pois' region_slug=request.region.slug language_slug=language.slug %}">
-                    {% translate "Automatically translate this location into Easy German" %}
-                </option>
-            {% endif %}
-        </select>
-        <button form="bulk-action-form" id="bulk-action-execute" class="btn" disabled>{% translate "Execute" %}</button>
-    </div>
+            </select>
+            <button form="bulk-action-form" id="bulk-action-execute" class="btn" disabled>{% translate "Execute" %}</button>
+        </div>
+    {% endif %}
     {% include "../generic_confirmation_dialog.html" %}
     {% url "pois" as url %}
     {% include "pagination.html" with chunk=pois %}

--- a/integreat_cms/cms/templates/pois/poi_list_archived.html
+++ b/integreat_cms/cms/templates/pois/poi_list_archived.html
@@ -50,17 +50,19 @@
             </tbody>
         </table>
     </div>
-    <div class="flex flex-wrap gap-2 mt-4">
-        <select id="bulk-action" class="w-auto max-w-full">
-            <option>
-                {% translate "Select bulk action" %}
-            </option>
-            <option data-bulk-action="{% url 'bulk_restore_pois' region_slug=request.region.slug language_slug=language.slug %}">
-                {% translate "Restore locations" %}
-            </option>
-        </select>
-        <button form="bulk-action-form" id="bulk-action-execute" class="btn" disabled>{% translate "Execute" %}</button>
-    </div>
+    {% if perms.cms.change_poi %}
+        <div class="flex flex-wrap gap-2 mt-4">
+            <select id="bulk-action" class="w-auto max-w-full">
+                <option>
+                    {% translate "Select bulk action" %}
+                </option>
+                <option data-bulk-action="{% url 'bulk_restore_pois' region_slug=request.region.slug language_slug=language.slug %}">
+                    {% translate "Restore locations" %}
+                </option>
+            </select>
+            <button form="bulk-action-form" id="bulk-action-execute" class="btn" disabled>{% translate "Execute" %}</button>
+        </div>
+    {% endif %}
     {% include "../generic_confirmation_dialog.html" %}
     {% url "pois" as url %}
     {% include "pagination.html" with chunk=pois %}

--- a/integreat_cms/cms/templates/pois/poi_list_archived_row.html
+++ b/integreat_cms/cms/templates/pois/poi_list_archived_row.html
@@ -71,14 +71,16 @@
         </a>
     </td>
     <td class="pl-2 pr-4 py-3 text-right min flex flex-nowrap gap-2">
-        <button title="{% translate "Restore location" %}"
-                class="confirmation-button btn-icon"
-                data-confirmation-title="{{ restore_dialog_title }}"
-                data-confirmation-text="{{ restore_dialog_text }}"
-                data-confirmation-subject="{{ poi_translation.title }}"
-                data-action="{% url 'restore_poi' poi_id=poi.id region_slug=request.region.slug language_slug=language.slug %}">
-            <i icon-name="refresh-ccw"></i>
-        </button>
+        {% if perms.cms.change_poi %}
+            <button title="{% translate "Restore location" %}"
+                    class="confirmation-button btn-icon"
+                    data-confirmation-title="{{ restore_dialog_title }}"
+                    data-confirmation-text="{{ restore_dialog_text }}"
+                    data-confirmation-subject="{{ poi_translation.title }}"
+                    data-action="{% url 'restore_poi' poi_id=poi.id region_slug=request.region.slug language_slug=language.slug %}">
+                <i icon-name="refresh-ccw"></i>
+            </button>
+        {% endif %}
         {% if perms.cms.delete_poi %}
             {% if poi.events.exists %}
                 {# djlint:off H023 #}

--- a/integreat_cms/cms/templates/pois/poi_list_row.html
+++ b/integreat_cms/cms/templates/pois/poi_list_row.html
@@ -134,14 +134,16 @@
                 <i icon-name="external-link"></i>
             </button>
         {% endif %}
-        <button title="{% translate "Archive location" %}"
-                class="confirmation-button btn-icon"
-                data-confirmation-title="{{ archive_dialog_title }}"
-                data-confirmation-text="{{ archive_dialog_text }}"
-                data-confirmation-subject="{{ poi_translation.title }}"
-                data-action="{% url 'archive_poi' poi_id=poi.id region_slug=request.region.slug language_slug=language.slug %}">
-            <i icon-name="archive"></i>
-        </button>
+        {% if perms.cms.change_poi %}
+            <button title="{% translate "Archive location" %}"
+                    class="confirmation-button btn-icon"
+                    data-confirmation-title="{{ archive_dialog_title }}"
+                    data-confirmation-text="{{ archive_dialog_text }}"
+                    data-confirmation-subject="{{ poi_translation.title }}"
+                    data-action="{% url 'archive_poi' poi_id=poi.id region_slug=request.region.slug language_slug=language.slug %}">
+                <i icon-name="archive"></i>
+            </button>
+        {% endif %}
         {% if perms.cms.delete_poi %}
             {% if poi.events.exists %}
                 {# djlint:off H023 #}

--- a/integreat_cms/cms/views/pois/poi_context_mixin.py
+++ b/integreat_cms/cms/views/pois/poi_context_mixin.py
@@ -72,6 +72,7 @@ class POIContextMixin(ContextMixin):
                     "Opening time is identical with the closing time of the previous slot"
                 ),
             },
+            "canChangeLocation": self.request.user.has_perm("cms.change_poi"),
         }
         context.update(
             {

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8345,6 +8345,9 @@ msgstr ""
 "Diese Seite konnte nicht importiert werden, da sie zu einer anderen Region "
 "gehört ({})."
 
+#~ msgid "No icon is set"
+#~ msgstr "Kein Icon ist ausgewählt"
+
 #~ msgid "Currently not visible in apps"
 #~ msgstr "Wird noch nicht in den Apps angezeigt"
 

--- a/integreat_cms/static/src/js/pois/opening-hours/component/opening-hours-display.tsx
+++ b/integreat_cms/static/src/js/pois/opening-hours/component/opening-hours-display.tsx
@@ -1,6 +1,7 @@
 /*
  * This component renders the opening hours of a location
  */
+import cn from "classnames";
 import { StateUpdater } from "preact/hooks";
 import { OpeningHours } from "../index";
 
@@ -9,9 +10,10 @@ type Props = {
     setSelectedDays: StateUpdater<number[]>;
     translations: any;
     days: any;
+    canChangeLocation: boolean;
 };
 
-const OpeningHoursDisplay = ({ openingHours, setSelectedDays, translations, days }: Props) => {
+const OpeningHoursDisplay = ({ openingHours, setSelectedDays, translations, days, canChangeLocation }: Props) => {
     // Select a given list of weekdays for the input fields
     const select = (event: Event, days: number[]) => {
         event.preventDefault();
@@ -24,9 +26,11 @@ const OpeningHoursDisplay = ({ openingHours, setSelectedDays, translations, days
                 <div
                     key={translations.weekdays[day]}
                     title={translations.editWeekdayLabel}
-                    className="flex flex-wrap justify-between gap-2 hover:bg-gray-50 p-4 border-b cursor-pointer"
-                    onClick={() => setSelectedDays([day])}
-                    onKeyDown={() => setSelectedDays([day])}>
+                    className={cn("flex flex-wrap justify-between gap-2 p-4 border-b", {
+                        "hover:bg-gray-50 cursor-pointer": canChangeLocation,
+                    })}
+                    onClick={() => canChangeLocation && setSelectedDays([day])}
+                    onKeyDown={() => canChangeLocation && setSelectedDays([day])}>
                     <label class="secondary my-0 !cursor-pointer">{translations.weekdays[day]}</label>
                     <div class="text-right">
                         {dayOpeningHours.closed && translations.closedLabel}
@@ -39,23 +43,28 @@ const OpeningHoursDisplay = ({ openingHours, setSelectedDays, translations, days
                     </div>
                 </div>
             ))}
-            <div class="flex flex-wrap p-4 gap-2">
-                <button class="btn btn-small !rounded-full" onClick={(event) => select(event, days.all)} type="button">
-                    {translations.editAllLabel}
-                </button>
-                <button
-                    class="btn btn-small !rounded-full"
-                    onClick={(event) => select(event, days.workingDays)}
-                    type="button">
-                    {translations.editWorkingDaysLabel}
-                </button>
-                <button
-                    class="btn btn-small !rounded-full"
-                    onClick={(event) => select(event, days.weekend)}
-                    type="button">
-                    {translations.editWeekendLabel}
-                </button>
-            </div>
+            {canChangeLocation && (
+                <div class="flex flex-wrap p-4 gap-2">
+                    <button
+                        class="btn btn-small !rounded-full"
+                        onClick={(event) => select(event, days.all)}
+                        type="button">
+                        {translations.editAllLabel}
+                    </button>
+                    <button
+                        class="btn btn-small !rounded-full"
+                        onClick={(event) => select(event, days.workingDays)}
+                        type="button">
+                        {translations.editWorkingDaysLabel}
+                    </button>
+                    <button
+                        class="btn btn-small !rounded-full"
+                        onClick={(event) => select(event, days.weekend)}
+                        type="button">
+                        {translations.editWeekendLabel}
+                    </button>
+                </div>
+            )}
         </div>
     );
 };

--- a/integreat_cms/static/src/js/pois/opening-hours/index.tsx
+++ b/integreat_cms/static/src/js/pois/opening-hours/index.tsx
@@ -14,6 +14,7 @@ type Props = {
     translations: any;
     days: any;
     initial: OpeningHours[];
+    canChangeLocation: boolean;
 };
 
 type TimeSlot = {
@@ -27,7 +28,7 @@ export type OpeningHours = {
     closed: boolean;
 };
 
-const OpeningHoursWidget = ({ translations, days, initial }: Props) => {
+const OpeningHoursWidget = ({ translations, days, initial, canChangeLocation }: Props) => {
     // The state contains the current opening hours of the location
     const [openingHours, setOpeningHours] = useState<OpeningHours[]>(initial);
     // This state contains the days which are currently selected for being edited
@@ -55,6 +56,7 @@ const OpeningHoursWidget = ({ translations, days, initial }: Props) => {
                         setSelectedDays={setSelectedDays}
                         translations={translations}
                         days={days}
+                        canChangeLocation={canChangeLocation}
                     />
                     {selectedDays.length > 0 && (
                         <OpeningHoursInputFields

--- a/integreat_cms/static/src/js/pois/poi-map.ts
+++ b/integreat_cms/static/src/js/pois/poi-map.ts
@@ -139,7 +139,7 @@ const renderMap = () => {
     // Initialize map and marker
     const map = new Map(options);
     const marker = new Marker();
-    marker.setDraggable(true);
+    marker.setDraggable(container.dataset.changePermission === "True");
 
     // If initial coordinates are given, set the marker to this position
     if (coordinates) {


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR deactivates page order change by drag&drop in the page form if user does not have permission to change the page.

While working on this issue, I found a similar problem with icon setting of page/poi/event. Icon choise is now deactivated too when user does not have change permission.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Set the page node in the page order section undraggable if user has no change permission.
- Deactivate all the event listners of the page order section.
- Hide icon set/change buttons in page/poi/event form if user has no change permission.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- None (I hope)


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1970 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
