### PR TITLE
Add graceful error messages when sending mail

### DIFF
--- a/integreat_cms/cms/utils/welcome_mail_utils.py
+++ b/integreat_cms/cms/utils/welcome_mail_utils.py
@@ -2,12 +2,12 @@ import logging
 
 from django.conf import settings
 from django.contrib import messages
-from django.core.mail import BadHeaderError
 from django.utils.encoding import force_bytes
 from django.utils.http import urlsafe_base64_encode
 from django.utils.text import capfirst
 from django.utils.translation import gettext as _
 
+from ..utils.translation_utils import gettext_many_lazy as __
 from .account_activation_token_generator import account_activation_token_generator
 from .email_utils import send_mail
 
@@ -73,9 +73,11 @@ def send_welcome_mail(request, user, activation):
                 debug_mail_type, user.full_user_name
             ),
         )
-    except BadHeaderError as e:
-        logger.exception(e)
+    except RuntimeError as e:
         messages.error(
             request,
-            _("An error occurred! Could not send {}.").format(debug_mail_type),
+            __(
+                _("An error occurred! Could not send {}.").format(debug_mail_type),
+                e,
+            ),
         )

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -7370,6 +7370,22 @@ msgstr ""
 "verändern soll und keine Aktualisierung der Übersetzungen in anderen "
 "Sprachen erfordert."
 
+#: cms/utils/email_utils.py
+msgid "Malformed header data."
+msgstr "Fehlerhafte Header-Daten."
+
+#: cms/utils/email_utils.py
+msgid "Invalid email credentials."
+msgstr "Ungültige E-Mail-Anmeldedaten."
+
+#: cms/utils/email_utils.py
+msgid "An SMTP error occured."
+msgstr "Ein SMTP-Fehler ist aufgetreten."
+
+#: cms/utils/email_utils.py
+msgid "The email server refused the connection."
+msgstr "Der E-Mail-Server hat die Verbindung abgelehnt."
+
 #: cms/utils/internal_link_checker.py
 msgid "Imprint does not exist or is not public in this language"
 msgstr ""
@@ -7468,6 +7484,7 @@ msgid "{} was successfully sent to user {}."
 msgstr "{} wurde erfolgreich an {} gesendet."
 
 #: cms/utils/welcome_mail_utils.py
+#: cms/views/authentication/password_reset_view.py
 msgid "An error occurred! Could not send {}."
 msgstr "Es ist ein Fehler aufgetreten! Die {} konnte nicht versendet werden."
 
@@ -7546,6 +7563,10 @@ msgstr ""
 "Wenn Sie keine E-Mail erhalten, vergewissern Sie sich bitte, dass Sie die "
 "Adresse eingegeben haben, mit der Sie sich registriert haben, und überprüfen "
 "Sie Ihren Spam-Ordner."
+
+#: cms/views/authentication/password_reset_view.py
+msgid "password reset email"
+msgstr "E-Mail zum Zurücksetzen des Passworts"
 
 #: cms/views/authentication/totp_login_view.py
 msgid "Login failed."
@@ -8998,6 +9019,9 @@ msgid "This page belongs to another region ({})."
 msgstr ""
 "Diese Seite konnte nicht importiert werden, da sie zu einer anderen Region "
 "gehört ({})."
+
+#~ msgid "SMTP error."
+#~ msgstr "SMTP-Fehler."
 
 #~ msgid "You can however archive this page."
 #~ msgstr "Sie können diese Seite jedoch archivieren."

--- a/integreat_cms/release_notes/current/unreleased/2046.yml
+++ b/integreat_cms/release_notes/current/unreleased/2046.yml
@@ -1,0 +1,2 @@
+en: Show graceful error message when failing to send mail
+de: Zeige hilfreichere Fehlermeldung, wenn das Senden von E-Mails fehlschlägt


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Display a graceful error message instead of Internal Server Error when failing to send mail.


### Proposed changes
<!-- Describe this PR in more detail. -->

- Catch multiple types of exceptions
  - *BadHeaderError (was already there, now giving slightly more context)*
  - SMTPAuthenticationError (special SMTPException)
  - SMTPException
  - ConnectionRefusedError
- Every exception gets the same base message that already existed, with a brief hint on what the actual problem is. This might make them more content (they get a feeling of knowing what's wrong, not only that something is wrong) and possibly speed up the investigation process when they report it.

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Only a few hours ago I claimed I would be focusing on Reviews and not submit any new PRs for now. With this I kinda loose credibility, don't I? :sweat_smile: 
- Code should be fine


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2046 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
