### PR TITLE
Fix translation status for outdated mts

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/2155.yml
+++ b/integreat_cms/release_notes/current/unreleased/2155.yml
@@ -1,0 +1,2 @@
+en: Fix translation status for outdated translations after machine translation
+de: Behebe Fehler beim Übersetzungsstatus für veraltete maschinelle Übersetzungen


### PR DESCRIPTION
### Short description
The translation status for machine translations used to still show the bot icon even when the translation wasn't up-to-date anymore. This PR fixes this and only shows the bot icon for machine translations that are up-to-date and shows the warning icon for machine translations that are outdated. 


### Proposed changes
<!-- Describe this PR in more detail. -->

- Adds distinction between up-to-date and outdated machine translations and decides for the correct translation status and icon


### Side effects

- I restricted the query for machine translations and this could cause some side effects, although I don't have an exact idea how this might show 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2137


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
