### PR TITLE
Extend machine translation popup to events and pois

### DIFF
--- a/integreat_cms/cms/templates/_machine_translation_overlay.html
+++ b/integreat_cms/cms/templates/_machine_translation_overlay.html
@@ -33,22 +33,28 @@
                 </div>
                 <div class="mt-4">
                     <h3>
-                        <b>{% translate "Pages to be translated" %} (<span id="machine-translation-overlay-pages-number"></span>/<span id="machine-translation-overlay-pages-total-number"></span>)</b>
+                        <b>
+                            {% blocktranslate trimmed %}
+                                {{ content_type }} to be translated
+                            {% endblocktranslate %}
+                        (<span id="number-of-translatable-content"></span>/<span id="number-of-selected-content"></span>)</b>
                     </h3>
                     <div class="mt-2">
-                        <div id="machine-translation-overlay-pages-no-pages-warning"
+                        <div id="no-content-warning"
                              class="hidden bg-red-100 border-l-4 border-red-500 text-red-500 px-4 py-3 mb-5">
                             {% if source_language.slug in textlab_languages %}
                                 {% blocktranslate trimmed with hix_threshold=hix_threshold|floatformat:0 %}
-                                    None of the selected pages fullfills the required HIX score of {{ hix_threshold }}.
+                                    None of the selected {{ content_type }} fullfills the required HIX score of {{ hix_threshold }}.
                                 {% endblocktranslate %}
                             {% else %}
-                                {% translate "None of the selected pages has a source translation." %}
+                                {% blocktranslate trimmed %}
+                                    None of the selected {{ content_type }} has a source translation.
+                                {% endblocktranslate %}
                             {% endif %}
                         </div>
-                        <ul id="machine-translation-overlay-pages">
+                        <ul id="preview-list">
                         </ul>
-                        <ul id="machine-translation-overlay-pages-optional" class="hidden">
+                        <ul id="list-of-optional-content" class="hidden">
                         </ul>
                         <a id="machine-translation-overlay-expansion-trigger"
                            data-default-text="{% translate "Show all" %}"
@@ -87,25 +93,32 @@
                 </div>
                 <div class="mt-4 hidden" id="machine-translation-overlay-warning">
                     <h3>
-                        <b>{% translate "Pages that can't be translated" %}</b>
+                        <b>
+                            {% blocktranslate trimmed %}
+                                {{ content_type }} that can't be translated
+                            {% endblocktranslate %}
+                        </b>
                     </h3>
                     <div class="my-2 bg-yellow-100 border-l-4 border-yellow-500 text-yellow-600 px-4 py-3 mb-5"
                          role="alert">
                         <i class="mr-2" icon-name="alert-triangle"></i>
                         {% if source_language.slug in textlab_languages %}
                             {% blocktranslate trimmed with hix_threshold=hix_threshold|floatformat:0 %}
-                                The HIX value is too low for <span id="not-translatable"></span> pages. Please improve it to a value of at least {{ hix_threshold }} to enable machine translations for them. Currently, the following pages cannot be machine translated:
+                                The HIX value is too low for <span id="not-translatable"></span> {{ content_type }}. Please improve it to a value of at least {{ hix_threshold }} to enable machine translations for them. Currently, the following {{ content_type }} cannot be machine translated:
                             {% endblocktranslate %}
                         {% else %}
                             {% blocktranslate trimmed %}
-                                There are currently <span id="not-translatable"></span> page(s) that can't be translated. These pages can't be translated because they have no translation in the source language.
+                                There are currently <span id="not-translatable"></span> {{ content_type }} that can't be translated. These {{ content_type }} can't be translated because they have no translation in the source language.
                             {% endblocktranslate %}
                         {% endif %}
                     </div>
                     <ul class="hidden mb-2" id="machine-translation-overlay-warning-optional">
                     </ul>
-                    <a id="machine-translation-overlay-warning-more" data-default-text="{% translate "Show pages" %}" data-alternative-text="{% translate "Don't show pages" %}"  class="text-blue-500">
-                        {% translate "Show pages" %}
+                    <a id="machine-translation-overlay-warning-more"
+                       data-default-text="{% translate "Show more" %}"
+                       data-alternative-text="{% translate "Show less" %}"
+                       class="text-blue-500">
+                        {% translate "Show more" %}
                     </a>
                 </div>
                 <div class="flex justify-between mt-4">

--- a/integreat_cms/cms/templates/events/event_list.html
+++ b/integreat_cms/cms/templates/events/event_list.html
@@ -141,7 +141,10 @@
                 {% if MT_PERMITTED %}
                     {% translate "events" as content_type %}
                     {% if MT_PROVIDER %}
-                        <option data-bulk-action="{% url 'machine_translation_events' region_slug=request.region.slug language_slug=language.slug %}">
+                        <option id="machine-translation-option"
+                                data-mt-provider="{{ MT_PROVIDER.name }}"
+                                data-bulk-action="{% url 'machine_translation_events' region_slug=request.region.slug language_slug=language.slug %}"
+                                data-url="{% url 'word_count' region_slug=request.region.slug language_slug=language.slug model_type="event" %}">
                             {% blocktranslate trimmed with provider=MT_PROVIDER.name %}
                                 Machine translate {{ content_type }} via {{ provider }} to {{ language }}
                             {% endblocktranslate %}
@@ -162,6 +165,7 @@
         </div>
     {% endif %}
     {% include "../generic_confirmation_dialog.html" %}
+    {% include "../_machine_translation_overlay.html" %}
     {% url "events" as url %}
     {% include "pagination.html" with chunk=events %}
 {% endblock content %}

--- a/integreat_cms/cms/templates/pages/page_tree.html
+++ b/integreat_cms/cms/templates/pages/page_tree.html
@@ -178,7 +178,7 @@
                     {% if MT_PROVIDER %}
                         <option id="machine-translation-option"
                                 data-mt-provider="{{ MT_PROVIDER.name }}"
-                                data-url="{% url 'post_hix_and_word_number_per_page' region_slug=request.region.slug language_slug=language.slug %}"
+                                data-url="{% url 'word_count' region_slug=request.region.slug language_slug=language.slug model_type='page' %}"
                                 data-bulk-action="{% url 'machine_translation_pages' region_slug=request.region.slug language_slug=language.slug %}">
                             {% blocktranslate trimmed with provider=MT_PROVIDER.name %}
                                 Machine translate {{ content_type }} via {{ provider }} to {{ language }}

--- a/integreat_cms/cms/templates/pois/poi_list.html
+++ b/integreat_cms/cms/templates/pois/poi_list.html
@@ -130,7 +130,10 @@
                 {% if MT_PERMITTED %}
                     {% translate "locations" as content_type %}
                     {% if MT_PROVIDER %}
-                        <option data-bulk-action="{% url 'machine_translation_pois' region_slug=request.region.slug language_slug=language.slug %}">
+                        <option id="machine-translation-option"
+                                data-mt-provider="{{ MT_PROVIDER.name }}"
+                                data-bulk-action="{% url 'machine_translation_pois' region_slug=request.region.slug language_slug=language.slug %}"
+                                data-url="{% url 'word_count' region_slug=request.region.slug language_slug=language.slug model_type="poi" %}">
                             {% blocktranslate trimmed with provider=MT_PROVIDER.name %}
                                 Machine translate {{ content_type }} via {{ provider }} to {{ language }}
                             {% endblocktranslate %}
@@ -151,6 +154,7 @@
         </div>
     {% endif %}
     {% include "../generic_confirmation_dialog.html" %}
+    {% include "../_machine_translation_overlay.html" %}
     {% url "pois" as url %}
     {% include "pagination.html" with chunk=pois %}
 {% endblock content %}

--- a/integreat_cms/cms/urls/protected.py
+++ b/integreat_cms/cms/urls/protected.py
@@ -555,9 +555,9 @@ urlpatterns = [
                                             name="slugify_ajax",
                                         ),
                                         path(
-                                            "auto-translate-hix-and-words-per-page/",
-                                            pages.post_hix_and_word_number_per_page,
-                                            name="post_hix_and_word_number_per_page",
+                                            "<model_type>/word_count/",
+                                            utils.build_json_for_machine_translation,
+                                            name="word_count",
                                         ),
                                     ]
                                 ),

--- a/integreat_cms/cms/views/events/event_list_view.py
+++ b/integreat_cms/cms/views/events/event_list_view.py
@@ -115,5 +115,7 @@ class EventListView(TemplateView, EventContextMixin, MachineTranslationContextMi
                 "filter_poi": poi,
                 "translation_status": translation_status,
                 "search_query": query,
+                "source_language": region.get_source_language(language.slug),
+                "content_type": "events",
             },
         )

--- a/integreat_cms/cms/views/pages/__init__.py
+++ b/integreat_cms/cms/views/pages/__init__.py
@@ -10,7 +10,6 @@ from .page_actions import (
     get_page_order_table_ajax,
     grant_page_permission_ajax,
     move_page,
-    post_hix_and_word_number_per_page,
     preview_page_ajax,
     refresh_date,
     render_mirrored_page_field,

--- a/integreat_cms/cms/views/pages/page_actions.py
+++ b/integreat_cms/cms/views/pages/page_actions.py
@@ -19,7 +19,6 @@ from django.views.decorators.http import require_POST
 from treebeard.exceptions import InvalidMoveToDescendant, InvalidPosition
 
 from ....api.decorators import json_response
-from ....textlab_api.utils import check_hix_score
 from ...constants import text_directions
 from ...decorators import permission_required
 from ...forms import PageForm
@@ -905,70 +904,3 @@ def refresh_date(
             "region_slug": request.region.slug,
         },
     )
-
-
-@require_POST
-@json_response
-# pylint: disable=unused-argument
-def post_hix_and_word_number_per_page(request, region_slug, language_slug):
-    """
-    This function collects the hix score and the amount of words per page from the source
-
-    :param request: The current request
-    :type request: ~django.http.HttpRequest
-
-    :param region_slug: The slug of the current region
-    :type region_slug: str
-
-    :param language_slug: The slug of the current language
-    :type language_slug: str
-
-    :return: A json response of {{"id": id, "title": title, "words": number of words, "hix": if HIX value is high enough}} in case of success
-    :rtype: ~django.http.JsonResponse
-    """
-    selected_page_ids = json.loads(request.body.decode("utf-8"))
-    selected_pages = request.region.get_pages(return_unrestricted_queryset=True).filter(
-        id__in=selected_page_ids
-    )
-
-    filtered_pages = {}
-    translatable = {}
-    not_translatable = {}
-
-    source_language = request.region.get_source_language(language_slug)
-
-    for page in selected_pages:
-        source_translation = page.get_translation(source_language.slug)
-        words = (
-            len(source_translation.content.split())
-            + len(source_translation.title.split())
-            if source_translation
-            else 0
-        )
-
-        if source_translation and check_hix_score(
-            request, source_translation, show_message=False
-        ):
-            page_data = {
-                "id": page.id,
-                "title": source_translation.title,
-                "words": words,
-                "hix": True,
-            }
-            translatable.update({page.id: page_data})
-        else:
-            page_data = {
-                "id": page.id,
-                "title": source_translation.title
-                if source_translation
-                else page.best_translation.title,
-                "words": words,
-                "hix": False,
-            }
-            not_translatable.update({page.id: page_data})
-
-    filtered_pages = {
-        "translatable": translatable,
-        "not_translatable": not_translatable,
-    }
-    return JsonResponse(filtered_pages)

--- a/integreat_cms/cms/views/pages/page_tree_view.py
+++ b/integreat_cms/cms/views/pages/page_tree_view.py
@@ -148,6 +148,7 @@ class PageTreeView(TemplateView, PageContextMixin, MachineTranslationContextMixi
                 "pages": pages,
                 "language": language,
                 "source_language": region.get_source_language(language.slug),
+                "content_type": "page",
                 "languages": region.active_languages,
                 "textlab_languages": settings.TEXTLAB_API_LANGUAGES,
                 "filter_form": filter_form,

--- a/integreat_cms/cms/views/pois/poi_list_view.py
+++ b/integreat_cms/cms/views/pois/poi_list_view.py
@@ -124,6 +124,8 @@ class POIListView(TemplateView, POIContextMixin, MachineTranslationContextMixin)
                 "language": language,
                 "languages": region.active_languages,
                 "search_query": query,
+                "source_language": region.get_source_language(language.slug),
+                "content_type": "locations",
             },
         )
 

--- a/integreat_cms/cms/views/utils/__init__.py
+++ b/integreat_cms/cms/views/utils/__init__.py
@@ -1,4 +1,5 @@
 from .content_edit_lock import content_edit_lock_heartbeat, content_edit_lock_release
 from .hix import get_hix_score
+from .machine_translations import build_json_for_machine_translation
 from .search_content_ajax import search_content_ajax
 from .slugify_ajax import slugify_ajax

--- a/integreat_cms/cms/views/utils/machine_translations.py
+++ b/integreat_cms/cms/views/utils/machine_translations.py
@@ -1,0 +1,91 @@
+"""
+This module contains the generalized function to build the AJAX call for the machine translation popup
+"""
+import json
+import logging
+
+from django.http import JsonResponse
+
+from ....textlab_api.utils import check_hix_score
+from ...models import Event, Page, POI
+
+logger = logging.getLogger(__name__)
+
+
+# pylint: disable=unused-argument, too-many-locals
+def build_json_for_machine_translation(request, region_slug, language_slug, model_type):
+    """
+    This function collects the hix score and the amount of words per content entry from the source
+
+    :param request: The current request
+    :type request: ~django.http.HttpRequest
+
+    :param region_slug: slug of the according region
+    :type region_slug: str
+
+    :param language_slug: The slug of the current language
+    :type language_slug: str
+
+    :param model_type: The according model to the different content types
+    :type model_type: ~integreat_cms.cms.models.abstract_content_model.AbstractContentModel
+
+    :return: A dictionary that contains the data for the machine translation popup (page id, title, amount of words and optional hix value)
+    :rtype: dict
+    """
+
+    model_types = {
+        "event": Event,
+        "page": Page,
+        "poi": POI,
+    }
+
+    try:
+        selected_content_ids = json.loads(request.body.decode("utf-8"))
+    except json.decoder.JSONDecodeError as e:
+        logger.warning("Malformed request body! %r", e)
+        selected_content_ids = []
+    selected_content = model_types[model_type].objects.filter(
+        region=request.region, id__in=selected_content_ids
+    )
+
+    filtered_content = {}
+    translatable = {}
+    non_translatable = {}
+
+    source_language = request.region.get_source_language(language_slug)
+
+    for content in selected_content:
+        source_translation = content.get_translation(source_language.slug)
+        words = (
+            len(source_translation.content.split())
+            + len(source_translation.title.split())
+            if source_translation
+            else 0
+        )
+
+        if source_translation and check_hix_score(
+            request, source_translation, show_message=False
+        ):
+            content_data = {
+                "id": content.id,
+                "title": source_translation.title,
+                "words": words,
+                "hix": True,
+            }
+            translatable.update({content.id: content_data})
+        else:
+            content_data = {
+                "id": content.id,
+                "title": source_translation.title
+                if source_translation
+                else content.best_translation.title,
+                "words": words,
+                "hix": False,
+            }
+            non_translatable.update({content.id: content_data})
+
+    filtered_content = {
+        "translatable": translatable,
+        "non_translatable": non_translatable,
+    }
+    return JsonResponse(filtered_content)

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -4101,21 +4101,23 @@ msgid "Language selection"
 msgstr "Sprachauswahl"
 
 #: cms/templates/_machine_translation_overlay.html
-msgid "Pages to be translated"
-msgstr "Zu übersetzende Seiten"
+#, python-format
+msgid "%(content_type)s to be translated"
+msgstr "Zu übersetzende %(content_type)s"
 
 #: cms/templates/_machine_translation_overlay.html
 #, python-format
 msgid ""
-"None of the selected pages fullfills the required HIX score of "
+"None of the selected %(content_type)s fullfills the required HIX score of "
 "%(hix_threshold)s."
 msgstr ""
-"Keiner der ausgewählten Seiten erfüllt den benötigten HIX-Wert von "
+"Keine der ausgewählten %(content_type)s erfüllt den benötigten HIX-Wert von "
 "%(hix_threshold)s."
 
 #: cms/templates/_machine_translation_overlay.html
-msgid "None of the selected pages has a source translation."
-msgstr "Keine der ausgewählten Seiten hat eine Quellübersetzung."
+#, python-format
+msgid "None of the selected %(content_type)s has a source translation."
+msgstr "Keine der ausgewählten %(content_type)s hat eine Quellübersetzung."
 
 #: cms/templates/_machine_translation_overlay.html
 msgid "Show all"
@@ -4142,39 +4144,37 @@ msgid "Remaining budget: "
 msgstr "Verbleibendes Budget:"
 
 #: cms/templates/_machine_translation_overlay.html
-msgid "Pages that can't be translated"
-msgstr "Seiten, die nicht übersetzt werden können"
+#, python-format
+msgid "%(content_type)s that can't be translated"
+msgstr "Nicht übersetzbare %(content_type)s"
 
 #: cms/templates/_machine_translation_overlay.html
 #, python-format
 msgid ""
-"The HIX value is too low for <span id=\"not-translatable\"></span> pages. "
-"Please improve it to a value of at least %(hix_threshold)s to enable machine "
-"translations for them. Currently, the following pages cannot be machine "
-"translated:"
+"The HIX value is too low for <span id=\"not-translatable\"></span> "
+"%(content_type)s. Please improve it to a value of at least %(hix_threshold)s "
+"to enable machine translations for them. Currently, the following "
+"%(content_type)s cannot be machine translated:"
 msgstr ""
 "Der Wert der Textverständlichkeit von <span id=\"not-translatable\"></span> "
-"Seiten ist zu gering. Bitte verbessern Sie den Wert auf mindestens "
-"%(hix_threshold)s. Dann können Sie die Seiten automatisiert übersetzen. "
-"Folgende Seiten werden aktuell nicht übersetzt:"
+"%(content_type)s ist zu gering. Bitte verbessern Sie den Wert auf mindestens "
+"%(hix_threshold)s. Dann können Sie die %(content_type)s automatisiert "
+"übersetzen. Folgende %(content_type)s werden aktuell nicht übersetzt:"
 
 #: cms/templates/_machine_translation_overlay.html
+#, python-format
 msgid ""
-"There are currently <span id=\"not-translatable\"></span> page(s) that can't "
-"be translated. These pages can't be translated because they have no "
-"translation in the source language."
+"There are currently <span id=\"not-translatable\"></span> %(content_type)s "
+"that can't be translated. These %(content_type)s can't be translated because "
+"they have no translation in the source language."
 msgstr ""
-"Es gibt aktuell <span id=\"not-translatable\"></span> Seiten, die nicht "
-"übersetzt werden können. Diese Seiten können nicht übersetzt werden, weil "
-"sie keine Übersetzung in der Quellsprache haben."
+"Es gibt aktuell <span id=\"not-translatable\"></span> %(content_type)s, die "
+"nicht übersetzt werden können. Diese %(content_type)s können nicht übersetzt "
+"werden, weil sie keine Übersetzung in der Quellsprache haben."
 
 #: cms/templates/_machine_translation_overlay.html
-msgid "Show pages"
-msgstr "Seiten anzeigen"
-
-#: cms/templates/_machine_translation_overlay.html
-msgid "Don't show pages"
-msgstr "Seiten nicht anzeigen"
+msgid "Show more"
+msgstr "Weniger anzeigen"
 
 #: cms/templates/_machine_translation_overlay.html
 #: cms/templates/_tinymce_config.html
@@ -9231,6 +9231,15 @@ msgstr ""
 
 #~ msgid "url"
 #~ msgstr "URL"
+
+#~ msgid "Show pages"
+#~ msgstr "Seiten anzeigen"
+
+#~ msgid "Don't show pages"
+#~ msgstr "Seiten nicht anzeigen"
+
+#~ msgid "Pages that can't be translated"
+#~ msgstr "Seiten, die nicht übersetzt werden können"
 
 #~ msgid "Links could not be replaced."
 #~ msgstr "Links konnten nicht ersetzt werden"

--- a/integreat_cms/release_notes/current/unreleased/2314.yml
+++ b/integreat_cms/release_notes/current/unreleased/2314.yml
@@ -1,0 +1,2 @@
+en: Generalize the DeepL popup to events and POI
+de: Verallgemeinere das DeepL Popup für Veranstaltungen und Orte


### PR DESCRIPTION
### Short description
This PR extends the pre-existing machine translation popup from pages only also to POI and events. Since POI and events don't need a check for HIX, in these cases the HIX check is skipped.


### Proposed changes
<!-- Describe this PR in more detail. -->

- Add release note 
- Extend the machine translation popup to POI and events
- Store code for creating AJAX call in a new general function
- Refactor the TS file a little by shortening some of the variable names and by using content type neutral variable names


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None of that I'm aware of at the moment


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2314 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
