### PR TITLE
Change 'last updated' field in region list to refer to their content

### DIFF
--- a/integreat_cms/cms/models/regions/region.py
+++ b/integreat_cms/cms/models/regions/region.py
@@ -818,6 +818,42 @@ class Region(AbstractBaseModel):
             },
         )
 
+    @cached_property
+    def last_content_update(self):
+        """
+        Find the latest date at which any content of the
+        region has been modified.
+
+        :return: the last content update date
+        :rtype: datetime.datetime
+        """
+        latest_page_update = self.pages.aggregate(
+            latest_update=models.Max("translations__last_updated")
+        )["latest_update"]
+        latest_poi_update = self.pois.aggregate(
+            latest_update=models.Max("translations__last_updated")
+        )["latest_update"]
+        latest_event_update = self.events.aggregate(
+            latest_update=models.Max("translations__last_updated")
+        )["latest_update"]
+        latest_imprint_update = (
+            self.imprint.translations.aggregate(
+                latest_update=models.Max("last_updated")
+            )["latest_update"]
+            if self.imprint
+            else django_timezone.make_aware(
+                django_timezone.datetime.min, django_timezone.get_default_timezone()
+            )
+        )
+
+        return max(
+            latest_page_update,
+            latest_poi_update,
+            latest_event_update,
+            latest_imprint_update,
+            self.last_updated,
+        )
+
     def __str__(self):
         """
         This overwrites the default Django :meth:`~django.db.models.Model.__str__` method which would return ``Region object (id)``.

--- a/integreat_cms/cms/templates/regions/region_list_row.html
+++ b/integreat_cms/cms/templates/regions/region_list_row.html
@@ -10,7 +10,7 @@
     </td>
     <td>
         <a href="{% url 'edit_region' slug=region.slug %}"
-           class="block py-3 px-2 text-gray-800">{{ region.last_updated }}</a>
+           class="block py-3 px-2 text-gray-800">{{ region.last_content_update }}</a>
     </td>
     <td>
         <a href="{% url 'edit_region' slug=region.slug %}"

--- a/integreat_cms/release_notes/current/unreleased/1836.yml
+++ b/integreat_cms/release_notes/current/unreleased/1836.yml
@@ -1,0 +1,2 @@
+en: '"Last Updated" in the region overview now refers to the contents of that region'
+de: '"Zuletzt aktualisiert" in der Regionsübersicht bezieht sich nun auf die Regionsinhalte'


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Change 'last updated' field in region list to each region's content instead of the region object itself.

### Proposed changes
<!-- Describe this PR in more detail. -->

- add `last_content_update` cached property to region model
- use it instead of `last_updated` in the region list


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none I could find, keeping the `last_updated` field unmodified should prevent any backwards compatibility issues


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1836 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
