### PR TITLE
Add list of worst pages based on HIX to dashboard

### DIFF
--- a/integreat_cms/cms/templates/analytics/_page_hix_row.html
+++ b/integreat_cms/cms/templates/analytics/_page_hix_row.html
@@ -1,0 +1,14 @@
+{% load i18n %}
+{% with page_translation.page.id as page_id %}
+    {% with page_translation.hix_score as hix %}
+        <tr class="{% if hix < hix_threshold %} bg-red-100 hover:bg-red-200 text-red-500 hover:text-red-600 border-l-4 border-red-500 {% else %} hover:bg-gray-100 border-l-4 border-white hover:border-gray-400 {% endif %}">
+            <td>
+                <a class="block p-1"
+                   href="{% url 'edit_page' region_slug=request.region.slug language_slug="de" page_id=page_id %}">
+                    {{ page_translation.title }}
+                </a>
+            </td>
+            <td>{{ hix|floatformat:2 }}</td>
+        </tr>
+    {% endwith %}
+{% endwith %}

--- a/integreat_cms/cms/templates/analytics/_page_hix_widget.html
+++ b/integreat_cms/cms/templates/analytics/_page_hix_widget.html
@@ -1,0 +1,46 @@
+{% extends "_collapsible_box.html" %}
+{% load i18n %}
+{% block collapsible_box_icon %}
+    gauge
+{% endblock collapsible_box_icon %}
+{% block collapsible_box_title %}
+    {% translate "Overview of the text understandability of the pages" %}
+{% endblock collapsible_box_title %}
+{% block collapsible_box_content %}
+    <div class="flex flex-wrap justify-between gap-2">
+        <p>
+            {% blocktranslate trimmed with n=page_translations|length %}
+                The list shows the first {{ n }} pages with the lowest HIX value in ascending order.
+            {% endblocktranslate %}
+        </p>
+        <p>
+            <b>{{ ready_for_mt }}%</b> {% translate " of all pages are ready for automatic translation." %}
+        </p>
+    </div>
+    <div class="mt-4">
+        <table id="page_hix_list" class="w-full max-w-xl mb-4">
+            <thead>
+                <tr class="border-b border-gray-400">
+                    <th class="text-sm text-left uppercase p-1">{% translate "Page name" %}</th>
+                    <th class="text-sm text-left uppercase p-1">{% translate "HIX value" %}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for page_translation in page_translations %}
+                    {% include "analytics/_page_hix_row.html" %}
+                {% empty %}
+                    {% translate "There is no page." %}
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+    <p>
+        {# djlint:off #}
+        {% blocktranslate trimmed with threshold=hix_threshold|floatformat:0 %}
+            To be able to machine translate pages, the page must have a HIX score of at least {{ threshold }}.
+        {% endblocktranslate %}
+        {# djlint:on #}
+        {% translate "If the row is marked red, the HIX value of the corresponding page is not sufficient." %}
+        {% translate "Pages with disabled HIX or no HIX-value are excluded." %}
+    </p>
+{% endblock collapsible_box_content %}

--- a/integreat_cms/cms/templates/dashboard/dashboard.html
+++ b/integreat_cms/cms/templates/dashboard/dashboard.html
@@ -17,6 +17,10 @@
                 {% endif %}
                 <!-- Translation Status Widget: TODO-->
                 <!-- App Size Widget: TODO -->
+                <!-- Page HIX Widget-->
+                {% if TEXTLAB_API_ENABLED and request.region.hix_enabled %}
+                    {% include "analytics/_page_hix_widget.html" %}
+                {% endif %}
             </div>
             <div class="xl:w-1/2">
                 <!-- Broken Link Widget -->

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -4137,6 +4137,56 @@ msgstr "Nicht geprüfte Links"
 msgid "Total links"
 msgstr "Links insgesamt"
 
+#: cms/templates/analytics/_page_hix_widget.html
+msgid "Overview of the text understandability of the pages"
+msgstr "Übersicht der Textverständlichkeiten der Seiten"
+
+#: cms/templates/analytics/_page_hix_widget.html
+#, python-format
+msgid ""
+"The list shows the first %(n)s pages with the lowest HIX value in ascending "
+"order."
+msgstr ""
+"Die Liste zeigt die ersten %(n)s Seiten mit dem niedrigsten HIX-Wert "
+"aufsteigend sortiert."
+
+#: cms/templates/analytics/_page_hix_widget.html
+msgid " of all pages are ready for automatic translation."
+msgstr " der Seiten sind für maschienelle Übersetzung bereit."
+
+#: cms/templates/analytics/_page_hix_widget.html
+msgid "Page name"
+msgstr "Name der Seite"
+
+#: cms/templates/analytics/_page_hix_widget.html
+msgid "HIX value"
+msgstr "HIX-Wert"
+
+#: cms/templates/analytics/_page_hix_widget.html
+msgid "There is no page."
+msgstr "Es gibt keine Seite."
+
+#: cms/templates/analytics/_page_hix_widget.html
+#, python-format
+msgid ""
+"To be able to machine translate pages, the page must have a HIX score of at "
+"least %(threshold)s."
+msgstr ""
+"Um Seiten maschinell übersetzen zu können, muss die Seite einen HIX-Wert von "
+"mindestens %(threshold)s haben."
+
+#: cms/templates/analytics/_page_hix_widget.html
+msgid ""
+"If the row is marked red, the HIX value of the corresponding page is not "
+"sufficient."
+msgstr ""
+"Wenn die Zeile rot markiert ist, ist der HIX-Wert der entsprechenden Seite "
+"nicht ausreichend."
+
+#: cms/templates/analytics/_page_hix_widget.html
+msgid "Pages with disabled HIX or no HIX-value are excluded."
+msgstr "Seiten mit deaktiviertem HIX oder keinem HIX-Wert sind ausgeschlossen."
+
 #: cms/templates/analytics/_translation_overview_widget.html
 msgid "Translation Status"
 msgstr "Status der Übersetzungen"
@@ -8568,6 +8618,9 @@ msgstr ""
 "Diese Seite konnte nicht importiert werden, da sie zu einer anderen Region "
 "gehört ({})."
 
+#~ msgid "This page has no HIX value"
+#~ msgstr "Diese Seite hat keinen HIX-Wert."
+
 #~ msgid "Unknown"
 #~ msgstr "Unbekannt"
 
@@ -8576,6 +8629,9 @@ msgstr ""
 
 #~ msgid "Status message"
 #~ msgstr "Status-Nachricht"
+
+#~ msgid "There is no page yet."
+#~ msgstr "Es gibt keinen Seiteninhalt."
 
 #~ msgid "Current machine translation"
 #~ msgstr "Die Übersetzung ist aktuell und wurde maschinell erzeugt"
@@ -8632,9 +8688,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Kreuzen Sie an, wenn Änderungen automatisch in alle Sprachen übersetzt "
 #~ "werden sollen, die ansonsten veraltet wären."
-
-#~ msgid "Minor edit and automatic translations"
-#~ msgstr "Geringfügige Änderungen und automatische Übersetzungen"
 
 #~ msgid "Edit language tree node"
 #~ msgstr "Sprach-Knoten bearbeiten"
@@ -9510,9 +9563,6 @@ msgstr ""
 
 #~ msgid "key"
 #~ msgstr "Schlüssel"
-
-#~ msgid "value"
-#~ msgstr "Wert"
 
 #~ msgid "configurations"
 #~ msgstr "Einstellungen"

--- a/integreat_cms/release_notes/current/unreleased/2088.yml
+++ b/integreat_cms/release_notes/current/unreleased/2088.yml
@@ -1,0 +1,2 @@
+en: Add list of pages with worst HIX value to dashboard
+de: Füge Liste der Seiten mit dem schlechtesten HIX-Wert zum Dashboard hinzu


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds a list of pages sorted ascendingly by HIX-value.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add a new widget in region dashbord and show it when HIX is enabled in the region
- Sort and show non archived pages with HIX enabled by HIX-Value with link to form
- Mark pages with low HIX-value with red background
- Show percentage of pages ready for automatic translation between all non archived pages

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
Following poits are probably to discuss.
- Pages with good HIX-value or hix_ignore=true are counted as "ready for automatic translation" 
- For HIX-value check the latest draft or public translation is considered.
- The list widget is shown to all users independently from their role and whether they are expert user.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2088 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
