### PR TITLE
Fix feedback filter error

### DIFF
--- a/integreat_cms/cms/forms/feedback/region_feedback_filter_form.py
+++ b/integreat_cms/cms/forms/feedback/region_feedback_filter_form.py
@@ -115,4 +115,9 @@ class RegionFeedbackFilterForm(CustomFilterForm):
             if "" in self.cleaned_data["rating"]:
                 feedback = feedback.union(feedback_without_rating)
 
+                # Generate a new unrestricted queryset containing the same feedback
+                # so that select_related can be used on it without error
+                feedback_ids = [each.id for each in feedback]
+                feedback = Feedback.objects.filter(id__in=feedback_ids)
+
         return feedback, query

--- a/integreat_cms/release_notes/current/unreleased/2273.yml
+++ b/integreat_cms/release_notes/current/unreleased/2273.yml
@@ -1,0 +1,2 @@
+en: Fix feedback filter error
+de: Behebe Fehler im Feedback Filter


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes `NotSupportedError` which occurs in the feedback filter.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Make an unrestricted query set after `.union()` so `select_related` can be operated on the query set (like in `get_pages` method of region).


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- None (I hope), since no change on the filter query calcuration.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2273 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
