### PR TITLE
Downgrade `django-cacheops` to version `6.2`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,7 @@ pinned = [
     "decorator==5.1.1",
     "deepl==1.14.0",
     "Django==3.2.18",
-    "django-cacheops==7.0",
+    "django-cacheops==6.2",
     "django-cors-headers==3.14.0",
     "django-db-mutex==3.0.0",
     "django_debug_toolbar==3.8.1",


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
When deploying the current develop state to the test system, I noticed an error with the new version of our caching library (https://github.com/Suor/django-cacheops/issues/449) which was implicitly updated in https://github.com/digitalfabrik/integreat-cms/commit/64aa4472298a7b83b5c6a172461d8a0a51af3178#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Downgrade `django-cacheops` to version `6.2`

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
