### PR TITLE
Make prettier ignore webpack-stats.json

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@
 *.md
 .venv/**
 build/**
+webpack-stats.json


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
`prettier --check .` keeps complaining about `webpack-stats.json`, and `prettier --write .` always "fixes" it (unnecessarily, since the file gets regenerated constantly)

### Proposed changes
<!-- Describe this PR in more detail. -->

- add the file to `.prettierignore`
- 


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: # n/a


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
