### PR TITLE
Fixes MT for languages with faulty BCP code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ UNRELEASED
 * [ [#2048](https://github.com/digitalfabrik/integreat-cms/issues/2048) ] Add possibility to show media file usages in sidebar
 * [ [#1875](https://github.com/digitalfabrik/integreat-cms/issues/1875) ] Add automatic translation options to Pages, Events and Locations
 * [ [#2118](https://github.com/digitalfabrik/integreat-cms/issues/2118) ] Move and rename menu button for automatic translation management
+* [ [#2124](https://github.com/digitalfabrik/integreat-cms/issues/2124) ] Fixes MT for languages with faulty BCP code
 
 
 2023.3.0

--- a/integreat_cms/cms/templates/languages/language_form.html
+++ b/integreat_cms/cms/templates/languages/language_form.html
@@ -54,7 +54,20 @@
                         </div>
                         <label for="{{ form.bcp47_tag.id_for_label }}" class="block mb-2">{{ form.bcp47_tag.label }}</label>
                         {% render_field form.bcp47_tag|add_error_class:"border-red-500" %}
-                        <div class="mb-2 text-s text-gray-600">{{ form.bcp47_tag.help_text }}</div>
+                        <div class="mb-2 text-s text-gray-600">
+                            {{ form.bcp47_tag.help_text }}
+                            {% if DEEPL_ENABLED %}
+                                <br />
+                                <br />
+                                <i class="h-5" icon-name="alert-triangle"></i>
+                                {# djlint:off #}
+                                {% blocktranslate trimmed with link="href='https://www.deepl.com/de/docs-api/translate-text/translate-text/' target='_blank' class='underline'" %}
+                                    For some languages, DeepL needs a correct BCP47 tag (for example English or Portuguese).
+                                    For more information, please checkout the <a {{ link }}>DeepL documentation</a>.
+                                {% endblocktranslate %}
+                                {# djlint:on #}
+                            {% endif %}
+                        </div>
                     </div>
                 </div>
             </div>

--- a/integreat_cms/cms/views/events/event_list_view.py
+++ b/integreat_cms/cms/views/events/event_list_view.py
@@ -109,7 +109,7 @@ class EventListView(TemplateView, EventContextMixin, SummAiContextMixin):
 
         if settings.DEEPL_ENABLED:
             deepl = DeepLApi()
-            DEEPL_AVAILABLE = deepl.check_availability(request, language_slug)
+            DEEPL_AVAILABLE = deepl.check_availability(request, language)
         else:
             DEEPL_AVAILABLE = False
         MT_PERMITTED = mt_is_permitted(

--- a/integreat_cms/cms/views/pois/poi_list_view.py
+++ b/integreat_cms/cms/views/pois/poi_list_view.py
@@ -120,7 +120,7 @@ class POIListView(TemplateView, POIContextMixin, SummAiContextMixin):
         # DeepL available
         if settings.DEEPL_ENABLED:
             deepl = DeepLApi()
-            DEEPL_AVAILABLE = deepl.check_availability(request, language_slug)
+            DEEPL_AVAILABLE = deepl.check_availability(request, language)
         else:
             DEEPL_AVAILABLE = False
         MT_PERMITTED = mt_is_permitted(

--- a/integreat_cms/deepl_api/apps.py
+++ b/integreat_cms/deepl_api/apps.py
@@ -48,7 +48,7 @@ class DeepLApiConfig(AppConfig):
                     )
                     assert self.supported_source_languages
                     self.supported_target_languages = [
-                        target_languages.code.lower()[:2]
+                        target_languages.code.lower()
                         for target_languages in deepl.translator.get_target_languages()
                     ]
                     logger.debug(

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -5128,6 +5128,17 @@ msgid "or"
 msgstr "oder"
 
 #: cms/templates/languages/language_form.html
+#, python-format
+msgid ""
+"For some languages, DeepL needs a correct BCP47 tag (for example English or "
+"Portuguese). For more information, please checkout the <a %(link)s>DeepL "
+"documentation</a>."
+msgstr ""
+"Für einige Sprachen benötigt DeepL den korrekten BCP47-Tag (zum Beispiel für "
+"Englisch oder Portugiesisch). Für weitere Informationen lesen Sie bitte   "
+"die <a %(link)s>DeepL Dokumentation</a>."
+
+#: cms/templates/languages/language_form.html
 msgid "Translations"
 msgstr "Übersetzungen"
 


### PR DESCRIPTION
### Short description
This PR fixes an error that occurred while using the MT for English or Portuguese. With this PR now it gets checked if a. the BCP47 code is in the correct format as expected, and either returns an error message or for the edge case that the BCP47 tag for English or Portuguese were incorrect sets en-GB respectively pt-PT as default.


### Proposed changes
<!-- Describe this PR in more detail. -->

- Add check if BCP47 code is correct
- Set pt-PT and en-GB as default values if the BCP47 code wasn't correct
- Return an error message for all other cases in which the BCP47 code wasn't correct
- Remove the check from the main function and put it in a separate function in order to pass pylint (too many if-branches in one function 15 out of 12). However I had to add the check "if target_language_key is None" to the main function, which is quite ugly. If someone else has a better idea for this, please let me know :smile: 


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- I didn't into any


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2116


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
