### PR TITLE
Add option to duplicate regions with initial page status

### DIFF
--- a/integreat_cms/cms/templates/regions/region_form.html
+++ b/integreat_cms/cms/templates/regions/region_form.html
@@ -448,9 +448,16 @@
                 </div>
                 <div class="px-4 pb-4">
                     <label for="{{ form.duplicated_region.id_for_label }}">
-                        {% translate "Copy languages, pages and media from another region" %}
+                        {{ form.duplicated_region.label }}
                     </label>
                     {% render_field form.duplicated_region %}
+                    {% render_field form.duplication_keep_status %}
+                    <label for="{{ form.duplication_keep_status.id_for_label }}">
+                        {{ form.duplication_keep_status.label }}
+                    </label>
+                    <div class="help-text">
+                        {{ form.duplication_keep_status.help_text }}
+                    </div>
                 </div>
             </div>
         {% endif %}

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -2020,8 +2020,24 @@ msgid "Other timezones"
 msgstr "Sonstige Zeitzonen"
 
 #: cms/forms/regions/region_form.py
+msgid "Copy languages, pages and media from another region"
+msgstr "Sprachen, Seiten und Medien aus einer anderen Region kopieren"
+
+#: cms/forms/regions/region_form.py
 msgid "Do no import initial content"
 msgstr "Keine Inhalte übernehmen"
+
+#: cms/forms/regions/region_form.py
+msgid "Keep publication status of pages"
+msgstr "Veröffentlichungsstatus der Seiten beibehalten"
+
+#: cms/forms/regions/region_form.py
+msgid ""
+"Enable it to keep the initial publication status of the pages and don't "
+"overwrite them to draft."
+msgstr ""
+"Durch das Häkchen wird der Veröffentlichungsstatus der Seiten ebenfalls "
+"geklont und nicht auf Entwurf gesetzt."
 
 #: cms/forms/regions/region_form.py
 msgid "Timezone area"
@@ -6618,10 +6634,6 @@ msgstr "Verbleibende Wörter"
 #: cms/templates/regions/region_form.html
 msgid "Duplicate content of another region"
 msgstr "Inhalte aus einer anderen Region duplizieren"
-
-#: cms/templates/regions/region_form.html
-msgid "Copy languages, pages and media from another region"
-msgstr "Sprachen, Seiten und Medien aus einer anderen Region kopieren"
 
 #: cms/templates/regions/region_form.html
 msgid "Delete region"

--- a/integreat_cms/release_notes/current/unreleased/2245.yml
+++ b/integreat_cms/release_notes/current/unreleased/2245.yml
@@ -1,0 +1,2 @@
+en: Add option to duplicate regions with pages keeping their initial status
+de: Ermögliche es Regionen mit dem ursprünglichen Status der Seiten zu klonen


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR enables team user to keep the status of the pages of a cloned region.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add boolean field to region_form
- Skip the status reset if the field is set


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- If the initial cloning mechanism works as expected no issues should arise from this :man_shrugging: 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2245 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
