### PR TITLE
Fix transit of translation status icons

### DIFF
--- a/integreat_cms/cms/views/pages/page_actions.py
+++ b/integreat_cms/cms/views/pages/page_actions.py
@@ -325,7 +325,10 @@ def cancel_translation_process_ajax(request, region_slug, language_slug, page_id
             },
             status=404,
         )
-    page_translation.all_versions.update(currently_in_translation=False)
+    if settings.REDIS_CACHE:
+        page_translation.all_versions.invalidated_update(currently_in_translation=False)
+    else:
+        page_translation.all_versions.update(currently_in_translation=False)
     # Get new (respectively old) translation state
     translation_state = page.get_translation_state(language_slug)
     return JsonResponse(

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -307,8 +307,11 @@ INSTALLED_APPS = [
     "widget_tweaks",
 ]
 
+#: Check whether redis is activated
+REDIS_CACHE = bool(strtobool(os.environ.get("INTEGREAT_CMS_REDIS_CACHE", "False")))
+
 # Install cacheops only if redis cache is available
-if "INTEGREAT_CMS_REDIS_CACHE" in os.environ:
+if REDIS_CACHE:
     INSTALLED_APPS.append("cacheops")
 
 # The default Django Admin application and debug toolbar will only be activated if the system is in debug mode.
@@ -923,7 +926,7 @@ CACHES = {
 }
 
 # Use RedisCache when activated
-if bool(strtobool(os.environ.get("INTEGREAT_CMS_REDIS_CACHE", "False"))):
+if REDIS_CACHE:
     if unix_socket := os.environ.get("INTEGREAT_CMS_REDIS_UNIX_SOCKET"):
         # Use unix socket if available (and also tell cacheops about it)
         redis_location = f"unix://{unix_socket}?db=0"

--- a/integreat_cms/deepl_api/deepl_api_client.py
+++ b/integreat_cms/deepl_api/deepl_api_client.py
@@ -197,9 +197,15 @@ class DeepLApiClient(MachineTranslationApiClient):
                     content_translation_form.save()
                     # Revert "currently in translation" value of all versions
                     if existing_target_translation:
-                        existing_target_translation.all_versions.update(
-                            currently_in_translation=False
-                        )
+                        if settings.REDIS_CACHE:
+                            existing_target_translation.all_versions.invalidated_update(
+                                currently_in_translation=False
+                            )
+                        else:
+                            existing_target_translation.all_versions.update(
+                                currently_in_translation=False
+                            )
+
                     logger.debug(
                         "Successfully translated for: %r",
                         content_translation_form.instance,

--- a/integreat_cms/release_notes/current/unreleased/2318.yml
+++ b/integreat_cms/release_notes/current/unreleased/2318.yml
@@ -1,0 +1,2 @@
+en: Fix transit of translation status icons
+de: Behebe Übertragung von Übersetzungsstatussymbolen

--- a/integreat_cms/summ_ai_api/utils.py
+++ b/integreat_cms/summ_ai_api/utils.py
@@ -372,9 +372,15 @@ class TranslationHelper:
         content_translation_form.save()
         # Revert "currently in translation" value of all versions
         if existing_target_translation:
-            existing_target_translation.all_versions.update(
-                currently_in_translation=False
-            )
+            if settings.REDIS_CACHE:
+                existing_target_translation.all_versions.invalidated_update(
+                    currently_in_translation=False
+                )
+            else:
+                existing_target_translation.all_versions.update(
+                    currently_in_translation=False
+                )
+
         logger.debug(
             "Successfully translated %r into Easy German",
             content_translation_form.instance,

--- a/integreat_cms/xliff/base_serializer.py
+++ b/integreat_cms/xliff/base_serializer.py
@@ -229,7 +229,12 @@ class Deserializer(xml_serializer.Deserializer):
         page_translation.version += 1
         # Make sure object is not in translation anymore if it was before
         page_translation.currently_in_translation = False
-        page_translation.all_versions.update(currently_in_translation=False)
+        if settings.REDIS_CACHE:
+            page_translation.all_versions.invalidated_update(
+                currently_in_translation=False
+            )
+        else:
+            page_translation.all_versions.update(currently_in_translation=False)
         # Make sure object is not a minor edit anymore if it was before
         page_translation.minor_edit = False
         # Set the id to None to make sure a new object is stored in the database when save() is called

--- a/integreat_cms/xliff/utils.py
+++ b/integreat_cms/xliff/utils.py
@@ -205,7 +205,12 @@ def page_to_xliff(page, target_language, dir_name, only_public=False):
     logger.debug("Created XLIFF file %r", actual_filename)
 
     # Set "currently in translation" status for existing target translations
-    target_page_translation.all_versions.update(currently_in_translation=True)
+    if settings.REDIS_CACHE:
+        target_page_translation.all_versions.invalidated_update(
+            currently_in_translation=True
+        )
+    else:
+        target_page_translation.all_versions.update(currently_in_translation=True)
 
     return download_storage.path(actual_filename)
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the problem that translation status icons sometimes do not transit correctly and quickly.

The problem can be observed when Redis is activated and especially in/after transit to/from `currently_in_translation`. Therefore I assume that cache of the field `currently_in_translation`, which suppresses other translation statuses, is the cause.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Invalidate cache if Redis is activated.

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- As I could not reproduce the exact cases reported in the issues, this solution may not cover all the cases.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2318
Fixes: #2319 

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
