### PR TITLE
Add user story section to feature request template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -17,9 +17,15 @@ labels: feature
 <!-- A clear and concise description of any alternative solutions or features you've considered, and why you're proposed solution is better. -->
 
 
+### User Story
+<!-- A clear description of the User Stories that should be achieved by the new feature. The User Stories should follow this pattern: 
+As a [type of user] I want [goals or objectives] so that [values or benefits]. -->
+
+
 ### Additional Context
 <!-- Add any other information or screenshots about the feature request here. -->
 
 
 ### Design Requirements
 <!-- If the customization includes input from our design team, the detailed requirements will be collected here. Note: These will exist mainly in German to simplify internal communication. -->
+


### PR DESCRIPTION
### Short description
This PR adds two new subsections to our feature request template in GitHub.


### Proposed changes
<!-- Describe this PR in more detail. -->

- Add User Story subsection to the Design Requirements. I added the pattern that the user story should follow to the comments. One could argue that we could also put the pattern outside of the comments into the body, because everyone filling out a feature report should be using the pattern. I guess I depends on how which way you prefer
- Add Link To Figma subsection to the Design Requirements. I also added this section for the UI/UX team to fill this out. Again, there is some room for discussions here, since we could already provide the permanent Figma link to the CMS project. Since the UI/UX team labels the subprojects with the issue ids the project is referring to, this would make sure that there is already a link even if the UI/UX team forgot to add it

Please let me know what you think about these changes

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- I didn't know how to test this and implemented it blindly. Do you have suggestions on how to test this? 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2143


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
