### PR TITLE
Fix version parsing on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -423,7 +423,8 @@ jobs:
             CURRENT_VERSION=$(python -c "import integreat_cms; print(integreat_cms.__version__)")
             echo "Current production version: ${CURRENT_VERSION}"
             # Bump version to current alpha version if it is newer
-            if [[ "${CURRENT_VERSION}" < "${CURRENT_ALPHA_VERSION}" ]]; then
+            # Attention: exit(True) in Python means exit(1) which is False in Bash :)
+            if python -c "from looseversion import LooseVersion; exit(LooseVersion('${CURRENT_VERSION}') > LooseVersion('${CURRENT_ALPHA_VERSION}'))"; then
               echo "Bump to the currently existing version"
               bumpver update -n --set-version="${CURRENT_ALPHA_VERSION}" --no-commit
             fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,7 @@ dev = [
     "bumpver",
     "djlint",
     "isort",
+    "looseversion",
     "pre-commit",
     "pyjwt",
     "pylint",


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Let the version be parsed by an external tool instead of bash.
(`looseversion` is already installed as dependency of `bumpver`, so no need to update the pinned versions)

### Proposed changes
<!-- Describe this PR in more detail. -->

- Do the comparison in Python instead of Bash


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2288


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
