### PR TITLE
Repair tree cmd for orphans w/o parent, fix #2432

### DIFF
--- a/integreat_cms/core/management/commands/repair_tree.py
+++ b/integreat_cms/core/management/commands/repair_tree.py
@@ -131,10 +131,9 @@ class Command(LogCommand):
             )
             for orphan in orphans:
                 self.stdout.write(self.bold(f"Page {orphan.id}:"))
-                self.print_error(
-                    f"\tparent_id: {orphan.parent_id}\n"
-                    f"\tparent.tree_id: {orphan.parent.tree_id}"
-                )
+                self.print_error(f"\tparent_id: {orphan.parent_id}")
+                if orphan.parent_id:
+                    self.print_error(f"\tparent.tree_id: {orphan.parent.tree_id}")
                 self.stdout.write(
                     self.bold(
                         f"\tdepth {orphan.depth}\n"


### PR DESCRIPTION
### Short description
Repair tree works if it encounters an orphan w/o a parent.


### Proposed changes
- Skip print parent information if parent is not available. 


### Side effects
- N/a


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2432 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
