### PR TITLE
Remove link text field from link replacement form

### DIFF
--- a/integreat_cms/cms/forms/linkcheck/edit_url_form.py
+++ b/integreat_cms/cms/forms/linkcheck/edit_url_form.py
@@ -74,4 +74,3 @@ class EditUrlForm(forms.Form):
     """
 
     url = LinkField()
-    text = forms.CharField(widget=forms.TextInput(attrs={"readonly": "readonly"}))

--- a/integreat_cms/cms/templates/linkcheck/link_list_row.html
+++ b/integreat_cms/cms/templates/linkcheck/link_list_row.html
@@ -101,23 +101,11 @@
     </tr>
     {% if url.id == view.kwargs.url_id %}
         <tr>
-            <td colspan="{% if request.user.expert_mode %}6{% else %}5{% endif %}">
-                <div class="px-2 pb-2">
+            <td colspan="10">
+                <div class="flex gap-2 p-2">
                     {% render_field edit_url_form.url|add_error_class:"border-red-500" type="url" form="edit-url-form" %}
-                </div>
-            </td>
-            <td colspan="3"
-                title="{% translate "The link text cannot be replaced centrally, because it may differ in the other source content." %}">
-                <div class="pr-2 pb-2">
-                    {% render_field edit_url_form.text|add_error_class:"border-red-500" form="edit-url-form" %}
-                </div>
-            </td>
-            <td>
-                <div class="flex gap-2 pr-2 pb-2">
                     <a href="{% url 'linkcheck' url_filter=view.kwargs.url_filter region_slug=request.region.slug %}{{ pagination_params }}"
-                       class="btn btn-red">
-                        {% translate "Cancel" %}
-                    </a>
+                       class="btn btn-red">{% translate "Cancel" %}</a>
                     <button type="submit" form="edit-url-form" class="btn">{% translate "Save" %}</button>
                 </div>
             </td>

--- a/integreat_cms/cms/views/linkcheck/linkcheck_list_view.py
+++ b/integreat_cms/cms/views/linkcheck/linkcheck_list_view.py
@@ -112,12 +112,7 @@ class LinkcheckListView(ListView):
             if request.POST:
                 form_kwargs = {"data": request.POST}
             else:
-                form_kwargs = {
-                    "initial": {
-                        "url": self.instance,
-                        "text": self.instance.region_links[0].text,
-                    }
-                }
+                form_kwargs = {"initial": {"url": self.instance}}
             self.form = EditUrlForm(**form_kwargs)
         return super().dispatch(request, *args, **kwargs)
 

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -5502,14 +5502,6 @@ msgstr "Inhalt aufrufen"
 msgid "Replace URL globally"
 msgstr "URL zentral ersetzen"
 
-#: cms/templates/linkcheck/link_list_row.html
-msgid ""
-"The link text cannot be replaced centrally, because it may differ in the "
-"other source content."
-msgstr ""
-"Der Link-Text kann nicht zentral ersetzt werden, da er sich eventuell in den "
-"anderen Quell-Inhalten unterscheidet"
-
 #: cms/templates/linkcheck/links_by_filter.html
 msgid "Broken links"
 msgstr "Fehlerhafte Links"

--- a/integreat_cms/release_notes/current/unreleased/2307.yml
+++ b/integreat_cms/release_notes/current/unreleased/2307.yml
@@ -1,0 +1,2 @@
+en: Remove link text field from link replacement form
+de: Entferne Linktextfeld aus Link-Ersetzungsformular


### PR DESCRIPTION
### Short description
Disabled link text field in the link replacement form caused several issues:
- The existence of the field led to confusion
- The replacement form required scrolling on smaller screens
- It was no longer possible to replace the src attributes of img tags


### Proposed changes
Revert the previous link replacement form (without the disabled link text field)


### Side effects
No?

However I am not quite sure what was meant by _It was no longer possible to replace the src attributes of img tags_ because I think I can replace src value for images on develop.


### Resolved issues
Fixes: #2307


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
