### PR TITLE
Fix events endpoint for recurring events

### DIFF
--- a/integreat_cms/api/v3/events.py
+++ b/integreat_cms/api/v3/events.py
@@ -193,8 +193,12 @@ def events(request, region_slug, language_slug):
     now = timezone.now().date()
     for event in region.events.prefetch_public_translations().filter(archived=False):
         if event_translation := event.get_public_translation(language_slug):
+            event_is_not_recurring = not event.recurrence_rule
+            recurring_event_should_be_appended_once = "combine_recurring" in request.GET
             # Either it's in the future or it's recurring and the last recurrence is >= now
-            if not event.is_past:
+            if not event.is_past and (
+                event_is_not_recurring or recurring_event_should_be_appended_once
+            ):
                 result.append(transform_event_translation(event_translation))
             if "combine_recurring" not in request.GET:
                 for future_event in transform_event_recurrences(event_translation, now):


### PR DESCRIPTION
### Short description
For every recurring event the first event was appended, event if it is in the past. Fixed this.


### Proposed changes
The first event of a recurring event is only appended if recurring events are delivered as one event with rrule.

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- 
- 


### Resolved issues
[<!-- List all issues which should be closed when this PR is merged. -->](https://chat.tuerantuer.org/digitalfabrik/pl/j7o19wr7yff1xq5mo8a51t1jja)

Fixes: #


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
