### PR TITLE
Allow localized translations

### DIFF
--- a/example-configs/integreat-cms.ini
+++ b/example-configs/integreat-cms.ini
@@ -27,6 +27,8 @@ LANGUAGES =
 LANGUAGE_CODE = de
 # The default timeout in seconds for retrieving external APIs etc. [optional, defaults to 10]
 DEFAULT_REQUEST_TIMEOUT = 10
+# To adjust text and/or translations in the CMS, local .po files can be included from a directory
+CUSTOM_LOCALE_PATH = /etc/integreat-cms/locale/
 
 [secrets]
 # The secret key for this installation [required]

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -122,6 +122,10 @@ DEFAULT_REQUEST_TIMEOUT = int(
 #: Where release notes are stored
 RELEASE_NOTES_DIRS = os.path.join(BASE_DIR, "release_notes")
 
+#: Custom path for additional local translation files
+CUSTOM_LOCALE_PATH = os.environ.get(
+    "INTEGREAT_CMS_CUSTOM_LOCALE_PATH", "/etc/integreat-cms/locale"
+)
 
 ##############################################################
 # Firebase Push Notifications (Firebase Cloud Messaging FCM) #
@@ -697,7 +701,7 @@ LANGUAGES = [
 
 #: A list of directories where Django looks for translation files
 #: (see :setting:`django:LOCALE_PATHS` and :doc:`django:topics/i18n/index`)
-LOCALE_PATHS = (os.path.join(BASE_DIR, "locale"),)
+LOCALE_PATHS = [os.path.join(BASE_DIR, "locale"), CUSTOM_LOCALE_PATH]
 
 #: A string representing the language slug for this installation
 #: (see :setting:`django:LANGUAGE_CODE` and :doc:`django:topics/i18n/index`)


### PR DESCRIPTION
### Short description
Allow adding local translations in `/etc/integreat/locale`.


### Proposed changes
- Add an additional source path for locales.


### Side effects
- We can use individual strings everywhere ;-)


### Resolved issues
Fixes: #2206


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
