### PR TITLE
Fix wrongfully shown 'HIX too low' error message

### DIFF
--- a/integreat_cms/cms/templates/events/event_form_sidebar/minor_edit_box.html
+++ b/integreat_cms/cms/templates/events/event_form_sidebar/minor_edit_box.html
@@ -18,7 +18,7 @@
         </label>
         <div class="help-text">{% minor_edit_help_text request.region language event_translation_form %}</div>
     </div>
-    {% if event_translation_form.mt_is_enabled %}
+    {% if event_translation_form.mt_form_is_enabled %}
         <div>
             {% render_field event_translation_form.automatic_translation class+="mutually-exclusive-checkbox" %}
             <label for="{{ event_translation_form.automatic_translation.id_for_label }}"

--- a/integreat_cms/cms/templates/pages/page_form_sidebar/minor_edit_box.html
+++ b/integreat_cms/cms/templates/pages/page_form_sidebar/minor_edit_box.html
@@ -18,7 +18,7 @@
         </label>
         <div class="help-text">{% minor_edit_help_text request.region language page_translation_form %}</div>
     </div>
-    {% if page_translation_form.mt_is_enabled %}
+    {% if page_translation_form.mt_form_is_enabled %}
         <div id="machine-translation-form" data-minimum-hix="{{ minimum_hix }}">
             {% render_field page_translation_form.automatic_translation class+="mutually-exclusive-checkbox" %}
             <label for="{{ page_translation_form.automatic_translation.id_for_label }}"

--- a/integreat_cms/cms/templates/pois/poi_form_sidebar/minor_edit_box.html
+++ b/integreat_cms/cms/templates/pois/poi_form_sidebar/minor_edit_box.html
@@ -18,7 +18,7 @@
         </label>
         <div class="help-text">{% minor_edit_help_text request.region language poi_translation_form %}</div>
     </div>
-    {% if poi_translation_form.mt_is_enabled %}
+    {% if poi_translation_form.mt_form_is_enabled %}
         <div>
             {% render_field poi_translation_form.automatic_translation class+="mutually-exclusive-checkbox" %}
             <label for="{{ poi_translation_form.automatic_translation.id_for_label }}"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
The "HIX score too low for MT" error message was shown whenever the HIX score was too low, even when MT had not been attempted by the user.

### Proposed changes
<!-- Describe this PR in more detail. -->

- if automatic MT was unchecked, all translation target languages were removed from the forms `cleaned_data`, however to check if MT was possible, the querysets assigned to the fields themselves were checked for emptiness -> fixed


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2230


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
