### PR TITLE
Raise minimum required nodejs version to 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This content management system helps local integration experts to provide multil
 Following packages are required before installing the project (install them with your package manager):
 
 * `npm` version 7 or later
-* `nodejs` version 12 or later
+* `nodejs` version 18 or later
 * `python3` version 3.9 or later
 * `python3-pip` (Debian-based distributions) / `python-pip` (Arch-based distributions)
 * `python3-venv` (only on Debian-based distributions)

--- a/docs/src/installation.rst
+++ b/docs/src/installation.rst
@@ -14,7 +14,7 @@ Following packages are required before installing the project (install them with
 
 * `git <https://git-scm.com/>`_
 * `npm <https://www.npmjs.com/>`_ version 7 or later
-* `nodejs <https://nodejs.org/>`_ version 12 or later
+* `nodejs <https://nodejs.org/>`_ version 18 or later
 * `python3 <https://www.python.org/>`_ version 3.9 or later
 * `python3-pip <https://packages.ubuntu.com/search?keywords=python3-pip>`_ (`Debian-based distributions <https://en.wikipedia.org/wiki/Category:Debian-based_distributions>`_, e.g. `Ubuntu <https://ubuntu.com>`__) / `python-pip <https://www.archlinux.de/packages/extra/x86_64/python-pip>`_ (`Arch-based distributions <https://wiki.archlinux.org/index.php/Arch-based_distributions>`_)
 * `python3-venv <https://packages.ubuntu.com/search?keywords=python3+venv>`_ (Only `Debian-based distributions <https://en.wikipedia.org/wiki/Category:Debian-based_distributions>`_, e.g. `Ubuntu <https://ubuntu.com>`__)

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -73,7 +73,7 @@ if [[ $(major "$npm_version") -lt "$required_npm_version" ]]; then
     exit 1
 fi
 # Define the required npm version
-required_node_version="12"
+required_node_version="18"
 # Check if nodejs is installed
 if [[ ! -x "$(command -v node)" ]]; then
     echo "The package nodejs is not installed. Please install nodejs version ${required_node_version} or higher manually and run this script again."  | print_error


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Installing integreat with node 12 causes this error on initial startup:

```
[webpack] [webpack-cli] Failed to load '/home/user/dev/integreat-cms/webpack.config.js' config
[webpack] [webpack-cli] /home/user/dev/integreat-cms/node_modules/jest-worker/build/index.js:126
[webpack]       enableWorkerThreads: this._options.enableWorkerThreads ?? false,
[webpack]                                                               ^
```

Support for the nullish coalescing operator was added in node 14, which seems to be the minimal required version now (Though it is outdated).

### Proposed changes
<!-- Describe this PR in more detail. -->
- Replace version 12 with 18


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
/ 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: /


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
