### PR TITLE
Invalidate cache after events have been updated

### DIFF
--- a/integreat_cms/cms/views/events/event_form_view.py
+++ b/integreat_cms/cms/views/events/event_form_view.py
@@ -1,5 +1,6 @@
 import logging
 
+from cacheops import invalidate_model
 from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
@@ -250,6 +251,9 @@ class EventFormView(
                     machine_translation_form.data.get("automatic_translation")
                 )
             event_translation_instance.save()
+
+            # Invalidate event translation cache to refresh API result
+            invalidate_model(EventTranslation)
 
             # If automatic translations where requested, pass on to MT API
             if (

--- a/integreat_cms/release_notes/current/unreleased/2197.yml
+++ b/integreat_cms/release_notes/current/unreleased/2197.yml
@@ -1,0 +1,2 @@
+en: Invalidate cache after events have been updated
+de: Leere Cache, nachdem Veranstaltungen aktualisiert wurden


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
I have to admit that I neither understand why the bug is happening, nor why exactly this line is fixing it (I also tried `invalidate_obj(region)`, `invalidate_obj(event)`, `invalidate_obj(event_translation)`, `invalidate_model(Region)`, `invalidate_model(Event)`, neither of which worked), but the important thing is that it seems to fix the issue :see_no_evil: 

### Proposed changes
<!-- Describe this PR in more detail. -->

- Invalidate event translation cache after events have been updated


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- The cache in all regions is invalidated when an event in one region is updated


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2197


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
