### PR TITLE
Fix error when archiving a page

### DIFF
--- a/integreat_cms/cms/views/bulk_action_views.py
+++ b/integreat_cms/cms/views/bulk_action_views.py
@@ -278,14 +278,14 @@ class BulkArchiveView(BulkActionView):
                     messages.error(
                         request,
                         _(
-                            "{} cannot be archived because it was embedded as live content from another page."
-                        ).format(content_object.backend_translation.title),
+                            'Page "{}" cannot be archived because it was embedded as live content from another page.'
+                        ).format(content_object.default_translation),
                     )
                 else:
                     messages.success(
                         request,
-                        _("{} was successfully archived").format(
-                            content_object.backend_translation.title
+                        _('Page "{}" was successfully archived').format(
+                            content_object.default_translation
                         ),
                     )
                     content_object.archive()

--- a/integreat_cms/cms/views/bulk_action_views.py
+++ b/integreat_cms/cms/views/bulk_action_views.py
@@ -279,13 +279,13 @@ class BulkArchiveView(BulkActionView):
                         request,
                         _(
                             'Page "{}" cannot be archived because it was embedded as live content from another page.'
-                        ).format(content_object.default_translation),
+                        ).format(content_object.best_translation),
                     )
                 else:
                     messages.success(
                         request,
                         _('Page "{}" was successfully archived').format(
-                            content_object.default_translation
+                            content_object.best_translation
                         ),
                     )
                     content_object.archive()

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -7739,15 +7739,15 @@ msgstr "Die ausgewählten {} wurden erfolgreich {}"
 
 #: cms/views/bulk_action_views.py
 msgid ""
-"{} cannot be archived because it was embedded as live content from another "
-"page."
+"Page \"{}\" cannot be archived because it was embedded as live content from "
+"another page."
 msgstr ""
-"{} kann nicht archiviert werden, da sie von einer anderen Seite als Live-"
-"Inhalt eingebunden wurde."
+"Seite \"{}\" kann nicht archiviert werden, da sie von einer anderen Seite "
+"als Live-Inhalt eingebunden wurde."
 
 #: cms/views/bulk_action_views.py
-msgid "{} was successfully archived"
-msgstr "{} wurde erfolgreich archiviert"
+msgid "Page \"{}\" was successfully archived"
+msgstr "Seite \"{}\" wurde erfolgreich archiviert"
 
 #: cms/views/bulk_action_views.py
 msgid "The selected {} were successfully archived"

--- a/integreat_cms/release_notes/current/unreleased/2404.yml
+++ b/integreat_cms/release_notes/current/unreleased/2404.yml
@@ -1,0 +1,2 @@
+en: Move the clear formatting button to the center in the editor
+de: Verschiebe die Schaltfläche "Formatierung entfernen" in die Mitte des Editors

--- a/integreat_cms/release_notes/current/unreleased/2405.yml
+++ b/integreat_cms/release_notes/current/unreleased/2405.yml
@@ -1,0 +1,2 @@
+en: Fix error when trying to archive a page without backend language translation
+de: Behebe Fehler bei der Archivierung einer Seite ohne Backend-Sprachübersetzung

--- a/integreat_cms/static/src/js/forms/tinymce-init.ts
+++ b/integreat_cms/static/src/js/forms/tinymce-init.ts
@@ -105,7 +105,7 @@ window.addEventListener("load", () => {
             branding: false,
             paste_as_text: true,
             toolbar:
-                "bold italic underline forecolor | bullist numlist | styleselect | undo redo | ltr rtl notranslate | aligncenter indent outdent | link openmediacenter | export | removeformat ",
+                "bold italic underline forecolor | bullist numlist | styleselect | removeformat | undo redo | ltr rtl notranslate | aligncenter indent outdent | link openmediacenter | export ",
             style_formats: [
                 {
                     title: "Headings",


### PR DESCRIPTION
### Short description
The error occurs when trying to archive pages without translation in the backend language, because this action uses a title in the backend language to print a success message


### Proposed changes
- use default language to print a success message

I also included a change for another tiny task: move "Clear formatting" button to the center in the editor to make it more visible


### Side effects
- no ?


### Resolved issues
Fixes: #2405
Fixes: #2404


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
