### PR TITLE
Add option to expand HIX list on dashboard

### DIFF
--- a/integreat_cms/cms/templates/analytics/_page_hix_widget.html
+++ b/integreat_cms/cms/templates/analytics/_page_hix_widget.html
@@ -7,18 +7,18 @@
     {% translate "Overview of the text understandability of the pages" %}
 {% endblock collapsible_box_title %}
 {% block collapsible_box_content %}
-    <div class="flex flex-wrap justify-between gap-2">
+    <div class="flex flex-wrap gap-2">
         <p>
-            {% blocktranslate trimmed with n=page_translations|length %}
-                The list shows the first {{ n }} pages with the lowest HIX value in ascending order.
+            {% blocktranslate trimmed %}
+                The list shows the pages with the lowest HIX value in ascending order.
             {% endblocktranslate %}
         </p>
         <p>
             <b>{{ ready_for_mt }}%</b> {% translate " of all pages are ready for automatic translation." %}
         </p>
     </div>
-    <div class="mt-4">
-        <table id="page_hix_list" class="w-full max-w-xl mb-4">
+    <div class="mt-4 overflow-y-scroll max-h-160">
+        <table id="page_hix_list" class="w-full max-w-xl mb-4 show-n-rows">
             <thead>
                 <tr class="border-b border-gray-400">
                     <th class="text-sm text-left uppercase p-1">{% translate "Page name" %}</th>
@@ -26,14 +26,15 @@
                 </tr>
             </thead>
             <tbody>
-                {% for page_translation in page_translations %}
+                {% for page_translation in worst_hix_translations %}
                     {% include "analytics/_page_hix_row.html" %}
-                {% empty %}
-                    {% translate "There is no page." %}
                 {% endfor %}
             </tbody>
         </table>
     </div>
+    <a id="toggle-hix-score-list-trigger"
+       data-alternative-text="{% translate "Show less pages" %}"
+       class="text-blue-500 hover:underline mb-2 block">{% translate "Show all pages" %}</a>
     <p>
         {# djlint:off #}
         {% blocktranslate trimmed with threshold=hix_threshold|floatformat:0 %}

--- a/integreat_cms/cms/templates/dashboard/dashboard.html
+++ b/integreat_cms/cms/templates/dashboard/dashboard.html
@@ -18,7 +18,7 @@
                 <!-- Translation Status Widget: TODO-->
                 <!-- App Size Widget: TODO -->
                 <!-- Page HIX Widget-->
-                {% if TEXTLAB_API_ENABLED and request.region.hix_enabled %}
+                {% if TEXTLAB_API_ENABLED and request.region.hix_enabled and worst_hix_translations %}
                     {% include "analytics/_page_hix_widget.html" %}
                 {% endif %}
             </div>

--- a/integreat_cms/cms/views/dashboard/dashboard_view.py
+++ b/integreat_cms/cms/views/dashboard/dashboard_view.py
@@ -74,10 +74,9 @@ class DashboardView(TemplateView, ChatContextMixin):
         hix_translations_with_score = [pt for pt in hix_translations if pt.hix_score]
 
         # Get the worst n pages
-        worst_his_translations = sorted(
+        worst_hix_translations = sorted(
             hix_translations_with_score, key=lambda pt: pt.hix_score
-        )[:10]
-
+        )
         # Get the number of translations which are ready for MT
         ready_for_mt_count = sum(
             pt.hix_score >= settings.HIX_REQUIRED_FOR_MT
@@ -86,7 +85,7 @@ class DashboardView(TemplateView, ChatContextMixin):
         ready_for_mt = math.trunc(100 * ready_for_mt_count / len(hix_translations))
 
         return {
-            "page_translations": worst_his_translations,
+            "worst_hix_translations": worst_hix_translations,
             "hix_threshold": settings.HIX_REQUIRED_FOR_MT,
             "ready_for_mt": ready_for_mt,
         }

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -4148,17 +4148,14 @@ msgid "Overview of the text understandability of the pages"
 msgstr "Übersicht der Textverständlichkeiten der Seiten"
 
 #: cms/templates/analytics/_page_hix_widget.html
-#, python-format
-msgid ""
-"The list shows the first %(n)s pages with the lowest HIX value in ascending "
-"order."
+msgid "The list shows the pages with the lowest HIX value in ascending order."
 msgstr ""
-"Die Liste zeigt die ersten %(n)s Seiten mit dem niedrigsten HIX-Wert "
-"aufsteigend sortiert."
+"Die Liste zeigt alle Seiten in aufsteigender Reihenfolge nach ihrem HIX-Wert "
+"sortiert."
 
 #: cms/templates/analytics/_page_hix_widget.html
 msgid " of all pages are ready for automatic translation."
-msgstr " der Seiten sind für maschienelle Übersetzung bereit."
+msgstr " der Seiten sind für maschinelle Übersetzung bereit."
 
 #: cms/templates/analytics/_page_hix_widget.html
 msgid "Page name"
@@ -4169,8 +4166,12 @@ msgid "HIX value"
 msgstr "HIX-Wert"
 
 #: cms/templates/analytics/_page_hix_widget.html
-msgid "There is no page."
-msgstr "Es gibt keine Seite."
+msgid "Show less pages"
+msgstr "Weniger Seiten anzeigen"
+
+#: cms/templates/analytics/_page_hix_widget.html
+msgid "Show all pages"
+msgstr "Alle Seiten anzeigen"
 
 #: cms/templates/analytics/_page_hix_widget.html
 #, python-format
@@ -8611,6 +8612,22 @@ msgstr ""
 "Diese Seite konnte nicht importiert werden, da sie zu einer anderen Region "
 "gehört ({})."
 
+#~ msgid ""
+#~ "Currently there is not yet a page for which the HIX value has been "
+#~ "calculated."
+#~ msgstr ""
+#~ "Es gibt aktuell noch keine Seite, für die der HIX Wert berechnet wurde."
+
+#~ msgid ""
+#~ "The list shows the first %(n)s pages with the lowest HIX value in "
+#~ "ascending order."
+#~ msgstr ""
+#~ "Die Liste zeigt die ersten %(n)s Seiten mit dem niedrigsten HIX-Wert "
+#~ "aufsteigend sortiert."
+
+#~ msgid "There is no page."
+#~ msgstr "Es gibt keine Seite."
+
 #~ msgid "This page has no HIX value"
 #~ msgstr "Diese Seite hat keinen HIX-Wert."
 
@@ -8652,9 +8669,6 @@ msgstr ""
 
 #~ msgid "This language is not supported by DeepL"
 #~ msgstr "Diese Sprache wird von DeepL nicht unterstützt"
-
-#~ msgid "Show all"
-#~ msgstr "Datei anzeigen"
 
 #~ msgid "Show unused media files"
 #~ msgstr "Ungenutzte Mediendateien zeigen"

--- a/integreat_cms/release_notes/current/unreleased/2088.yml
+++ b/integreat_cms/release_notes/current/unreleased/2088.yml
@@ -1,2 +1,2 @@
-en: Add list of pages with worst HIX value to dashboard
-de: Füge Liste der Seiten mit dem schlechtesten HIX-Wert zum Dashboard hinzu
+en: Add expandable list of pages with worst HIX value to dashboard
+de: Füge eine ausklappbare Liste der Seiten mit dem schlechtesten HIX-Wert zum Dashboard hinzu

--- a/integreat_cms/static/src/css/style.scss
+++ b/integreat_cms/static/src/css/style.scss
@@ -314,6 +314,10 @@ label:not([for]) {
     }
 }
 
+.show-n-rows tbody tr:nth-child(n + 11) {
+    display: none;
+}
+
 #page_order_table .table-listing {
     table {
         tr {

--- a/integreat_cms/static/src/index.ts
+++ b/integreat_cms/static/src/index.ts
@@ -68,6 +68,7 @@ import "./js/mfa/login.ts";
 import "./js/analytics/statistics-charts.ts";
 import "./js/analytics/translation_coverage.ts";
 import "./js/analytics/linkcheck-widget.ts";
+import "./js/analytics/hix-list";
 
 import "./js/translations/budget-graph.ts";
 

--- a/integreat_cms/static/src/js/analytics/hix-list.ts
+++ b/integreat_cms/static/src/js/analytics/hix-list.ts
@@ -1,0 +1,15 @@
+window.addEventListener("load", () => {
+    const table = document.getElementById("page_hix_list") as HTMLTableElement;
+    const trigger = document.getElementById("toggle-hix-score-list-trigger");
+
+    const maxRows = 10;
+    if (table.tBodies[0].rows.length <= maxRows) {
+        trigger.classList.add("hidden");
+        return;
+    }
+
+    trigger.addEventListener("click", () => {
+        table.classList.toggle("show-n-rows");
+        [trigger.textContent, trigger.dataset.alternativeText] = [trigger.dataset.alternativeText, trigger.textContent];
+    });
+});


### PR DESCRIPTION
### Short description
Add toggle option to expand the list of pages by HIX score on dashboard.


### Proposed changes
<!-- Describe this PR in more detail. -->

- Add new release note
- Add toggle trigger to show all pages (starting from the eleventh)
- Refactor a little bit: a. show yellow warning alert if there is no HIX value and b. only show this message and hide table head (different than it was before) / see screenshot below
- Fix minor spelling error in German translation file

![grafik](https://user-images.githubusercontent.com/72705147/232445153-642fd84b-9c7c-40ee-9a14-e6a9ac0fad95.png)


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- The double tbody and the double message on top of the list aren't great, but it was the only solution I could come up with to fix it. For the double tbody I read on SO that it's better to have two tbody than for example just to wrap the second one inside a div or another HTML tag. For the double message, it's not possible to add a HTML tag inside Django's blocktranslate, therefore I had to move it into a separate paragraph.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2229 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
