### PR TITLE
Remove gap between sidebar boxes (for pages and events)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ UNRELEASED
 ----------
 
 * [ [#1245](https://github.com/digitalfabrik/integreat-cms/issues/1245) ] Restore expanded state of page tree
+* [ [#2032](https://github.com/digitalfabrik/integreat-cms/issues/2032) ] Remove gap between sidebar boxes in event and page form
 
 
 2023.2.2

--- a/integreat_cms/cms/templates/events/event_form.html
+++ b/integreat_cms/cms/templates/events/event_form.html
@@ -53,10 +53,10 @@
                 {% endif %}
             {% endif %}
         </div>
-        <div class="md:grid grid-cols-2 3xl:grid-cols-[minmax(0px,_1fr)_400px] 4xl:grid-cols-[minmax(0px,_1fr)_400px_400px] gap-4">
+        <div class="3xl:grid grid-cols-2 3xl:grid-cols-[minmax(0px,_1fr)_400px] 4xl:grid-cols-[minmax(0px,_1fr)_816px] gap-4">
             <div class="col-span-2 3xl:col-span-1 flex flex-wrap flex-col">
                 {% include "_form_language_tabs.html" with target="edit_event" instance=event_form.instance content_field="event_id" %}
-                <div class="w-full rounded border border-blue-500 bg-white shadow-2xl flex flex-col flex-auto">
+                <div class="w-full rounded border border-blue-500 bg-white shadow-2xl flex flex-col">
                     <div class="w-full p-4 flex flex-col flex-auto">
                         <div class="flex justify-between">
                             <label for="{{ event_translation_form.title.id_for_label }}"
@@ -119,21 +119,23 @@
                     </div>
                 </div>
             </div>
-            <div id="left-sidebar-column"
-                 class="mt-3 md:mt-0 3xl:col-end-3 4xl:col-end-auto flex flex-wrap flex-col md:gap-2"
-                 {% if request.user.distribute_sidebar_boxes %} data-enable-automatic-sidebar-distribution{% endif %}>
-                {% if event_form.instance.id and perms.cms.change_event %}
-                    {% include "./event_form_sidebar/minor_edit_box.html" with box_id="event-minor-edit" %}
-                {% endif %}
-                {% include "./event_form_sidebar/date_and_time_box.html" with box_id="event-date-time" %}
-            </div>
-            <div id="right-sidebar-column"
-                 class="3xl:col-end-3 4xl:col-end-auto flex flex-wrap flex-col md:gap-2">
-                {% include "./event_form_sidebar/venue_box.html" with box_id="event-venue" %}
-                {% include "./event_form_sidebar/icon_box.html" with box_id="event-icon" %}
-                {% if event_form.instance.id and perms.cms.change_event %}
-                    {% include "./event_form_sidebar/actions_box.html" with box_id="event-actions" %}
-                {% endif %}
+            <div class="md:flex mt-4 3xl:mt-0 block 3xl:block 4xl:flex">
+                <div id="left-sidebar-column"
+                     class="md:mr-4 md:w-full 3xl:mr-0 md:mt-0 sm:block md:flex sm:mt-4 flex-wrap flex-col 4xl:mr-4"
+                     {% if request.user.distribute_sidebar_boxes %} data-enable-automatic-sidebar-distribution{% endif %}>
+                    {% if event_form.instance.id and perms.cms.change_event %}
+                        {% include "./event_form_sidebar/minor_edit_box.html" with box_id="event-minor-edit" %}
+                    {% endif %}
+                    {% include "./event_form_sidebar/date_and_time_box.html" with box_id="event-date-time" %}
+                </div>
+                <div id="right-sidebar-column"
+                     class="md:w-full 3xl:col-end-3 4xl:col-end-auto flex flex-wrap flex-col">
+                    {% include "./event_form_sidebar/venue_box.html" with box_id="event-venue" %}
+                    {% include "./event_form_sidebar/icon_box.html" with box_id="event-icon" %}
+                    {% if event_form.instance.id and perms.cms.change_event %}
+                        {% include "./event_form_sidebar/actions_box.html" with box_id="event-actions" %}
+                    {% endif %}
+                </div>
             </div>
         </div>
     </form>

--- a/integreat_cms/cms/templates/pages/page_form.html
+++ b/integreat_cms/cms/templates/pages/page_form.html
@@ -63,10 +63,10 @@
                 </div>
             {% endif %}
         </div>
-        <div class="md:grid grid-cols-2 3xl:grid-cols-[minmax(0px,_1fr)_400px] {% if page %} 4xl:grid-cols-[minmax(0px,_1fr)_400px_400px]{% endif %} gap-4">
+        <div class="3xl:grid grid-cols-2 3xl:grid-cols-[minmax(0px,_1fr)_400px] {% if page %} 4xl:grid-cols-[minmax(0px,_1fr)_816px]{% endif %} gap-4">
             <div class="col-span-2 3xl:col-span-1 flex flex-wrap flex-col flex-auto">
                 {% include "_form_language_tabs.html" with target="edit_page" instance=page_form.instance content_field="page_id" %}
-                <div class="w-full rounded border border-blue-500 bg-white shadow-2xl flex flex-col flex-auto">
+                <div class="w-full rounded border border-blue-500 bg-white shadow-2xl flex flex-col">
                     <div class="flex flex-col flex-auto p-4">
                         {% if page_translation_form.instance.currently_in_translation %}
                             <div id="currently-in-translation-warning">
@@ -164,26 +164,28 @@
                     </div>
                 </div>
             </div>
-            <div id="left-sidebar-column"
-                 class="mt-3 md:mt-0 flex flex-wrap flex-col md:gap-2"
-                 {% if request.user.distribute_sidebar_boxes %} data-enable-automatic-sidebar-distribution{% endif %}>
-                {% if language.slug in TEXTLAB_API_LANGUAGES and request.region.hix_enabled and TEXTLAB_API_ENABLED %}
-                    {% include "../hix_widget.html" with box_id="hix-widget" %}
-                {% endif %}
-                {% if page %}
-                    {% include "./page_form_sidebar/minor_edit_box.html" with box_id="page-minor-edit" %}
-                {% endif %}
-                {% include "./page_form_sidebar/settings_box.html" with box_id="page-setting" %}
-            </div>
-            {% if page %}
-                <div id="right-sidebar-column"
-                     class="3xl:col-end-3 4xl:col-end-auto flex flex-wrap flex-col md:gap-2">
-                    {% if can_edit_page %}
-                        {% include "./page_form_sidebar/actions_box.html" with box_id="page-actions" %}
+            <div class="md:flex mt-4 3xl:mt-0 block 3xl:block 4xl:flex">
+                <div id="left-sidebar-column"
+                     class="md:mr-4 md:w-full 3xl:mr-0 md:mt-0 sm:block md:flex sm:mt-4 flex-wrap flex-col 4xl:mr-4"
+                     {% if request.user.distribute_sidebar_boxes %} data-enable-automatic-sidebar-distribution{% endif %}>
+                    {% if language.slug in TEXTLAB_API_LANGUAGES and request.region.hix_enabled and TEXTLAB_API_ENABLED %}
+                        {% include "../hix_widget.html" with box_id="hix-widget" %}
                     {% endif %}
-                    {% include "./page_form_sidebar/translator_view_box.html" with box_id="page-side-by-side" %}
+                    {% if page %}
+                        {% include "./page_form_sidebar/minor_edit_box.html" with box_id="page-minor-edit" %}
+                    {% endif %}
+                    {% include "./page_form_sidebar/settings_box.html" with box_id="page-setting" %}
                 </div>
-            {% endif %}
+                {% if page %}
+                    <div id="right-sidebar-column"
+                         class="md:w-full 3xl:col-end-3 4xl:col-end-auto flex flex-wrap flex-col">
+                        {% if can_edit_page %}
+                            {% include "./page_form_sidebar/actions_box.html" with box_id="page-actions" %}
+                        {% endif %}
+                        {% include "./page_form_sidebar/translator_view_box.html" with box_id="page-side-by-side" %}
+                    </div>
+                {% endif %}
+            </div>
         </div>
     </form>
     {{ media_config_data|json_script:"media_config_data" }}


### PR DESCRIPTION
### Short description
This PR removes the gap between the sidebar boxes for pages and events. The PR is similar to [the one where I remove the gap for POIs](https://github.com/digitalfabrik/integreat-cms/pull/2043).

### Proposed changes

- Switch from gap to flex for pages and events
- Adjust the spacing to be 16px / 1rem for all boxes to all sides

### Side effects
I think none


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2032


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
