### PR TITLE
Add popup to DeepL bulk action of page tree view

### DIFF
--- a/integreat_cms/cms/templates/_machine_translation_overlay.html
+++ b/integreat_cms/cms/templates/_machine_translation_overlay.html
@@ -1,0 +1,117 @@
+{% load i18n %}
+<div id="machine-translation-overlay"
+     class="hidden fixed items-center justify-center inset-0 bg-opacity-75 bg-gray-800 z-50 cursor-pointer">
+    <div class="cursor-auto justify-center w-[500px] max-h-fit px-[10px] z-50 m-auto">
+        <div class="bg-white opacity-100 content rounded shadow-md w-full">
+            <div class="flex items-center w-full rounded p-4 bg-water-500">
+                <h2 class="font-bold font-default">
+                    <i icon-name="bot" class="pb-1"></i>
+                    {% translate "Machine translation" %}
+                </h2>
+            </div>
+            <div class="w-full p-4 rounded shadow overflow-scroll max-h-[80vh]">
+                <span class="block">{% translate "This report shows a summary of your attempted machine translation. Please confirm if everything is correct" %}</span>
+                <div class="mt-4">
+                    <h3>
+                        <b>{% translate "Language selection" %}</b>
+                    </h3>
+                    <div class="flex items-center mt-2">
+                        <div class="flex">
+                            <span class="fp fp-rounded fp-{{ source_language.primary_country_code }} w-7 mr-2"></span>
+                            <p>{{ source_language }}</p>
+                        </div>
+                        <i class="mx-4" icon-name="arrow-big-right"></i>
+                        <div class="flex">
+                            <span class="fp fp-rounded fp-{{ language.primary_country_code }} w-7 mr-2"></span>
+                            <p>{{ language }}</p>
+                        </div>
+                    </div>
+                </div>
+                <div class="mt-4">
+                    <h3>
+                        <b>{% translate "Pages to be translated" %} (<span id="machine-translation-overlay-pages-number"></span>/<span id="machine-translation-overlay-pages-total-number"></span>)</b>
+                    </h3>
+                    <div class="mt-2">
+                        <div id="machine-translation-overlay-pages-no-pages-warning"
+                             class="hidden bg-red-100 border-l-4 border-red-500 text-red-500 px-4 py-3 mb-5">
+                            {% if source_language.slug in textlab_languages %}
+                                {% blocktranslate trimmed with hix_threshold=hix_threshold|floatformat:0 %}
+                                    None of the selected pages fullfills the required HIX score of {{ hix_threshold }}.
+                                {% endblocktranslate %}
+                            {% else %}
+                                {% translate "None of the selected pages has a source translation." %}
+                            {% endif %}
+                        </div>
+                        <ul id="machine-translation-overlay-pages">
+                        </ul>
+                        <ul id="machine-translation-overlay-pages-optional" class="hidden">
+                        </ul>
+                        <a id="machine-translation-overlay-expansion-trigger"
+                           data-default-text="{% translate "Show all" %}"
+                           data-alternative-text="{% translate "Show less" %}"
+                           class="text-blue-500 hidden">{% translate "Show all" %}</a>
+                    </div>
+                </div>
+                <div class="mt-4">
+                    <h3>
+                        <b>{% translate "Budget" %}</b>
+                    </h3>
+                    <table>
+                        <tr>
+                            <td id="machine-translation-overlay-current-budget-label">{% translate "Current budget" %}</td>
+                            <td class="pl-2" id="machine-translation-overlay-current-budget-result">
+                                {{ request.region.deepl_budget_remaining }}
+                            </td>
+                        </tr>
+                        <tr>
+                            <td id="machine-translation-overlay-budget-usage-label">{% translate "Number of words you would use" %}</td>
+                            <td class="pl-2" id="machine-translation-overlay-budget-usage-result"></td>
+                        </tr>
+                        <tr class="border-solid border-t-2">
+                            <td id="machine-translation-overlay-budget-remains-label">{% translate "Remaining budget: " %}</td>
+                            <td class="pl-2" id="machine-translation-overlay-budget-remains-result"></td>
+                        </tr>
+                    </table>
+                </div>
+                <div class="mt-4 hidden" id="machine-translation-overlay-warning">
+                    <h3>
+                        <b>{% translate "Pages that can't be translated" %}</b>
+                    </h3>
+                    <div class="my-2 bg-yellow-100 border-l-4 border-yellow-500 text-yellow-600 px-4 py-3 mb-5"
+                         role="alert">
+                        <i class="mr-2" icon-name="alert-triangle"></i>
+                        {% blocktranslate trimmed %}
+                            There are currently <span id="not-translatable"></span> page(s) that can't be translated.
+                        {% endblocktranslate %}
+                        {% if source_language.slug in textlab_languages %}
+                            {% blocktranslate trimmed with hix_threshold=hix_threshold|floatformat:0 %}
+                                These pages can't be translated because the text understandibility is too low or because their hix value has been ignored. Please improve it to a value of at least {{ hix_threshold }} to translate these pages. You can identify the pages that couldn't be translated in the page tree via the translation status.
+                            {% endblocktranslate %}
+                        {% else %}
+                            {% translate "These pages can't be translated because they have no translation in the source language." %}
+                        {% endif %}
+                    </div>
+                    <ul class="hidden mb-2" id="machine-translation-overlay-warning-optional">
+                    </ul>
+                    <a id="machine-translation-overlay-warning-more" data-default-text="{% translate "Show pages" %}" data-alternative-text="{% translate "Don't show pages" %}"  class="text-blue-500">
+                        {% translate "Show pages" %}
+                    </a>
+                </div>
+                <div class="flex justify-between mt-4">
+                    <button type="button"
+                            id="btn-close-machine-translation-overlay"
+                            class="btn !bg-red-500">
+                        {% translate "Cancel" %}
+                    </button>
+                    <button id="machine-translation-overlay-bulk-action-execute"
+                            class="btn"
+                            form="bulk-action-form"
+                            type="submit"
+                            disabled>
+                        {% translate "Confirm" %}
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/integreat_cms/cms/templates/pages/page_tree.html
+++ b/integreat_cms/cms/templates/pages/page_tree.html
@@ -159,7 +159,10 @@
                 {% if MT_PERMITTED %}
                     {% translate "pages" as content_type %}
                     {% if MT_PROVIDER %}
-                        <option data-bulk-action="{% url 'machine_translation_pages' region_slug=request.region.slug language_slug=language.slug %}">
+                        <option id="machine-translation-option"
+                                data-mt-provider="{{ MT_PROVIDER.name }}"
+                                data-url="{% url 'post_hix_and_word_number_per_page' region_slug=request.region.slug language_slug=language.slug %}"
+                                data-bulk-action="{% url 'machine_translation_pages' region_slug=request.region.slug language_slug=language.slug %}">
                             {% blocktranslate trimmed with provider=MT_PROVIDER.name %}
                                 Machine translate {{ content_type }} via {{ provider }} to {{ language }}
                             {% endblocktranslate %}
@@ -246,4 +249,5 @@
     {% include "../tutorials/page_tree.html" with tutorial_id="page-tree" hidden=request.user.page_tree_tutorial_seen %}
     {% include "pages/_page_preview_overlay.html" %}
     {% include "pages/_page_xliff_export_overlay.html" %}
+    {% include "_machine_translation_overlay.html" %}
 {% endblock content %}

--- a/integreat_cms/cms/urls/protected.py
+++ b/integreat_cms/cms/urls/protected.py
@@ -554,6 +554,11 @@ urlpatterns = [
                                             utils.slugify_ajax,
                                             name="slugify_ajax",
                                         ),
+                                        path(
+                                            "auto-translate-hix-and-words-per-page/",
+                                            pages.post_hix_and_word_number_per_page,
+                                            name="post_hix_and_word_number_per_page",
+                                        ),
                                     ]
                                 ),
                             ),

--- a/integreat_cms/cms/views/pages/__init__.py
+++ b/integreat_cms/cms/views/pages/__init__.py
@@ -10,6 +10,7 @@ from .page_actions import (
     get_page_order_table_ajax,
     grant_page_permission_ajax,
     move_page,
+    post_hix_and_word_number_per_page,
     preview_page_ajax,
     refresh_date,
     render_mirrored_page_field,

--- a/integreat_cms/cms/views/pages/page_actions.py
+++ b/integreat_cms/cms/views/pages/page_actions.py
@@ -19,6 +19,7 @@ from django.views.decorators.http import require_POST
 from treebeard.exceptions import InvalidMoveToDescendant, InvalidPosition
 
 from ....api.decorators import json_response
+from ....textlab_api.utils import check_hix_score
 from ...constants import text_directions
 from ...decorators import permission_required
 from ...forms import PageForm
@@ -896,3 +897,70 @@ def refresh_date(
             "region_slug": request.region.slug,
         },
     )
+
+
+@require_POST
+@json_response
+# pylint: disable=unused-argument
+def post_hix_and_word_number_per_page(request, region_slug, language_slug):
+    """
+    This function collects the hix score and the amount of words per page from the source
+
+    :param request: The current request
+    :type request: ~django.http.HttpRequest
+
+    :param region_slug: The slug of the current region
+    :type region_slug: str
+
+    :param language_slug: The slug of the current language
+    :type language_slug: str
+
+    :return: A json response of {{"id": id, "title": title, "words": number of words, "hix": if HIX value is high enough}} in case of success
+    :rtype: ~django.http.JsonResponse
+    """
+    selected_page_ids = json.loads(request.body.decode("utf-8"))
+    selected_pages = request.region.get_pages(return_unrestricted_queryset=True).filter(
+        id__in=selected_page_ids
+    )
+
+    filtered_pages = {}
+    translatable = {}
+    not_translatable = {}
+
+    source_language = request.region.get_source_language(language_slug)
+
+    for page in selected_pages:
+        source_translation = page.get_translation(source_language.slug)
+        words = (
+            len(source_translation.content.split())
+            + len(source_translation.title.split())
+            if source_translation
+            else 0
+        )
+
+        if source_translation and check_hix_score(
+            request, source_translation, show_message=False
+        ):
+            page_data = {
+                "id": page.id,
+                "title": source_translation.title,
+                "words": words,
+                "hix": True,
+            }
+            translatable.update({page.id: page_data})
+        else:
+            page_data = {
+                "id": page.id,
+                "title": source_translation.title
+                if source_translation
+                else page.best_translation.title,
+                "words": words,
+                "hix": False,
+            }
+            not_translatable.update({page.id: page_data})
+
+    filtered_pages = {
+        "translatable": translatable,
+        "not_translatable": not_translatable,
+    }
+    return JsonResponse(filtered_pages)

--- a/integreat_cms/cms/views/pages/page_tree_view.py
+++ b/integreat_cms/cms/views/pages/page_tree_view.py
@@ -140,7 +140,6 @@ class PageTreeView(TemplateView, PageContextMixin, MachineTranslationContextMixi
 
         # Filter pages according to given filters, if any
         pages = filter_form.apply(pages, language_slug)
-
         return render(
             request,
             self.template_name,
@@ -148,8 +147,11 @@ class PageTreeView(TemplateView, PageContextMixin, MachineTranslationContextMixi
                 **self.get_context_data(**kwargs),
                 "pages": pages,
                 "language": language,
+                "source_language": region.get_source_language(language.slug),
                 "languages": region.active_languages,
+                "textlab_languages": settings.TEXTLAB_API_LANGUAGES,
                 "filter_form": filter_form,
                 "XLIFF_EXPORT_VERSION": settings.XLIFF_EXPORT_VERSION,
+                "hix_threshold": settings.HIX_REQUIRED_FOR_MT,
             },
         )

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -3951,6 +3951,125 @@ msgstr "Standard-Sprache wird dupliziert"
 msgid "Other Languages"
 msgstr "Weitere Sprachen"
 
+#: cms/templates/_machine_translation_overlay.html
+msgid "Machine translation"
+msgstr "Maschinelle Übersetzung"
+
+#: cms/templates/_machine_translation_overlay.html
+msgid ""
+"This report shows a summary of your attempted machine translation. Please "
+"confirm if everything is correct"
+msgstr ""
+"Hier finden Sie eine Übersicht über die maschinelle Übersetzung. Bitte "
+"bestätigen Sie, dass alle Angaben korrekt sind."
+
+#: cms/templates/_machine_translation_overlay.html
+msgid "Language selection"
+msgstr "Sprachauswahl"
+
+#: cms/templates/_machine_translation_overlay.html
+msgid "Pages to be translated"
+msgstr "Zu übersetzende Seiten"
+
+#: cms/templates/_machine_translation_overlay.html
+#, python-format
+msgid ""
+"None of the selected pages fullfills the required HIX score of "
+"%(hix_threshold)s."
+msgstr ""
+"Keiner der ausgewählten Seiten erfüllt den benötigten HIX-Wert von "
+"%(hix_threshold)s."
+
+#: cms/templates/_machine_translation_overlay.html
+msgid "None of the selected pages has a source translation."
+msgstr "Keine der ausgewählten Seiten hat eine Quellübersetzung."
+
+#: cms/templates/_machine_translation_overlay.html
+msgid "Show all"
+msgstr "Alle anzeigen"
+
+#: cms/templates/_machine_translation_overlay.html
+msgid "Show less"
+msgstr "Weniger anzeigen"
+
+#: cms/templates/_machine_translation_overlay.html
+msgid "Budget"
+msgstr "Budget"
+
+#: cms/templates/_machine_translation_overlay.html
+msgid "Current budget"
+msgstr "Aktuelles Gesamtbudget"
+
+#: cms/templates/_machine_translation_overlay.html
+msgid "Number of words you would use"
+msgstr "Benötiges Budget"
+
+#: cms/templates/_machine_translation_overlay.html
+msgid "Remaining budget: "
+msgstr "Verbleibendes Budget:"
+
+#: cms/templates/_machine_translation_overlay.html
+msgid "Pages that can't be translated"
+msgstr "Seiten, die nicht übersetzt werden können"
+
+#: cms/templates/_machine_translation_overlay.html
+msgid ""
+"There are currently <span id=\"not-translatable\"></span> page(s) that can't "
+"be translated."
+msgstr ""
+"Es gibt aktuell <span id=\"not-translatable\"></span> Seiten, die nicht "
+"übersetzt werden können."
+
+#: cms/templates/_machine_translation_overlay.html
+#, python-format
+msgid ""
+"These pages can't be translated because the text understandibility is too "
+"low or because their hix value has been ignored. Please improve it to a "
+"value of at least %(hix_threshold)s to translate these pages. You can "
+"identify the pages that couldn't be translated in the page tree via the "
+"translation status."
+msgstr ""
+"Diese Seiten können nicht übersetzt werden, weil die Textverständlichkeit zu "
+"gering ist oder weil der HIX-Wert für diese Seiten ignoriert wurde. Bitte "
+"verbessern Sie den HIX-Wert auf einen Wert von mindestens %(hix_threshold)s, "
+"um diese Seiten übersetzen zu können. Sie können die Seiten, die nicht "
+"übersetzt werden konnten an ihrem Status im Seitenbaum erkennen."
+
+#: cms/templates/_machine_translation_overlay.html
+msgid ""
+"These pages can't be translated because they have no translation in the "
+"source language."
+msgstr ""
+"Diese Seiten können nicht übersetzt werden, weil sie keine Übersetzung in "
+"der Quellsprache haben."
+
+#: cms/templates/_machine_translation_overlay.html
+msgid "Show pages"
+msgstr "Seiten anzeigen"
+
+#: cms/templates/_machine_translation_overlay.html
+msgid "Don't show pages"
+msgstr "Seiten nicht anzeigen"
+
+#: cms/templates/_machine_translation_overlay.html
+#: cms/templates/_tinymce_config.html
+#: cms/templates/generic_confirmation_dialog.html
+#: cms/templates/linkcheck/link_list_row.html
+#: cms/templates/pois/poi_form_sidebar/position_box.html
+#: cms/views/pois/poi_context_mixin.py
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: cms/templates/_machine_translation_overlay.html
+#: cms/templates/authentication/totp_login.html
+#: cms/templates/generic_confirmation_dialog.html
+#: cms/templates/pages/page_xliff_import_view.html
+#: cms/templates/pois/poi_form_sidebar/position_box.html
+#: cms/templates/settings/delete_totp.html
+#: cms/templates/settings/register_totp.html
+msgid "Confirm"
+msgstr "Bestätigen"
+
 #: cms/templates/_raw.html
 msgid "Editorial System"
 msgstr "Redaktionssystem"
@@ -4011,14 +4130,6 @@ msgstr "Aktualisieren"
 #: cms/templates/_tinymce_config.html cms/views/media/media_context_mixin.py
 msgid "Submit"
 msgstr "Speichern"
-
-#: cms/templates/_tinymce_config.html
-#: cms/templates/generic_confirmation_dialog.html
-#: cms/templates/linkcheck/link_list_row.html
-#: cms/templates/pois/poi_form_sidebar/position_box.html
-#: cms/views/pois/poi_context_mixin.py
-msgid "Cancel"
-msgstr "Abbrechen"
 
 #: cms/templates/_tinymce_config.html
 msgid "- no results -"
@@ -4335,15 +4446,6 @@ msgid ""
 msgstr ""
 "Bitte öffnen Sie Ihre Authenticator-App und geben Sie den 6-stelligen Code "
 "für \"%(BRANDING)s\" ein, um ihre Identität zu bestätigen:"
-
-#: cms/templates/authentication/totp_login.html
-#: cms/templates/generic_confirmation_dialog.html
-#: cms/templates/pages/page_xliff_import_view.html
-#: cms/templates/pois/poi_form_sidebar/position_box.html
-#: cms/templates/settings/delete_totp.html
-#: cms/templates/settings/register_totp.html
-msgid "Confirm"
-msgstr "Bestätigen"
 
 #: cms/templates/chat/_chat_messages.html
 msgid "Delete chat message"

--- a/integreat_cms/release_notes/current/unreleased/2102.yml
+++ b/integreat_cms/release_notes/current/unreleased/2102.yml
@@ -1,0 +1,2 @@
+en: Add page bulk actions with popup for machine translations into one target language
+de: Ermögliche maschinelle Übersetzungen von Seiten in eine Zielsprache über Mehrfachaktionen mit Popup

--- a/integreat_cms/static/src/index.ts
+++ b/integreat_cms/static/src/index.ts
@@ -27,6 +27,7 @@ import "./js/copy-clipboard.ts";
 import "./js/bulk-actions.ts";
 import "./js/conditional-fields.ts";
 import "./js/confirmation-popups.ts";
+import "./js/machine-translation-overlay";
 import "./js/revisions.ts";
 import "./js/search-query.ts";
 

--- a/integreat_cms/static/src/js/machine-translation-overlay.ts
+++ b/integreat_cms/static/src/js/machine-translation-overlay.ts
@@ -1,0 +1,225 @@
+import { getCsrfToken } from "./utils/csrf-token";
+
+const resetValue = 0;
+const budgetThreshold = 0;
+const limitOfPreview = 5;
+
+type PageAttributes = {
+    [id: number]: { id: number; title: string; words: number; hix: boolean };
+};
+type Pages = {
+    [category: string]: PageAttributes;
+};
+
+const toggleMachineTranslationForPagesButton = () => {
+    // Only activate button if budget is sufficient
+    const budget: number = +document.getElementById("machine-translation-overlay-budget-remains-result").innerText;
+    const MachineTranslationButton = document.getElementById(
+        "machine-translation-overlay-bulk-action-execute"
+    ) as HTMLButtonElement;
+    if (budget >= budgetThreshold && document.getElementById("machine-translation-overlay-pages").hasChildNodes()) {
+        MachineTranslationButton.disabled = false;
+    } else {
+        MachineTranslationButton.disabled = true;
+    }
+};
+
+const getSelectedIDs = () => {
+    // get the IDs of the selected pages
+    const selectedItems = document.querySelectorAll(".bulk-select-item:checked");
+    const selectedPages: Array<number> = [];
+    selectedItems.forEach((selectedItem) => {
+        selectedPages.push(parseInt((selectedItem as HTMLInputElement).value, 10));
+    });
+    return selectedPages;
+};
+
+const getAllPages = async (url: string, selectedPages: Array<number>): Promise<Pages> => {
+    // make AJAX call to get all pages and return them as Promise <object>
+    const response = await fetch(url, {
+        method: "POST",
+        headers: {
+            "X-CSRFToken": getCsrfToken(),
+        },
+        body: JSON.stringify(selectedPages),
+    });
+    const pages = await response.json();
+    return pages;
+};
+
+const calculateAndSetRemainingBudget = () => {
+    // calculate and set the remaining budget after translation will be executed and call toggleMachineTranslationForPagesButton in case the budget is not sufficient
+    const currentBudgetElement: number = +document.getElementById("machine-translation-overlay-current-budget-result")
+        .innerText;
+    const usageOfBudgetElement: number = +document.getElementById("machine-translation-overlay-budget-usage-result")
+        .innerText;
+    const remainingBudgetElement = document.getElementById("machine-translation-overlay-budget-remains-result");
+    const remainingBudget = currentBudgetElement - usageOfBudgetElement;
+    remainingBudgetElement.textContent = remainingBudget.toString();
+    toggleMachineTranslationForPagesButton();
+};
+
+const buildTranslatableList = (
+    translatablePages: PageAttributes,
+    previewListOfPages: HTMLElement,
+    listOfOptionalPages: HTMLElement
+) => {
+    const pages = Object.values(translatablePages);
+
+    let numberOfTranslatablePages = resetValue;
+    let numberOfWords = resetValue;
+
+    pages.forEach((page) => {
+        const list = document.createElement("li");
+        list.classList.add("list-disc", "ml-4");
+        list.textContent = page.title;
+
+        if (previewListOfPages.children.length < limitOfPreview) {
+            previewListOfPages.appendChild(list);
+        } else {
+            listOfOptionalPages.appendChild(list);
+        }
+
+        numberOfTranslatablePages += 1;
+        numberOfWords += page.words;
+    });
+
+    document.getElementById("machine-translation-overlay-pages-number").textContent =
+        numberOfTranslatablePages.toString();
+    document.getElementById("machine-translation-overlay-budget-usage-result").textContent = numberOfWords.toString();
+    calculateAndSetRemainingBudget();
+};
+
+const buildNotTranslatableList = (notTranslatablePages: PageAttributes, expandableWarningListElement: HTMLElement) => {
+    const pages = Object.values(notTranslatablePages);
+
+    let numberOfNotTranslatablePages = 0;
+
+    pages.forEach((page) => {
+        const list = document.createElement("li");
+        list.classList.add("list-disc", "ml-4");
+        list.textContent = page.title;
+        expandableWarningListElement.appendChild(list);
+        numberOfNotTranslatablePages += 1;
+    });
+
+    document.getElementById("not-translatable").textContent = numberOfNotTranslatablePages.toString();
+};
+
+const prepareOverlay = (filteredPages: Pages) => {
+    const previewListOfPages = document.getElementById("machine-translation-overlay-pages");
+    previewListOfPages.textContent = "";
+    const listOfOptionalPages = document.getElementById("machine-translation-overlay-pages-optional");
+    listOfOptionalPages.textContent = "";
+    buildTranslatableList(filteredPages.translatable, previewListOfPages, listOfOptionalPages);
+
+    const warningListElement = document.getElementById("machine-translation-overlay-warning");
+    const expandableWarningListElement = document.getElementById("machine-translation-overlay-warning-optional");
+    expandableWarningListElement.textContent = "";
+    buildNotTranslatableList(filteredPages.not_translatable, expandableWarningListElement);
+
+    const expansionTrigger = document.getElementById("machine-translation-overlay-expansion-trigger");
+    const noPageWarning = document.getElementById("machine-translation-overlay-pages-no-pages-warning");
+
+    if (previewListOfPages.children.length === 0) {
+        noPageWarning.classList.remove("hidden");
+    } else {
+        noPageWarning.classList.add("hidden");
+    }
+
+    if (listOfOptionalPages.children.length === 0) {
+        expansionTrigger.classList.add("hidden");
+        expansionTrigger.classList.remove("block");
+    } else {
+        expansionTrigger.classList.remove("hidden");
+        expansionTrigger.classList.add("block");
+    }
+
+    toggleMachineTranslationForPagesButton();
+
+    if (expandableWarningListElement.children.length !== 0) {
+        warningListElement.classList.add("block");
+        warningListElement.classList.remove("hidden");
+    } else {
+        warningListElement.classList.remove("block");
+        warningListElement.classList.add("hidden");
+    }
+};
+
+const setAmountOfSelectedPages = (numberOfSelectedPages: number) => {
+    // set the number of selected pages
+    const numberOfSelectedPagesElement = document.getElementById("machine-translation-overlay-pages-total-number");
+    numberOfSelectedPagesElement.textContent = numberOfSelectedPages.toString();
+};
+
+const closeMachineTranslationOverlay = (overlay: HTMLElement) => {
+    // close overlay
+    overlay.classList.add("hidden");
+    overlay.classList.remove("flex");
+};
+
+const toggleOptionalText = (trigger: HTMLElement, optionalText: HTMLElement) => {
+    // function to toggle optional text
+    trigger.addEventListener("click", () => {
+        optionalText.classList.toggle("hidden");
+        optionalText.classList.toggle("block");
+        if (optionalText.classList.contains("block")) {
+            trigger.textContent = trigger.dataset.alternativeText; // eslint-disable-line no-param-reassign
+        } else {
+            trigger.textContent = trigger.dataset.defaultText; // eslint-disable-line no-param-reassign
+        }
+    });
+};
+
+const addMachineTranslationOverlayEventListeners = () => {
+    // add event listeners to overlay
+    const overlay = document.getElementById("machine-translation-overlay");
+    const provider = document.getElementById("machine-translation-option").getAttribute("data-mt-provider");
+    if (overlay && provider === "DeepL") {
+        // Set listener for bulk action execute button.
+        document.getElementById("bulk-action-execute")?.addEventListener("click", (event) => {
+            const machineTranslationOptionIndex = (
+                document.getElementById("machine-translation-option") as HTMLOptionElement
+            ).index;
+            const { selectedIndex } = document.getElementById("bulk-action") as HTMLSelectElement;
+
+            if (machineTranslationOptionIndex === selectedIndex) {
+                const url = (document.getElementById("machine-translation-option") as HTMLElement).dataset.url;
+                const selectedIDs = getSelectedIDs();
+                const filteredPages = getAllPages(url, selectedIDs);
+
+                event.preventDefault();
+                overlay.classList.remove("hidden");
+                overlay.classList.add("flex");
+
+                filteredPages.then((filteredPages: Pages) => {
+                    prepareOverlay(filteredPages);
+                });
+                setAmountOfSelectedPages(selectedIDs.length);
+            }
+        });
+        document.getElementById("btn-close-machine-translation-overlay").addEventListener("click", () => {
+            closeMachineTranslationOverlay(overlay);
+        });
+        // Close window by clicking on backdrop.
+        overlay.addEventListener("click", (e) => {
+            if (e.target === overlay) {
+                closeMachineTranslationOverlay(overlay);
+            }
+        });
+
+        toggleOptionalText(
+            document.getElementById("machine-translation-overlay-warning-more"),
+            document.getElementById("machine-translation-overlay-warning-optional")
+        );
+        toggleOptionalText(
+            document.getElementById("machine-translation-overlay-expansion-trigger"),
+            document.getElementById("machine-translation-overlay-pages-optional")
+        );
+    }
+};
+
+window.addEventListener("load", () => {
+    // main function
+    addMachineTranslationOverlayEventListeners();
+});

--- a/integreat_cms/textlab_api/utils.py
+++ b/integreat_cms/textlab_api/utils.py
@@ -10,7 +10,7 @@ from django.utils.translation import gettext as _
 logger = logging.getLogger(__name__)
 
 
-def check_hix_score(request, source_translation):
+def check_hix_score(request, source_translation, show_message=True):
     """
     Check whether the required HIX score is met and it is not ignored
 
@@ -19,6 +19,9 @@ def check_hix_score(request, source_translation):
 
     :param source_translation: The source translation
     :type source_translation: ~integreat_cms.cms.models.abstract_content_translation.AbstractContentTranslation
+
+    :param show_message: whether the massage should be shown to users.
+    :type show_message: bool
 
     :return: Whether the HIX constraints are valid
     :rtype: bool
@@ -32,30 +35,32 @@ def check_hix_score(request, source_translation):
             source_translation,
             settings.HIX_REQUIRED_FOR_MT,
         )
-        messages.error(
-            request,
-            _(
-                'HIX score {:.2f} of "{}" is too low for machine translation (minimum required: {})'
-            ).format(
-                source_translation.hix_score,
-                source_translation,
-                settings.HIX_REQUIRED_FOR_MT,
-            ),
-        )
+        if show_message:
+            messages.error(
+                request,
+                _(
+                    'HIX score {:.2f} of "{}" is too low for machine translation (minimum required: {})'
+                ).format(
+                    source_translation.hix_score,
+                    source_translation,
+                    settings.HIX_REQUIRED_FOR_MT,
+                ),
+            )
         return False
     if source_translation.hix_ignore:
         logger.debug(
             "Machine translations are disabled for %r, because its HIX value is ignored",
             source_translation,
         )
-        messages.error(
-            request,
-            _(
-                'Machine translations are disabled for "{}", because its HIX value is ignored'
-            ).format(
-                source_translation.title,
-            ),
-        )
+        if show_message:
+            messages.error(
+                request,
+                _(
+                    'Machine translations are disabled for "{}", because its HIX value is ignored'
+                ).format(
+                    source_translation.title,
+                ),
+            )
         return False
     logger.debug(
         "HIX score %.2f of %r is sufficient for machine translation",


### PR DESCRIPTION
### Short description
This PR adds the option to translate pages via MT through a bulk action inside the page tree view. Please note, this PR is not yet ready for review, since I still want to take the time to attempt refactoring it myself. This PR is supposed to fulfill the following use case: I, as CMS user, want to get an overview about my MT budget, the pages that will be able to be translated and those that can't be translated (due to too low HIX score), before translating them.


### Proposed changes

- Add release note
- Add a option for MT to the bulk action dropdown
- Add a popup to get a report about the attempted MT
  - Show from which to which language this translation is going to be
  - Show the pages that can be translated
  - Show the pages that can't be translated
  - Show the budget and calculate, if there is enough budget for it
- Request hix score and amount of words per page via AJAX  

### Background information
- After a chat with @osmers we decided to disable the option to switch the language inside the popup, since a. we don't want to encourage this behavior, and it would have increased the scope of this PR quite a bit
- After a chat with @hauf-toni we decided to keep most of the structure for the popup in comparison to the XLIFF popup, but add two significant changes: 1. remove the X to close the popup and instead adding a "Cancel" button, since it's more prominent and gives clearer instruction to the user of what to do and 2. widen the popup from 400px to 500px, because 400px were too narrow and added a lot of additional vertical scroll. 

### Side effects

- This could be effecting the MT via page, event or poi form
- There might be a bunch of merge conflicts after #2209 is merged
- Let's say you have 1 page that can be translated and one that can't be, you'll get two error messages for the page that can't be translated (one inside the popup via JS/TS and the second one after confirming via Dj/Py).
- I noticed, that currently I can re-translate a page via MT although the translation status is "Up to date" or "Machine translated and up to date". In order to be more user friendly and prevent unnecessary usage of MT budget, I would suggest adding a check if a machine translation is actually needed or not. First I think it's up for discussion if we really want this or not, and secondly I think that would also be out of scope for this PR and rather something for another issue  


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2102 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
