### PR TITLE
Fix sorting in release notes tool

### DIFF
--- a/tools/make_release_notes.sh
+++ b/tools/make_release_notes.sh
@@ -135,7 +135,7 @@ elif [[ -n ${ALL} ]]; then
     done
 else
     # Only return the latest version by default
-    format_release_notes_version "$(find "${RELEASE_NOTES_DIR}"/* -mindepth 1 -maxdepth 1 -type d | tail -n1)" | sed '$ d' | sed '$ d' >> "${OUTPUT}"
+    format_release_notes_version "$(find "${RELEASE_NOTES_DIR}"/* -mindepth 1 -maxdepth 1 -type d | sort --version-sort | tail -n1)" | sed '$ d' | sed '$ d' >> "${OUTPUT}"
 fi
 
 if [[ "${OUTPUT}" != "/dev/stdout" ]]; then


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
I noticed that the sorting is broken in some environments when there are no unreleased release notes.

E.g. on the current develop branch, the tools outputs the following on my machine (and version 2023.2.2 is clearly older than version 2023.3.1):
```
$ ./tools/make_release_notes.sh
# Release notes

## 2023.2.2

- [ [#2012](https://github.com/digitalfabrik/integreat-cms/issues/2012) ] Exclude archived pages when cloning a region
- [ [#2093](https://github.com/digitalfabrik/integreat-cms/issues/2093) ] Fix recurring events API endpoint
```

### Proposed changes
<!-- Describe this PR in more detail. -->

- Fix sorting in release notes tool

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
