### PR TITLE
Add bot icon in "other languages" tab in content forms

### DIFF
--- a/integreat_cms/cms/templates/_form_language_tabs.html
+++ b/integreat_cms/cms/templates/_form_language_tabs.html
@@ -96,6 +96,10 @@
                                         <span title="{% translate "Translation missing" %}" class="no-trans">
                                             <i icon-name="x"></i>
                                         </span>
+                                    {% elif other_status == translation_status.MACHINE_TRANSLATED %}
+                                        <span title="{% translate "Machine translated" %}">
+                                            <i icon-name="bot"></i>
+                                        </span>
                                     {% endif %}
                                     <span class="px-2 max-w-max truncate">{{ other_language.translated_name }}</span>
                                 </div>

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8514,6 +8514,9 @@ msgstr ""
 "Diese Seite konnte nicht importiert werden, da sie zu einer anderen Region "
 "gehört ({})."
 
+#~ msgid "Current machine translation"
+#~ msgstr "Die Übersetzung ist aktuell und wurde maschinell erzeugt"
+
 #~ msgid "Both"
 #~ msgstr "Beide"
 

--- a/integreat_cms/release_notes/current/unreleased/2117.yml
+++ b/integreat_cms/release_notes/current/unreleased/2117.yml
@@ -1,0 +1,2 @@
+en: Add bot icon to language dropdown in content forms
+de: Das Bot-Icon wird jetzt auch im Sprachen-Dropdown in den Inhaltsformularen angezeigt


### PR DESCRIPTION
### Short description
This PR adds the bot icon for languages that are in the "Other languages" dropdown


### Proposed changes
<!-- Describe this PR in more detail. -->

- Add changelog entry
- Add if statement for machine translations
- Add translation for it


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- I didn't find any


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes:  #2117


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
