### PR TITLE
Fix remaining grayed button to outline button

### DIFF
--- a/integreat_cms/cms/templates/imprint/imprint_sbs.html
+++ b/integreat_cms/cms/templates/imprint/imprint_sbs.html
@@ -14,7 +14,7 @@
             </h1>
             <div class="flex flex-wrap grow justify-between gap-2 mb-4">
                 <a href="{% url 'edit_imprint' region_slug=request.region.slug language_slug=target_language.slug %}"
-                   class="bg-gray-400 hover:bg-gray-500 text-center cursor-pointer text-white font-bold py-3 px-4 rounded">
+                   class="btn btn-outline">
                     <i icon-name="arrow-left-circle" class="align-top"></i> {% translate "Back to the imprint form" %}
                 </a>
                 {% if perms.cms.change_imprintpage %}

--- a/integreat_cms/cms/templates/pages/page_form_sidebar/settings_box.html
+++ b/integreat_cms/cms/templates/pages/page_form_sidebar/settings_box.html
@@ -20,7 +20,7 @@
         {% render_field page_form|get_private_member:"ref_node_id" %}
         {% render_field page_form|get_private_member:"position" %}
         {% render_field page_form.parent id="parent" %}
-        <label class="btn-gray">{% translate "Order" %}</label>
+        <label>{% translate "Order" %}</label>
         <div id="page_order_table" class="mb-4">{% include "pages/_page_order_table.html" %}</div>
     </div>
     <div {% if not request.user.expert_mode %}hidden{% endif %}>

--- a/integreat_cms/cms/templates/pages/page_sbs.html
+++ b/integreat_cms/cms/templates/pages/page_sbs.html
@@ -14,7 +14,7 @@
             </h1>
             <div class="flex flex-wrap grow justify-between gap-2 mb-4">
                 <a href="{% url 'edit_page' page_id=source_page_translation.page.id region_slug=request.region.slug language_slug=target_language.slug %}"
-                   class="bg-gray-400 hover:bg-gray-500 text-center cursor-pointer text-white font-bold py-3 px-4 rounded">
+                   class="btn btn-outline">
                     <i icon-name="arrow-left-circle" class="align-top"></i> {% translate "Back to the page form" %}
                 </a>
                 <div class="flex flex-wrap gap-2">

--- a/integreat_cms/static/src/css/style.scss
+++ b/integreat_cms/static/src/css/style.scss
@@ -143,12 +143,6 @@ input[type="submit"] {
         &.btn-small {
             @apply py-2 px-3;
         }
-        &.btn-gray {
-            @apply bg-gray-500;
-            &:hover {
-                @apply bg-gray-600;
-            }
-        }
         &.btn-red {
             @apply bg-red-500;
             &:hover {

--- a/integreat_cms/static/src/js/media-management/library.tsx
+++ b/integreat_cms/static/src/js/media-management/library.tsx
@@ -257,7 +257,7 @@ const Library = ({
                             <button
                                 id="show-all-files-btn"
                                 title={mediaTranslations.btn_reset_filter}
-                                className="btn"
+                                className="btn btn-ghost"
                                 type="submit"
                                 onClick={() => route("/")}>
                                 <FilterX className="inline-block mr-2 h-5" />
@@ -267,7 +267,7 @@ const Library = ({
                             <button
                                 id="unused-media-filter-btn"
                                 title={mediaTranslations.btn_filter_unused}
-                                className="btn"
+                                className="btn btn-ghost"
                                 type="submit"
                                 action={apiEndpoints.filterUnusedMediaFiles}
                                 onClick={() => {


### PR DESCRIPTION
### Short description
While reviewing, I noticed that I had missed out on the "Back to Form" button in the side-by-side view while I was working on  #2253. This PR fixes this.


### Proposed changes
<!-- Describe this PR in more detail. -->

- Changes "Back to form" button in side-by-side view from a grayed button (looks like it was disabled) to outline-button (introduced by PR  #2253)
- Remove unused / not rendered class btn-gray from "Order"-Section inside the collapsible box "Settings"


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- I think none
- If you find the time, please double-check if you can find any grayed buttons that are not disabled. While going through the views and the code-base I didn't find any anymore, but maybe my keywords weren't great and I don't know all of the views
- I double-checked with UI/UX and they told me to use outline-buttons and not ghost-buttons for "Go back to..." buttons


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: Leftover of #2253


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
