### PR TITLE
Use cached HIX score on page load

### DIFF
--- a/integreat_cms/cms/templates/hix_widget.html
+++ b/integreat_cms/cms/templates/hix_widget.html
@@ -1,5 +1,6 @@
 {% extends "_collapsible_box.html" %}
 {% load i18n %}
+{% load l10n %}
 {% load widget_tweaks %}
 {% block collapsible_box_icon %}
     gauge
@@ -26,7 +27,9 @@
         {% endif %}
         <div id="hix-block"
              class="{% if page_form.instance.hix_ignore %}hidden{% endif %}">
-            <div id="hix-container" data-content-changed>
+            <div id="hix-container"
+                 data-content-changed
+                 data-initial-hix-score="{{ page_translation_form.instance.hix_score|unlocalize }}">
                 <canvas id="hix-chart"></canvas>
             </div>
             <div class="mb-2">

--- a/integreat_cms/static/src/js/analytics/hix-widget.ts
+++ b/integreat_cms/static/src/js/analytics/hix-widget.ts
@@ -194,7 +194,13 @@ window.addEventListener("load", async () => {
             setHixLabelState("no-content");
             document.getElementById("hix-loading")?.classList.add("hidden");
         } else {
-            const initialHixValue = await getHixValue(updateButton.dataset.url);
+            let initialHixValue = parseFloat(document.getElementById("hix-container").dataset.initialHixScore);
+            if (initialHixValue) {
+                setHixLabelState("updated");
+                document.getElementById("hix-loading")?.classList.add("hidden");
+            } else {
+                initialHixValue = await getHixValue(updateButton.dataset.url);
+            }
             updateChart(chart, initialHixValue);
             toggleMTAvailability(initialHixValue);
         }

--- a/integreat_cms/static/src/js/conditional-fields.ts
+++ b/integreat_cms/static/src/js/conditional-fields.ts
@@ -8,7 +8,6 @@ window.addEventListener("load", () => {
     ];
     toggleables.forEach((it) => {
         const toggleControl = document.getElementById(it[0]);
-        console.log(toggleControl);
         const toBeToggled = document.getElementById(it[1]);
 
         // remove "hidden" if toggleControl is already checked on page load


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
If as HIX score is already stored in the DB, we can use it in the page form view instead of making an (unnecessary) request to the Textlab API.

### Proposed changes
<!-- Describe this PR in more detail. -->

- if the current language is in `TEXTLAB_API_LANGUAGES` and the HIX score is set on the page_translation model, use it as the `initialHixValue` instead of calling to the API
- if the content was unchanged, keep the score from the previous version in the pre-save signal

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none that I could find


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2144


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
