### PR TITLE
Fix "HIX score outdated"

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/2300.yml
+++ b/integreat_cms/release_notes/current/unreleased/2300.yml
@@ -1,0 +1,2 @@
+en: HIX value is no longer instantly outdated, if only some text was selected
+de: HIX-Wert ist nicht mehr sofort veraltet, wenn Text lediglich ausgewählt wurde

--- a/integreat_cms/static/src/js/analytics/hix-widget.ts
+++ b/integreat_cms/static/src/js/analytics/hix-widget.ts
@@ -16,6 +16,8 @@ import { getCsrfToken } from "../utils/csrf-token";
 // See https://www.chartjs.org/docs/latest/getting-started/integration.html#bundlers-webpack-rollup-etc for details
 Chart.register(DoughnutController, ArcElement, CategoryScale, LinearScale, Tooltip, Title);
 
+let initialContent: string = null;
+
 const updateChart = (chart: Chart, value: number) => {
     const hixMaxValue = 20;
     const hixThresholdGood = 15;
@@ -78,13 +80,14 @@ const setHixLabelState = (state: string) => {
 const getHixValue = async () => {
     const updateButton = document.getElementById("btn-update-hix-value");
     let result;
+    const sentContent = getContent().trim();
     await fetch(updateButton.dataset.url, {
         method: "POST",
         headers: {
             "X-CSRFToken": getCsrfToken(),
         },
         body: JSON.stringify({
-            text: getContent(),
+            text: sentContent,
         }),
     })
         .then((response) => response.json())
@@ -92,6 +95,9 @@ const getHixValue = async () => {
             const labelState = json.error ? "error" : "updated";
             setHixLabelState(labelState);
             result = json.score;
+            if (!json.error) {
+                initialContent = sentContent;
+            }
         });
     return result;
 };
@@ -170,7 +176,9 @@ window.addEventListener("load", async () => {
     };
 
     const initHixValue = async () => {
-        if (!getContent().trim()) {
+        initialContent = getContent().trim();
+
+        if (!initialContent) {
             setHixLabelState("no-content");
             return;
         }
@@ -188,9 +196,19 @@ window.addEventListener("load", async () => {
     document.querySelectorAll("[data-content-changed]").forEach((element) => {
         // make sure initHixValue is called only after tinyMCE is initialized
         element.addEventListener("tinyMCEInitialized", initHixValue);
-        element.addEventListener("contentChanged", () =>
-            setHixLabelState(getContent().trim() ? "outdated" : "no-content")
-        );
+        element.addEventListener("contentChanged", () => {
+            const content = getContent().trim();
+            const labelState = (() => {
+                if (!content) {
+                    return "no-content";
+                }
+                if (content !== initialContent) {
+                    return "outdated";
+                }
+                return "updated";
+            })();
+            return setHixLabelState(labelState);
+        });
     });
 
     // Set listener for update button


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

Any action within the tinymce editor modifies the content, and should thus set the content to be *dirty*. At least, this is the assumption of tinymce. But there are actions that do not modify the content, like making a selection, or end up at a previous state, like adding a character back after accidentally removing it.

This PR fixes this problem by simply monkeypatching tinymce's `isDirty()` and `setDirty()` methods, always comparing it to a previous value and saving that on successful autosaves.
Evaluating the HIX score also sets such a value to use as basis for determining whether an earlier score is actually outdated or not.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Monkeypatch tinymce `isDirty()` and `setDirty()` to actually represent the content being different from the last saved state
    - tinymce provides this nice `startContent` property that is initialised to the initial content and then never used anywhere
    - We compare against that and set it after successful autosaves (using the actual content that was sent when the autosave was triggered)
- Have a similar value to compare whether the content is different from the last HIX evaluation and display the hints based on that

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- `isDirty()` behaves differently now (not relying on the `isNotDirty` property anymore) and `setDirty()` tries to keep `isNotDirty` in line with what the new `isDirty()` would probably return if no changes to this are missed (this might get out of sync when an autosave is performed)


### Additional notes

- Where should I best put the monkeypatch?
- Do we want a monkeypatch at all? (It seems very logical to me in this case, but it still feels… dirty :upside_down_face:)

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2300


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
