### PR TITLE
test.sh: Allow specific and multiple tests

### DIFF
--- a/tools/_functions.sh
+++ b/tools/_functions.sh
@@ -434,3 +434,12 @@ function format_grep_output {
             -e "s/^([0-9]+)-(.*)/\1\2/"                     `# Remove dash of unmatched line`
     done
 }
+
+# Use (multi-char) delimiter to join strings
+# Taken from https://stackoverflow.com/a/17841619
+function join_by {
+    local d=${1-} f=${2-}
+    if shift 2; then
+        printf %s "$f" "${@/#/$d}"
+    fi
+}

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -19,6 +19,8 @@ export INTEGREAT_CMS_SUMM_AI_API_KEY="dummy"
 # Disable linkcheck listeners during testing
 export INTEGREAT_CMS_LINKCHECK_DISABLE_LISTENERS=1
 
+TESTS=()
+
 # Parse given command line arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -26,8 +28,12 @@ while [[ $# -gt 0 ]]; do
         --changed) CHANGED=1;shift;;
         # Verbosity for pytest
         -v|-vv|-vvv|-vvvv) VERBOSITY="$1";shift;;
+        # Select tests by keyword expression
+        -k) shift;KW_EXPR="$1";shift;;
+        # Select tests by marker
+        -m) shift;MARKER="$1";shift;;
         # If only particular tests should be run, test path can be passed as CLI argument
-        *) TEST_PATH=$1;shift;;
+        *) TESTS+=("$1");shift;;
     esac
 done
 
@@ -52,7 +58,7 @@ if [[ -n "${CHANGED}" ]]; then
         echo -e "\nIt looks like you have not run pytest without the \"--changed\" flag before." | print_warning
         echo -e "Pytest has to build a dependency database by running all tests without the flag once.\n" | print_warning
         # Override test path argument
-        unset TEST_PATH
+        unset TESTS
         # Tell testmon to run all tests and collect data
         PYTEST_ARGS+=("--testmon-noselect")
     fi
@@ -62,19 +68,34 @@ else
 fi
 
 # Determine whether coverage data should be collected
-if [[ -z "${CHANGED}" && -z "${TEST_PATH}" ]]; then
+if [[ -z "${CHANGED}" ]] && (( ${#TESTS[@]} == 0 )); then
     PYTEST_ARGS+=("--cov=integreat_cms" "--cov-report=html")
 fi
 
-# Check whether test path exists
-if [[ -e "${TEST_PATH}" ]]; then
-    # Adapt message and append to pytest arguments
-    TEST_MESSAGE=" in ${TEST_PATH}"
-    PYTEST_ARGS+=("${TEST_PATH}")
-elif [[ -n "${TEST_PATH}" ]]; then
-    # If the test path does not exist but was non-zero, show an error
-    echo -e "${TEST_PATH}: No such file or directory" | print_error
-    exit 1
+if [[ -n "${KW_EXPR}" ]] || [[ -n "${MARKER}" ]] || (( ${#TESTS[@]} )); then
+    MESSAGES=()
+    if [[ -n "${KW_EXPR}" ]]; then
+        MESSAGES+=("\"${KW_EXPR}\"")
+        PYTEST_ARGS+=("-k" "${KW_EXPR}")
+    fi
+    if [[ -n "${MARKER}" ]]; then
+        MESSAGES+=("with ${MARKER}")
+        PYTEST_ARGS+=("-m" "${KW_EXPR}")
+    fi
+    # Check whether test paths exist
+    for t in "${TESTS[@]}"; do
+        if [[ -e "${t%%::*}" ]]; then
+            # Adapt message and append to pytest arguments
+            MESSAGES+=("${t}")
+            PYTEST_ARGS+=("${t}")
+        elif [[ -n "${t}" ]]; then
+            # If the test path does not exist but was non-zero, show an error
+            echo -e "${t%%::*}: No such file or directory" | print_error
+            exit 1
+        fi
+    done
+    TEST_MESSAGE=$(join_by ", " "${MESSAGES[@]}")
+    TEST_MESSAGE=" in ${TEST_MESSAGE}"
 fi
 
 echo -e "Running all tests${TEST_MESSAGE}${CHANGED_MESSAGE}..." | print_info


### PR DESCRIPTION
### Short description
This PR adds comfort feature for development in making it easier to run one or a set of specific tests without running other modules or even undesired tests within the same module.
It is essentially an extension of the existing specify-a-single-tests-module feature, adding support for the pytest `::` syntax and passing through markers and keyword expressions. (https://docs.pytest.org/en/latest/how-to/usage.html#specifying-which-tests-to-run)

*Example: Selecting the one test that still fails for a specific role, to quickly test the difference of small changes without waiting for the other integration tests in the same test module:*
`tools/test.sh -vv tests/summ_ai_api/summ_ai_test.py::test_summ_ai_error_handling[OBSERVER-pyloop]`

### Proposed changes

- instead of saving arguments not matching any specific pattern into `TEST_PATH` (overriding potential previous contents), add them to the `TESTS` array
- loop over the array and strip everything from the first `::` before checking whether a file with that name exists
- look for `-m` and `-k` arguments and pass them to pytest as well
- display the selection sanely: keyword expressions are enclosed in quotes (`""`), tags are prefixed using `with `, and all individual criteria are joined with `, `.

### Side effects

None come to mind, but I don't trust myself to not forget something here

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
