### PR TITLE
Invalidate cache when organization was saved

### DIFF
--- a/integreat_cms/core/signals/__init__.py
+++ b/integreat_cms/core/signals/__init__.py
@@ -1,4 +1,4 @@
 """
 This package contains signal handlers (see :doc:`django:topics/signals`).
 """
-from . import auth_signals, feedback_signals, hix_signals
+from . import auth_signals, feedback_signals, hix_signals, organization_signals

--- a/integreat_cms/core/signals/organization_signals.py
+++ b/integreat_cms/core/signals/organization_signals.py
@@ -1,0 +1,21 @@
+"""
+This module contains signal handlers related to organization objects.
+"""
+
+from cacheops import invalidate_model
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from ...cms.models import Organization, Page, PageTranslation
+
+
+@receiver(post_save, sender=Organization)
+def organization_create_handler(**kwargs):
+    r"""
+    Invalidate page translation cache after organization creation
+
+    :param \**kwargs: The supplied keyword arguments
+    :type \**kwargs: dict
+    """
+    invalidate_model(Page)
+    invalidate_model(PageTranslation)

--- a/integreat_cms/release_notes/2021/unreleased/2363.yml
+++ b/integreat_cms/release_notes/2021/unreleased/2363.yml
@@ -1,0 +1,2 @@
+en: Fix bug where outdated organization properties were still delivered in the api
+de: Behebe ein Problem, bei dem veraltete Eigenschaften von Organisationen ausgeliefert wurden


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Another caching related bugfix, where the automatic invalidation system did not invalidate PageTranslations when an organization changed.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Invalidate all PageTranslations when an organization gets saved


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- Also unrelated PageTranslations will not be cached after an organization gets saved


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2363 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
