### PR TITLE
Fix events endpoint for recurring events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ UNRELEASED
 ----------
 
 * [ [#2012](https://github.com/digitalfabrik/integreat-cms/issues/2012) ] Exclude archived pages when cloning a region
+* [ [#2093](https://github.com/digitalfabrik/integreat-cms/issues/2093) ] Fix recurring events endpoint
 
 
 2023.2.1

--- a/tests/api/expected-outputs/augsburg_ar_events.json
+++ b/tests/api/expected-outputs/augsburg_ar_events.json
@@ -1,8 +1,8 @@
 [
   {
     "id": null,
-    "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung/",
-    "path": "/augsburg/ar/events/test-veranstaltung/",
+    "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung$2030-01-01/",
+    "path": "/augsburg/ar/events/test-veranstaltung$2030-01-01/",
     "title": "Test-Veranstaltung",
     "modified_gmt": "2020-01-22T12:46:33.967Z",
     "last_updated": "2020-01-22T13:46:33.967+01:00",
@@ -10,19 +10,19 @@
     "content": "<p>Dies ist die Beschreibung einer Test-Veranstaltung.</p>",
     "available_languages": {
       "de": {
-        "id": 2,
-        "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung/",
-        "path": "/augsburg/de/events/test-veranstaltung/"
+        "id": null,
+        "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung$2030-01-01/",
+        "path": "/augsburg/de/events/test-veranstaltung$2030-01-01/"
       },
       "en": {
-        "id": 3,
-        "url": "http://localhost:8000/augsburg/en/events/test-event/",
-        "path": "/augsburg/en/events/test-event/"
+        "id": null,
+        "url": "http://localhost:8000/augsburg/en/events/test-event$2030-01-01/",
+        "path": "/augsburg/en/events/test-event$2030-01-01/"
       },
       "fa": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung/",
-        "path": "/augsburg/fa/events/test-veranstaltung/"
+        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung$2030-01-01/",
+        "path": "/augsburg/fa/events/test-veranstaltung$2030-01-01/"
       }
     },
     "thumbnail": null,
@@ -39,7 +39,7 @@
       "longitude": null
     },
     "event": {
-      "id": 1,
+      "id": null,
       "start": "2030-01-01T13:00:00+01:00",
       "start_date": "2030-01-01",
       "start_time": "13:00:00",

--- a/tests/api/expected-outputs/augsburg_de_events.json
+++ b/tests/api/expected-outputs/augsburg_de_events.json
@@ -1,8 +1,8 @@
 [
   {
-    "id": 2,
-    "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung/",
-    "path": "/augsburg/de/events/test-veranstaltung/",
+    "id": null,
+    "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung$2030-01-01/",
+    "path": "/augsburg/de/events/test-veranstaltung$2030-01-01/",
     "title": "Test-Veranstaltung",
     "modified_gmt": "2020-01-22T12:46:33.967Z",
     "last_updated": "2020-01-22T13:46:33.967+01:00",
@@ -10,19 +10,19 @@
     "content": "<p>Dies ist die Beschreibung einer Test-Veranstaltung.</p>",
     "available_languages": {
       "en": {
-        "id": 3,
-        "url": "http://localhost:8000/augsburg/en/events/test-event/",
-        "path": "/augsburg/en/events/test-event/"
+        "id": null,
+        "url": "http://localhost:8000/augsburg/en/events/test-event$2030-01-01/",
+        "path": "/augsburg/en/events/test-event$2030-01-01/"
       },
       "ar": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung/",
-        "path": "/augsburg/ar/events/test-veranstaltung/"
+        "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung$2030-01-01/",
+        "path": "/augsburg/ar/events/test-veranstaltung$2030-01-01/"
       },
       "fa": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung/",
-        "path": "/augsburg/fa/events/test-veranstaltung/"
+        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung$2030-01-01/",
+        "path": "/augsburg/fa/events/test-veranstaltung$2030-01-01/"
       }
     },
     "thumbnail": null,
@@ -39,7 +39,7 @@
       "longitude": null
     },
     "event": {
-      "id": 1,
+      "id": null,
       "start": "2030-01-01T13:00:00+01:00",
       "start_date": "2030-01-01",
       "start_time": "13:00:00",

--- a/tests/api/expected-outputs/augsburg_en_events.json
+++ b/tests/api/expected-outputs/augsburg_en_events.json
@@ -1,8 +1,8 @@
 [
   {
-    "id": 3,
-    "url": "http://localhost:8000/augsburg/en/events/test-event/",
-    "path": "/augsburg/en/events/test-event/",
+    "id": null,
+    "url": "http://localhost:8000/augsburg/en/events/test-event$2030-01-01/",
+    "path": "/augsburg/en/events/test-event$2030-01-01/",
     "title": "Test-Event",
     "modified_gmt": "2020-01-22T12:46:16.746Z",
     "last_updated": "2020-01-22T13:46:16.746+01:00",
@@ -10,19 +10,19 @@
     "content": "<p>This is the content of a test-event.</p>",
     "available_languages": {
       "de": {
-        "id": 2,
-        "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung/",
-        "path": "/augsburg/de/events/test-veranstaltung/"
+        "id": null,
+        "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung$2030-01-01/",
+        "path": "/augsburg/de/events/test-veranstaltung$2030-01-01/"
       },
       "ar": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung/",
-        "path": "/augsburg/ar/events/test-veranstaltung/"
+        "url": "http://localhost:8000/augsburg/ar/events/test-veranstaltung$2030-01-01/",
+        "path": "/augsburg/ar/events/test-veranstaltung$2030-01-01/"
       },
       "fa": {
         "id": null,
-        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung/",
-        "path": "/augsburg/fa/events/test-veranstaltung/"
+        "url": "http://localhost:8000/augsburg/fa/events/test-veranstaltung$2030-01-01/",
+        "path": "/augsburg/fa/events/test-veranstaltung$2030-01-01/"
       }
     },
     "thumbnail": null,
@@ -39,7 +39,7 @@
       "longitude": null
     },
     "event": {
-      "id": 1,
+      "id": null,
       "start": "2030-01-01T13:00:00+01:00",
       "start_date": "2030-01-01",
       "start_time": "13:00:00",

--- a/tests/api/expected-outputs/nurnberg_de_events.json
+++ b/tests/api/expected-outputs/nurnberg_de_events.json
@@ -1,8 +1,8 @@
 [
   {
-    "id": 5,
-    "url": "http://localhost:8000/nurnberg/de/events/test-veranstaltung/",
-    "path": "/nurnberg/de/events/test-veranstaltung/",
+    "id": null,
+    "url": "http://localhost:8000/nurnberg/de/events/test-veranstaltung$2031-01-01/",
+    "path": "/nurnberg/de/events/test-veranstaltung$2031-01-01/",
     "title": "Test-Veranstaltung",
     "modified_gmt": "2020-01-22T12:46:33.967Z",
     "last_updated": "2020-01-22T13:46:33.967+01:00",
@@ -10,9 +10,9 @@
     "content": "<p>Dies ist die Beschreibung einer Test-Veranstaltung.</p>",
     "available_languages": {
       "en": {
-        "id": 6,
-        "url": "http://localhost:8000/nurnberg/en/events/test-event/",
-        "path": "/nurnberg/en/events/test-event/"
+        "id": null,
+        "url": "http://localhost:8000/nurnberg/en/events/test-event$2031-01-01/",
+        "path": "/nurnberg/en/events/test-event$2031-01-01/"
       }
     },
     "thumbnail": null,
@@ -29,7 +29,7 @@
       "longitude": 1
     },
     "event": {
-      "id": 2,
+      "id": null,
       "start": "2031-01-01T15:00:00+01:00",
       "start_date": "2031-01-01",
       "start_time": "15:00:00",

--- a/tests/api/expected-outputs/nurnberg_en_events.json
+++ b/tests/api/expected-outputs/nurnberg_en_events.json
@@ -1,8 +1,8 @@
 [
   {
-    "id": 6,
-    "url": "http://localhost:8000/nurnberg/en/events/test-event/",
-    "path": "/nurnberg/en/events/test-event/",
+    "id": null,
+    "url": "http://localhost:8000/nurnberg/en/events/test-event$2031-01-01/",
+    "path": "/nurnberg/en/events/test-event$2031-01-01/",
     "title": "Test-Event",
     "modified_gmt": "2020-01-22T12:46:16.746Z",
     "last_updated": "2020-01-22T13:46:16.746+01:00",
@@ -10,9 +10,9 @@
     "content": "<p>This is the content of a test-event.</p>",
     "available_languages": {
       "de": {
-        "id": 5,
-        "url": "http://localhost:8000/nurnberg/de/events/test-veranstaltung/",
-        "path": "/nurnberg/de/events/test-veranstaltung/"
+        "id": null,
+        "url": "http://localhost:8000/nurnberg/de/events/test-veranstaltung$2031-01-01/",
+        "path": "/nurnberg/de/events/test-veranstaltung$2031-01-01/"
       }
     },
     "thumbnail": null,
@@ -29,7 +29,7 @@
       "longitude": 1
     },
     "event": {
-      "id": 2,
+      "id": null,
       "start": "2031-01-01T15:00:00+01:00",
       "start_date": "2031-01-01",
       "start_time": "15:00:00",


### PR DESCRIPTION
### Short description
For every recurring event the first event was appended, even if it is in the past. Fixed this.

### Proposed changes
The first event of a recurring event is only appended if recurring events are delivered as one event with rrule.



### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->



### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
