### PR TITLE
Add success message when page/event/poi has been auto saved

### DIFF
--- a/integreat_cms/cms/templates/events/event_form.html
+++ b/integreat_cms/cms/templates/events/event_form.html
@@ -38,7 +38,8 @@
             </h1>
             {% if perms.cms.change_event %}
                 {% if not event_form.instance.id or not event_form.instance.archived %}
-                    <div class="flex flex-wrap gap-4 ml-auto mr-0">
+                    <div class="flex flex-wrap gap-4 ml-auto mr-0 items-center">
+                        {% include "generic_auto_save_note.html" with form_instance=event_form.instance %}
                         {% if perms.cms.publish_event %}
                             <button name="status" value="{{ DRAFT }}" class="btn btn-outline">
                                 {% translate "Save as draft" %}

--- a/integreat_cms/cms/templates/generic_auto_save_note.html
+++ b/integreat_cms/cms/templates/generic_auto_save_note.html
@@ -1,0 +1,6 @@
+{% load i18n %}
+<span id="auto-save"
+      class="{% if form_instance.status != AUTO_SAVE %} hidden {% endif %}">
+    <i icon-name="check"></i>
+    {% trans "Automatically saved on:" %} <span id="auto-save-time">{{ form_instance.last_updated }}</span>
+</span>

--- a/integreat_cms/cms/templates/imprint/imprint_form.html
+++ b/integreat_cms/cms/templates/imprint/imprint_form.html
@@ -21,7 +21,8 @@
                     {% translate "Create imprint" %}
                 {% endif %}
             </h1>
-            <div class="flex flex-wrap gap-4">
+            <div class="flex flex-wrap gap-4 ml-auto mr-0 items-center">
+                {% include "generic_auto_save_note.html" with form_instance=imprint_translation_form.instance %}
                 {% if perms.cms.change_imprintpage %}
                     <button name="status" value="{{ DRAFT }}" class="btn btn-outline">
                         {% translate "Save as draft" %}

--- a/integreat_cms/cms/templates/imprint/imprint_sbs.html
+++ b/integreat_cms/cms/templates/imprint/imprint_sbs.html
@@ -20,7 +20,8 @@
                     <i icon-name="arrow-left-circle" class="align-top"></i> {% translate "Back to the imprint form" %}
                 </a>
                 {% if perms.cms.change_imprintpage %}
-                    <div class="flex flex-wrap gap-2">
+                    <div class="flex flex-wrap gap-2 ml-auto mr-0 items-center">
+                        {% include "generic_auto_save_note.html" with form_instance=imprint_translation_form.instance %}
                         <button name="status" value="{{ DRAFT }}" class="btn btn-outline">
                             {% translate "Save as draft" %}
                         </button>

--- a/integreat_cms/cms/templates/pages/page_form.html
+++ b/integreat_cms/cms/templates/pages/page_form.html
@@ -45,7 +45,8 @@
                 {% endif %}
             </h1>
             {% if not page_form.instance.id or not page_form.instance.archived %}
-                <div class="flex flex-wrap grow justify-end gap-2">
+                <div class="flex flex-wrap grow justify-end gap-2 items-center">
+                    {% include "generic_auto_save_note.html" with form_instance=page_translation_form.instance %}
                     <button name="preview_page" type="button" data-preview-page data-edit-page-mode data-right-to-left={{ right_to_left }} class="btn btn-ghost">
                         {% translate "Preview" %}
                     </button>

--- a/integreat_cms/cms/templates/pages/page_sbs.html
+++ b/integreat_cms/cms/templates/pages/page_sbs.html
@@ -19,7 +19,8 @@
                    class="btn btn-outline">
                     <i icon-name="arrow-left-circle" class="align-top"></i> {% translate "Back to the page form" %}
                 </a>
-                <div class="flex flex-wrap gap-2">
+                <div class="flex flex-wrap gap-2 ml-auto mr-0 items-center">
+                    {% include "generic_auto_save_note.html" with form_instance=page_translation_form.instance %}
                     {% has_perm 'cms.change_page_object' request.user source_page_translation.page as can_edit_page %}
                     {% if not source_page_translation.page.archived %}
                         {% has_perm 'cms.publish_page_object' request.user source_page_translation.page as can_publish_page %}

--- a/integreat_cms/cms/templates/pois/poi_form.html
+++ b/integreat_cms/cms/templates/pois/poi_form.html
@@ -33,7 +33,8 @@
                 {% endif %}
             </h1>
             {% if not poi_form.instance.archived and perms.cms.change_poi %}
-                <div class="flex flex-wrap gap-4 ml-auto mr-0">
+                <div class="flex flex-wrap gap-4 ml-auto mr-0 items-center">
+                    {% include "generic_auto_save_note.html" with form_instance=poi_translation_form.instance %}
                     <button name="status" value="{{ DRAFT }}" class="btn btn-outline">
                         {% translate "Save as draft" %}
                     </button>

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -5381,6 +5381,10 @@ msgstr "Kein Feedback mit diesen Filtern gefunden."
 msgid "No feedback available yet."
 msgstr "Noch kein Feedback vorhanden."
 
+#: cms/templates/generic_auto_save_note.html
+msgid "Automatically saved on:"
+msgstr "Automatisch gespeichert am:"
+
 #: cms/templates/generic_confirmation_dialog.html
 #: cms/templates/pages/page_form.html
 msgid "Warning"

--- a/integreat_cms/release_notes/current/unreleased/2002.yml
+++ b/integreat_cms/release_notes/current/unreleased/2002.yml
@@ -1,0 +1,2 @@
+en: Add success message when page/event/location was automatically saved
+de: Füge Erfolgsmeldung hinzu, wenn Seite/Veranstaltung/Ort automatisch gespeichert wurde

--- a/integreat_cms/static/src/js/forms/autosave.ts
+++ b/integreat_cms/static/src/js/forms/autosave.ts
@@ -1,6 +1,18 @@
 import tinymce from "tinymce";
 import { getCsrfToken } from "../utils/csrf-token";
 
+const formatDate = (date: Date) => {
+    const options: Intl.DateTimeFormatOptions = {
+        day: "2-digit",
+        month: "long",
+        year: "numeric",
+        hour: "2-digit",
+        minute: "2-digit",
+    };
+
+    return new Intl.DateTimeFormat(document.documentElement.lang, options).format(date);
+};
+
 export const autosaveEditor = async () => {
     const form = document.getElementById("content_form") as HTMLFormElement;
     tinymce.triggerSave();
@@ -9,6 +21,14 @@ export const autosaveEditor = async () => {
     formData.append("status", "AUTO_SAVE");
     // Override minor edit field to keep translation status
     formData.set("minor_edit", "on");
+    // Show auto save remark
+    const autoSaveNote = document.getElementById("auto-save");
+    autoSaveNote.classList.remove("hidden");
+    const autoSaveTime = document.getElementById("auto-save-time");
+    autoSaveTime.innerText = formatDate(new Date());
+    form.addEventListener("input", () => {
+        autoSaveNote.classList.add("hidden");
+    });
     const data = await fetch(form.action, {
         method: "POST",
         headers: {


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds a message incl. a timestamp to the page form when either the status is automatically saved or when the page form has been automatically saved. 

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add remark that automatically saved to page/event and poi form
- Show remark if last save was auto save
- Show remark if page/event/poi has been auto saved


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- I was struggling to test because my server crashed whenever I tried to reload. But given the fact that I also have this issue on the develop branch I assumed I could ignore it for this PR. To me it seemed like it had more to do [with issue 2128](https://github.com/digitalfabrik/integreat-cms/issues/2128)
- In mobile views this doesn't look great


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2002 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
