### PR TITLE
Remove duplicate sitemap entries

### DIFF
--- a/integreat_cms/sitemap/sitemaps.py
+++ b/integreat_cms/sitemap/sitemaps.py
@@ -147,7 +147,7 @@ class PageSitemap(WebappSitemap):
         self.queryset = self.queryset.filter(
             page__in=self.region.get_pages(return_unrestricted_queryset=True),
             language=self.language,
-        )
+        ).distinct("page__pk")
 
 
 class EventSitemap(WebappSitemap):
@@ -182,7 +182,7 @@ class EventSitemap(WebappSitemap):
         # Filter queryset based on region and language
         self.queryset = self.queryset.filter(
             event__in=self.region.events.all(), language=self.language
-        )
+        ).distinct("event__pk")
 
 
 class POISitemap(WebappSitemap):
@@ -213,7 +213,7 @@ class POISitemap(WebappSitemap):
         # Filter queryset based on region and language
         self.queryset = self.queryset.filter(
             poi__in=self.region.pois.all(), language=self.language
-        )
+        ).distinct("poi__pk")
 
 
 class OfferSitemap(WebappSitemap):


### PR DESCRIPTION
### Short description
This improves the performance of the sitemap. This is quite relevant as some search engine crawlers frequently crash our server by inducing too much load.

Reference: https://integreat-test.tuerantuer.org/augsburg/de/sitemap.xml

- w/o patch: 24,4MB/2,03min
- w/ patch: 1kB/23ms

### Proposed changes
- Remove duplicate entries


### Side effects
- N/A


### Resolved issues
Fixes: #1750


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
