### PR TITLE
Add new todo dashboard

### DIFF
--- a/integreat_cms/api/v3/pdf_export.py
+++ b/integreat_cms/api/v3/pdf_export.py
@@ -38,7 +38,7 @@ def pdf_export(request, region_slug, language_slug):
     """
     region = request.region
     # Request unrestricted queryset because pdf generator performs further operations (e.g. aggregation) on the queryset
-    pages = region.get_pages(return_unrestricted_queryset=True)
+    pages = region.get_pages()
     if request.GET.get("url"):
         # remove leading and trailing slashed to avoid ambiguous urls
         url = request.GET.get("url").strip("/")

--- a/integreat_cms/cms/models/pages/page.py
+++ b/integreat_cms/cms/models/pages/page.py
@@ -224,9 +224,10 @@ class Page(AbstractTreeNode, AbstractBasePage):
         """
         This returns all of the page's ancestors which are archived.
 
-        :return: The QuerySet of archived ancestors
+        :return: The list of archived ancestors
         :rtype: list [ ~integreat_cms.cms.models.pages.page.Page ]
         """
+
         return [
             ancestor
             for ancestor in self.get_cached_ancestors()

--- a/integreat_cms/cms/models/regions/region.py
+++ b/integreat_cms/cms/models/regions/region.py
@@ -631,31 +631,47 @@ class Region(AbstractBaseModel):
             raise Http404("No language matches the given query.") from e
 
     @cached_property
+    def explicitly_archived_ancestors_subquery(self):
+        """
+        This property returns a subquery for all explicitly archived anchestors of a given page.
+        Needs to be used as part of another query because in order to resolve :class:`~django.db.models.OuterRef`,
+        e.g. in a :class:`~django.db.models.Subquery` or in :class:`~django.db.models.Exists`.
+
+        :return: A queryset of the explicitly archived ancestors.
+        :rtype: ~django.db.models.query.QuerySet
+        """
+
+        return self.pages.filter(
+            tree_id=models.OuterRef("tree_id"),
+            lft__lt=models.OuterRef("lft"),
+            rgt__gt=models.OuterRef("rgt"),
+            explicitly_archived=True,
+        )
+
+    @cached_property
     def archived_pages(self):
         """
         This property returns a QuerySet of all archived pages and their descendants of this region.
 
-        Per default, the returned queryset has some limitations because of the usage of
-        :meth:`~django.db.models.query.QuerySet.union`. To perform the extra effort of returning an unrestricted
-        queryset, use :meth:`~integreat_cms.cms.models.regions.region.Region.get_pages` with the parameters ``archived`` and
-        ``return_unrestricted_queryset`` set to ``True``.
-
         :return: A QuerySet of all archived pages of this region
         :rtype: ~treebeard.ns_tree.NS_NodeQuerySet [ ~integreat_cms.cms.models.pages.page.Page ]
         """
-        # Queryset of explicitly archived pages
-        explicitly_archived_pages = self.pages.filter(explicitly_archived=True)
-        # Multiple order_by clauses are not allowed in sql queries, so to make combined queries with union() work,
-        # we have to remove ordering from the input querysets and apply the default ordering to the resulting queryset.
-        explicitly_archived_pages = explicitly_archived_pages.order_by()
-        # List of QuerySets of descendants of archived pages
-        implicitly_archived_pages = [
-            page.get_descendants().order_by() for page in explicitly_archived_pages
-        ]
-        # Merge explicitly and implicitly archived pages
-        archived_pages = explicitly_archived_pages.union(*implicitly_archived_pages)
-        # Order the resulting :class:`~treebeard.ns_tree.NS_NodeQuerySet` to restore the tree-structure
-        return archived_pages.order_by("tree_id", "lft")
+
+        return self.pages.filter(
+            id=models.Case(
+                models.When(
+                    models.Exists(
+                        self.explicitly_archived_ancestors_subquery.values("pk")
+                    ),
+                    then=models.F("pk"),
+                ),
+                models.When(
+                    explicitly_archived=True,
+                    then=models.F("pk"),
+                ),
+                default=None,
+            )
+        )
 
     @cached_property
     def non_archived_pages(self):
@@ -664,27 +680,26 @@ class Region(AbstractBaseModel):
         A page is considered as "non-archived" if its ``explicitly_archived`` property is ``False`` and all the
         page's ancestors are not archived as well.
 
-        Per default, the returned queryset has some limitations because of the usage of
-        :meth:`~django.db.models.query.QuerySet.difference` (see :meth:`~django.db.models.query.QuerySet.union` for some
-        restrictions). To perform the extra effort of returning an unrestricted queryset, use
-        :meth:`~integreat_cms.cms.models.regions.region.Region.get_pages` with the parameter
-        ``return_unrestricted_queryset`` set to ``True``.
-
         :return: A QuerySet of all non-archived pages of this region
         :rtype: ~treebeard.ns_tree.NS_NodeQuerySet [ ~integreat_cms.cms.models.pages.page.Page ]
         """
-        # Multiple order_by clauses are not allowed in sql queries, so to make combined queries with difference() work,
-        # we have to remove ordering from the input querysets and apply the default ordering to the resulting queryset.
-        archived_pages = self.archived_pages.order_by()
-        # Exclude archived pages from all pages
-        non_archived_pages = self.pages.difference(archived_pages)
-        # Order the resulting TreeQuerySet to restore the tree-structure
-        return non_archived_pages.order_by("tree_id", "lft")
+
+        return self.pages.filter(
+            id=models.Case(
+                models.When(
+                    models.Exists(
+                        self.explicitly_archived_ancestors_subquery.values("pk")
+                    ),
+                    then=None,
+                ),
+                default=models.F("pk"),
+            ),
+            explicitly_archived=False,
+        )
 
     def get_pages(
         self,
         archived=False,
-        return_unrestricted_queryset=False,
         prefetch_translations=False,
         prefetch_public_translations=False,
         annotate_language_tree=False,
@@ -694,17 +709,8 @@ class Region(AbstractBaseModel):
         To retrieve all pages independently of their archived-state, use the reverse foreign key
         :attr:`~integreat_cms.cms.models.regions.region.Region.pages`.
 
-        Per default, the returned queryset has some limitations because of the usage of
-        :meth:`~django.db.models.query.QuerySet.difference` and :meth:`~django.db.models.query.QuerySet.union`.
-        To perform the extra effort of returning an unrestricted queryset, set the parameter
-        ``return_unrestricted_queryset`` to ``True``.
-
         :param archived: Whether or not only archived pages should be returned (default: ``False``)
         :type archived: bool
-
-        :param return_unrestricted_queryset: Whether or not the result should be returned as unrestricted queryset.
-                                             (default: ``False``)
-        :type return_unrestricted_queryset: bool
 
         :param prefetch_translations: Whether the latest translations for each language should be prefetched
                                       (default: ``False``)
@@ -722,14 +728,6 @@ class Region(AbstractBaseModel):
         :rtype: ~treebeard.ns_tree.NS_NodeQuerySet [ ~integreat_cms.cms.models.pages.page.Page ]
         """
         pages = self.archived_pages if archived else self.non_archived_pages
-        if (
-            return_unrestricted_queryset
-            or prefetch_translations
-            or prefetch_public_translations
-        ):
-            # Generate a new unrestricted queryset containing the same pages
-            page_ids = [page.id for page in pages]
-            pages = self.pages.filter(id__in=page_ids)
         if prefetch_translations:
             pages = pages.prefetch_translations()
         if prefetch_public_translations:
@@ -756,7 +754,7 @@ class Region(AbstractBaseModel):
         :param query: The query string used for filtering the regions
         :type query: str
         :return: A query for all matching objects
-        :rtype: ~django.db.models.QuerySet
+        :rtype: ~django.db.models.query.QuerySet
         """
         return cls.objects.filter(name__icontains=query)
 

--- a/integreat_cms/cms/templates/analytics/translation_coverage.html
+++ b/integreat_cms/cms/templates/analytics/translation_coverage.html
@@ -110,6 +110,9 @@
                     </table>
                 </div>
             </div>
+            {% if TEXTLAB_API_ENABLED and request.region.hix_enabled and worst_hix_translations %}
+                {% include "analytics/_page_hix_widget.html" with box_id="hix-overview" %}
+            {% endif %}
         </div>
     </div>
     {{ chart_data|json_script:"chart_data" }}

--- a/integreat_cms/cms/templates/dashboard/_todo_dashboard_row.html
+++ b/integreat_cms/cms/templates/dashboard/_todo_dashboard_row.html
@@ -1,0 +1,26 @@
+{% load i18n %}
+<div class="flex justify-between border-t-2 border-zinc-600 p-4 w-full">
+    <div class="flex items-center">
+        <div class="mr-6">
+            <i icon-name="{% spaceless %}{% block todo_dashboard_icon %}{% endblock todo_dashboard_icon %}{% endspaceless %}"></i>
+        </div>
+        <div>
+            <a href="{% spaceless %}{% block todo_dashboard_title_link %}{% endblock todo_dashboard_title_link %}{% endspaceless %}"
+               class="text-blue-500 font-bold underline">
+                {% block todo_dashboard_title %}
+                {% endblock todo_dashboard_title %}
+            </a>
+            {% block todo_dashboard_number %}
+                <span>({% translate "in total" %} {{ total }})</span>
+            {% endblock todo_dashboard_number %}
+            <p>
+                {% block todo_dashboard_description %}
+                {% endblock todo_dashboard_description %}
+            </p>
+        </div>
+    </div>
+    <div class="flex items-center justify-end w-80 text-center">
+        {% block todo_dashboard_button_link %}
+        {% endblock todo_dashboard_button_link %}
+    </div>
+</div>

--- a/integreat_cms/cms/templates/dashboard/_todo_dashboard_widget.html
+++ b/integreat_cms/cms/templates/dashboard/_todo_dashboard_widget.html
@@ -1,0 +1,33 @@
+{% extends "_collapsible_box.html" %}
+{% load i18n %}
+{% block collapsible_box_icon %}
+    clipboard-list
+{% endblock collapsible_box_icon %}
+{% block collapsible_box_title %}
+    {% translate "To-Do's" %}
+{% endblock collapsible_box_title %}
+{% block collapsible_box_content %}
+    <div class="flex flex-wrap gap-2">
+        <p class="pt-2 px-4">
+            {% blocktranslate trimmed %}
+                Every day you can find a list of ideas on how you can improve the content of your pages
+            {% endblocktranslate %}
+        </p>
+        {% if perms.cms.change_page %}
+            {% include "dashboard/todo_dashboard_rows/_unreviewed_pages_row.html" %}
+            {% include "dashboard/todo_dashboard_rows/_automatically_saved_pages_row.html" %}
+        {% endif %}
+        {% if perms.cms.change_feedback %}
+            {% include "dashboard/todo_dashboard_rows/_unread_feedback_row.html" %}
+        {% endif %}
+        {% if perms.cms.change_page and perms.cms.view_broken_links %}
+            {% include "dashboard/todo_dashboard_rows/_broken_links_row.html" %}
+        {% endif %}
+        {% if perms.cms.change_page and TEXTLAB_API_ENABLED and request.region.hix_enabled %}
+            {% include "dashboard/todo_dashboard_rows/_low_hix_row.html" %}
+        {% endif %}
+        {% if perms.cms.change_page %}
+            {% include "dashboard/todo_dashboard_rows/_outdated_pages_row.html" %}
+        {% endif %}
+    </div>
+{% endblock collapsible_box_content %}

--- a/integreat_cms/cms/templates/dashboard/dashboard.html
+++ b/integreat_cms/cms/templates/dashboard/dashboard.html
@@ -9,25 +9,19 @@
         </h1>
         <div class="xl:flex gap-3 pt-2">
             <div class="xl:w-1/2">
+                <!-- Task Widget -->
+                {% if perms.cms.change_page or perms.cms.change_feedback %}
+                    {% include "dashboard/_todo_dashboard_widget.html" with no_padding=True %}
+                {% endif %}
                 <!-- Statistic Widget -->
                 {% if request.region.statistics_enabled and perms.cms.view_statistics %}
                     {% include "statistics/_statistics_widget.html" with box_id="dashboard-statistics" %}
                 {% endif %}
+            </div>
+            <div class="xl:w-1/2">
                 <!-- Chat Widget -->
                 {% if chat_form and perms.cms.change_chatmessage %}
                     {% include "chat/_chat_widget.html" with box_id="dashboard-chat" %}
-                {% endif %}
-                <!-- Translation Status Widget: TODO-->
-                <!-- App Size Widget: TODO -->
-                <!-- Page HIX Widget-->
-                {% if TEXTLAB_API_ENABLED and request.region.hix_enabled and worst_hix_translations %}
-                    {% include "analytics/_page_hix_widget.html" %}
-                {% endif %}
-            </div>
-            <div class="xl:w-1/2">
-                <!-- Broken Link Widget -->
-                {% if perms.cms.view_broken_links %}
-                    {% include "analytics/_broken_links_widget.html" with box_id="dashboard-links" %}
                 {% endif %}
                 <!-- News Widget -->
                 {% include "dashboard/_news_widget.html" with box_id="dashboard-news" %}

--- a/integreat_cms/cms/templates/dashboard/todo_dashboard_rows/_automatically_saved_pages_row.html
+++ b/integreat_cms/cms/templates/dashboard/todo_dashboard_rows/_automatically_saved_pages_row.html
@@ -1,0 +1,37 @@
+{% extends "../_todo_dashboard_row.html" %}
+{% load i18n %}
+{% block todo_dashboard_icon %}
+    save
+{% endblock todo_dashboard_icon %}
+{% block todo_dashboard_title_link %}
+    {% url 'pages' region_slug=request.region.slug language_slug=default_language_slug %}?status=AUTO_SAVE
+{% endblock todo_dashboard_title_link %}
+{% block todo_dashboard_title %}
+    {% translate "Automatically saved pages" %}
+{% endblock todo_dashboard_title %}
+{% block todo_dashboard_number %}
+    {% with total=automatically_saved_pages|length %}
+        {{ block.super }}
+    {% endwith %}
+{% endblock todo_dashboard_number %}
+{% block todo_dashboard_description %}
+    {% if automatically_saved_pages %}
+        {% blocktranslate trimmed with single_automatically_saved_page=automatically_saved_pages.0 %}
+            The page <b>{{ single_automatically_saved_page }}</b> has been saved automatically. Please don't forget to publish this page once it's ready.
+        {% endblocktranslate %}
+    {% else %}
+        {% blocktranslate trimmed %}
+            At the moment there are no automatically saved pages. Good job!
+        {% endblocktranslate %}
+    {% endif %}
+{% endblock todo_dashboard_description %}
+{% block todo_dashboard_button_link %}
+    {% if automatically_saved_pages %}
+        <a class="btn !rounded-full"
+           href="{% url 'edit_page' region_slug=request.region.slug language_slug=default_language_slug page_id=automatically_saved_pages.0.page_id %}">
+            {% translate "Go to page" %}
+        </a>
+    {% else %}
+        <i class="mr-12" icon-name="check-circle-2"></i>
+    {% endif %}
+{% endblock todo_dashboard_button_link %}

--- a/integreat_cms/cms/templates/dashboard/todo_dashboard_rows/_broken_links_row.html
+++ b/integreat_cms/cms/templates/dashboard/todo_dashboard_rows/_broken_links_row.html
@@ -1,0 +1,37 @@
+{% extends "../_todo_dashboard_row.html" %}
+{% load i18n %}
+{% block todo_dashboard_icon %}
+    link
+{% endblock todo_dashboard_icon %}
+{% block todo_dashboard_title_link %}
+    {% url 'linkcheck' region_slug=request.region.slug url_filter='invalid' %}
+{% endblock todo_dashboard_title_link %}
+{% block todo_dashboard_title %}
+    {% translate "Broken links" %}
+{% endblock todo_dashboard_title %}
+{% block todo_dashboard_number %}
+    {% with total=broken_links|length %}
+        {{ block.super }}
+    {% endwith %}
+{% endblock todo_dashboard_number %}
+{% block todo_dashboard_description %}
+    {% if broken_links %}
+        {% blocktranslate trimmed %}
+            The page <b>{{ relevant_translation }}</b> has a broken link. Please replace it by a functional link.
+        {% endblocktranslate %}
+    {% else %}
+        {% blocktranslate trimmed %}
+            At the moment there are no broken links. Good job!
+        {% endblocktranslate %}
+    {% endif %}
+{% endblock todo_dashboard_description %}
+{% block todo_dashboard_button_link %}
+    {% if broken_links %}
+        <a class="btn !rounded-full"
+           href="{% url 'edit_url' region_slug=request.region.slug url_filter='invalid' url_id=relevant_url.id %}#replace-url">
+            {% translate "Go to link" %}
+        </a>
+    {% else %}
+        <i class="mr-12" icon-name="check-circle-2"></i>
+    {% endif %}
+{% endblock todo_dashboard_button_link %}

--- a/integreat_cms/cms/templates/dashboard/todo_dashboard_rows/_low_hix_row.html
+++ b/integreat_cms/cms/templates/dashboard/todo_dashboard_rows/_low_hix_row.html
@@ -1,0 +1,37 @@
+{% extends "../_todo_dashboard_row.html" %}
+{% load i18n %}
+{% block todo_dashboard_icon %}
+    check-circle
+{% endblock todo_dashboard_icon %}
+{% block todo_dashboard_title_link %}
+    {% url 'translation_coverage' region_slug=request.region.slug %}#hix-overview
+{% endblock todo_dashboard_title_link %}
+{% block todo_dashboard_title %}
+    {% translate "Pages with low hix score" %}
+{% endblock todo_dashboard_title %}
+{% block todo_dashboard_number %}
+    {% with total=pages_under_hix_threshold|length %}
+        {{ block.super }}
+    {% endwith %}
+{% endblock todo_dashboard_number %}
+{% block todo_dashboard_description %}
+    {% if pages_under_hix_threshold %}
+        {% blocktranslate trimmed with worst_page=pages_under_hix_threshold.0 %}
+            The page <b>{{ worst_page }}</b> has a HIX score of {{ worst_page.hix_score|floatformat:2 }}. Please adjust the hix score of this page to be able to machine translate it
+        {% endblocktranslate %}
+    {% else %}
+        {% blocktranslate trimmed %}
+            At the moment all pages are ready for machine translation. Good job!
+        {% endblocktranslate %}
+    {% endif %}
+{% endblock todo_dashboard_description %}
+{% block todo_dashboard_button_link %}
+    {% if pages_under_hix_threshold %}
+        <a class="btn !rounded-full"
+           href="{% url 'edit_page' region_slug=request.region.slug language_slug=default_language_slug page_id=pages_under_hix_threshold.0.page_id %}">
+            {% translate "Go to page" %}
+        </a>
+    {% else %}
+        <i class="mr-12" icon-name="check-circle-2"></i>
+    {% endif %}
+{% endblock todo_dashboard_button_link %}

--- a/integreat_cms/cms/templates/dashboard/todo_dashboard_rows/_outdated_pages_row.html
+++ b/integreat_cms/cms/templates/dashboard/todo_dashboard_rows/_outdated_pages_row.html
@@ -1,0 +1,37 @@
+{% extends "../_todo_dashboard_row.html" %}
+{% load i18n %}
+{% block todo_dashboard_icon %}
+    file-search
+{% endblock todo_dashboard_icon %}
+{% block todo_dashboard_title_link %}
+    {% url 'pages' region_slug=request.region.slug language_slug=default_language_slug %}?date_to={{ outdated_threshold_date }}
+{% endblock todo_dashboard_title_link %}
+{% block todo_dashboard_title %}
+    {% translate "Outdated pages" %}
+{% endblock todo_dashboard_title %}
+{% block todo_dashboard_number %}
+    {% with total=outdated_pages|length %}
+        {{ block.super }}
+    {% endwith %}
+{% endblock todo_dashboard_number %}
+{% block todo_dashboard_description %}
+    {% if outdated_pages %}
+        {% blocktranslate trimmed %}
+            The page <b>{{ most_outdated_page }}</b> hasn't been updated in {{ days_since_last_updated }} days. Please make sure that the content on this page is still relevant and up-to-date
+        {% endblocktranslate %}
+    {% else %}
+        {% blocktranslate trimmed %}
+            At the moment there is no page that hasn't been updated in the last 365 days. Good job!
+        {% endblocktranslate %}
+    {% endif %}
+{% endblock todo_dashboard_description %}
+{% block todo_dashboard_button_link %}
+    {% if outdated_pages %}
+        <a class="btn !rounded-full"
+           href="{% url 'edit_page' region_slug=request.region.slug language_slug=default_language_slug page_id=most_outdated_page.page_id %}">
+            {% translate "Go to page" %}
+        </a>
+    {% else %}
+        <i class="mr-12" icon-name="check-circle-2"></i>
+    {% endif %}
+{% endblock todo_dashboard_button_link %}

--- a/integreat_cms/cms/templates/dashboard/todo_dashboard_rows/_unread_feedback_row.html
+++ b/integreat_cms/cms/templates/dashboard/todo_dashboard_rows/_unread_feedback_row.html
@@ -1,0 +1,37 @@
+{% extends "../_todo_dashboard_row.html" %}
+{% load i18n %}
+{% block todo_dashboard_icon %}
+    thumbs-up
+{% endblock todo_dashboard_icon %}
+{% block todo_dashboard_title_link %}
+    {% url 'region_feedback' region_slug=request.region.slug %}?read_status=UNREAD
+{% endblock todo_dashboard_title_link %}
+{% block todo_dashboard_title %}
+    {% translate "Unread feedback" %}
+{% endblock todo_dashboard_title %}
+{% block todo_dashboard_number %}
+    {% with total=unread_feedback|length %}
+        {{ block.super }}
+    {% endwith %}
+{% endblock todo_dashboard_number %}
+{% block todo_dashboard_description %}
+    {% if unread_feedback %}
+        {% blocktranslate trimmed %}
+            You have unread feedback. Please answer your feedback to improve the quality of your pages and improve the relationship to the users.
+        {% endblocktranslate %}
+    {% else %}
+        {% blocktranslate trimmed %}
+            At the moment there is no unread feedback. Good job!
+        {% endblocktranslate %}
+    {% endif %}
+{% endblock todo_dashboard_description %}
+{% block todo_dashboard_button_link %}
+    {% if unread_feedback %}
+        <a href="{% url 'region_feedback' region_slug=request.region.slug %}"
+           class="btn !rounded-full">
+            {% translate "Go to page" %}
+        </a>
+    {% else %}
+        <i class="mr-12" icon-name="check-circle-2"></i>
+    {% endif %}
+{% endblock todo_dashboard_button_link %}

--- a/integreat_cms/cms/templates/dashboard/todo_dashboard_rows/_unreviewed_pages_row.html
+++ b/integreat_cms/cms/templates/dashboard/todo_dashboard_rows/_unreviewed_pages_row.html
@@ -1,0 +1,37 @@
+{% extends "../_todo_dashboard_row.html" %}
+{% load i18n %}
+{% block todo_dashboard_icon %}
+    view
+{% endblock todo_dashboard_icon %}
+{% block todo_dashboard_title_link %}
+    {% url 'pages' region_slug=request.region.slug language_slug=default_language_slug %}?status=REVIEW
+{% endblock todo_dashboard_title_link %}
+{% block todo_dashboard_title %}
+    {% translate "Pages that are waiting for review" %}
+{% endblock todo_dashboard_title %}
+{% block todo_dashboard_number %}
+    {% with total=unreviewed_pages|length %}
+        {{ block.super }}
+    {% endwith %}
+{% endblock todo_dashboard_number %}
+{% block todo_dashboard_description %}
+    {% if unreviewed_pages %}
+        {% blocktranslate trimmed with single_unreviewed_page=unreviewed_pages.0 %}
+            The page <b>{{ single_unreviewed_page }}</b> is waiting for a review. Please review, if the content on the page is correct.
+        {% endblocktranslate %}
+    {% else %}
+        {% blocktranslate trimmed %}
+            At the moment there is no page waiting for a review. Good job!
+        {% endblocktranslate %}
+    {% endif %}
+{% endblock todo_dashboard_description %}
+{% block todo_dashboard_button_link %}
+    {% if unreviewed_pages %}
+        <a class="btn !rounded-full"
+           href="{% url 'edit_page' region_slug=request.region.slug language_slug=default_language_slug page_id=unreviewed_pages.0.page_id %}">
+            {% translate "Go to page" %}
+        </a>
+    {% else %}
+        <i class="mr-12" icon-name="check-circle-2"></i>
+    {% endif %}
+{% endblock todo_dashboard_button_link %}

--- a/integreat_cms/cms/views/analytics/translation_coverage_view.py
+++ b/integreat_cms/cms/views/analytics/translation_coverage_view.py
@@ -1,6 +1,7 @@
 import logging
 from collections import Counter
 
+from django.conf import settings
 from django.utils.decorators import method_decorator
 from django.views.generic import TemplateView
 
@@ -12,6 +13,7 @@ from ...constants.translation_status import (
     UP_TO_DATE,
 )
 from ...decorators import permission_required
+from ...models import PageTranslation
 
 logger = logging.getLogger(__name__)
 
@@ -104,4 +106,51 @@ class TranslationCoverageView(TemplateView):
                 "total_missing_words": sum(c[MISSING] for c in word_count.values()),
             }
         )
+        context.update(self.get_hix_context())
         return context
+
+    def get_hix_context(self):
+        """
+        Extend context by HIX info
+
+        :return: The HIX context dictionary
+        :rtype: dict
+        """
+        if not settings.TEXTLAB_API_ENABLED:
+            return {}
+
+        # Get the current region
+        region = self.request.region
+        if not region.hix_enabled:
+            return {}
+
+        # Get all pages of this region which are considered for the HIX value
+        hix_pages = region.get_pages(return_unrestricted_queryset=True).filter(
+            hix_ignore=False
+        )
+
+        # Get the latest versions of the page translations for these pages
+        hix_translations = PageTranslation.objects.filter(
+            language__slug__in=settings.TEXTLAB_API_LANGUAGES, page__in=hix_pages
+        ).distinct("page_id", "language_id")
+
+        # Get all hix translations where the score is set
+        hix_translations_with_score = [pt for pt in hix_translations if pt.hix_score]
+
+        # Get the worst n pages
+        worst_hix_translations = sorted(
+            hix_translations_with_score, key=lambda pt: pt.hix_score
+        )
+
+        # Get the number of translations which are not ready for MT
+        not_ready_for_mt_count = sum(
+            pt.hix_score < settings.HIX_REQUIRED_FOR_MT
+            for pt in hix_translations_with_score
+        )
+
+        return {
+            "worst_hix_translations": worst_hix_translations,
+            "hix_threshold": settings.HIX_REQUIRED_FOR_MT,
+            "ready_for_mt_count": len(hix_translations) - not_ready_for_mt_count,
+            "total_count": len(hix_translations),
+        }

--- a/integreat_cms/cms/views/analytics/translation_coverage_view.py
+++ b/integreat_cms/cms/views/analytics/translation_coverage_view.py
@@ -125,9 +125,7 @@ class TranslationCoverageView(TemplateView):
             return {}
 
         # Get all pages of this region which are considered for the HIX value
-        hix_pages = region.get_pages(return_unrestricted_queryset=True).filter(
-            hix_ignore=False
-        )
+        hix_pages = region.get_pages().filter(hix_ignore=False)
 
         # Get the latest versions of the page translations for these pages
         hix_translations = PageTranslation.objects.filter(

--- a/integreat_cms/cms/views/dashboard/dashboard_view.py
+++ b/integreat_cms/cms/views/dashboard/dashboard_view.py
@@ -1,10 +1,15 @@
 import logging
+from datetime import datetime
 
+from dateutil.relativedelta import relativedelta
 from django.conf import settings
+from django.db.models import Case, Exists, F, OuterRef, Subquery, When
 from django.utils import translation
 from django.views.generic import TemplateView
 
-from ...models import PageTranslation
+from ...constants import status
+from ...models import Feedback, Page, PageTranslation
+from ...utils.linkcheck_utils import filter_urls
 from ..chat.chat_context_mixin import ChatContextMixin
 
 logger = logging.getLogger(__name__)
@@ -42,51 +47,224 @@ class DashboardView(TemplateView, ChatContextMixin):
                 ),
             }
         )
-        context.update(self.get_hix_context())
+
+        context.update(self.get_unreviewed_pages_context())
+        context.update(self.get_automatically_saved_pages())
+        context.update(self.get_unread_feedback_context())
+        context.update(self.get_broken_links_context())
+        context.update(self.get_low_hix_value_context())
+        context.update(self.get_outdated_pages_context())
         return context
 
-    def get_hix_context(self):
+    def get_unreviewed_pages_context(self):
         """
-        Extend context by HIX info
+        Extend context by info on unreviewed pages
 
-        :return: The HIX context dictionary
+        :return: Dictionary containing the context for unreviewed pages
         :rtype: dict
         """
-        if not settings.TEXTLAB_API_ENABLED:
-            return {}
 
-        # Get the current region
-        region = self.request.region
-        if not region.hix_enabled:
-            return {}
+        explicitly_archived_ancestors = Page.objects.filter(
+            tree_id=OuterRef("pk"),
+            lft__lt=OuterRef("lft"),
+            rgt__gt=OuterRef("rgt"),
+            explicitly_archived=True,
+        ).values("pk")
 
-        # Get all pages of this region which are considered for the HIX value
-        hix_pages = region.get_pages(return_unrestricted_queryset=True).filter(
-            hix_ignore=False
+        not_implicitly_archived_ids = Page.objects.filter(
+            id=Case(
+                When(
+                    Exists(explicitly_archived_ancestors),
+                    then=None,
+                ),
+                default=F("pk"),
+            )
         )
 
-        # Get the latest versions of the page translations for these pages
-        hix_translations = PageTranslation.objects.filter(
-            language__slug__in=settings.TEXTLAB_API_LANGUAGES, page__in=hix_pages
-        ).distinct("page_id", "language_id")
-
-        # Get all hix translations where the score is set
-        hix_translations_with_score = [pt for pt in hix_translations if pt.hix_score]
-
-        # Get the worst n pages
-        worst_hix_translations = sorted(
-            hix_translations_with_score, key=lambda pt: pt.hix_score
-        )
-
-        # Get the number of translations which are not ready for MT
-        not_ready_for_mt_count = sum(
-            pt.hix_score < settings.HIX_REQUIRED_FOR_MT
-            for pt in hix_translations_with_score
+        unreviewed_pages = (
+            PageTranslation.objects.filter(
+                page__region=self.request.region,
+                status=status.REVIEW,
+                page__explicitly_archived=False,
+                language__slug=self.request.region.default_language.slug,
+                page__id__in=Subquery(not_implicitly_archived_ids.values("pk")),
+            )
+            .order_by("page__id", "language__id", "-version")
+            .distinct("page__id", "language__id")
+            .all()
         )
 
         return {
-            "worst_hix_translations": worst_hix_translations,
-            "hix_threshold": settings.HIX_REQUIRED_FOR_MT,
-            "ready_for_mt_count": len(hix_translations) - not_ready_for_mt_count,
-            "total_count": len(hix_translations),
+            "unreviewed_pages": unreviewed_pages,
+            "default_language_slug": self.request.region.default_language.slug,
+        }
+
+    def get_automatically_saved_pages(self):
+        r"""
+        Extend context by info on automatically saved pages
+
+        :return: Dictionary containing the context for auto saved pages
+        :rtype: dict
+        """
+        explicitly_archived_ancestors = Page.objects.filter(
+            tree_id=OuterRef("pk"),
+            lft__lt=OuterRef("lft"),
+            rgt__gt=OuterRef("rgt"),
+            explicitly_archived=True,
+        ).values("pk")
+
+        not_implicitly_archived_ids = Page.objects.filter(
+            id=Case(
+                When(
+                    Exists(explicitly_archived_ancestors),
+                    then=None,
+                ),
+                default=F("pk"),
+            )
+        )
+
+        last_versions = (
+            PageTranslation.objects.filter(
+                page__explicitly_archived=False,
+                page__id__in=Subquery(not_implicitly_archived_ids.values("pk")),
+                page__region=self.request.region,
+                language__slug=self.request.region.default_language.slug,
+            )
+            .order_by("page__id", "language__id", "-version")
+            .distinct("page__id", "language__id")
+        )
+
+        automatically_saved_pages = PageTranslation.objects.filter(
+            id__in=Subquery(last_versions.values("pk")),
+            status=status.AUTO_SAVE,
+        )
+
+        return {
+            "automatically_saved_pages": automatically_saved_pages,
+            "default_language_slug": self.request.region.default_language.slug,
+        }
+
+    def get_unread_feedback_context(self):
+        r"""
+        Extend context by info on unread feedback
+
+        :return: Dictionary containing the context for unreviewed pages
+        :rtype: dict
+        """
+        unread_feedback = Feedback.objects.filter(
+            read_by=None, archived=False, region=self.request.region
+        )
+        return {
+            "unread_feedback": unread_feedback,
+        }
+
+    def get_broken_links_context(self):
+        r"""
+        Extend context by info on broken links
+
+        :return: Dictionary containing the context for broken links
+        :rtype: dict
+        """
+        invalid_urls = filter_urls(self.request.region.slug, "invalid")[0]
+        invalid_url = invalid_urls[0] if invalid_urls else None
+
+        relevant_translation = (
+            invalid_url.region_links[0].content_object if invalid_url else None
+        )
+
+        return {
+            "broken_links": invalid_urls,
+            "relevant_translation": relevant_translation,
+            "relevant_url": invalid_url,
+        }
+
+    def get_low_hix_value_context(self):
+        r"""
+        Extend context by info on pages with low hix value
+
+        :return: Dictionary containing the context for pages with low hix value
+        :rtype: dict
+        """
+        pages_under_hix_threshold = []
+        if settings.TEXTLAB_API_ENABLED and self.request.region.hix_enabled:
+            hix_pages = self.request.region.get_pages(
+                return_unrestricted_queryset=True
+            ).filter(hix_ignore=False)
+            hix_translations = PageTranslation.objects.filter(
+                language__slug__in=settings.TEXTLAB_API_LANGUAGES, page__in=hix_pages
+            ).distinct("page_id", "language_id")
+
+            for hix_translation in hix_translations:
+                if (
+                    hix_translation.hix_score is not None
+                    and hix_translation.hix_score < settings.HIX_REQUIRED_FOR_MT
+                ):
+                    pages_under_hix_threshold.append(hix_translation)
+
+            return {
+                "pages_under_hix_threshold": pages_under_hix_threshold,
+            }
+        return {}
+
+    def get_outdated_pages_context(self):
+        r"""
+        Extend context by info on outdated pages
+
+        :return: Dictionary containing the context for outdated pages
+        :rtype: dict
+        """
+        OUTDATED_THRESHOLD_DATE = datetime.now() - relativedelta(
+            days=settings.OUTDATED_THRESHOLD_DAYS
+        )
+
+        explicitly_archived_ancestors = Page.objects.filter(
+            tree_id=OuterRef("pk"),
+            lft__lt=OuterRef("lft"),
+            rgt__gt=OuterRef("rgt"),
+            explicitly_archived=True,
+        ).values("pk")
+
+        not_implicitly_archived_ids = Page.objects.filter(
+            id=Case(
+                When(
+                    Exists(explicitly_archived_ancestors),
+                    then=None,
+                ),
+                default=F("pk"),
+            )
+        )
+
+        last_versions = (
+            PageTranslation.objects.filter(
+                page__region=self.request.region,
+                page__explicitly_archived=False,
+                page__id__in=Subquery(not_implicitly_archived_ids.values("pk")),
+                language__slug=self.request.region.default_language.slug,
+            )
+            .order_by("page__id", "language__id", "-version", "last_updated")
+            .distinct("page__id", "language__id")
+        )
+
+        outdated_pages = PageTranslation.objects.filter(
+            id__in=Subquery(last_versions.values("pk")),
+            last_updated__lte=OUTDATED_THRESHOLD_DATE.date(),
+        )
+
+        # print(outdated_pages)
+
+        days_since_last_updated = (
+            (
+                datetime.today() - most_outdated_page.last_updated.replace(tzinfo=None)
+            ).days
+            if (most_outdated_page := outdated_pages[0] if outdated_pages else None)
+            else None
+        )
+
+        OUTDATED_THRESHOLD_DATE = OUTDATED_THRESHOLD_DATE.strftime("%Y-%m-%d")
+
+        return {
+            "outdated_pages": outdated_pages,
+            "most_outdated_page": most_outdated_page,
+            "days_since_last_updated": days_since_last_updated,
+            "outdated_threshold_date": OUTDATED_THRESHOLD_DATE,
         }

--- a/integreat_cms/cms/views/pages/page_actions.py
+++ b/integreat_cms/cms/views/pages/page_actions.py
@@ -873,9 +873,7 @@ def refresh_date(
     :rtype: ~django.http.HttpResponseRedirect
     """
     region = request.region
-    page = get_object_or_404(
-        region.get_pages(archived=False, return_unrestricted_queryset=True), id=page_id
-    )
+    page = get_object_or_404(region.get_pages(archived=False), id=page_id)
 
     if not request.user.has_perm("cms.change_page_object", page):
         raise PermissionDenied(

--- a/integreat_cms/cms/views/regions/region_update_view.py
+++ b/integreat_cms/cms/views/regions/region_update_view.py
@@ -64,9 +64,7 @@ class RegionUpdateView(CustomUpdateView):
         response = super().post(request, *args, **kwargs)
 
         if self.object.status == region_status.ARCHIVED:
-            self.object.get_pages(return_unrestricted_queryset=True).update(
-                mirrored_page=None
-            )
+            self.object.get_pages().update(mirrored_page=None)
             invalidate_model(Page)
 
         return response

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -1125,3 +1125,10 @@ XLIFF_URL = "/xliff/"
 
 # Our database operations should never exceed 60 seconds
 DB_MUTEX_TTL_SECONDS = 60
+
+#############
+# Dashboard #
+#############
+
+#: Days after which a page is considered to be outdated in the todo dashboard
+OUTDATED_THRESHOLD_DAYS = 365

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -4783,9 +4783,149 @@ msgstr "Seite neu laden"
 msgid "Continue reading"
 msgstr "Weiterlesen"
 
+#: cms/templates/dashboard/_todo_dashboard_row.html
+msgid "in total"
+msgstr "Insgesamt"
+
+#: cms/templates/dashboard/_todo_dashboard_widget.html
+msgid "To-Do's"
+msgstr "To-Dos"
+
+#: cms/templates/dashboard/_todo_dashboard_widget.html
+msgid ""
+"Every day you can find a list of ideas on how you can improve the content of "
+"your pages"
+msgstr ""
+"Hier finden Sie jeden Tag eine Liste mit Vorschlägen, wie Sie die Inhalte "
+"auf Ihren Seiten verbessern können."
+
 #: cms/templates/dashboard/region_selection.html
 msgid "Select region"
 msgstr "Region auswählen"
+
+#: cms/templates/dashboard/todo_dashboard_rows/_automatically_saved_pages_row.html
+msgid "Automatically saved pages"
+msgstr "Automatisch gespeicherte Seiten"
+
+#: cms/templates/dashboard/todo_dashboard_rows/_automatically_saved_pages_row.html
+#, python-format
+msgid ""
+"The page <b>%(single_automatically_saved_page)s</b> has been saved "
+"automatically. Please don't forget to publish this page once it's ready."
+msgstr ""
+"Die Seite <b>%(single_automatically_saved_page)s</b> wurde automatisch "
+"gesepeichert. Bitte vergessen Sie nicht die Seite zu veröffentlichen, sobald "
+"diese fertig ist."
+
+#: cms/templates/dashboard/todo_dashboard_rows/_automatically_saved_pages_row.html
+msgid "At the moment there are no automatically saved pages. Good job!"
+msgstr "Aktuell gibt es keine automatisch gespeicherte Seite. Gute Arbeit!"
+
+#: cms/templates/dashboard/todo_dashboard_rows/_automatically_saved_pages_row.html
+#: cms/templates/dashboard/todo_dashboard_rows/_low_hix_row.html
+#: cms/templates/dashboard/todo_dashboard_rows/_outdated_pages_row.html
+#: cms/templates/dashboard/todo_dashboard_rows/_unread_feedback_row.html
+#: cms/templates/dashboard/todo_dashboard_rows/_unreviewed_pages_row.html
+msgid "Go to page"
+msgstr "Zur Seite"
+
+#: cms/templates/dashboard/todo_dashboard_rows/_broken_links_row.html
+#: cms/templates/linkcheck/links_by_filter.html
+msgid "Broken links"
+msgstr "Fehlerhafte Links"
+
+#: cms/templates/dashboard/todo_dashboard_rows/_broken_links_row.html
+#, python-format
+msgid ""
+"The page <b>%(relevant_translation)s</b> has a broken link. Please replace "
+"it by a functional link."
+msgstr ""
+"Auf der Seite <b>%(relevant_translation)s</b> befindet sich ein fehlerhafter "
+"Link. Tauschen Sie diesen aus."
+
+#: cms/templates/dashboard/todo_dashboard_rows/_broken_links_row.html
+msgid "At the moment there are no broken links. Good job!"
+msgstr "Aktuell gibt es keine fehlerhaften Links. Gute Arbeit!"
+
+#: cms/templates/dashboard/todo_dashboard_rows/_broken_links_row.html
+msgid "Go to link"
+msgstr "Zum Link"
+
+#: cms/templates/dashboard/todo_dashboard_rows/_low_hix_row.html
+msgid "Pages with low hix score"
+msgstr "Seiten mit niedrigem HIX-Wert"
+
+#: cms/templates/dashboard/todo_dashboard_rows/_low_hix_row.html
+#, python-format
+msgid ""
+"The page <b>%(worst_page)s</b> has a HIX score of "
+"%(worst_page.hix_score|floatformat:2)s. Please adjust the hix score of this "
+"page to be able to machine translate it"
+msgstr ""
+"Der HIX-Wert der Seite <b>%(worst_page)s</b> befträgt aktuell "
+"%(worst_page.hix_score|floatformat:2)s. Passen Sie die Seite an, damit sie "
+"maschinell übersetzt werden kann."
+
+#: cms/templates/dashboard/todo_dashboard_rows/_low_hix_row.html
+msgid "At the moment all pages are ready for machine translation. Good job!"
+msgstr ""
+"Aktuell sind alle Seiten bereit zur maschinellen Übersetzung. Gute Arbeit!"
+
+#: cms/templates/dashboard/todo_dashboard_rows/_outdated_pages_row.html
+msgid "Outdated pages"
+msgstr "Veraltete Seiten"
+
+#: cms/templates/dashboard/todo_dashboard_rows/_outdated_pages_row.html
+#, python-format
+msgid ""
+"The page <b>%(most_outdated_page)s</b> hasn't been updated in "
+"%(days_since_last_updated)s days. Please make sure that the content on this "
+"page is still relevant and up-to-date"
+msgstr ""
+"Die Seite <b>%(most_outdated_page)s</b> wurde seit "
+"%(days_since_last_updated)s Tagen nicht mehr aktualisiert. Prüfen Sie jetzt, "
+"ob die Inhalte noch aktuell sind."
+
+#: cms/templates/dashboard/todo_dashboard_rows/_outdated_pages_row.html
+msgid ""
+"At the moment there is no page that hasn't been updated in the last 365 "
+"days. Good job!"
+msgstr ""
+"Aktuell gibt es keine Seite, die nicht in den letzten 365 Tagen aktualisiert "
+"wurde. Gute Arbeit!"
+
+#: cms/templates/dashboard/todo_dashboard_rows/_unread_feedback_row.html
+msgid "Unread feedback"
+msgstr "Ungelesenes Feedback"
+
+#: cms/templates/dashboard/todo_dashboard_rows/_unread_feedback_row.html
+msgid ""
+"You have unread feedback. Please answer your feedback to improve the quality "
+"of your pages and improve the relationship to the users."
+msgstr ""
+"Sie haben ungelesenes Feedback. Beantworten Sie dieses, um die Qualität "
+"Ihrer Seiten und den Kontakt zu Nutzer*innen zu verbessern."
+
+#: cms/templates/dashboard/todo_dashboard_rows/_unread_feedback_row.html
+msgid "At the moment there is no unread feedback. Good job!"
+msgstr "Aktuell gibt es kein unglesenes Feedback. Gute Arbeit!"
+
+#: cms/templates/dashboard/todo_dashboard_rows/_unreviewed_pages_row.html
+msgid "Pages that are waiting for review"
+msgstr "Seiten, die zum Review vorliegen"
+
+#: cms/templates/dashboard/todo_dashboard_rows/_unreviewed_pages_row.html
+#, python-format
+msgid ""
+"The page <b>%(single_unreviewed_page)s</b> is waiting for a review. Please "
+"review, if the content on the page is correct."
+msgstr ""
+"Die Seite <b>%(single_unreviewed_page)s</b> liegt zur Überprüfung vor. Bitte "
+"beurteilen Sie, ob die Seite fehlerfrei ist."
+
+#: cms/templates/dashboard/todo_dashboard_rows/_unreviewed_pages_row.html
+msgid "At the moment there is no page waiting for a review. Good job!"
+msgstr "Aktuell liegen keine Seiten zur Überprüfung vor.Gute Arbeit!"
 
 #: cms/templates/emails/_base_email.html
 #: cms/templates/emails/password_reset_email.txt
@@ -5811,10 +5951,6 @@ msgstr "Inhalt aufrufen"
 #: cms/templates/linkcheck/link_list_row.html
 msgid "Replace URL globally"
 msgstr "URL zentral ersetzen"
-
-#: cms/templates/linkcheck/links_by_filter.html
-msgid "Broken links"
-msgstr "Fehlerhafte Links"
 
 #: cms/templates/linkcheck/links_by_filter.html
 msgid "All links"
@@ -9447,6 +9583,9 @@ msgstr ""
 #~ msgstr ""
 #~ "Es ist möglich, dass Push-Benachrichtigungen nur stündlich gesendet werden"
 
+#~ msgid "Good job! You don't have any open task."
+#~ msgstr "Aktuell liegen keine Seiten zur Überprüfung vor. Gute Arbeit!"
+
 #~ msgid "You can however archive this page."
 #~ msgstr "Sie können diese Seite jedoch archivieren."
 
@@ -10739,9 +10878,6 @@ msgstr ""
 
 #~ msgid "Enter the role's name here"
 #~ msgstr "Name der Rolle hier eingeben"
-
-#~ msgid "Hits (total)"
-#~ msgstr "Aufrufe (absolut)"
 
 #~ msgid ""
 #~ "There was an error during the establishment of a connection. Please check "

--- a/integreat_cms/release_notes/current/unreleased/2107.yml
+++ b/integreat_cms/release_notes/current/unreleased/2107.yml
@@ -1,0 +1,2 @@
+en: Add todo dashboard
+de: Füge ToDo-Dashboard hinzu

--- a/integreat_cms/sitemap/sitemaps.py
+++ b/integreat_cms/sitemap/sitemaps.py
@@ -145,7 +145,7 @@ class PageSitemap(WebappSitemap):
         super().__init__(region, language)
         # Filter queryset based on region and language
         self.queryset = self.queryset.filter(
-            page__in=self.region.get_pages(return_unrestricted_queryset=True),
+            page__in=self.region.get_pages(),
             language=self.language,
         ).distinct("page__pk")
 

--- a/tests/cms/views/view_config.py
+++ b/tests/cms/views/view_config.py
@@ -480,6 +480,22 @@ VIEWS = [
                     "offers": [3],
                 },
             ),
+            (
+                "edit_region",
+                PRIV_STAFF_ROLES,
+                {
+                    "administrative_division": "CITY",
+                    "name": "Augsburg",
+                    "admin_mail": "augsburg@example.com",
+                    "postal_code": "86150",
+                    "status": "ARCHIVED",
+                    "longitude": 1,
+                    "latitude": 1,
+                    "timezone": "Europe/Berlin",
+                    "deepl_renewal_month": 6,
+                    "offers": [3],
+                },
+            ),
         ],
         # The kwargs for these views
         {"slug": "augsburg"},

--- a/tests/sitemap/sitemap_config.py
+++ b/tests/sitemap/sitemap_config.py
@@ -7,46 +7,46 @@ SITEMAPS = [
     (
         "/sitemap.xml",
         "tests/sitemap/expected-sitemaps/sitemap-index.xml",
-        43,
+        38,
     ),
     (
         "/augsburg/de/sitemap.xml",
         "tests/sitemap/expected-sitemaps/sitemap-augsburg-de.xml",
-        144,
+        142,
     ),
     (
         "/augsburg/en/sitemap.xml",
         "tests/sitemap/expected-sitemaps/sitemap-augsburg-en.xml",
-        130,
+        128,
     ),
     (
         "/augsburg/ar/sitemap.xml",
         "tests/sitemap/expected-sitemaps/sitemap-augsburg-ar.xml",
-        106,
+        104,
     ),
     (
         "/augsburg/fa/sitemap.xml",
         "tests/sitemap/expected-sitemaps/sitemap-augsburg-fa.xml",
-        85,
+        83,
     ),
     (
         "/nurnberg/de/sitemap.xml",
         "tests/sitemap/expected-sitemaps/sitemap-nurnberg-de.xml",
-        75,
+        73,
     ),
     (
         "/nurnberg/en/sitemap.xml",
         "tests/sitemap/expected-sitemaps/sitemap-nurnberg-en.xml",
-        54,
+        52,
     ),
     (
         "/nurnberg/ar/sitemap.xml",
         "tests/sitemap/expected-sitemaps/sitemap-nurnberg-ar.xml",
-        33,
+        31,
     ),
     (
         "/nurnberg/fa/sitemap.xml",
         "tests/sitemap/expected-sitemaps/sitemap-nurnberg-fa.xml",
-        26,
+        24,
     ),
 ]


### PR DESCRIPTION
### Short description
This PR adds the new todo dashboard to the dashboard. It takes the place of the HIX analysis box. The HIX analysis box is instead moved to the translation coverage section.


### Proposed changes
<!-- Describe this PR in more detail. -->

- Add new todo dashboard box
- Add template for todos
- Add six todos for the first version of the todo dashboard
- Move the HIX analysis to translation coverage


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
I think none


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2107


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
