### PR TITLE
Do not archive mirrored pages

### DIFF
--- a/integreat_cms/cms/templates/pages/page_form_sidebar/actions_box.html
+++ b/integreat_cms/cms/templates/pages/page_form_sidebar/actions_box.html
@@ -49,15 +49,51 @@
         {% endfor %}
     {% else %}
         <label>{% translate "Archive page" %}</label>
-        <button title="{% translate "Archive page" %}"
-                class="btn confirmation-button w-full"
-                data-confirmation-title="{{ archive_dialog_title }}"
-                data-confirmation-text="{{ archive_dialog_text }}"
-                data-confirmation-subject="{{ page_translation_form.instance.title }}"
-                data-action="{% url 'archive_page' page_id=page_form.instance.id region_slug=request.region.slug language_slug=language.slug %}">
-            <i icon-name="archive" class="mr-2"></i>
-            {% translate "Archive this page" %}
-        </button>
+        {% if not page.mirroring_pages.exists %}
+            <button title="{% translate "Archive page" %}"
+                    class="btn confirmation-button w-full"
+                    data-confirmation-title="{{ archive_dialog_title }}"
+                    data-confirmation-text="{{ archive_dialog_text }}"
+                    data-confirmation-subject="{{ page_translation_form.instance.title }}"
+                    data-action="{% url 'archive_page' page_id=page_form.instance.id region_slug=request.region.slug language_slug=language.slug %}">
+                <i icon-name="archive" class="mr-2"></i>
+                {% translate "Archive this page" %}
+            </button>
+        {% else %}
+            {% with page.mirroring_pages.all.prefetch_translations as mirroring_pages %}
+                <div class="bg-orange-100 border-l-4 border-orange-500 text-orange-500 px-4 py-3 mb-5"
+                     role="alert">
+                    <p>{% translate "You cannot archive a page which is embedded as live content from another page." %}</p>
+                </div>
+                <p>
+                    {% blocktranslate count counter=mirroring_pages|length trimmed %}
+                        To archive this page, you have to remove the embedded live content from this page first:
+                    {% plural %}
+                        To archive this page, you have to remove the embedded live content from these pages first:
+                    {% endblocktranslate %}
+                </p>
+                {% for mirroring_page in mirroring_pages %}
+                    {% has_perm 'cms.change_page_object' request.user mirroring_page as can_change_page_object %}
+                    {% if can_change_page_object %}
+                        <a href="{% url 'edit_page' page_id=mirroring_page.id region_slug=mirroring_page.region.slug language_slug=language.slug %}"
+                           class="block pt-2 hover:underline">
+                            <i icon-name="edit" class="mr-2"></i>
+                            {{ mirroring_page.best_translation.title }}
+                            {% if mirroring_page.region != request.region %}({{ mirroring_page.region }}){% endif %}
+                        </a>
+                    {% else %}
+                        <a href="{{ WEBAPP_URL }}{{ mirroring_page.best_translation.get_absolute_url }}"
+                           class="block pt-2 hover:underline"
+                           target="_blank"
+                           rel="noopener noreferrer">
+                            <i icon-name="external-link" class="mr-2"></i>
+                            {{ mirroring_page.best_translation.title }}
+                            {% if mirroring_page.region != request.region %}({{ mirroring_page.region }}){% endif %}
+                        </a>
+                    {% endif %}
+                {% endfor %}
+            {% endwith %}
+        {% endif %}
     {% endif %}
     {% if perms.cms.delete_page %}
         <label>{% translate "Delete page" %}</label>

--- a/integreat_cms/cms/templates/pages/page_tree_node.html
+++ b/integreat_cms/cms/templates/pages/page_tree_node.html
@@ -173,14 +173,22 @@
             <i icon-name="edit"></i>
         </a>
         {% if can_edit_pages %}
-            <button title="{% translate "Archive page" %}"
-                    class="confirmation-button btn-icon"
-                    data-confirmation-title="{{ archive_dialog_title }}"
-                    data-confirmation-text="{{ archive_dialog_text }}"
-                    data-confirmation-subject="{{ page.best_translation.title }}"
-                    data-action="{% url 'archive_page' page_id=page.id region_slug=request.region.slug language_slug=language.slug %}">
-                <i icon-name="archive"></i>
-            </button>
+            {% if page.mirroring_pages.exists %}
+                <button title="{% translate "This page cannot be archived because it was embedded as live content from another page." %}"
+                        class="btn-icon"
+                        disabled>
+                    <i icon-name="archive"></i>
+                </button>
+            {% else %}
+                <button title="{% translate "Archive page" %}"
+                        class="confirmation-button btn-icon"
+                        data-confirmation-title="{{ archive_dialog_title }}"
+                        data-confirmation-text="{{ archive_dialog_text }}"
+                        data-confirmation-subject="{{ page.best_translation.title }}"
+                        data-action="{% url 'archive_page' page_id=page.id region_slug=request.region.slug language_slug=language.slug %}">
+                    <i icon-name="archive"></i>
+                </button>
+            {% endif %}
         {% endif %}
         {% if perms.cms.delete_page %}
             {# djlint:off H023 #}
@@ -191,7 +199,7 @@
                     <i icon-name="trash-2"></i>
                 </button>
             {% elif page.mirroring_pages.exists %}
-                <button title="{% translate "This page cannot be deleted because it was embedded as live content from another page." %}&#013;{% translate "You can however archive this page." %}"
+                <button title="{% translate "This page cannot be deleted because it was embedded as live content from another page." %}"
                         class="btn-icon"
                         disabled>
                     <i icon-name="trash-2"></i>

--- a/integreat_cms/cms/views/pages/page_actions.py
+++ b/integreat_cms/cms/views/pages/page_actions.py
@@ -59,10 +59,18 @@ def archive_page(request, page_id, region_slug, language_slug):
             f"{request.user!r} does not have the permission to archive {page!r}"
         )
 
-    page.archive()
+    if page.mirroring_pages.exists():
+        messages.error(
+            request,
+            _(
+                "This page cannot be archived because it was embedded as live content from another page."
+            ),
+        )
+    else:
+        page.archive()
 
-    logger.debug("%r archived by %r", page, request.user)
-    messages.success(request, _("Page was successfully archived"))
+        logger.debug("%r archived by %r", page, request.user)
+        messages.success(request, _("Page was successfully archived"))
 
     return redirect(
         "pages",

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -6035,6 +6035,28 @@ msgid "Archive this page"
 msgstr "Diese Seite archivieren"
 
 #: cms/templates/pages/page_form_sidebar/actions_box.html
+msgid ""
+"You cannot archive a page which is embedded as live content from another "
+"page."
+msgstr ""
+"Diese Seite kann nicht archiviert werden, da sie von einer anderen Seite als "
+"Live-Inhalt eingebunden wurde."
+
+#: cms/templates/pages/page_form_sidebar/actions_box.html
+msgid ""
+"To archive this page, you have to remove the embedded live content from this "
+"page first:"
+msgid_plural ""
+"To archive this page, you have to remove the embedded live content from "
+"these pages first:"
+msgstr[0] ""
+"Um diese Seite zu archivieren, müssen Sie den eingebetteten Live-Inhalt von "
+"dieser Seite entfernen:"
+msgstr[1] ""
+"Um diese Seite zu archivieren, müssen Sie den eingebetteten Live-Inhalt von "
+"diesen Seiten entfernen:"
+
+#: cms/templates/pages/page_form_sidebar/actions_box.html
 #: cms/templates/pages/page_tree_archived_node.html
 #: cms/templates/pages/page_tree_node.html
 msgid "Delete page"
@@ -6324,13 +6346,17 @@ msgstr ""
 msgid "Edit page"
 msgstr "Seite bearbeiten"
 
+#: cms/templates/pages/page_tree_node.html cms/views/pages/page_actions.py
+msgid ""
+"This page cannot be archived because it was embedded as live content from "
+"another page."
+msgstr ""
+"Diese Seite kann nicht archiviert werden, da sie von einer anderen Seite als "
+"Live-Inhalt eingebunden wurde."
+
 #: cms/templates/pages/page_tree_node.html
 msgid "This also involves archived subpages."
 msgstr "Dies betrifft auch archivierte Unterseiten."
-
-#: cms/templates/pages/page_tree_node.html
-msgid "You can however archive this page."
-msgstr "Sie können diese Seite jedoch archivieren."
 
 #: cms/templates/pages/page_tree_node.html
 msgid "Copy short link"
@@ -7507,6 +7533,18 @@ msgstr ""
 #: cms/views/bulk_action_views.py
 msgid "The selected {} were successfully {}"
 msgstr "Die ausgewählten {} wurden erfolgreich {}"
+
+#: cms/views/bulk_action_views.py
+msgid ""
+"{} cannot be archived because it was embedded as live content from another "
+"page."
+msgstr ""
+"{} kann nicht archiviert werden, da sie von einer anderen Seite als Live-"
+"Inhalt eingebunden wurde."
+
+#: cms/views/bulk_action_views.py
+msgid "{} was successfully archived"
+msgstr "{} wurde erfolgreich archiviert"
 
 #: cms/views/bulk_action_views.py
 msgid "The selected {} were successfully archived"
@@ -8928,6 +8966,9 @@ msgid "This page belongs to another region ({})."
 msgstr ""
 "Diese Seite konnte nicht importiert werden, da sie zu einer anderen Region "
 "gehört ({})."
+
+#~ msgid "You can however archive this page."
+#~ msgstr "Sie können diese Seite jedoch archivieren."
 
 #~ msgid "Links could not be replaced."
 #~ msgstr "Links konnten nicht ersetzt werden"

--- a/integreat_cms/release_notes/current/unreleased/2171.yml
+++ b/integreat_cms/release_notes/current/unreleased/2171.yml
@@ -1,0 +1,2 @@
+en: Do not archive mirrored pages
+de: Archiviere keine gespiegelten Seiten


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR solves the inconsistent state of mirrored pages by prevanting archiving of mirrored pages.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Deactivate the archiving icon of mirrored pages in the tree 
- Hide the archiving button in the form if the page is mirrored
- Check if there are mirorring pages before archiving a page (both in single request and bulk action)
- Adjust error/success messages of the bulk action and titles of the icon


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- None?
- I have chosen the first one among the two suggested solutions (expected behaviour) because it seems to be more in accordance with the existing behaviour of page deletion and probably causes less confusion than the second option.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2171 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
