### PR TITLE
Feature/global push notifications

### DIFF
--- a/integreat_cms/api/v3/push_notifications.py
+++ b/integreat_cms/api/v3/push_notifications.py
@@ -27,7 +27,7 @@ def sent_push_notifications(request, region_slug, language_slug):
     channel = request.GET.get("channel", "all")
     query_result = (
         PushNotificationTranslation.objects.filter(
-            push_notification__region__slug=region_slug
+            push_notification__regions__slug=region_slug
         )
         .filter(
             push_notification__sent_date__gte=timezone.now()

--- a/integreat_cms/cms/fixtures/test_data.json
+++ b/integreat_cms/cms/fixtures/test_data.json
@@ -3583,7 +3583,7 @@
     "model": "cms.pushnotification",
     "pk": 1,
     "fields": {
-      "region": 2,
+      "regions": [2],
       "channel": "news",
       "draft": false,
       "sent_date": "2022-03-05T10:32:33.118Z",
@@ -3617,7 +3617,7 @@
     "model": "cms.pushnotification",
     "pk": 2,
     "fields": {
-      "region": 2,
+      "regions": [2],
       "channel": "news",
       "draft": true,
       "sent_date": null,

--- a/integreat_cms/cms/fixtures/test_data.json
+++ b/integreat_cms/cms/fixtures/test_data.json
@@ -3637,6 +3637,29 @@
     }
   },
   {
+    "model": "cms.pushnotification",
+    "pk": 3,
+    "fields": {
+      "regions": [1, 2],
+      "channel": "news",
+      "draft": true,
+      "sent_date": null,
+      "created_date": "2023-07-18T20:15:00.000Z",
+      "mode": "ONLY_AVAILABLE"
+    }
+  },
+  {
+    "model": "cms.pushnotificationtranslation",
+    "pk": 4,
+    "fields": {
+      "title": "Mehrere Regionen",
+      "text": "Inhalt für mehrere Regionen",
+      "language": 1,
+      "push_notification": 3,
+      "last_updated": "2023-07-18T20:15:00.000Z"
+    }
+  },
+  {
     "model": "cms.mediafile",
     "pk": 1,
     "fields": {

--- a/integreat_cms/cms/migrations/0075_add_pushnotification_multiple_regions.py
+++ b/integreat_cms/cms/migrations/0075_add_pushnotification_multiple_regions.py
@@ -1,0 +1,73 @@
+from django.db import migrations, models
+from django.db.models.deletion import CASCADE
+
+
+# pylint: disable=unused-argument
+def forwards_func(apps, schema_editor):
+    """
+    Adopting the old data when applying this migration
+
+    :param apps: The configuration of installed applications
+    :type apps: ~django.apps.registry.Apps
+
+    :param schema_editor: The database abstraction layer that creates actual SQL code
+    :type schema_editor: ~django.db.backends.base.schema.BaseDatabaseSchemaEditor
+    """
+    PushNotification = apps.get_model("cms", "PushNotification")
+    for pn in PushNotification.objects.all():
+        pn.regions.add(pn.region)
+
+
+# pylint: disable=unused-argument
+def reverse_func(apps, schema_editor):
+    """
+    Reverting (most of the) newer data when reverting this migration
+
+    :param apps: The configuration of installed applications
+    :type apps: ~django.apps.registry.Apps
+
+    :param schema_editor: The database abstraction layer that creates actual SQL code
+    :type schema_editor: ~django.db.backends.base.schema.BaseDatabaseSchemaEditor
+    """
+    PushNotification = apps.get_model("cms", "PushNotification")
+    for pn in PushNotification.objects.all():
+        pn.region = pn.regions.first()
+        pn.save()
+
+
+class Migration(migrations.Migration):
+    """
+    Replace ReferenceField `region` with a ManyToManyField `regions` in PushNotification.
+    """
+
+    dependencies = [
+        ("cms", "0074_pushnotification_scheduled_send_date"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="pushnotification",
+            name="regions",
+            field=models.ManyToManyField(
+                related_name="push_notifications",
+                to="cms.Region",
+                verbose_name="regions",
+            ),
+        ),
+        migrations.AlterField(
+            model_name="pushnotification",
+            name="region",
+            field=models.ForeignKey(
+                null=True,
+                on_delete=CASCADE,
+                related_name="push_notifications",
+                to="cms.region",
+                verbose_name="region",
+            ),
+        ),
+        migrations.RunPython(forwards_func, reverse_func),
+        migrations.RemoveField(
+            model_name="pushnotification",
+            name="region",
+        ),
+    ]

--- a/integreat_cms/cms/models/push_notifications/push_notification.py
+++ b/integreat_cms/cms/models/push_notifications/push_notification.py
@@ -19,11 +19,10 @@ class PushNotification(AbstractBaseModel):
     Data model representing a push notification
     """
 
-    region = models.ForeignKey(
+    regions = models.ManyToManyField(
         Region,
-        on_delete=models.CASCADE,
         related_name="push_notifications",
-        verbose_name=_("region"),
+        verbose_name=_("regions"),
     )
     channel = models.CharField(
         max_length=60,
@@ -99,7 +98,9 @@ class PushNotification(AbstractBaseModel):
         :return: The default translation of a push notification
         :rtype: ~integreat_cms.cms.models.push_notifications.push_notification_translation.PushNotificationTranslation
         """
-        return self.translations.filter(language=self.region.default_language).first()
+        return self.translations.filter(
+            language=self.regions.first().default_language
+        ).first()
 
     @property
     def best_translation(self):
@@ -157,7 +158,7 @@ class PushNotification(AbstractBaseModel):
         :return: The canonical string representation of the push notification
         :rtype: str
         """
-        return f"<PushNotification (id: {self.id}, channel: {self.channel}, region: {self.region.slug})>"
+        return f"<PushNotification (id: {self.id}, channel: {self.channel}, regions: {self.regions.values_list('slug', flat=True)})>"
 
     class Meta:
         #: The verbose name of the model

--- a/integreat_cms/cms/models/push_notifications/push_notification_translation.py
+++ b/integreat_cms/cms/models/push_notifications/push_notification_translation.py
@@ -50,7 +50,7 @@ class PushNotificationTranslation(AbstractBaseModel):
         :rtype: ~django.db.models.QuerySet
         """
         return cls.objects.filter(
-            push_notification__region=region,
+            push_notification__regions__contains=region,
             language__slug=language_slug,
             title__icontains=query,
         )
@@ -96,7 +96,7 @@ class PushNotificationTranslation(AbstractBaseModel):
         :return: The link to the news
         :rtype: str
         """
-        return f"/{self.push_notification.region.slug}/{self.language.slug}/{self.push_notification.channel}/local/{self.id}"
+        return f"/{self.push_notification.regions.first().slug}/{self.language.slug}/{self.push_notification.channel}/local/{self.id}"
 
     def __str__(self):
         """

--- a/integreat_cms/cms/templates/push_notifications/push_notification_form.html
+++ b/integreat_cms/cms/templates/push_notifications/push_notification_form.html
@@ -19,12 +19,12 @@
                     {% endif %}
                 </h1>
                 <div class="flex flex-wrap gap-4 ml-auto mr-0">
-                    {% if perms.cms.change_pushnotification %}
+                    {% if perms.cms.change_pushnotification and not not_accessible_regions_warning %}
                         <button name="submit_save" class="btn btn-outline">
                             {% translate "Save" %}
                         </button>
                     {% endif %}
-                    {% if perms.cms.send_push_notification and not push_notification_form.instance.sent_date %}
+                    {% if perms.cms.send_push_notification and not push_notification_form.instance.sent_date and not not_accessible_regions_warning %}
                         <button name="submit_send" class="btn">
                             {% translate "Save & Send" %}
                         </button>
@@ -32,10 +32,10 @@
                 </div>
             </div>
             <div class="flex flex-wrap flex-col grow pr-4 tabbed">
-                <ul class="flex flex-wrap pl-4 cursor-pointer text-black">
+                <ul class="flex flex-wrap pl-4 text-black">
                     {% for other_language in languages %}
                         <li id="li-{{ other_language.id }}"
-                            class="language-tab-header mr-2 -mb-[2px] {% if other_language.id == language.id %} z-10 text-blue-500 bg-white cursor-default {% else %} bg-water-500 {% endif %} hover:text-blue-500 hover:bg-white border-l border-t border-r border-blue-500 font-bold rounded-t-lg"
+                            class="language-tab-header mr-2 -mb-[2px] {% if other_language.id == language.id %} z-10 text-blue-500 bg-white cursor-default {% else %} bg-water-500 {% endif %} hover:text-blue-500 hover:bg-white border-l border-t border-r border-blue-500 font-bold rounded-t-lg cursor-pointer"
                             data-switch-language="{{ other_language.id }}"
                             data-text-direction="{{ other_language.text_direction }}">
                             <div class="border-b-2 border-white">
@@ -129,6 +129,25 @@
                                 {% endblocktranslate %}
                             {% endif %}
                         </div>
+                        {% if push_notification_form.regions|length > 1 %}
+                            <label for="{{ push_notification_form.regions.id_for_label }}">
+                                {{ push_notification_form.regions.label }}
+                            </label>
+                            <p>
+                                {% if not_accessible_regions_warning %}
+                                    <i icon-name="x" class="text-red-500 align-text-top"></i>
+                                    {{ not_accessible_regions_warning }}
+                                {% else %}
+                                    {% translate "Any manager with access to only some of the selected regions can view but not edit this news message." %}
+                                {% endif %}
+                            </p>
+                            {% render_field push_notification_form.regions|add_error_class:"border-red-500" %}
+                        {% elif not_accessible_regions_warning %}
+                            <p class="pt-6">
+                                <i icon-name="x" class="text-red-500 align-text-top"></i>
+                                {{ not_accessible_regions_warning }}
+                            </p>
+                        {% endif %}
                     </div>
                 </div>
                 {% if push_notification_form.instance.id %}

--- a/integreat_cms/cms/views/regions/region_actions.py
+++ b/integreat_cms/cms/views/regions/region_actions.py
@@ -11,7 +11,7 @@ from django.utils.translation import gettext as _
 from django.views.decorators.http import require_POST
 
 from ...decorators import permission_required
-from ...models import Page, Region
+from ...models import Page, PushNotification, Region
 
 logger = logging.getLogger(__name__)
 
@@ -104,10 +104,18 @@ def delete_region(request, *args, **kwargs):
     )
     if orphan_users.exists():
         logger.info(
-            "Deleted orphan users: %r",
+            "Deleting orphan users: %r",
             orphan_users,
         )
         orphan_users.delete()
+    # Get orphan push notifications
+    orphan_pns = PushNotification.objects.filter(regions=None)
+    if orphan_pns.exists():
+        logger.info(
+            "Deleting orphan PushNotifications: %r",
+            orphan_pns,
+        )
+        orphan_pns.delete()
 
     messages.success(request, _("Region was successfully deleted"))
 

--- a/integreat_cms/firebase_api/firebase_api_client.py
+++ b/integreat_cms/firebase_api/firebase_api_client.py
@@ -41,7 +41,7 @@ class FirebaseApiClient:
         self.prepared_pnts = []
         self.primary_pnt = PushNotificationTranslation.objects.get(
             push_notification=push_notification,
-            language=push_notification.region.default_language,
+            language=push_notification.regions.first().default_language,
         )
         if self.primary_pnt.title:
             self.prepared_pnts.append(self.primary_pnt)
@@ -59,7 +59,7 @@ class FirebaseApiClient:
                 raise ImproperlyConfigured(
                     f"The system runs with DEBUG=True but the region with TEST_REGION_SLUG={settings.TEST_REGION_SLUG} does not exist."
                 ) from e
-        self.region = push_notification.region
+        self.regions = push_notification.regions.all()
 
     def load_secondary_pnts(self):
         """
@@ -97,22 +97,25 @@ class FirebaseApiClient:
                 return False
         return True
 
-    def send_pn(self, pnt):
+    def send_pn(self, pnt, region):
         """
         Send single push notification translation
 
-        :param pnt: the prepared push notification translation to be sent
+        :param pnt: The prepared push notification translation to be sent
         :type pnt: ~integreat_cms.cms.models.push_notifications.push_notification_translation.PushNotificationTranslation
+
+        :param region: The region for which to send the prepared push notification translation
+        :type region: ~integreat_cms.cms.models.regions.region.Region
 
         :return: Response of the :mod:`requests` library
         :rtype: ~requests.Response
         """
         payload = {
-            "to": f"/topics/{self.region.slug}-{pnt.language.slug}-{self.push_notification.channel}",
+            "to": f"/topics/{region.slug}-{pnt.language.slug}-{self.push_notification.channel}",
             "notification": {"title": pnt.title, "body": pnt.text},
             "data": {
                 "news_id": str(pnt.id),
-                "city_code": self.region.slug,
+                "city_code": region.slug,
                 "language_code": pnt.language.slug,
                 "group": self.push_notification.channel,
             },
@@ -145,20 +148,26 @@ class FirebaseApiClient:
         """
         status = True
         for pnt in self.prepared_pnts:
-            res = self.send_pn(pnt)
-            if res.status_code == 200:
-                if "message_id" in res.json():
-                    logger.info("%r sent, FCM id: %r", pnt, res.json()["message_id"])
-                else:
-                    logger.warning(
-                        "%r sent, but unexpected API response: %r", pnt, res.json()
-                    )
-            else:
-                status = False
-                logger.error(
-                    "Received invalid response from FCM for %r, status: %r, body: %r",
-                    pnt,
-                    res.status_code,
-                    res.text,
-                )
+            for region in self.regions:
+                if pnt.language in region.active_languages:
+                    res = self.send_pn(pnt, region)
+                    if res.status_code == 200:
+                        if "message_id" in res.json():
+                            logger.info(
+                                "%r sent, FCM id: %r", pnt, res.json()["message_id"]
+                            )
+                        else:
+                            logger.warning(
+                                "%r sent, but unexpected API response: %r",
+                                pnt,
+                                res.json(),
+                            )
+                    else:
+                        status = False
+                        logger.error(
+                            "Received invalid response from FCM for %r, status: %r, body: %r",
+                            pnt,
+                            res.status_code,
+                            res.text,
+                        )
         return status

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -2328,9 +2328,8 @@ msgstr "Die Passwörter stimmen nicht überein."
 
 #: cms/models/abstract_content_model.py cms/models/abstract_tree_node.py
 #: cms/models/feedback/feedback.py cms/models/media/directory.py
-#: cms/models/media/media_file.py
-#: cms/models/push_notifications/push_notification.py
-#: cms/models/regions/region.py cms/models/users/organization.py
+#: cms/models/media/media_file.py cms/models/regions/region.py
+#: cms/models/users/organization.py
 msgid "region"
 msgstr "Region"
 
@@ -3350,6 +3349,11 @@ msgid "location translations"
 msgstr "Orts-Übersetzungen"
 
 #: cms/models/push_notifications/push_notification.py
+#: cms/models/regions/region.py cms/models/users/user.py
+msgid "regions"
+msgstr "Regionen"
+
+#: cms/models/push_notifications/push_notification.py
 msgid "channel"
 msgstr "Kanal"
 
@@ -3736,10 +3740,6 @@ msgstr "Seiten"
 #: cms/templates/events/event_list.html
 msgid "Events"
 msgstr "Veranstaltungen"
-
-#: cms/models/regions/region.py cms/models/users/user.py
-msgid "regions"
-msgstr "Regionen"
 
 #: cms/models/users/organization.py
 msgid "organizations"
@@ -6719,6 +6719,14 @@ msgid "Messages are sent every %(schedule_interval)s minutes"
 msgstr "Nachrichten werden alle %(schedule_interval)s Minuten gesendet"
 
 #: cms/templates/push_notifications/push_notification_form.html
+msgid ""
+"Any manager with access to only some of the selected regions can view but "
+"not edit this news message."
+msgstr ""
+"Verwalter:innen, die nur auf einige der ausgewählten Regionen Zugriff haben, "
+"können diese Nachricht ansehen, aber nicht bearbeiten."
+
+#: cms/templates/push_notifications/push_notification_form.html
 #: cms/templates/push_notifications/push_notification_list.html
 msgid "Sent"
 msgstr "Gesendet"
@@ -8663,6 +8671,25 @@ msgstr ""
 "Nachträgliche Änderungen werden im \"Nachrichten\"-Bereich der App "
 "angezeigt, haben allerdings keine Auswirkung auf die gesendete Push-"
 "Benachrichtigung."
+
+#: cms/views/push_notifications/push_notification_form_view.py
+msgid ""
+"This news message is also assigned to regions you don't have access to: {}."
+msgstr ""
+"Diese Nachricht ist auch Regionen zugewiesen, auf die Sie keinen Zugriff "
+"haben: {}."
+
+#: cms/views/push_notifications/push_notification_form_view.py
+msgid "Thus you cannot edit or delete this news message."
+msgstr "Daher können Sie diese Nachricht nicht bearbeiten oder löschen."
+
+#: cms/views/push_notifications/push_notification_form_view.py
+msgid ""
+"Please ask the one responsible for all of these regions or contact an "
+"administrator."
+msgstr ""
+"Bitte wenden Sie sich an denjenigen, der für all diese Regionen zuständig "
+"ist oder kontaktieren Sie eine:n Administrator:in."
 
 #: cms/views/push_notifications/push_notification_form_view.py
 msgid "News message \"{}\" was successfully created"

--- a/integreat_cms/release_notes/current/unreleased/2187.yml
+++ b/integreat_cms/release_notes/current/unreleased/2187.yml
@@ -1,0 +1,2 @@
+en: News can now be simultaneously assigned to any of regions the manager has access to
+de: Nachrichten können jetzt gleichzeitig mehreren der Regionen zugewiesen sein, zu denen ein:e Verwalter:in Zugriff hat

--- a/tests/cms/views/view_config.py
+++ b/tests/cms/views/view_config.py
@@ -1147,6 +1147,7 @@ if settings.FCM_ENABLED:
                         "translations-1-title": "",
                         "translations-1-text": "",
                         "translations-1-language": 6,
+                        "regions": [1],
                         "channel": "news",
                         "mode": "ONLY_AVAILABLE",
                     },

--- a/tests/firebase_api/test_firebase_api_client.py
+++ b/tests/firebase_api/test_firebase_api_client.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ImproperlyConfigured
 from integreat_cms.cms.models.push_notifications.push_notification import (
     PushNotification,
 )
+from integreat_cms.cms.models.regions.region import Region
 from integreat_cms.firebase_api.firebase_api_client import FirebaseApiClient
 
 
@@ -223,3 +224,56 @@ class TestFirebaseApiClient:
         notification = PushNotification.objects.first()
         pns = FirebaseApiClient(notification)
         return pns.send_all()
+
+    @pytest.mark.django_db
+    def test_region_notification_send(self, settings, load_test_data, requests_mock):
+        targets = set()
+
+        def evaluate_request(request, context):
+            targets.add(request.json()["to"])
+            return self.response_mock_data["200_success"]
+
+        requests_mock.post(settings.FCM_URL, json=evaluate_request, status_code=200)
+
+        settings.FCM_ENABLED = True
+
+        notification = PushNotification.objects.get(pk=1)
+
+        pns = FirebaseApiClient(notification)
+        pns.send_all()
+
+        assert targets == set(
+            [
+                "/topics/nurnberg-en-news",
+                "/topics/nurnberg-de-news",
+            ]
+        )
+
+    @pytest.mark.django_db
+    def test_multiple_regions_notification_send(
+        self, settings, load_test_data, requests_mock
+    ):
+        targets = set()
+
+        def evaluate_request(request, context):
+            targets.add(request.json()["to"])
+            return self.response_mock_data["200_success"]
+
+        requests_mock.post(settings.FCM_URL, json=evaluate_request, status_code=200)
+
+        settings.FCM_ENABLED = True
+
+        notification = PushNotification.objects.get(pk=1)
+        notification.regions.add(Region.objects.get(slug="augsburg"))
+
+        pns = FirebaseApiClient(notification)
+        pns.send_all()
+
+        assert targets == set(
+            [
+                "/topics/nurnberg-en-news",
+                "/topics/nurnberg-de-news",
+                "/topics/augsburg-en-news",
+                "/topics/augsburg-de-news",
+            ]
+        )


### PR DESCRIPTION
### Short description
This PR makes Push Notifications assignable to multiple regions.


### Proposed changes

- Replace `PushNotification.region` in model with a ManyToManyField `.regions`
- Add CheckboxSelectMultiple to the PushNotificationForm, fed by `[request.region]+list(request.region_selection)` (ten regions the user has access to, *including* the current one)

### Known problems and TODOs

- ~~*forgot to adapt FirebaseApiClient, oops*~~

- ~~**Migration not properly reversible:** getting `django.db.utils.IntegrityError: column "region_id" of relation "cms_pushnotification" contains null values`~~
- ~~If `PushNotification.regions` becomes empty, the object won't be deleted (CASCADE on the earlier ReferenceField not adapted for ManyToManyField)~~
- ~~**No handling of any besides the trivial case:**
  If a user has access to region **A** and **B** and creates a PushNotification for both, a user who has access to region **B** and **C** will only get **B** and **C** displayed as options (with **B** selected), and have no indication that the PushNotification is also assigned to **A**. This will require a thorough discussion on how to handle such cases in the future.~~
  *In these cases now all fields will be disabled and the user will get a list of assigned regions outside his access and an explanation both as a message at the top of the page and below the new region selection.*

- ~~Documentation, Changelog etc. missing~~
- Tests ~~missing~~ incomplete?

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

should be pretty contained


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2187 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
