### PR TITLE
Add management command to reset DeepL budget

### DIFF
--- a/docs/src/management-commands.rst
+++ b/docs/src/management-commands.rst
@@ -137,6 +137,18 @@ Translate an entire region into Easy German via SUMM.AI::
 * ``--initial``: Whether existing translations should not be updated
 
 
+``reset_deepl_budget``
+~~~~~~~~~~~~~~~~~~~~~~
+
+Reset DeepL budget of regions whose renewal month is the current month::
+
+    integreat-cms-cli reset_deepl_budget [--force]
+
+**Options:**
+
+* ``--force``: Allow to reset the budget even if it's not the first day of the month
+
+
 Create new commands
 -------------------
 

--- a/integreat_cms/core/management/commands/reset_deepl_budget.py
+++ b/integreat_cms/core/management/commands/reset_deepl_budget.py
@@ -1,0 +1,55 @@
+import logging
+from datetime import datetime
+
+from django.core.management.base import CommandError
+
+from ....cms.models import Region
+from ..log_command import LogCommand
+
+logger = logging.getLogger(__name__)
+
+
+class Command(LogCommand):
+    """
+    Management command to reset DeepL budget
+    """
+
+    help = "Reset DeepL budget"
+
+    def add_arguments(self, parser):
+        """
+        Define the arguments of this command
+
+        :param parser: The argument parser
+        :type parser: ~django.core.management.base.CommandParser
+        """
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Whether the reset should be run despite it's not the 1st day of the month",
+        )
+
+    # pylint: disable=arguments-differ
+    def handle(self, *args, force, **options):
+        """
+        Try to run the command
+        """
+
+        current_day = datetime.now().day
+        current_month = datetime.now().month - 1
+
+        if current_day != 1 and not force:
+            raise CommandError(
+                "It is not the 1st day of the month. If you want to reset DeepL budget despite that, run the command with --force"
+            )
+
+        if not (regions := Region.objects.filter(deepl_renewal_month=current_month)):
+            self.print_info(
+                "✔ There is no region whose DeepL budget needs to be reset."
+            )
+        else:
+            for region in regions:
+                region.deepl_budget_used = 0
+                region.deepl_midyear_start_month = None
+                region.save()
+            self.print_info("✔ DeepL budget has been reset.")

--- a/tests/core/management/commands/test_reset_deepl_budget.py
+++ b/tests/core/management/commands/test_reset_deepl_budget.py
@@ -1,0 +1,82 @@
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+from django.core.management.base import CommandError
+
+from integreat_cms.cms.models import Region
+
+from ..utils import get_command_output
+
+
+# pylint: disable=too-few-public-methods
+class datetime_not_first_day:
+    """
+    Fake datetime object where now() is never the first day of the month
+    """
+
+    @classmethod
+    def now(cls):
+        """
+        generate a date with day=2
+
+        :returns: a date which is never the 1st day of the month
+        :rtype: datetime.datetime
+        """
+        real_now = datetime.now()
+        return real_now.replace(day=2)
+
+
+@patch("datetime.datetime", datetime_not_first_day)
+def test_not_first_day():
+    """
+    Ensure that the command will not run when it's not the 1st day of the month without --force
+    """
+    with pytest.raises(CommandError) as exc_info:
+        assert not any(get_command_output("reset_deepl_budget"))
+        assert (
+            str(exc_info.value)
+            == "It is not the 1st day of the month. If you want to reset DeepL budget despite that, run the command with --force"
+        )
+
+
+# pylint: disable=unused-argument
+@pytest.mark.order("last")
+@pytest.mark.django_db(transaction=True, serialized_rollback=True)
+def test_reset_deepl_budget(load_test_data_transactional):
+    """
+    Ensure that DeepL budget gets reset successfully
+    """
+
+    current_month = datetime.now().month - 1
+
+    region1 = Region.objects.create(
+        slug="deepl_test_1",
+        deepl_renewal_month=current_month,
+        deepl_midyear_start_month=current_month + 1,
+        deepl_budget_used=42,
+    )
+    region2 = Region.objects.create(
+        slug="deepl_test_2",
+        deepl_renewal_month=current_month + 1,
+        deepl_midyear_start_month=current_month + 1,
+        deepl_budget_used=42,
+    )
+
+    out, err = get_command_output("reset_deepl_budget", "--force")
+    region1.refresh_from_db()
+    region2.refresh_from_db()
+    assert "✔ DeepL budget has been reset." in out
+    assert not err
+    assert (
+        not region1.deepl_budget_used
+    ), "The DeepL budget of region 1 should have been reset to 0."
+    assert (
+        region2.deepl_budget_used == 42
+    ), "The DeepL budget of region 2 should remain unchanged."
+    assert (
+        region1.deepl_midyear_start_month is None
+    ), "The midyear start month of region 1 should have been reset to None."
+    assert (
+        region2.deepl_midyear_start_month == current_month + 1
+    ), "The midyear start month of region 2 should not have been reset to None."


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds a management command that resets the DeepL budget to 0 if a region's renewal month is the current month.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Query regions whose renewal month is the current month, reset their `deepl_budget_used` to 0, set `deepl_midyear_start_month` to the current month.
- Add a test for the command (and some test data for it too).


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- It seems `datetime.now()` returns the current time of GMT. If the cronjob starts between 00:00 and 02:00 of the first day of the month, the returned value must be adjusted.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1999 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
