### PR TITLE
Count empty translations as ready for MT in the dashboard

### DIFF
--- a/integreat_cms/cms/templates/analytics/_page_hix_widget.html
+++ b/integreat_cms/cms/templates/analytics/_page_hix_widget.html
@@ -14,7 +14,9 @@
             {% endblocktranslate %}
         </p>
         <p>
-            <b>{{ ready_for_mt }}%</b> {% translate " of all pages are ready for automatic translation." %}
+            {% blocktranslate trimmed %}
+                <b>{{ ready_for_mt_count }}</b> out of <b>{{ total_count }}</b> pages are ready for automatic translation.
+            {% endblocktranslate %}
         </p>
     </div>
     <div class="mt-4 overflow-y-scroll max-h-160">

--- a/integreat_cms/cms/views/dashboard/dashboard_view.py
+++ b/integreat_cms/cms/views/dashboard/dashboard_view.py
@@ -70,6 +70,11 @@ class DashboardView(TemplateView, ChatContextMixin):
             language__slug__in=settings.TEXTLAB_API_LANGUAGES, page__in=hix_pages
         ).distinct("page_id", "language_id")
 
+        # Get all translations with empty content
+        hix_translations_with_empty_content = [
+            pt for pt in hix_translations if not pt.content.strip()
+        ]
+
         # Get all hix translations where the score is set
         hix_translations_with_score = [pt for pt in hix_translations if pt.hix_score]
 
@@ -77,11 +82,13 @@ class DashboardView(TemplateView, ChatContextMixin):
         worst_hix_translations = sorted(
             hix_translations_with_score, key=lambda pt: pt.hix_score
         )
+
         # Get the number of translations which are ready for MT
         ready_for_mt_count = sum(
             pt.hix_score >= settings.HIX_REQUIRED_FOR_MT
             for pt in hix_translations_with_score
-        )
+        ) + len(hix_translations_with_empty_content)
+
         ready_for_mt = math.trunc(100 * ready_for_mt_count / len(hix_translations))
 
         return {

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -4135,8 +4135,13 @@ msgstr ""
 "sortiert."
 
 #: cms/templates/analytics/_page_hix_widget.html
-msgid " of all pages are ready for automatic translation."
-msgstr " der Seiten sind für maschinelle Übersetzung bereit."
+#, python-format
+msgid ""
+"<b>%(ready_for_mt_count)s</b> out of <b>%(total_count)s</b> pages are ready "
+"for automatic translation."
+msgstr ""
+"<b>%(ready_for_mt_count)s</b> Seiten von <b>%(total_count)s</b> Seiten sind "
+"für maschinelle Übersetzung bereit."
 
 #: cms/templates/analytics/_page_hix_widget.html
 msgid "Page name"

--- a/integreat_cms/release_notes/current/unreleased/2296.yml
+++ b/integreat_cms/release_notes/current/unreleased/2296.yml
@@ -1,0 +1,2 @@
+en: Change percentage-value for HIX-widget in the dashboard to numbers
+de: Ändere Prozentwert für HIX-Widget im Dashboard in Zahlen

--- a/integreat_cms/release_notes/current/unreleased/2317.yml
+++ b/integreat_cms/release_notes/current/unreleased/2317.yml
@@ -1,2 +1,0 @@
-en: Count empty translations as ready for MT in the dashboard
-de: Zähle leere Übersetzungen als bereit für MT im Dashboard

--- a/integreat_cms/release_notes/current/unreleased/2317.yml
+++ b/integreat_cms/release_notes/current/unreleased/2317.yml
@@ -1,0 +1,2 @@
+en: Count empty translations as ready for MT in the dashboard
+de: Zähle leere Übersetzungen als bereit für MT im Dashboard


### PR DESCRIPTION
### Short description
The value of "ready for MT" in the dashboard calculates the percentage of all pages with HIX above the threshold in relation to all translations.
This is incorrect since e.g. empty pages without a HIX score are allowed for MT


### Proposed changes
Add the number of empty translations to the ready_for_mt_count value


### Side effects
No?


### Resolved issues
Fixes: #2317
Fixes: #2296
Fixes: #2310 (self-resolved as a side effect)


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
