### PR TITLE
Only allow machine translation if the HIX value is high enough

### DIFF
--- a/example-configs/integreat-cms.ini
+++ b/example-configs/integreat-cms.ini
@@ -147,6 +147,8 @@ TEXTLAB_API_KEY = <your-textlab-api-key>
 TEXTLAB_API_URL = <your-textlab-api-endpoint>
 # Username for the textlab api [optional, defaults to "Integreat"]
 TEXTLAB_API_USERNAME = <your-textlab-api-username>
+# Minimum HIX score required for machine translation [optional, defaults to 15.0]
+HIX_REQUIRED_FOR_MT = 15.0
 
 [xliff]
 # Which XLIFF version to use for export [optional, defaults to "xliff-1.2"]

--- a/integreat_cms/cms/models/abstract_content_model.py
+++ b/integreat_cms/cms/models/abstract_content_model.py
@@ -119,6 +119,9 @@ class AbstractContentModel(AbstractBaseModel):
     #: Whether translations should be returned in the default language if they do not exist
     fallback_translations_enabled = False
 
+    #: Whether the HIX value is ignored (this is ``False`` by default if not overwritten by a submodel)
+    hix_ignore = False
+
     @cached_property
     def languages(self):
         """
@@ -357,6 +360,31 @@ class AbstractContentModel(AbstractBaseModel):
         :rtype: ~integreat_cms.cms.models.abstract_content_translation.AbstractContentTranslation
         """
         return self.prefetched_major_translations_by_language_slug.get(language_slug)
+
+    def invalidate_cached_translations(self):
+        """
+        Delete all cached translations and query them from the
+        database again when they are accessed next time.
+
+        This is helpful when new translations have been created
+        and the content model should be reused.
+        """
+        for prefetched_attr in [
+            "backend_translation",
+            "best_translation",
+            "default_translation",
+            "default_public_translation",
+            "prefetched_translations_by_language_slug",
+            "prefetched_major_public_translations_by_language_slug",
+            "prefetched_major_translations_by_language_slug",
+            "prefetched_public_or_draft_translations_by_language_slug",
+            "prefetched_public_translations_by_language_slug",
+            "translation_states",
+        ]:
+            try:
+                delattr(self, prefetched_attr)
+            except AttributeError:
+                pass
 
     @cached_property
     def backend_translation(self):

--- a/integreat_cms/cms/templates/hix_widget.html
+++ b/integreat_cms/cms/templates/hix_widget.html
@@ -38,7 +38,7 @@
             </div>
             <div data-hix-state="error" class="bg-red-400 rounded p-2 hidden">
                 <i icon-name="alert-triangle"></i>
-                {% translate "Some error occurred. Please try again later." %}
+                {% translate "HIX value could not be calculated." %} {% translate "Please try again later." %}
             </div>
             <div data-hix-state="no-content" class="bg-blue-400 rounded p-2 hidden">
                 <i icon-name="info"></i>

--- a/integreat_cms/cms/templates/pages/page_form_sidebar/minor_edit_box.html
+++ b/integreat_cms/cms/templates/pages/page_form_sidebar/minor_edit_box.html
@@ -19,12 +19,18 @@
         <div class="help-text">{% minor_edit_help_text request.region language page_translation_form %}</div>
     </div>
     {% if MT_ENABLED %}
-        <div>
+        <div id="machine-translation-form" data-minimum-hix="{{ minimum_hix }}">
             {% render_field machine_translation_form.automatic_translation class+="mutually-exclusive-checkbox" %}
             <label for="{{ machine_translation_form.automatic_translation.id_for_label }}"
                    class="secondary">
                 {{ machine_translation_form.automatic_translation.label }}
             </label>
+            <div id="hix-score-warning"
+                 class="hidden bg-yellow-100 border-l-4 border-yellow-500 text-yellow-600 px-4 py-3 mb-2">
+                <p>
+                    {% blocktranslate %}Increase the HIX score to at least {{ minimum_hix }} to enable automatic translations.{% endblocktranslate %}
+                </p>
+            </div>
             <div class="help-text">{{ machine_translation_form.automatic_translation.help_text }}</div>
             <div id="language-options" class="pl-2 hidden">
                 {% if machine_translation_form.translations_to_update.field.queryset.exists %}

--- a/integreat_cms/cms/views/events/event_form_view.py
+++ b/integreat_cms/cms/views/events/event_form_view.py
@@ -246,17 +246,17 @@ class EventFormView(
             )
             # If automatic translations where requested, pass on to MT API
             if (
-                event_translation_instance
-                and settings.DEEPL_ENABLED
+                settings.DEEPL_ENABLED
                 and machine_translation_form.is_valid()
                 and machine_translation_form.data.get("automatic_translation")
                 and not event_translation_form.data.get("minor_edit")
             ):
-                event_translation_instance.refresh_from_db()
+                # Invalidate cached property to take new version into account
+                event_form.instance.invalidate_cached_translations()
                 deepl = DeepLApi()
                 deepl.deepl_translate_to_languages(
                     request,
-                    event_translation_instance.event,
+                    event_translation_form.instance,
                     machine_translation_form.get_target_languages(),
                     EventTranslationForm,
                 )

--- a/integreat_cms/cms/views/pages/page_form_view.py
+++ b/integreat_cms/cms/views/pages/page_form_view.py
@@ -239,6 +239,7 @@ class PageFormView(
                 ),
                 "translation_states": page.translation_states if page else [],
                 "MT_ENABLED": MT_ENABLED,
+                "minimum_hix": settings.HIX_REQUIRED_FOR_MT,
             },
         )
 
@@ -347,17 +348,17 @@ class PageFormView(
 
             # If automatic translations where requested, pass on to MT API
             if (
-                page_translation_instance
-                and settings.DEEPL_ENABLED
+                settings.DEEPL_ENABLED
                 and machine_translation_form.is_valid()
                 and machine_translation_form.data.get("automatic_translation")
                 and not page_translation_form.data.get("minor_edit")
             ):
-                page_translation_instance.refresh_from_db()
+                # Invalidate cached property to take new version into account
+                page_form.instance.invalidate_cached_translations()
                 deepl = DeepLApi()
                 deepl.deepl_translate_to_languages(
                     request,
-                    page_translation_instance.page,
+                    page_translation_form.instance,
                     machine_translation_form.get_target_languages(),
                     PageTranslationForm,
                 )

--- a/integreat_cms/cms/views/pois/poi_form_view.py
+++ b/integreat_cms/cms/views/pois/poi_form_view.py
@@ -196,17 +196,17 @@ class POIFormView(
 
             # If automatic translations where requested, pass on to MT API
             if (
-                poi_translation_instance
-                and settings.DEEPL_ENABLED
+                settings.DEEPL_ENABLED
                 and machine_translation_form.is_valid()
                 and machine_translation_form.data.get("automatic_translation")
                 and not poi_translation_form.data.get("minor_edit")
             ):
-                poi_translation_instance.refresh_from_db()
+                # Invalidate cached property to take new version into account
+                poi_form.instance.invalidate_cached_translations()
                 deepl = DeepLApi()
                 deepl.deepl_translate_to_languages(
                     request,
-                    poi_translation_instance.poi,
+                    poi_translation_form.instance,
                     machine_translation_form.get_target_languages(),
                     POITranslationForm,
                 )

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -196,6 +196,12 @@ TEXTLAB_API_USERNAME = os.environ.get("INTEGREAT_CMS_TEXTLAB_API_USERNAME", "Int
 #: Which language slugs are allowed for the Textlab API
 TEXTLAB_API_LANGUAGES = ["de"]
 
+#: Which content types are enabled for the Textlab API
+TEXTLAB_API_CONTENT_TYPES = ["pagetranslation"]
+
+#: The minimum HIX score required for machine translation
+HIX_REQUIRED_FOR_MT = float(os.environ.get("INTEGREAT_CMS_HIX_REQUIRED_FOR_MT", 15.0))
+
 
 ############
 # WEBAUTHN #

--- a/integreat_cms/core/signals/hix_signals.py
+++ b/integreat_cms/core/signals/hix_signals.py
@@ -1,7 +1,6 @@
 import logging
 
-from django.conf import settings
-from django.db.models.signals import post_save
+from django.db.models.signals import pre_save
 from django.dispatch import receiver
 
 from ...cms.models import PageTranslation
@@ -10,10 +9,10 @@ from ...cms.views.utils.hix import lookup_hix_score
 logger = logging.getLogger(__name__)
 
 
-@receiver(post_save, sender=PageTranslation)
+@receiver(pre_save, sender=PageTranslation)
 def page_translation_save_handler(instance, **kwargs):
     r"""
-    Calculates a hix store for a page translation after saving
+    Calculates a hix store for a page translation before saving
 
     :param instance: The page translation that gets saved
     :type instance: ~integreat_cms.cms.models.pages.page_translation.PageTranslation
@@ -21,38 +20,27 @@ def page_translation_save_handler(instance, **kwargs):
     :param \**kwargs: The supplied keyword arguments
     :type \**kwargs: dict
     """
+    if kwargs.get("raw"):
+        return
     if (
-        kwargs.get("raw")
-        or instance.hix_score
-        or not hix_enabled(instance)
+        instance.hix_score
+        or instance.hix_ignore
+        or not instance.hix_enabled
         or not instance.content.strip()
     ):
+        logger.debug(
+            "HIX calculation pre save signal skipped for %r (score=%s, ignored=%s, enabled=%s, empty=%s)",
+            instance,
+            instance.hix_score,
+            instance.hix_ignore,
+            instance.hix_enabled,
+            bool(instance.content.strip()),
+        )
+        instance.hix_score = None
         return
 
     if score := lookup_hix_score(instance.content):
-        logger.debug(
-            "Storing hix score %s for new page translation %r", score, instance
-        )
+        logger.debug("Storing hix score %s for %r", score, instance)
         instance.hix_score = score
-        instance.save(update_timestamp=False)
     else:
-        logger.warning(
-            "Could not store the hix score for new page translation %r", instance
-        )
-
-
-def hix_enabled(instance):
-    """
-    This function returns whether the hix api is enabled for this instance
-
-    :param instance: The page translation to check for
-    :type instance: ~integreat_cms.cms.models.pages.page_translation.PageTranslation
-
-    :returns: Whether hix is enabled
-    :rtype: bool
-    """
-    return (
-        settings.TEXTLAB_API_ENABLED
-        and instance.language.slug in settings.TEXTLAB_API_LANGUAGES
-        and instance.page.region.hix_enabled
-    )
+        logger.warning("Could not store the hix score for %r", instance)

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -4083,7 +4083,7 @@ msgid "A network error has occurred."
 msgstr "Ein Netzwerkfehler ist aufgetreten."
 
 #: cms/templates/analytics/_broken_links_widget.html
-#: cms/templates/chat/_chat_widget.html
+#: cms/templates/chat/_chat_widget.html cms/templates/hix_widget.html
 #: cms/templates/statistics/_statistics_widget.html
 #: cms/templates/statistics/statistics_overview.html
 #: cms/views/media/media_context_mixin.py
@@ -4897,8 +4897,8 @@ msgid "HIX value is outdated."
 msgstr "Der HIX-Wert ist veraltet."
 
 #: cms/templates/hix_widget.html
-msgid "Some error occurred. Please try again later."
-msgstr "Ein Fehler ist aufgetreten. Bitte versuchen Sie es später erneut."
+msgid "HIX value could not be calculated."
+msgstr "Der HIX-Wert konnte nicht berechnet werden."
 
 #: cms/templates/hix_widget.html
 msgid "There is no page content."
@@ -5688,6 +5688,15 @@ msgstr[1] ""
 #: cms/templates/pages/page_form_sidebar/actions_box.html
 msgid "Delete this page"
 msgstr "Diese Seite löschen"
+
+#: cms/templates/pages/page_form_sidebar/minor_edit_box.html
+#, python-format
+msgid ""
+"Increase the HIX score to at least %(minimum_hix)s to enable automatic "
+"translations."
+msgstr ""
+"Um automatische Übersetzungen nutzen zu können, muss der HIX-Wert mindestens "
+"%(minimum_hix)s betragen."
 
 #: cms/templates/pages/page_form_sidebar/settings_box.html
 msgid "Settings of the page"
@@ -8321,6 +8330,22 @@ msgstr "Niederländisch"
 msgid "DeepL API"
 msgstr "DeepL API"
 
+#: deepl_api/utils.py
+msgid ""
+"HIX score {:.2f} of \"{}\" is too low for machine translation (minimum "
+"required: {})"
+msgstr ""
+"HIX Wert {:.2f} für \"{}\" ist zu niedrig für maschinelle Übersetzung "
+"(erforderlicher Mindestwert: {})"
+
+#: deepl_api/utils.py
+msgid ""
+"Machine translations are disabled for \"{}\", because its HIX value is "
+"ignored"
+msgstr ""
+"Machinelle Übersetzungen sind für \"{}\" deaktiviert, da die Option \"HIX-"
+"Wert ignorieren\" aktiviert ist."
+
 #: deepl_api/utils.py summ_ai_api/summ_ai_api_client.py
 msgid ""
 "Machine translations are disabled for content type \"{}\", language \"{}\" "
@@ -8516,6 +8541,9 @@ msgstr ""
 
 #~ msgid "Current machine translation"
 #~ msgstr "Die Übersetzung ist aktuell und wurde maschinell erzeugt"
+
+#~ msgid "An error occurred. Please try again later."
+#~ msgstr "Ein Fehler ist aufgetreten. Bitte versuchen Sie es später erneut."
 
 #~ msgid "Both"
 #~ msgstr "Beide"

--- a/integreat_cms/release_notes/current/unreleased/2130.yml
+++ b/integreat_cms/release_notes/current/unreleased/2130.yml
@@ -1,0 +1,2 @@
+en: Ensure pages are written in sufficiently easy German before they can be machine translated
+de: Maschinelle Übersetzung deutscher Seiten erst bei hinreichend einfacher Sprache zulassen


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Make sure pages are written in sufficiently simple German before being able to translate them with DeepL


### Proposed changes
<!-- Describe this PR in more detail. -->

- for each `content_object` passed to the DeepL utils, make sure the HIX score is high enough (or not applicable)
- when loading the `page_form_view` or refreshing the HIX score, hide the Automatic Translation checkbox based on the score


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none that I could find


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2130


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
