### PR TITLE
Invalidate cache when archiving feedback

### DIFF
--- a/integreat_cms/cms/views/feedback/admin_feedback_actions.py
+++ b/integreat_cms/cms/views/feedback/admin_feedback_actions.py
@@ -3,7 +3,7 @@ This module contains action methods for feedback items (archive, restore, ...)
 """
 import logging
 
-from cacheops import invalidate_obj
+from cacheops import invalidate_model, invalidate_obj
 from django.contrib import messages
 from django.shortcuts import redirect
 from django.utils.translation import gettext as _
@@ -88,6 +88,7 @@ def archive_admin_feedback(request):
     Feedback.objects.filter(id__in=selected_ids, is_technical=True).update(
         archived=True
     )
+    invalidate_model(Feedback)
 
     logger.info("Feedback objects %r archived by %r", selected_ids, request.user)
     messages.success(request, _("Feedback was successfully archived"))
@@ -112,6 +113,7 @@ def restore_admin_feedback(request):
     Feedback.objects.filter(id__in=selected_ids, is_technical=True).update(
         archived=False
     )
+    invalidate_model(Feedback)
 
     logger.info("Feedback objects %r restored by %r", selected_ids, request.user)
     messages.success(request, _("Feedback was successfully restored"))

--- a/integreat_cms/cms/views/feedback/region_feedback_actions.py
+++ b/integreat_cms/cms/views/feedback/region_feedback_actions.py
@@ -3,7 +3,7 @@ This module contains action methods for feedback items (archive, restore, ...)
 """
 import logging
 
-from cacheops import invalidate_obj
+from cacheops import invalidate_model, invalidate_obj
 from django.contrib import messages
 from django.shortcuts import redirect
 from django.utils.translation import gettext as _
@@ -113,6 +113,7 @@ def archive_region_feedback(request, region_slug):
     Feedback.objects.filter(
         id__in=selected_ids, region=region, is_technical=False
     ).update(archived=True)
+    invalidate_model(Feedback)
 
     logger.info("Feedback objects %r archived by %r", selected_ids, request.user)
     messages.success(request, _("Feedback was successfully archived"))
@@ -142,6 +143,7 @@ def restore_region_feedback(request, region_slug):
     Feedback.objects.filter(
         id__in=selected_ids, region=region, is_technical=False
     ).update(archived=False)
+    invalidate_model(Feedback)
 
     logger.info("Feedback objects %r restored by %r", selected_ids, request.user)
     messages.success(request, _("Feedback was successfully restored"))

--- a/integreat_cms/release_notes/current/unreleased/2399.yml
+++ b/integreat_cms/release_notes/current/unreleased/2399.yml
@@ -1,0 +1,2 @@
+en: Fix a bug where feedback archiving and restoring did not work correctly
+de: Behebe ein Problem, bei dem Feedback nicht korrekt archiviert oder wiederhergestellt werden konnte


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr fixes a bug that feedback archiving does not work when caching is enabled.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Invalidate cache when archiving and restoring feedback


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- General slower performance for feedback queries after archiving or restoring since the invalidation used in this pr is very coarse


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2399 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
