### PR TITLE
Fix JS error in machine translation overlay

### DIFF
--- a/integreat_cms/static/src/js/machine-translation-overlay.ts
+++ b/integreat_cms/static/src/js/machine-translation-overlay.ts
@@ -176,7 +176,7 @@ const toggleOptionalText = (trigger: HTMLElement, optionalText: HTMLElement) => 
 const addMachineTranslationOverlayEventListeners = () => {
     // add event listeners to overlay
     const overlay = document.getElementById("machine-translation-overlay");
-    const provider = document.getElementById("machine-translation-option").getAttribute("data-mt-provider");
+    const provider = document.getElementById("machine-translation-option")?.getAttribute("data-mt-provider");
     if (overlay && provider === "DeepL") {
         // Set listener for bulk action execute button.
         document.getElementById("bulk-action-execute")?.addEventListener("click", (event) => {


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fix the error

```
Uncaught TypeError: document.getElementById(...) is null
```

In the JS console when the machine translation overlay is not available


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
