### PR TITLE
Fix text-direction for RTL push notifications

### DIFF
--- a/integreat_cms/cms/templates/push_notifications/push_notification_form.html
+++ b/integreat_cms/cms/templates/push_notifications/push_notification_form.html
@@ -30,7 +30,8 @@
                     {% for other_language in languages %}
                         <li id="li-{{ other_language.id }}"
                             class="language-tab-header mr-2 -mb-[2px] {% if other_language.id == language.id %} z-10 text-blue-500 bg-white cursor-default {% else %} bg-water-500 {% endif %} hover:text-blue-500 hover:bg-white border-l border-t border-r border-blue-500 font-bold rounded-t-lg"
-                            data-switch-language="{{ other_language.id }}">
+                            data-switch-language="{{ other_language.id }}"
+                            data-text-direction="{{ other_language.text_direction }}">
                             <div class="border-b-2 border-white">
                                 <div class="p-4">
                                     {{ other_language.translated_name }}

--- a/integreat_cms/release_notes/current/unreleased/2166.yml
+++ b/integreat_cms/release_notes/current/unreleased/2166.yml
@@ -1,0 +1,2 @@
+en: Fix text direction for RTL in push notifications
+de: Textrichtung für RTL in Push-Benachrichtigungen korrigiert

--- a/integreat_cms/static/src/js/push-notifications.ts
+++ b/integreat_cms/static/src/js/push-notifications.ts
@@ -10,10 +10,19 @@ const switchLanguage = (language: string) => {
     document.getElementById(`li-${language}`).classList.add("z-10", "text-blue-500", "bg-white", "cursor-default");
 };
 
+const adjustTextDirection = (textDirection: string, language: string) => {
+    if (textDirection === "RIGHT_TO_LEFT") {
+        (document.querySelector(`#tab-${language} input`) as HTMLElement).dir = "rtl";
+        (document.querySelector(`#tab-${language} textarea`) as HTMLElement).dir = "rtl";
+    }
+};
+
 window.addEventListener("load", () => {
     document.querySelectorAll("[data-switch-language]").forEach((node) => {
-        (node as HTMLElement).addEventListener("click", () => {
-            switchLanguage(node.getAttribute("data-switch-language"));
+        const nodeElement = node as HTMLElement;
+        nodeElement.addEventListener("click", () => {
+            switchLanguage(nodeElement.dataset.switchLanguage);
+            adjustTextDirection(nodeElement.dataset.textDirection, nodeElement.dataset.switchLanguage);
         });
     });
 });


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the text direction for RTL languages in the push notification form


### Proposed changes
<!-- Describe this PR in more detail. -->

- Add text-direction attribute to the HTML element
- Add check in Javascript, and if necessary adjust the text direction from LTR to RTL
- Add release note


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- The Typescript code doesn't look create once again, but I didn't know how to improve it. I thought I could do it in one line, but since getElementsByTagName didn't allow me to pass two elements and I needed the conversion to HTML Element it ended up being four lines. Suggestions for improvement are welcome!


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2166


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
