### PR TITLE
Fix HIX value difference

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/2224.yml
+++ b/integreat_cms/release_notes/current/unreleased/2224.yml
@@ -1,0 +1,2 @@
+en: Fix HIX value difference
+de: Behebe Differenz in HIX Wert


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR tries to keep the HIX value identical between pre save signal and tinymce.

### Proposed changes
<!-- Describe this PR in more detail. -->
- replace `\n` with `\r\n` before checking HIX value.
- replace entity reference with numeric reference (example: `&auml;` -> `&#228;`) before checking HIX value.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- Sadly I couldn't find a way to convert entity reference to numeric reference directly and needed some converting steps.
- It seems, so far observed in the test data, reference art of special letters does not cause difference in HIX value, but the style of new line does.
-  If "\n" appears in the text by chance, for example when an user writes "Please use \n as line break" in the editor, simple replacement might replace it too, even though it is not intended as a line break. I testet it and "\n" tipped in the editor was not replaced, but I cannot garant it...


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2224 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
