### PR TITLE
Mark bounding box field as not null in api

### DIFF
--- a/docs/src/api-docs.rst
+++ b/docs/src/api-docs.rst
@@ -57,7 +57,7 @@ RESPONSE
        "latitude": Number | null,       // latitude of the geographic center of the region
        "bounding_box": [                // The bounding box of the region, containing two coordinates
             [Number, Number], [Number, Number]
-        ] | null,
+        ],
        "aliases": {                     // value can also be NULL
            "<alias>": {                 // name of a region alias (smaller municipality within a region)
                "longitude": Number,     // longitude of the geographic center of the region alias


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr fixes a bug in the api documentation

### Proposed changes
<!-- Describe this PR in more detail. -->
- Don't mark the region bounding box field as potentially null, the cms always returns at least the `settings.DEFAULT_BOUNDING_BOX`


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
/


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

https://chat.tuerantuer.org/digitalfabrik/pl/1o1rgw9fi3ny8qtqa1q7by571y


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
