### PR TITLE
Fix `AttributeError` when form is saved with no options for MTs

### DIFF
--- a/integreat_cms/cms/forms/translations/machine_translation_form.py
+++ b/integreat_cms/cms/forms/translations/machine_translation_form.py
@@ -26,14 +26,14 @@ class MachineTranslationForm(forms.Form):
 
     translations_to_update = forms.ModelMultipleChoiceField(
         widget=forms.CheckboxSelectMultiple(),
-        queryset=None,
+        queryset=LanguageTreeNode.objects.none(),
         required=False,
         label=_("Update existing translations:"),
     )
 
     translations_to_create = forms.ModelMultipleChoiceField(
         widget=forms.CheckboxSelectMultiple(),
-        queryset=None,
+        queryset=LanguageTreeNode.objects.none(),
         required=False,
         label=_("Create new translations:"),
     )
@@ -89,7 +89,7 @@ class MachineTranslationForm(forms.Form):
         """
         cleaned_data = super().clean()
 
-        if not cleaned_data["automatic_translation"]:
+        if not cleaned_data.get("automatic_translation"):
             cleaned_data["translations_to_update"] = LanguageTreeNode.objects.none()
             cleaned_data["translations_to_create"] = LanguageTreeNode.objects.none()
         return cleaned_data

--- a/integreat_cms/release_notes/current/unreleased/2160.yml
+++ b/integreat_cms/release_notes/current/unreleased/2160.yml
@@ -1,0 +1,2 @@
+en: Fix error when saving content without available machine translations
+de: Behebe Fehler beim Speichern von Inhalten ohne verfügbare maschinnelle Übersetzungen


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fix `AttributeError` when form is saved with no options for machine translations

### Proposed changes
<!-- Describe this PR in more detail. -->

- Set queryset to `LanguageTreeNode.objects.none()` instead of literally `None`
- Account for case when `automatic_translation` checkbox is not in cleaned data



### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2160


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
