### PR TITLE
Only allow staff members to use the SUMM AI bulk action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ UNRELEASED
 * [ [#2032](https://github.com/digitalfabrik/integreat-cms/issues/2032) ] Remove gap between sidebar boxes in event and page form
 * [ [#1322](https://github.com/digitalfabrik/integreat-cms/issues/1322) ] Add organization name & logo to the page API response
 * [ [#2105](https://github.com/digitalfabrik/integreat-cms/issues/2105) ] Indicate that categories are now shown in the apps
+* [ [#2065](https://github.com/digitalfabrik/integreat-cms/issues/2065) ] Only allow staff members to use SUMM.AI bulk action
 
 
 2023.2.2

--- a/integreat_cms/cms/templates/pages/page_tree.html
+++ b/integreat_cms/cms/templates/pages/page_tree.html
@@ -156,7 +156,7 @@
                 <option data-bulk-action="{% url 'bulk_archive_pages' region_slug=request.region.slug language_slug=language.slug %}">
                     {% translate "Archive pages" %}
                 </option>
-                {% if SUMM_AI_ENABLED %}
+                {% if SUMM_AI_ENABLED and request.user.is_staff %}
                     <option data-bulk-action="{% url 'auto_translate_easy_german_pages' region_slug=request.region.slug language_slug=language.slug %}">
                         {% translate "Automatically translate this page into Easy German" %}
                     </option>

--- a/tests/summ_ai_api/summ_ai_test.py
+++ b/tests/summ_ai_api/summ_ai_test.py
@@ -10,9 +10,6 @@ from integreat_cms.cms.models import Page, Region
 from ..conftest import (
     ANONYMOUS,
     PRIV_STAFF_ROLES,
-    MANAGEMENT,
-    EDITOR,
-    AUTHOR,
 )
 from ..utils import assert_message_in_response
 
@@ -119,7 +116,7 @@ async def test_auto_translate_easy_german(
         translate_easy_german, data={"selected_ids[]": selected_ids}
     )
     print(response.headers)
-    if role in PRIV_STAFF_ROLES + [MANAGEMENT, EDITOR, AUTHOR]:
+    if role in PRIV_STAFF_ROLES:
         # If the role should be allowed to access the view, we expect a successful result
         assert response.status_code == 302
         page_tree = reverse(
@@ -209,7 +206,7 @@ async def test_summ_ai_error_handling(
     )
     response = await client.post(translate_easy_german, data={"selected_ids[]": [1]})
     print(response.headers)
-    if role in PRIV_STAFF_ROLES + [MANAGEMENT, EDITOR, AUTHOR]:
+    if role in PRIV_STAFF_ROLES:
         # If the role should be allowed to access the view, we expect a redirect to the page tree
         assert response.status_code == 302
         page_tree = reverse(


### PR DESCRIPTION
### Short description
This PR restricts the usage of the SUMM AI bulk action to staff members only


### Proposed changes
<!-- Describe this PR in more detail. -->

- Add a check in the template if the user is staff member or not
- Add an entry to the changelog to let others teams know that we have improved this (please correct me, if we should remove the entry in case it's not meant to be seen by everyone) 


### Side effects
I think none. I tested it for a few roles and didn't notice any side effects. 
One thing we should keep in mind. As for now the SUMM AI function was disabled globally. So once this PR is merged, we could turn it on again


### Resolved issues

Fixes: #2065 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
