### PR TITLE
Do not check links in past events

### DIFF
--- a/integreat_cms/cms/linklists.py
+++ b/integreat_cms/cms/linklists.py
@@ -1,7 +1,7 @@
 from django.conf import settings
 from linkcheck import Linklist
 
-from .models import EventTranslation, Page, PageTranslation, POITranslation
+from .models import Event, EventTranslation, Page, PageTranslation, POITranslation
 
 
 class ContentTranslationLinklist(Linklist):
@@ -59,6 +59,20 @@ class EventTranslationLinklist(ContentTranslationLinklist):
     """
 
     model = EventTranslation
+
+    @classmethod
+    def filter_callable(cls, objects):
+        """
+        Get only translations of upcoming events
+
+        :param objects: Objects to be filtered
+        :type objects: ~django.db.models.query.QuerySet
+
+        :return: Objects that passed the filter
+        :rtype: ~django.db.models.query.QuerySet
+        """
+        upcoming_events = Event.objects.filter_upcoming()
+        return objects.filter(event__in=upcoming_events)
 
 
 class POITranslationLinklist(ContentTranslationLinklist):

--- a/integreat_cms/release_notes/current/unreleased/2053.yml
+++ b/integreat_cms/release_notes/current/unreleased/2053.yml
@@ -1,0 +1,2 @@
+en: Do not check links in past events
+de: Prüfe keinen Link in vergangenen Veranstaltungen


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR excludes past events from link check.

### Proposed changes
<!-- Describe this PR in more detail. -->
- add a new filter in `EventTranslationLinklist`


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- This alone does not remove links in past events directly and immediately. When the link check is triggerd, for example by the command `findlinks` or other stimli, they dissapear from the link list. Is there already a scheduled job for link screening?


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2053 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
