### PR TITLE
Fix deleting Language Tree Node

### DIFF
--- a/integreat_cms/cms/views/language_tree/language_tree_actions.py
+++ b/integreat_cms/cms/views/language_tree/language_tree_actions.py
@@ -114,12 +114,6 @@ def delete_language_tree_node(request, region_slug, pk):
     poi_translations = language_node.language.poi_translations
     # filter those translation that belong to the region and delete them
     poi_translations.filter(poi__region=region).delete()
-    # get all push notification translation assigned to the language node
-    push_notification_translations = (
-        language_node.language.push_notification_translations
-    )
-    # filter those translation that belong to the region and delete them
-    push_notification_translations.filter(push_notification__region=region).delete()
 
     logger.debug("%r deleted by %r", language_node, request.user)
     language_node.delete()


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

This PR cleans up a forgotten `.filter(push_notification__region=region)` in `language_tree_actions.py`

### Proposed changes
<!-- Describe this PR in more detail. -->

- remove the statement for deleting PushNotificationTranslations, now they might be used in other regions the PushNotification is assigned to


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- PushNotificationTranslations might be left in the database that are not in use by any region


### Alternatives

- Clean up thoroughly by:
    - querying the  Language Tree of all regions the PushNotification is also assigned to
    - determining which PushNotificationTranslations are now "orphaned" (rather: no longer in use)
    - deleting those


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
