### PR TITLE
Fix `RelatedObjectDoesNotExist` when creating a new page

### DIFF
--- a/integreat_cms/cms/forms/machine_translation_form.py
+++ b/integreat_cms/cms/forms/machine_translation_form.py
@@ -68,7 +68,7 @@ class MachineTranslationForm(CustomContentModelForm):
         for target in translation_targets:
             target_type = (
                 to_update
-                if self.instance
+                if self.instance.id
                 and target.language in self.instance.foreign_object.languages
                 else to_create
             )


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
The problem was that the form instance is always an object (so evaluating to `True`), even when it's not yet saved to the database.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Checking whether the object is saved to the database before accessing the foreign object



### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2227


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
