### PR TITLE
Downgrade `pytest-testmon`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ dev = [
     "pytest-cov",
     "pytest-django",
     "pytest-order",
-    "pytest-testmon",
+    "pytest-testmon==1.4.5",
     "pytest-xdist",
     "pytest-icdiff",
     "requests-mock",


### PR DESCRIPTION
### Short description
If I run tests multiple times, I'm getting an error:

> INTERNALERROR> E                 init_testmon_data(config)
INTERNALERROR> E               File "/home/tory/Integreat/integreat-cms/.venv/lib/python3.9/site-packages/testmon/pytest_testmon.py", line 154, in init_testmon_data
INTERNALERROR> E                 testmon_data.determine_stable(bool(rpc_proxy))
INTERNALERROR> E               File "/home/tory/Integreat/integreat-cms/.venv/lib/python3.9/site-packages/testmon/testmon_core.py", line 234, in determine_stable
INTERNALERROR> E                 new_changed_file_data = self.db.fetch_unknown_files(
INTERNALERROR> E               File "/home/tory/Integreat/integreat-cms/.venv/lib/python3.9/site-packages/testmon/db.py", line 450, in fetch_unknown_files
INTERNALERROR> E                 con.execute(
INTERNALERROR> E             sqlite3.OperationalError: database is locked
INTERNALERROR> E           assert False>

### Proposed changes
- Set pytest-testmon version to 1.4.5 (it solves the issue for me)

I saw one more issue in the channel, but can't fixed it, because it's not reproduced for me
> WARNING: Failed to generate report: Couldn't use data file '/home/mizuki/integreat-cms/.coverage': no such table: line_bits"

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
