### PR TITLE
Catch network errors for textlab API, fix #2200

### DIFF
--- a/integreat_cms/cms/views/utils/hix.py
+++ b/integreat_cms/cms/views/utils/hix.py
@@ -1,10 +1,11 @@
 """
-This file contains functionality to communicate with the textlab api to get the hix-value
+This file contains functionality to communicate with the Textlab api to get the hix-value
 for a given text.
 """
 import json
 import logging
 from functools import lru_cache
+from urllib.error import URLError
 
 from django.conf import settings
 from django.http import JsonResponse
@@ -30,9 +31,13 @@ def lookup_hix_score(text):
     :return: The score for the given text
     :rtype: float
     """
-    return TextlabClient(
-        settings.TEXTLAB_API_USERNAME, settings.TEXTLAB_API_KEY
-    ).benchmark(text)
+    try:
+        return TextlabClient(
+            settings.TEXTLAB_API_USERNAME, settings.TEXTLAB_API_KEY
+        ).benchmark(text)
+    except (URLError, OSError) as e:
+        logger.warning("HIX benchmark API call failed: %r", e)
+        return None
 
 
 @require_POST

--- a/integreat_cms/release_notes/current/unreleased/2200.yml
+++ b/integreat_cms/release_notes/current/unreleased/2200.yml
@@ -1,0 +1,2 @@
+en: Catch network errors during Textlab interaction
+de: Abfangen von Netzwerkfehlern während der Textlab-Interaktion

--- a/integreat_cms/textlab_api/apps.py
+++ b/integreat_cms/textlab_api/apps.py
@@ -35,7 +35,7 @@ class TextlabApiConfig(AppConfig):
                     logger.info(
                         "Textlab API is available at: %r", settings.TEXTLAB_API_URL
                     )
-                except URLError:
-                    logger.info("Textlab API is unavailable")
+                except (URLError, OSError) as e:
+                    logger.info("Textlab API is unavailable: %r", e)
             else:
                 logger.info("Textlab API is disabled")

--- a/integreat_cms/textlab_api/textlab_api_client.py
+++ b/integreat_cms/textlab_api/textlab_api_client.py
@@ -1,7 +1,6 @@
 import json
 import logging
 from html import unescape
-from urllib.error import URLError
 from urllib.request import Request, urlopen
 
 from django.conf import settings
@@ -14,6 +13,8 @@ class TextlabClient:
     """
     Client for the textlab api.
     Supports login and hix-score retrieval.
+
+    A detailed API documentation can be found at https://comlab-ulm.github.io/swagger-V8/
     """
 
     def __init__(self, username, password):
@@ -48,11 +49,7 @@ class TextlabClient:
         """
         data = {"text": unescape(text), "locale_name": "de_DE"}
         path = "/benchmark/5"
-        try:
-            response = self.post_request(path, data, self.token)
-        except URLError as e:
-            logger.warning("HIX benchmark API call failed: %r", e)
-            return None
+        response = self.post_request(path, data, self.token)
         return response.get("formulaHix", None)
 
     @staticmethod


### PR DESCRIPTION
### Short description
Basic networking errors are not being caught with the URLError class. These are derived from the OSError class. If the textlab server is for some reason not reachable, we should catch these errors as well.


### Proposed changes
Catch the OSError class in the textlab API client.

### Side effects
Problems with auto translation? But I think we need to do this anyways.


### Resolved issues
Fixes: #2200 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
