### PR TITLE
Clean-up translation version history

### DIFF
--- a/integreat_cms/cms/models/abstract_content_translation.py
+++ b/integreat_cms/cms/models/abstract_content_translation.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from django.conf import settings
-from django.db import models
+from django.db import models, transaction
 from django.db.models import Q
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
+from linkcheck.listeners import disable_listeners
 
 if TYPE_CHECKING:
     from typing import Any, Literal
@@ -20,6 +22,8 @@ from ..utils.round_hix_score import round_hix_score
 from ..utils.translation_utils import gettext_many_lazy as __
 from .abstract_base_model import AbstractBaseModel
 from .languages.language import Language
+
+logger = logging.getLogger(__name__)
 
 
 # pylint: disable=too-many-public-methods
@@ -578,6 +582,62 @@ class AbstractContentTranslation(AbstractBaseModel):
         if kwargs.pop("update_timestamp", True):
             self.last_updated = timezone.now()
         super().save(*args, **kwargs)
+
+    @transaction.atomic
+    def cleanup_autosaves(self) -> None:
+        """
+        Delete all ``AUTO_SAVE`` translations older than the second last manual save
+        and renumber all affected versions to be continuous.
+        """
+        logger.debug("Cleaning up old autosaves")
+
+        try:
+            second_last_manual_save = (
+                self.foreign_object.translations.filter(language=self.language).exclude(
+                    status=status.AUTO_SAVE
+                )
+            )[1]
+
+            delete_auto_saves = list(
+                self.foreign_object.translations.filter(
+                    language=self.language,
+                    status=status.AUTO_SAVE,
+                    version__lt=second_last_manual_save.version,
+                )
+            )
+
+        except IndexError:
+            delete_auto_saves = []
+
+        if not delete_auto_saves:
+            logger.debug("Nothing to clean up")
+            return
+
+        logger.debug("Deleting autosaves: %r", delete_auto_saves)
+        first_deleted_version = delete_auto_saves[-1].version
+        self.foreign_object.translations.filter(
+            id__in=[t.id for t in delete_auto_saves]
+        ).delete()
+
+        # Get all versions which have now outdated version numbers and lock the database rows
+        remaining_versions = (
+            self.foreign_object.translations.select_for_update()
+            .filter(language=self.language, version__gt=first_deleted_version)
+            .order_by("version")
+        )
+        logger.debug("Remaining versions: %r", remaining_versions)
+
+        # Disable linkcheck listeners to prevent links to be created for outdated versions
+        with disable_listeners():
+            # Make version numbers continuous
+            for new_version, translation in enumerate(
+                remaining_versions, start=first_deleted_version
+            ):
+                logger.debug("Fixing version %s → %s", translation.version, new_version)
+                translation.version = new_version
+                if new_version == 1:
+                    translation.minor_edit = False
+                translation.save(update_timestamp=False)
 
     class Meta:
         #: This model is an abstract base class

--- a/integreat_cms/cms/views/pages/page_form_view.py
+++ b/integreat_cms/cms/views/pages/page_form_view.py
@@ -375,7 +375,7 @@ class PageFormView(
                     node.language for node in language_tree_node.get_descendants()
                 ]
                 page_translation_form.instance.page.translations.filter(
-                    language__in=languages
+                    language__in=languages, status=status.PUBLIC
                 ).update(status=status.DRAFT)
             # If this is the first version and the minor edit checkbox is checked, remove it
             if (
@@ -390,15 +390,9 @@ class PageFormView(
                         'The "minor edit" option was disabled because the first version can never be a minor edit.'
                     ),
                 )
-            # When a version is published and a minor edit, also publish the past versions
-            # (to make sure the translation state is updated correctly)
-            if (
-                page_translation_form.instance.status == status.PUBLIC
-                and page_translation_form.instance.minor_edit
-            ):
-                page_translation_form.instance.page.translations.filter(
-                    language=language
-                ).update(status=status.PUBLIC)
+            # If this is not an autosave, clean up previous auto saves
+            if page_translation_form.instance.status != status.AUTO_SAVE:
+                page_translation_form.instance.cleanup_autosaves()
 
             # Add the success message and redirect to the edit page
             if not page_instance:

--- a/integreat_cms/release_notes/current/unreleased/2067.yml
+++ b/integreat_cms/release_notes/current/unreleased/2067.yml
@@ -1,0 +1,2 @@
+en: Delete all old auto saves on saving page form
+de: Lösche alle alten automatischen Speicherungen beim Speichern des Seitenformulars

--- a/tests/cms/views/pages/test_page_translations.py
+++ b/tests/cms/views/pages/test_page_translations.py
@@ -1,0 +1,113 @@
+import pytest
+from django.test.client import Client
+from django.urls import resolve, reverse
+
+from integreat_cms.cms.constants import status
+from integreat_cms.cms.models.pages.page_translation import PageTranslation
+from tests.conftest import EDITOR, MANAGEMENT, PRIV_STAFF_ROLES
+
+
+@pytest.mark.parametrize(
+    "login_role_user", PRIV_STAFF_ROLES + [MANAGEMENT, EDITOR], indirect=True
+)
+@pytest.mark.django_db
+def test_cleanup_autosaves(
+    load_test_data: None,
+    login_role_user: tuple[Client, str],
+) -> None:
+    client, role = login_role_user
+
+    new_page_url = reverse(
+        "new_page",
+        kwargs={
+            "region_slug": "augsburg",
+            "language_slug": "de",
+        },
+    )
+
+    response = client.post(
+        new_page_url,
+        data={
+            "status": "PUBLIC",
+            "content": "",
+            "title": "Autosave Page",
+            "slug": "autosave-page",
+            "icon": "",
+            "_ref_node_id": 28,
+            "_position": "left",
+            "parent": "",
+            "mirrored_page_region": "",
+            "mirrored_page_first": True,
+            "api_token": "",
+            "authors": "",
+            "editors": "",
+            "organization": "",
+            "minor_edit": True,
+        },
+    )
+    assert response.status_code == 302
+    edit_page_url = response.headers.get("location")
+    id_of_page = resolve(edit_page_url).kwargs["page_id"]
+
+    translation = PageTranslation.objects.get(page__id=id_of_page)
+
+    # autosaves which will later not exist anymore
+    translation.pk = None
+    translation.status = status.AUTO_SAVE
+    translation.version = 2
+    translation.save()
+
+    translation.pk = None
+    translation.status = status.AUTO_SAVE
+    translation.version = 3
+    translation.save()
+
+    # first manual save
+    translation.pk = None
+    translation.status = status.PUBLIC
+    translation.version = 4
+    translation.save()
+
+    # second autosave that should still be existing
+    translation.pk = None
+    translation.status = status.AUTO_SAVE
+    translation.version = 5
+    translation.save()
+
+    # second manual save that should overwrite the first group of autosaves
+    translation.pk = None
+    translation.status = status.PUBLIC
+    translation.version = 6
+    translation.save()
+
+    translation.cleanup_autosaves()
+
+    # reload objects from database
+    versions = translation.page.translations.all()
+    assert len(versions) == 4
+
+    # iterate through the versions and check if the correct versions are deleted/still there
+    versions = list(reversed(versions))
+    assert versions[0].status == status.PUBLIC
+    assert versions[0].version == 1
+
+    assert versions[1].status == status.PUBLIC
+    assert versions[1].version == 2
+
+    assert versions[2].status == status.AUTO_SAVE
+    assert versions[2].version == 3
+
+    # manual saves that should overwrite the one remaining autosave
+    translation.pk = None
+    translation.status = status.PUBLIC
+    translation.version = 7
+    translation.save()
+
+    translation.pk = None
+    translation.status = status.PUBLIC
+    translation.version = 8
+    translation.save()
+
+    translation.cleanup_autosaves()
+    versions = translation.page.translations.all()
+    assert len(versions) == 5


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
 Delete all old autos-saves and renumber all affected versions to be continuous.

### Proposed changes
<!-- Describe this PR in more detail. -->

- we implemented a static method `cleanup_auto_save()`. This method clears all auto-save except the last three (per default). 
- Then we used the `bulk_update()` method to update the version of the pages.  
- Adds a test for this functionality


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- when we renumbering auto-save `bulk_update()` we previously got `IntegrityErrors` , probably because postgresql enforced unique constraints before the update statement was finished. We implemented the workaround using individual Data base statement in a `For-`loop, but revisiting this now we cannot reproduces this. We reverted to `bulk_update()` but please test this thoroughly to sure  this doesn't  break. 



### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: First part of #2067


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
