### PR TITLE
Visually indicate when a checkbox is disabled

### DIFF
--- a/integreat_cms/static/src/css/style.scss
+++ b/integreat_cms/static/src/css/style.scss
@@ -226,6 +226,10 @@ select,
 [type="checkbox"],
 [type="radio"] {
     @apply rounded text-blue-500 mr-2 align-text-top;
+
+    &:disabled {
+        @apply bg-gray-100 border-gray-300;
+    }
 }
 
 label {


### PR DESCRIPTION
### Short description
At the moment it's not very clear which checkboxes are enabled and which ones are disabled. Therefore we want to introduce some visual indicators to see a difference


### Proposed changes

- Add tailwind classes "bg-gray-100 border-gray-300" for disabled checkboxes and radio buttons  


### Side effects
None I'm aware of


### Resolved issues
Fixes: #2051 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
