### PR TITLE
Show less confusing message while HIX widget is loading

### DIFF
--- a/integreat_cms/cms/templates/hix_widget.html
+++ b/integreat_cms/cms/templates/hix_widget.html
@@ -11,8 +11,8 @@
 {% block collapsible_box_content %}
     <div class="relative">
         <div id="hix-loading"
-             class="hidden absolute w-full h-full bg-white bg-opacity-75">
-            <div class="relative top-1/3 m-auto w-1/3">
+             class="{% if page_form.instance.hix_ignore %} hidden{% endif %} absolute w-full h-full bg-white bg-opacity-75">
+            <div class="relative top-1/3 text-center">
                 <i icon-name="loader" class="animate-spin"></i> {% translate "Loading..." %}
             </div>
         </div>

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8652,6 +8652,9 @@ msgstr ""
 "Diese Seite konnte nicht importiert werden, da sie zu einer anderen Region "
 "gehört ({})."
 
+#~ msgid "HIX widget is loading..."
+#~ msgstr "HIX Widget lädt..."
+
 #~ msgid ""
 #~ "Currently there is not yet a page for which the HIX value has been "
 #~ "calculated."

--- a/integreat_cms/release_notes/current/unreleased/2222.yml
+++ b/integreat_cms/release_notes/current/unreleased/2222.yml
@@ -1,0 +1,2 @@
+en: Hide confusing message while HIX widget is loading
+de: Verwirrende Meldung ausblenden, während das HIX-Widget geladen wird

--- a/integreat_cms/static/src/js/analytics/hix-list.ts
+++ b/integreat_cms/static/src/js/analytics/hix-list.ts
@@ -2,6 +2,10 @@ window.addEventListener("load", () => {
     const table = document.getElementById("page_hix_list") as HTMLTableElement;
     const trigger = document.getElementById("toggle-hix-score-list-trigger");
 
+    if (!table || !trigger) {
+        return;
+    }
+
     const maxRows = 10;
     if (table.tBodies[0].rows.length <= maxRows) {
         trigger.classList.add("hidden");

--- a/integreat_cms/static/src/js/analytics/hix-widget.ts
+++ b/integreat_cms/static/src/js/analytics/hix-widget.ts
@@ -62,11 +62,23 @@ const setHixLabelState = (state: string) => {
     } else if (state === "updated") {
         document.getElementById("hix-container").classList.remove("hidden");
     }
+
+    // Hide the button if there is no content or the value is up-to-date
+    const updateButton = document.getElementById("btn-update-hix-value");
+    if (state === "updated" || state === "no-content") {
+        updateButton.classList.add("hidden");
+    } else {
+        updateButton.classList.remove("hidden");
+    }
+
+    // Hide the loading spinner
+    document.getElementById("hix-loading")?.classList.add("hidden");
 };
 
-const getHixValue = async (url: string) => {
+const getHixValue = async () => {
+    const updateButton = document.getElementById("btn-update-hix-value");
     let result;
-    await fetch(url, {
+    await fetch(updateButton.dataset.url, {
         method: "POST",
         headers: {
             "X-CSRFToken": getCsrfToken(),
@@ -75,11 +87,7 @@ const getHixValue = async (url: string) => {
             text: getContent(),
         }),
     })
-        .then((response) => {
-            // Hide loading spinner
-            document.getElementById("hix-loading")?.classList.add("hidden");
-            return response.json();
-        })
+        .then((response) => response.json())
         .then((json) => {
             const labelState = json.error ? "error" : "updated";
             setHixLabelState(labelState);
@@ -93,8 +101,6 @@ window.addEventListener("load", async () => {
     if (!document.getElementById("hix-chart")) {
         return;
     }
-
-    document.getElementById("hix-loading")?.classList.remove("hidden");
 
     // Define dummy data for empty default chart.
     const dummyData = {
@@ -163,48 +169,38 @@ window.addEventListener("load", async () => {
         }
     };
 
-    // Set listener for update button
-    document.getElementById("btn-update-hix-value").addEventListener("click", async (event) => {
-        document.getElementById("hix-loading")?.classList.remove("hidden");
-        event.preventDefault();
-        const newHixValue = await getHixValue((event.target as HTMLElement).dataset.url);
-        updateChart(chart, newHixValue);
-        toggleMTAvailability(newHixValue);
-    });
+    const initHixValue = async () => {
+        if (!getContent().trim()) {
+            setHixLabelState("no-content");
+            return;
+        }
+
+        const initialHixValue =
+            parseFloat(document.getElementById("hix-container").dataset.initialHixScore) || (await getHixValue());
+
+        setHixLabelState("updated");
+        updateChart(chart, initialHixValue);
+        toggleMTAvailability(initialHixValue);
+    };
 
     // Set listener, that checks, if tinyMCE content has changed to update the
     // HIX value status
     document.querySelectorAll("[data-content-changed]").forEach((element) => {
-        element.addEventListener("contentChanged", () => {
-            const updateButton = document.getElementById("btn-update-hix-value") as HTMLSelectElement;
-            if (!getContent().trim()) {
-                updateButton.disabled = true;
-                setHixLabelState("no-content");
-            } else {
-                updateButton.disabled = false;
-                setHixLabelState("outdated");
-            }
-        });
+        // make sure initHixValue is called only after tinyMCE is initialized
+        element.addEventListener("tinyMCEInitialized", initHixValue);
+        element.addEventListener("contentChanged", () =>
+            setHixLabelState(getContent().trim() ? "outdated" : "no-content")
+        );
     });
 
-    const initHixValue = async () => {
-        const updateButton = document.getElementById("btn-update-hix-value") as HTMLSelectElement;
-        if (!getContent().trim()) {
-            updateButton.disabled = true;
-            setHixLabelState("no-content");
-            document.getElementById("hix-loading")?.classList.add("hidden");
-        } else {
-            let initialHixValue = parseFloat(document.getElementById("hix-container").dataset.initialHixScore);
-            if (initialHixValue) {
-                setHixLabelState("updated");
-                document.getElementById("hix-loading")?.classList.add("hidden");
-            } else {
-                initialHixValue = await getHixValue(updateButton.dataset.url);
-            }
-            updateChart(chart, initialHixValue);
-            toggleMTAvailability(initialHixValue);
-        }
-    };
+    // Set listener for update button
+    document.getElementById("btn-update-hix-value").addEventListener("click", async (event) => {
+        document.getElementById("hix-loading")?.classList.remove("hidden");
+        event.preventDefault();
+        const newHixValue = await getHixValue();
+        updateChart(chart, newHixValue);
+        toggleMTAvailability(newHixValue);
+    });
 
     const toggleHixIgnore = async () => {
         const hixIgnore = document.getElementById("id_hix_ignore") as HTMLInputElement;
@@ -218,21 +214,10 @@ window.addEventListener("load", async () => {
             toggleMTCheckboxes(false);
             mtForm.classList.remove("hidden");
             hixBlock.classList.remove("hidden");
-            initHixValue();
         }
     };
 
     // Set listener to show/hide HIX widget when hix_ignore checkbox is clicked
     document.getElementById("id_hix_ignore")?.addEventListener("change", toggleHixIgnore);
     toggleHixIgnore();
-
-    if (!document.getElementById("hix-block")?.classList.contains("hidden")) {
-        // Delay the first request, so that tinyMCE can be initialized first
-        const initialDelayLength = 1000;
-        setTimeout(async () => {
-            initHixValue();
-        }, initialDelayLength);
-    } else {
-        document.getElementById("hix-loading")?.classList.add("hidden");
-    }
 });

--- a/integreat_cms/static/src/js/forms/tinymce-init.ts
+++ b/integreat_cms/static/src/js/forms/tinymce-init.ts
@@ -209,6 +209,9 @@ window.addEventListener("load", () => {
                 editor.shortcuts.add("meta+alt+7", "Add group icon", () => {
                     insertIcon(editor, tinymceConfig, "group");
                 });
+                document.querySelectorAll("[data-content-changed]").forEach((element) => {
+                    element.dispatchEvent(new Event("tinyMCEInitialized"));
+                });
 
                 editor.on("StoreDraft", autosaveEditor);
                 // When the editor becomes dirty, send an input event, so that the unsaved warning can be shown


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Show "HIX widget is loading..."  instead of "There is no page content." while the HIX widget is loading.

### Proposed changes
<!-- Describe this PR in more detail. -->

The issue was that the 1000ms timeout used to ensure tinyMCE was fully initialized before attempting to call `getContent()` was insufficient. Instead of increasing the timeout, I did the following:
- remove the timeout completely
- tinyMCE dispatches a new `tinyMCEInitialized` signal after completing initialization
- `initHixValue` is no longer called on page load, but only after that signal has been emitted
- some more refactoring and simplification of the `initHixValue` function
- unrelated: fixed an `uncaught TypeError` (it was such a small fix I did not think a separate issue was necessary)


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none that I could find. AFAIK the behaviour of the widget is as it was before, minus the confusing "no page content" message.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2222


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
