### PR TITLE
Change URL parameter field to make it editable

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/2252.yml
+++ b/integreat_cms/release_notes/current/unreleased/2252.yml
@@ -1,0 +1,2 @@
+en: Fix the problem of the URL parameter field not being editable
+de: Behebe das Problem, dass das URL-Parameterfeld nicht editierbar ist

--- a/integreat_cms/static/src/css/style.scss
+++ b/integreat_cms/static/src/css/style.scss
@@ -217,8 +217,7 @@ select,
 [type="tel"],
 [type="time"],
 [type="week"],
-textarea,
-.slug-field {
+textarea {
     &:read-only {
         @apply text-gray-500 pointer-events-none cursor-not-allowed;
     }


### PR DESCRIPTION
### Short description
This PR fixes the issue with the not editable URL parameter field by adding contenteditable to the parent element.


### Proposed changes
<!-- Describe this PR in more detail. -->

- ~~Add contenteditable to parent element~~
- Change the CSS selector from &:read-only to &[readonly] as suggested [here](https://stackoverflow.com/questions/69174538/css-read-only-is-applied-to-elements-that-are-not-readonly).


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- ~~I'm not sure if this is the best solution. I guess the best solution would be to let the input field know it's writeable. However every trick I tried didn't work, and therefore this is the next best solution. Let me know, what you think.~~
- I checked the places I know the read-only field is needed, but I'm not sure I know all the places. Can you please check all the places you know where a readonly field is needed to see if this doesn't mess anything up? 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2252


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
