### PR TITLE
Fix translation status of currently in translation pages after MT

### DIFF
--- a/integreat_cms/deepl_api/deepl_api_client.py
+++ b/integreat_cms/deepl_api/deepl_api_client.py
@@ -165,6 +165,7 @@ class DeepLApiClient(MachineTranslationApiClient):
                     if existing_target_translation
                     else source_translation.status,
                     "machine_translated": True,
+                    "currently_in_translation": False,
                 }
 
                 for attr in self.translatable_attributes:
@@ -192,6 +193,11 @@ class DeepLApiClient(MachineTranslationApiClient):
                 # Validate event translation
                 if content_translation_form.is_valid():
                     content_translation_form.save()
+                    # Revert "currently in translation" value of all versions
+                    if existing_target_translation:
+                        existing_target_translation.all_versions.update(
+                            currently_in_translation=False
+                        )
                     logger.debug(
                         "Successfully translated for: %r",
                         content_translation_form.instance,

--- a/integreat_cms/release_notes/current/unreleased/2318.yml
+++ b/integreat_cms/release_notes/current/unreleased/2318.yml
@@ -1,0 +1,2 @@
+en: Fix translation status change of currently in translation pages after machine translation
+de: Behebe Änderung des Übersetzungsstatus der aktuell in Übersetzung Seiten nach der maschinellen Übersetzung


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the translation status change of `currently in translation` pages after they are machine translated.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Count machine translation as cancellation of translation (XLIFF) process.
- Set "currently in translation" to false in the form.
- Revert the value of `currently in translation` in all the versions to false after machine translation (see #2214).


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- I'm very afraid that this change affects other constraints/rules of translation status and its calculation, though so far it looks good to me 🙈 

### Note
This needs to be done before the release of #2221.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2318 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
