### PR TITLE
Switch back to upstream doc library `sphinxcontrib-django`

### DIFF
--- a/integreat_cms/cms/templates/emails/_base_email.html
+++ b/integreat_cms/cms/templates/emails/_base_email.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 <!DOCTYPE html>
 {% get_current_language as LANGUAGE_CODE %}
-{# djlint:off H016,H030,H031 #}
+{# djlint:off H006,H016,H030,H031 #}
 <html lang="{{ LANGUAGE_CODE }}">
     <head>
         <meta charset="utf-8" />
@@ -39,7 +39,7 @@
             <br />
             <div id="logo">
                 <a href="{{ base_url }}">
-                    <img src="cid:logo" alt="" height="75px"/>
+                    <img src="cid:logo" alt="" height="75"/>
                 </a>
             </div>
         </div>

--- a/integreat_cms/cms/templates/pages/page_pdf.html
+++ b/integreat_cms/cms/templates/pages/page_pdf.html
@@ -11,7 +11,7 @@
     See https://github.com/xhtml2pdf/xhtml2pdf/issues/498 for more information.
     Once this issue is fixed, we can use tailwind in the pdf context.
 {% endcomment %}
-{# djlint:off H016,H030,H031 #}
+{# djlint:off H006,H016,H025,H030,H031 #}
 <html>
     <head>
         <!-- these style settings are only set to pdf exported pages
@@ -19,6 +19,9 @@
         the documentation of xhtml2pdf -->
         {% render_bundle 'pdf' 'css' %}
         <style>
+            .content {
+                padding-bottom: 30px;
+            }
             {% if language.slug == "zh-CN" %}
                 html, body {
                     font-family: "Noto Sans SC", sans-serif;
@@ -64,7 +67,8 @@
                     <td id="second-footer">{{ region.full_name }}</td>
                     <td id="third-footer">
                         <img src="{% static 'logos/'|add:BRANDING|add:'/'|add:BRANDING|add:'-logo.png' %}"
-                             height="40"/>
+                             height="40"
+                             alt="{{ BRANDING }}"/>
                     </td>
                 </tr>
             </table>
@@ -88,24 +92,28 @@
                 </div>
             {% endif %}
             {% for page, info in annotated_pages %}
+                {# djlint:off #}
                 {% if info.open %}
                     <ul>
                         <li>{% else %}</li>
-                        <li>
-                        {% endif %}
-                        {% get_public_translation page language.slug as page_translation %}
-                        <h1 class="level-{{ page.depth|add:"-1" }}">{{ page_translation.title }}</h1>
-                        <div class="content" style="padding-bottom: 30px;">
-                            {% if page.mirrored_page_first %}{{ page_translation.mirrored_translation_text|pdf_strip_fontstyles|safe }}{% endif %}
-                            {{ page_translation.content|pdf_strip_fontstyles|safe }}
-                            {% if not page.mirrored_page_first %}
-                                {{ page_translation.mirrored_translation_text|pdf_strip_fontstyles|safe }}
-                            {% endif %}
-                        </div>
-                        {% for close in info.close %}
+                    <li>
+                {% endif %}
+                {% get_public_translation page language.slug as page_translation %}
+                <h1 class="level-{{ page.depth|add:"-1" }}">{{ page_translation.title }}</h1>
+                <div class="content">
+                    {% if page.mirrored_page_first %}
+                        {{ page_translation.mirrored_translation_text|pdf_strip_fontstyles|safe }}
+                    {% endif %}
+                    {{ page_translation.content|pdf_strip_fontstyles|safe }}
+                    {% if not page.mirrored_page_first %}
+                        {{ page_translation.mirrored_translation_text|pdf_strip_fontstyles|safe }}
+                    {% endif %}
+                </div>
+                {% for close in info.close %}
                         </li>
                     </ul>
                 {% endfor %}
+                {# djlint:on #}
             {% endfor %}
         </div>
     </body>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ dev = [
     "requests-mock",
     "shellcheck-py",
     "sphinx",
-    "sphinxcontrib-django2",
+    "sphinxcontrib-django",
     "sphinx-last-updated-by-git",
     "sphinx-rtd-theme",
     "twine",

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -23,7 +23,7 @@ from integreat_cms.core import settings
 sys.path.append(os.path.abspath(".."))
 # Append sphinx source directory to path environment variable to allow documentation for this file
 sys.path.append(os.path.abspath("."))
-#: The path to the django settings module (see :doc:`sphinxcontrib-django2:readme`)
+#: The path to the django settings module (see :doc:`sphinxcontrib-django:readme`)
 django_settings = "integreat_cms.core.sphinx_settings"
 #: The "major.minor" version of Django
 django_version = f"{django_version[0]}.{django_version[1]}"
@@ -60,7 +60,7 @@ extensions = [
     "sphinx.ext.githubpages",
     "sphinx.ext.intersphinx",
     "sphinx.ext.linkcode",
-    "sphinxcontrib_django2",
+    "sphinxcontrib_django",
     "sphinx_rtd_theme",
     "sphinx_last_updated_by_git",
 ]
@@ -85,8 +85,8 @@ intersphinx_mapping = {
         "https://sphinx-rtd-theme.readthedocs.io/en/latest/",
         None,
     ),
-    "sphinxcontrib-django2": (
-        "https://sphinxcontrib-django2.readthedocs.io/en/latest/",
+    "sphinxcontrib-django": (
+        "https://sphinxcontrib-django.readthedocs.io/en/latest/",
         None,
     ),
     "sphinx-rtd-tutorial": (
@@ -280,7 +280,7 @@ def patch_django_for_autodoc(app):
 
 def setup(app):
     """
-    Connect to the ``django-configured`` event of :mod:`sphinxcontrib_django2` to monkeypatch application.
+    Connect to the ``django-configured`` event of :mod:`sphinxcontrib_django` to monkeypatch application.
 
     :param app: The Sphinx application object
     :type app: ~sphinx.application.Sphinx

--- a/sphinx/documentation.rst
+++ b/sphinx/documentation.rst
@@ -131,7 +131,7 @@ We use the following sphinx extensions:
 * :mod:`sphinx:sphinx.ext.linkcode` adds external links to the source code of documented modules, see
   :func:`~conf.linkcode_resolve`.
 
-* :mod:`sphinxcontrib_django2` adds improvements to the docstrings of Django models and forms.
+* :mod:`sphinxcontrib_django` adds improvements to the docstrings of Django models and forms.
 
 * `sphinx_rtd_theme <https://pypi.org/project/sphinx-rtd-theme/>`__ is the theme we use for our documentation:
   :doc:`sphinx-rtd-theme:index`


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
The changes from my fork [timoludwig/sphinxcontrib-django2](https://github.com/timoludwig/sphinxcontrib-django2) were now merged into [edoburu/sphinxcontrib-django](https://github.com/edoburu/sphinxcontrib-django) and I took over maintenance for the upstream package, so I suggest to use that one instead.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Switch back from `sphinxcontrib-django2` to `sphinxcontrib-django` (partially reverts changes from f4ab3c13ff1e92f4b82f8a87f31badabb6c8ed15)
- Adapt HTML code to new djLint version


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
