### PR TITLE
Suppress unsaved warnings for form elements that don't affect content

### DIFF
--- a/integreat_cms/cms/templates/events/event_form_sidebar/minor_edit_box.html
+++ b/integreat_cms/cms/templates/events/event_form_sidebar/minor_edit_box.html
@@ -11,7 +11,7 @@
 {% endblock collapsible_box_title %}
 {% block collapsible_box_content %}
     <div>
-        {% render_field event_translation_form.minor_edit class+="mutually-exclusive-checkbox" %}
+        {% render_field event_translation_form.minor_edit class+="mutually-exclusive-checkbox" data-unsaved-warning-exclude="" %}
         <label for="{{ event_translation_form.minor_edit.id_for_label }}"
                class="secondary">
             {{ event_translation_form.minor_edit.label }}

--- a/integreat_cms/cms/templates/imprint/imprint_form.html
+++ b/integreat_cms/cms/templates/imprint/imprint_form.html
@@ -145,7 +145,7 @@
                         </div>
                         <div class="px-4 pb-4">
                             <label for="side-by-side-select">{% translate "Direction of translation" %}</label>
-                            <select id="side-by-side-select">
+                            <select id="side-by-side-select" data-unsaved-warning-exclude>
                                 <option value="">---------</option>
                                 {% for side_by_side_language_option in side_by_side_language_options %}
                                     <option value="{% url 'sbs_edit_imprint' region_slug=request.region.slug language_slug=side_by_side_language_option.value %}"

--- a/integreat_cms/cms/templates/imprint/imprint_sbs.html
+++ b/integreat_cms/cms/templates/imprint/imprint_sbs.html
@@ -77,7 +77,7 @@
                                disabled />
                         <div class="mt-4">
                             <label class="block mt-4 font-bold">{{ imprint_translation_form.content.label }}</label>
-                            <textarea id="source_translation_tinymce" cols="40" rows="10" class="tinymce_textarea" disabled data-old="{{ old_translation_content }}" data-new="{{ source_imprint_translation.content }}">
+                            <textarea id="source_translation_tinymce" cols="40" rows="10" class="tinymce_textarea" disabled data-old="{{ old_translation_content }}" data-new="{{ source_imprint_translation.content }}" data-unsaved-warning-exclude>
                                 {{source_imprint_translation.content}}
                             </textarea>
                         </div>

--- a/integreat_cms/cms/templates/pages/page_form_sidebar/minor_edit_box.html
+++ b/integreat_cms/cms/templates/pages/page_form_sidebar/minor_edit_box.html
@@ -11,7 +11,7 @@
 {% endblock collapsible_box_title %}
 {% block collapsible_box_content %}
     <div>
-        {% render_field page_translation_form.minor_edit class+="mutually-exclusive-checkbox" %}
+        {% render_field page_translation_form.minor_edit class+="mutually-exclusive-checkbox" data-unsaved-warning-exclude="" %}
         <label for="{{ page_translation_form.minor_edit.id_for_label }}"
                class="secondary">
             {{ page_translation_form.minor_edit.label }}

--- a/integreat_cms/cms/templates/pages/page_form_sidebar/translator_view_box.html
+++ b/integreat_cms/cms/templates/pages/page_form_sidebar/translator_view_box.html
@@ -11,7 +11,7 @@
 {% endblock collapsible_box_title %}
 {% block collapsible_box_content %}
     <label for="side-by-side-select" class="mt-0">{% translate "Direction of translation" %}</label>
-    <select id="side-by-side-select">
+    <select id="side-by-side-select" data-unsaved-warning-exclude>
         <option value="">---------</option>
         {% for side_by_side_language_option in side_by_side_language_options %}
             <option value="{% url 'sbs_edit_page' page_id=page.id region_slug=request.region.slug language_slug=side_by_side_language_option.value %}"

--- a/integreat_cms/cms/templates/pages/page_sbs.html
+++ b/integreat_cms/cms/templates/pages/page_sbs.html
@@ -74,7 +74,7 @@
                                disabled />
                         <div>
                             <label class="block font-bold">{{ page_translation_form.content.label }}</label>
-                            <textarea id="source_translation_tinymce" cols="40" rows="10" class="tinymce_textarea" disabled data-old="{{ old_translation_content }}" data-new="{{ source_page_translation.content }}">
+                            <textarea id="source_translation_tinymce" cols="40" rows="10" class="tinymce_textarea" disabled data-old="{{ old_translation_content }}" data-new="{{ source_page_translation.content }}" data-unsaved-warning-exclude>
                                 {{source_page_translation.content}}
                             </textarea>
                         </div>

--- a/integreat_cms/cms/templates/pois/poi_form_sidebar/minor_edit_box.html
+++ b/integreat_cms/cms/templates/pois/poi_form_sidebar/minor_edit_box.html
@@ -11,7 +11,7 @@
 {% endblock collapsible_box_title %}
 {% block collapsible_box_content %}
     <div>
-        {% render_field poi_translation_form.minor_edit class+="mutually-exclusive-checkbox" %}
+        {% render_field poi_translation_form.minor_edit class+="mutually-exclusive-checkbox" data-unsaved-warning-exclude="" %}
         <label for="{{ poi_translation_form.minor_edit.id_for_label }}"
                class="secondary">
             {{ poi_translation_form.minor_edit.label }}

--- a/integreat_cms/release_notes/current/unreleased/1632.yml
+++ b/integreat_cms/release_notes/current/unreleased/1632.yml
@@ -1,0 +1,2 @@
+en: Suppress unsaved warning when navigating to translator view
+de: Unterdrücke die Warnung vor ungesicherten Inhalten bei der Navigation zur Übersetzungs-Ansicht

--- a/integreat_cms/release_notes/current/unreleased/2013.yml
+++ b/integreat_cms/release_notes/current/unreleased/2013.yml
@@ -1,0 +1,2 @@
+en: Suppress unsaved warning when updating content in the translator view
+de: Unterdrücke die Warnung ungesicherter Inhalte beim Aktualisieren von Inhalten in der Übersetzungs-Ansicht

--- a/integreat_cms/static/src/js/forms/tinymce-init.ts
+++ b/integreat_cms/static/src/js/forms/tinymce-init.ts
@@ -215,11 +215,14 @@ window.addEventListener("load", () => {
 
                 editor.on("StoreDraft", autosaveEditor);
                 // When the editor becomes dirty, send an input event, so that the unsaved warning can be shown
-                editor.on("dirty", () =>
+                editor.on("dirty", () => {
+                    if ((editor.targetElm as HTMLElement).hasAttribute("data-unsaved-warning-exclude")) {
+                        return;
+                    }
                     document.querySelectorAll("[data-unsaved-warning]").forEach((element) => {
                         element.dispatchEvent(new Event("input"));
-                    })
-                );
+                    });
+                });
                 // Create an event every time the content changes
                 editor.on("keyup", () =>
                     document.querySelectorAll("[data-content-changed]").forEach((element) => {

--- a/integreat_cms/static/src/js/unsaved-warning.ts
+++ b/integreat_cms/static/src/js/unsaved-warning.ts
@@ -16,7 +16,12 @@ window.addEventListener("beforeunload", (event) => {
 window.addEventListener("load", () => {
     const form = document.querySelector("[data-unsaved-warning]");
     // checks whether the user typed something in the content
-    form?.addEventListener("input", () => {
+    form?.addEventListener("input", (event) => {
+        // does not set the dirty flag, if the event target is explicitly excluded
+        const target = event.target as HTMLElement;
+        if (target.hasAttribute("data-unsaved-warning-exclude")) {
+            return;
+        }
         if (!dirty) {
             console.debug("editing detected, enabled beforeunload warning");
         }


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR should prevent a browser alert for unsaved content caused by form elements that don't actually change the content. This was the case for:

- The selection input on page and imprint form view in the "Translator View" box
- The tinyMCE comparison window (right side) in the side-by-side view
- The minor edit checkbox on page form, POI form and event form


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- I don't think, that there are side effects


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1632, (#2013)

*As a side node:* Neither me nor the service team could reproduce the chrome related bug as described in #2013, however I found that the warning e.g. showed up after toggling the button which shows differences to a previous version. I think this might be the issue that occurred there, but I'd be glad, if any reviewers will also test this with chrome.
__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
