### PR TITLE
Do not show empty mirrored content as fallback

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/2172.yml
+++ b/integreat_cms/release_notes/current/unreleased/2172.yml
@@ -1,0 +1,2 @@
+en: Do not show empty translation as fallback
+de: Zeige keine leere Übersetzung als Fallback


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the bug that not only non-empty translations but also empty translasions are suggested as fallback of the embedded content.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Filter empty translations out of the fallback list
- Return an empty string as in the case where the page has no mirrored content, if  there is no non-empty translations which can be a fallback. (Otherwise no language will be shown after the message _Part of the page does not exist in the selected language. It is however available in these languages:_ and it is confusing.)


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- I may have misunderstood some part of the functionalitry and/or the wished status 🙈 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2172 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
