### PR TITLE
Fix locations endpoint error when default translation is not public

### DIFF
--- a/integreat_cms/cms/fixtures/test_data.json
+++ b/integreat_cms/cms/fixtures/test_data.json
@@ -3097,6 +3097,20 @@
     }
   },
   {
+    "model": "cms.poi",
+    "pk": 6,
+    "fields": {
+      "region": 1,
+      "address": "Viktoriastraße 1",
+      "postcode": "86150",
+      "city": "Augsburg",
+      "country": "Deutschland",
+      "latitude": 48.36599805,
+      "longitude": 10.886110466584793,
+      "archived": false
+    }
+  },
+  {
     "model": "cms.poitranslation",
     "pk": 1,
     "fields": {
@@ -3195,6 +3209,38 @@
       "version": 1,
       "minor_edit": false,
       "last_updated": "2020-01-22T12:52:56.726Z",
+      "creator": 1
+    }
+  },
+  {
+    "model": "cms.poitranslation",
+    "pk": 7,
+    "fields": {
+      "title": "Entwurf-Ort",
+      "slug": "entwurf-ort",
+      "poi": 6,
+      "status": "DRAFT",
+      "content": "<p>Standort ohne öffentliche Übersetzung in der Standardsprache</p>",
+      "language": 1,
+      "version": 1,
+      "minor_edit": false,
+      "last_updated": "2020-01-21T12:52:13.616Z",
+      "creator": 1
+    }
+  },
+  {
+    "model": "cms.poitranslation",
+    "pk": 8,
+    "fields": {
+      "title": "Draft location",
+      "slug": "draft-location",
+      "poi": 6,
+      "status": "PUBLIC",
+      "content": "<p>Location without public translation in the default language</p>",
+      "language": 2,
+      "version": 1,
+      "minor_edit": false,
+      "last_updated": "2020-01-21T12:52:13.616Z",
       "creator": 1
     }
   },

--- a/integreat_cms/cms/migrations/0066_update_poi_translation_status.py
+++ b/integreat_cms/cms/migrations/0066_update_poi_translation_status.py
@@ -1,0 +1,48 @@
+from django.db import migrations
+
+from ..constants import status
+
+
+# pylint: disable=unused-argument
+def update_poi_translation_status(apps, schema_editor):
+    """
+    Update poi translation status to draft for pois without the default public translation
+
+    :param apps: The configuration of installed applications
+    :type apps: ~django.apps.registry.Apps
+
+    :param schema_editor: The database abstraction layer that creates actual SQL code
+    :type schema_editor: ~django.db.backends.base.schema.BaseDatabaseSchemaEditor
+    """
+    Region = apps.get_model("cms", "Region")
+    POITranslation = apps.get_model("cms", "POITranslation")
+
+    for region in Region.objects.filter(pois__isnull=False).distinct():
+        default_language = region.language_tree_nodes.values_list(
+            "language", flat=True
+        ).first()
+        POITranslation.objects.filter(
+            poi__region=region,
+            status=status.PUBLIC,
+        ).exclude(
+            poi__in=region.pois.filter(
+                translations__language=default_language,
+                translations__status=status.PUBLIC,
+            )
+        ).update(
+            status=status.DRAFT
+        )
+
+
+class Migration(migrations.Migration):
+    """
+    Migration file to update poi translation status to draft for pois without the default public translation
+    """
+
+    dependencies = [
+        ("cms", "0065_pagetranslation_hix_score"),
+    ]
+
+    operations = [
+        migrations.RunPython(update_poi_translation_status, migrations.RunPython.noop),
+    ]

--- a/integreat_cms/cms/templates/pois/poi_form.html
+++ b/integreat_cms/cms/templates/pois/poi_form.html
@@ -33,7 +33,10 @@
             {% if not poi_form.instance.archived and perms.cms.change_poi %}
                 <div class="flex flex-wrap gap-4 ml-auto mr-0">
                     <button name="status" value="{{ DRAFT }}" class="btn btn-gray">{% translate "Save as draft" %}</button>
-                    <button name="status" value="{{ PUBLIC }}" class="btn">
+                    <button name="status"
+                            value="{{ PUBLIC }}"
+                            class="btn"
+                            {% if language != request.region.default_language and not poi_form.instance.default_public_translation %} title="{% translate "The default translation is not yet published" %}" disabled {% endif %}>
                         {% if poi_translation_form.instance.status == PUBLIC %}
                             {% translate "Update" %}
                         {% else %}

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -6088,6 +6088,10 @@ msgid "Create new location"
 msgstr "Neuen Ort erstellen"
 
 #: cms/templates/pois/poi_form.html
+msgid "The default translation is not yet published"
+msgstr "Die Standardübersetzung ist noch nicht veröffentlicht"
+
+#: cms/templates/pois/poi_form.html
 msgid "The name is currently displayed to users only in the default language"
 msgstr ""
 "Der Name wird anderen Benutzer:innen momentan nur in der Standardsprache "

--- a/integreat_cms/release_notes/current/unreleased/2097.yml
+++ b/integreat_cms/release_notes/current/unreleased/2097.yml
@@ -1,0 +1,2 @@
+en: Fix locations endpoint error when default translation is not public
+de: Fehler in der Orts-API beheben, wenn die Standardübersetzung nicht öffentlich ist


### PR DESCRIPTION
### Short description
When a region creates a location which is a draft in the default language, but public in other languages, the location API returns an internal server error


### Proposed changes
- Disable "Publish" button in POI form for non-default languages, when default translation is not public
- Exclude POIs without public translation in the default language from the locations API response
- Add test data to cover the case


### Side effects
Didn't find any


### Resolved issues
Fixes: #2097


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
