### PR TITLE
Fix `NoReverseMatch` error in lists without language tree

### DIFF
--- a/integreat_cms/cms/views/events/event_list_view.py
+++ b/integreat_cms/cms/views/events/event_list_view.py
@@ -83,7 +83,7 @@ class EventListView(TemplateView, EventContextMixin, SummAiContextMixin):
                 request,
                 _("Please create at least one language node before creating events."),
             )
-            return redirect("language_tree", **{"region_slug": region.slug})
+            return redirect("languagetreenodes", **{"region_slug": region.slug})
 
         if not request.user.has_perm("cms.change_event"):
             messages.warning(

--- a/integreat_cms/cms/views/imprint/imprint_form_view.py
+++ b/integreat_cms/cms/views/imprint/imprint_form_view.py
@@ -73,7 +73,7 @@ class ImprintFormView(TemplateView, MediaContextMixin):
                 _("Please create at least one language node before creating pages."),
             )
             return redirect(
-                "language_tree",
+                "languagetreenodes",
                 **{
                     "region_slug": region.slug,
                 },

--- a/integreat_cms/cms/views/pages/page_tree_view.py
+++ b/integreat_cms/cms/views/pages/page_tree_view.py
@@ -81,7 +81,7 @@ class PageTreeView(TemplateView, PageContextMixin, SummAiContextMixin):
                 _("Please create at least one language node before creating pages."),
             )
             return redirect(
-                "language_tree",
+                "languagetreenodes",
                 **{
                     "region_slug": region.slug,
                 },

--- a/integreat_cms/cms/views/pois/poi_list_view.py
+++ b/integreat_cms/cms/views/pois/poi_list_view.py
@@ -86,7 +86,7 @@ class POIListView(TemplateView, POIContextMixin, SummAiContextMixin):
                 ),
             )
             return redirect(
-                "language_tree",
+                "languagetreenodes",
                 **{
                     "region_slug": region.slug,
                 },

--- a/integreat_cms/cms/views/push_notifications/push_notification_list_view.py
+++ b/integreat_cms/cms/views/push_notifications/push_notification_list_view.py
@@ -80,7 +80,7 @@ class PushNotificationListView(TemplateView):
                 ),
             )
             return redirect(
-                "language_tree",
+                "languagetreenodes",
                 **{
                     "region_slug": region.slug,
                 },

--- a/integreat_cms/release_notes/current/unreleased/2151.yml
+++ b/integreat_cms/release_notes/current/unreleased/2151.yml
@@ -1,0 +1,2 @@
+en: Fix error when listing content as long as no language nodes exist
+de: Behebe Fehler wenn Inhalte aufgelistet werden, solange keine Sprach-Knoten existieren


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fix `django.urls.exceptions.NoReverseMatch` when listing content as long as no language nodes exist

### Proposed changes
<!-- Describe this PR in more detail. -->

- Fix `NoReverseMatch` error in lists without language tree

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2151


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
