### PR TITLE
Show unsaved warning only when content model is changed

### DIFF
--- a/integreat_cms/cms/templates/events/event_form.html
+++ b/integreat_cms/cms/templates/events/event_form.html
@@ -119,7 +119,8 @@
                     </div>
                 </div>
             </div>
-            <div class="md:flex mt-4 3xl:mt-0 block 3xl:block 4xl:flex">
+            <div id="content_model_area"
+                 class="md:flex mt-4 3xl:mt-0 block 3xl:block 4xl:flex">
                 <div id="left-sidebar-column"
                      class="md:mr-4 md:w-full 3xl:mr-0 md:mt-0 sm:block md:flex sm:mt-4 flex-wrap flex-col 4xl:mr-4"
                      {% if request.user.distribute_sidebar_boxes %} data-enable-automatic-sidebar-distribution{% endif %}>

--- a/integreat_cms/cms/templates/pages/page_form.html
+++ b/integreat_cms/cms/templates/pages/page_form.html
@@ -164,7 +164,8 @@
                     </div>
                 </div>
             </div>
-            <div class="md:flex mt-4 3xl:mt-0 block 3xl:block 4xl:flex">
+            <div id="content_model_area"
+                 class="md:flex mt-4 3xl:mt-0 block 3xl:block 4xl:flex">
                 <div id="left-sidebar-column"
                      class="md:mr-4 md:w-full 3xl:mr-0 md:mt-0 sm:block md:flex sm:mt-4 flex-wrap flex-col 4xl:mr-4"
                      {% if request.user.distribute_sidebar_boxes %} data-enable-automatic-sidebar-distribution{% endif %}>

--- a/integreat_cms/cms/templates/pois/poi_form.html
+++ b/integreat_cms/cms/templates/pois/poi_form.html
@@ -139,7 +139,8 @@
                     {% endif %}
                 </div>
             </div>
-            <div class="sm:block md:flex sm:mt-4 3xl:mt-0 3xl:block 4xl:flex">
+            <div id="content_model_area"
+                 class="sm:block md:flex sm:mt-4 3xl:mt-0 3xl:block 4xl:flex">
                 <div id="left-sidebar-column"
                      class="flex flex-col flex-auto mt-4 md:mt-0 md:mr-4 3xl:mr-0 md:w-full 4xl:mr-4"
                      {% if request.user.distribute_sidebar_boxes %} data-enable-automatic-sidebar-distribution{% endif %}>

--- a/integreat_cms/release_notes/current/unreleased/2128.yml
+++ b/integreat_cms/release_notes/current/unreleased/2128.yml
@@ -1,0 +1,2 @@
+en: Show unsaved warning only when content model is changed
+de: Warnung vor nicht gespeichertem Inhalt nur bei Modelländerung zeigen

--- a/integreat_cms/static/src/js/forms/tinymce-init.ts
+++ b/integreat_cms/static/src/js/forms/tinymce-init.ts
@@ -211,12 +211,7 @@ window.addEventListener("load", () => {
                 });
 
                 editor.on("StoreDraft", autosaveEditor);
-                // When the editor becomes dirty, send an input event, so that the unsaved warning can be shown
-                editor.on("dirty", () =>
-                    document.querySelectorAll("[data-unsaved-warning]").forEach((element) => {
-                        element.dispatchEvent(new Event("input"));
-                    })
-                );
+
                 // Create an event every time the content changes
                 editor.on("keyup", () =>
                     document.querySelectorAll("[data-content-changed]").forEach((element) => {

--- a/integreat_cms/static/src/js/unsaved-warning.ts
+++ b/integreat_cms/static/src/js/unsaved-warning.ts
@@ -2,11 +2,11 @@
  * This file contains a function to warn the user when they leave a content without saving
  */
 
-let dirty = false;
+let contentModelChanged = false;
 
 window.addEventListener("beforeunload", (event) => {
     // trigger only when something is edited and no submit/save button clicked
-    if (dirty) {
+    if (contentModelChanged) {
         event.preventDefault();
         /* eslint-disable-next-line no-param-reassign */
         event.returnValue = "This content is not saved. Would you leave the page?";
@@ -15,21 +15,24 @@ window.addEventListener("beforeunload", (event) => {
 
 window.addEventListener("load", () => {
     const form = document.querySelector("[data-unsaved-warning]");
+    const contentEditArea = document.getElementById("content_model_area");
     // checks whether the user typed something in the content
-    form?.addEventListener("input", () => {
-        if (!dirty) {
-            console.debug("editing detected, enabled beforeunload warning");
-        }
-        dirty = true;
+    ["input", "click", "drag"].forEach((event) => {
+        contentEditArea?.addEventListener(event, () => {
+            if (!contentModelChanged) {
+                console.debug("change on content model detected, enabled beforeunload warning");
+            }
+            contentModelChanged = true;
+        });
     });
     // checks whether the user has saved or submitted the content
     form?.addEventListener("submit", () => {
-        dirty = false;
+        contentModelChanged = false;
         console.debug("form submitted, disabled beforeunload warning");
     });
     // removes the warning on autosave
     form?.addEventListener("autosave", () => {
-        dirty = false;
+        contentModelChanged = false;
         console.debug("Autosave, disabled beforeunload warning");
     });
 });

--- a/integreat_cms/static/src/js/unsaved-warning.ts
+++ b/integreat_cms/static/src/js/unsaved-warning.ts
@@ -1,12 +1,11 @@
 /**
  * This file contains a function to warn the user when they leave a content without saving
  */
-
-let contentModelChanged = false;
+let dirty = false;
 
 window.addEventListener("beforeunload", (event) => {
     // trigger only when something is edited and no submit/save button clicked
-    if (contentModelChanged) {
+    if (dirty) {
         event.preventDefault();
         /* eslint-disable-next-line no-param-reassign */
         event.returnValue = "This content is not saved. Would you leave the page?";
@@ -14,25 +13,23 @@ window.addEventListener("beforeunload", (event) => {
 });
 
 window.addEventListener("load", () => {
-    const form = document.querySelector("[data-unsaved-warning]");
-    const contentEditArea = document.getElementById("content_model_area");
+    const form = document.querySelector("[data-unsaved-warning]:not(content_form)");
     // checks whether the user typed something in the content
-    ["input", "click", "drag"].forEach((event) => {
-        contentEditArea?.addEventListener(event, () => {
-            if (!contentModelChanged) {
-                console.debug("change on content model detected, enabled beforeunload warning");
-            }
-            contentModelChanged = true;
-        });
+    form?.addEventListener("input", () => {
+        if (!dirty) {
+            console.debug("editing detected, enabled beforeunload warning");
+        }
+        dirty = true;
     });
+
     // checks whether the user has saved or submitted the content
     form?.addEventListener("submit", () => {
-        contentModelChanged = false;
+        dirty = false;
         console.debug("form submitted, disabled beforeunload warning");
     });
     // removes the warning on autosave
     form?.addEventListener("autosave", () => {
-        contentModelChanged = false;
+        dirty = false;
         console.debug("Autosave, disabled beforeunload warning");
     });
 });


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR changes the behavior of unsaved warning.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Give the sidebar block a new id, add event lisnter on it to detect changes on the content model.
- Show the warning when users leave the page without saving and something has been changed in the sidebar (content model). No warning when changes are only in the content translation (because it will be saved).


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- fetch in autosave fails in Firefox and changes in the content translation will not be saved when no change in the side bar has been made (and therefore no warning&leav confirmation done). Chrome, Opera and <s>Firefox</s> Edge  are fine. Could somebody give me an advice for this? 🥺 

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2128


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
