### PR TITLE
Do not show translation status of the root language

### DIFF
--- a/integreat_cms/cms/templates/events/event_list.html
+++ b/integreat_cms/cms/templates/events/event_list.html
@@ -74,10 +74,12 @@
                         <div class="lang-grid flags whitespace-nowrap">
                             {% spaceless %}
                                 {% for lang in languages %}
-                                    <a href="{% url 'events' region_slug=request.region.slug language_slug=lang.slug %}">
-                                        <span class="fp fp-rounded fp-{{ lang.primary_country_code }}"
-                                              title="{{ lang.translated_name }}"></span>
-                                    </a>
+                                    {% if lang != request.region.default_language %}
+                                        <a href="{% url 'events' region_slug=request.region.slug language_slug=lang.slug %}">
+                                            <span class="fp fp-rounded fp-{{ lang.primary_country_code }}"
+                                                  title="{{ lang.translated_name }}"></span>
+                                        </a>
+                                    {% endif %}
                                 {% endfor %}
                             {% endspaceless %}
                         </div>

--- a/integreat_cms/cms/templates/events/event_list_row.html
+++ b/integreat_cms/cms/templates/events/event_list_row.html
@@ -39,48 +39,50 @@
     <td class="py-3 pr-2 text-gray-800 lang-grid">
         {% spaceless %}
             {% for other_language, other_status in event.translation_states.values %}
-                <a href="{% url 'edit_event' event_id=event.id region_slug=request.region.slug language_slug=other_language.slug %}"
-                   class="{{ other_language.slug }}">
-                    <div id="translation-icon">
-                        {% if other_status == translation_status.MACHINE_TRANSLATED %}
-                            <span title="{% translate "Machine translated" %}">
-                                <i icon-name="bot"
-                                   class="{% if other_language.slug == language.slug %}text-violet-500{% else %}text-gray-800{% endif %}"></i>
-                            </span>
-                        {% elif other_status == translation_status.IN_TRANSLATION %}
+                {% if other_language != request.region.default_language %}
+                    <a href="{% url 'edit_event' event_id=event.id region_slug=request.region.slug language_slug=other_language.slug %}"
+                       class="{{ other_language.slug }}">
+                        <div id="translation-icon">
+                            {% if other_status == translation_status.MACHINE_TRANSLATED %}
+                                <span title="{% translate "Machine translated" %}">
+                                    <i icon-name="bot"
+                                       class="{% if other_language.slug == language.slug %}text-violet-500{% else %}text-gray-800{% endif %}"></i>
+                                </span>
+                            {% elif other_status == translation_status.IN_TRANSLATION %}
+                                <span title="{% translate "Currently in translation" %}">
+                                    <i icon-name="clock"
+                                       class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
+                                </span>
+                            {% elif other_status == translation_status.OUTDATED %}
+                                <span title="{% translate "Translation outdated" %}">
+                                    <i icon-name="alert-triangle"
+                                       class="{% if other_language.slug == language.slug %}text-yellow-500{% else %}text-gray-800{% endif %}"></i>
+                                </span>
+                            {% elif other_status == translation_status.UP_TO_DATE %}
+                                <span title="{% translate "Translation up-to-date" %}">
+                                    <i icon-name="check"
+                                       class="{% if other_language.slug == language.slug %}text-green-500{% else %}text-gray-800{% endif %}"></i>
+                                </span>
+                            {% elif other_status == translation_status.FALLBACK %}
+                                <span title="{% translate "Default language is duplicated" %}">
+                                    <i icon-name="copy"
+                                       class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
+                                </span>
+                            {% elif other_status == translation_status.MISSING %}
+                                <span title="{% translate "Translation missing" %}" class="no-trans">
+                                    <i icon-name="x"
+                                       class="{% if other_language.slug == language.slug %}text-red-500{% else %}text-gray-800{% endif %}"></i>
+                                </span>
+                            {% endif %}
+                        </div>
+                        <div id="ajax-icon" class="hidden">
                             <span title="{% translate "Currently in translation" %}">
                                 <i icon-name="clock"
                                    class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
                             </span>
-                        {% elif other_status == translation_status.OUTDATED %}
-                            <span title="{% translate "Translation outdated" %}">
-                                <i icon-name="alert-triangle"
-                                   class="{% if other_language.slug == language.slug %}text-yellow-500{% else %}text-gray-800{% endif %}"></i>
-                            </span>
-                        {% elif other_status == translation_status.UP_TO_DATE %}
-                            <span title="{% translate "Translation up-to-date" %}">
-                                <i icon-name="check"
-                                   class="{% if other_language.slug == language.slug %}text-green-500{% else %}text-gray-800{% endif %}"></i>
-                            </span>
-                        {% elif other_status == translation_status.FALLBACK %}
-                            <span title="{% translate "Default language is duplicated" %}">
-                                <i icon-name="copy"
-                                   class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
-                            </span>
-                        {% elif other_status == translation_status.MISSING %}
-                            <span title="{% translate "Translation missing" %}" class="no-trans">
-                                <i icon-name="x"
-                                   class="{% if other_language.slug == language.slug %}text-red-500{% else %}text-gray-800{% endif %}"></i>
-                            </span>
-                        {% endif %}
-                    </div>
-                    <div id="ajax-icon" class="hidden">
-                        <span title="{% translate "Currently in translation" %}">
-                            <i icon-name="clock"
-                               class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
-                        </span>
-                    </div>
-                </a>
+                        </div>
+                    </a>
+                {% endif %}
             {% endfor %}
         {% endspaceless %}
     </td>

--- a/integreat_cms/cms/templates/pages/page_tree.html
+++ b/integreat_cms/cms/templates/pages/page_tree.html
@@ -87,10 +87,12 @@
                             <div class="lang-grid flags whitespace-nowrap">
                                 {% spaceless %}
                                     {% for lang in languages %}
-                                        <a href="{% url 'pages' region_slug=request.region.slug language_slug=lang.slug %}">
-                                            <span class="fp fp-rounded fp-{{ lang.primary_country_code }}"
-                                                  title="{{ lang.translated_name }}"></span>
-                                        </a>
+                                        {% if lang != request.region.default_language %}
+                                            <a href="{% url 'pages' region_slug=request.region.slug language_slug=lang.slug %}">
+                                                <span class="fp fp-rounded fp-{{ lang.primary_country_code }}"
+                                                      title="{{ lang.translated_name }}"></span>
+                                            </a>
+                                        {% endif %}
                                     {% endfor %}
                                 {% endspaceless %}
                             </div>

--- a/integreat_cms/cms/templates/pages/page_tree_node.html
+++ b/integreat_cms/cms/templates/pages/page_tree_node.html
@@ -88,43 +88,45 @@
             <div class="lang-grid">
                 {% spaceless %}
                     {% for other_language, other_status in page.translation_states.values %}
-                        <a href="{% url 'edit_page' page_id=page.id region_slug=request.region.slug language_slug=other_language.slug %}"
-                           class="{{ other_language.slug }}">
-                            <div id="translation-icon">
-                                {% if other_status == translation_status.MACHINE_TRANSLATED %}
-                                    <span title="{% translate "Machine translated" %}">
-                                        <i icon-name="bot"
-                                           class="{% if other_language.slug == language.slug %}text-violet-500{% else %}text-gray-800{% endif %}"></i>
-                                    </span>
-                                {% elif other_status == translation_status.IN_TRANSLATION %}
+                        {% if other_language != request.region.default_language %}
+                            <a href="{% url 'edit_page' page_id=page.id region_slug=request.region.slug language_slug=other_language.slug %}"
+                               class="{{ other_language.slug }}">
+                                <div id="translation-icon">
+                                    {% if other_status == translation_status.MACHINE_TRANSLATED %}
+                                        <span title="{% translate "Machine translated" %}">
+                                            <i icon-name="bot"
+                                               class="{% if other_language.slug == language.slug %}text-violet-500{% else %}text-gray-800{% endif %}"></i>
+                                        </span>
+                                    {% elif other_status == translation_status.IN_TRANSLATION %}
+                                        <span title="{% translate "Currently in translation" %}">
+                                            <i icon-name="clock"
+                                               class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
+                                        </span>
+                                    {% elif other_status == translation_status.OUTDATED %}
+                                        <span title="{% translate "Translation outdated" %}">
+                                            <i icon-name="alert-triangle"
+                                               class="{% if other_language.slug == language.slug %}text-yellow-500{% else %}text-gray-800{% endif %}"></i>
+                                        </span>
+                                    {% elif other_status == translation_status.UP_TO_DATE %}
+                                        <span title="{% translate "Translation up-to-date" %}">
+                                            <i icon-name="check"
+                                               class="{% if other_language.slug == language.slug %}text-green-500{% else %}text-gray-800{% endif %}"></i>
+                                        </span>
+                                    {% elif other_status == translation_status.MISSING %}
+                                        <span title="{% translate "Translation missing" %}" class="no-trans">
+                                            <i icon-name="x"
+                                               class="{% if other_language.slug == language.slug %}text-red-500{% else %}text-gray-800{% endif %}"></i>
+                                        </span>
+                                    {% endif %}
+                                </div>
+                                <div id="ajax-icon" class="hidden">
                                     <span title="{% translate "Currently in translation" %}">
                                         <i icon-name="clock"
                                            class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
                                     </span>
-                                {% elif other_status == translation_status.OUTDATED %}
-                                    <span title="{% translate "Translation outdated" %}">
-                                        <i icon-name="alert-triangle"
-                                           class="{% if other_language.slug == language.slug %}text-yellow-500{% else %}text-gray-800{% endif %}"></i>
-                                    </span>
-                                {% elif other_status == translation_status.UP_TO_DATE %}
-                                    <span title="{% translate "Translation up-to-date" %}">
-                                        <i icon-name="check"
-                                           class="{% if other_language.slug == language.slug %}text-green-500{% else %}text-gray-800{% endif %}"></i>
-                                    </span>
-                                {% elif other_status == translation_status.MISSING %}
-                                    <span title="{% translate "Translation missing" %}" class="no-trans">
-                                        <i icon-name="x"
-                                           class="{% if other_language.slug == language.slug %}text-red-500{% else %}text-gray-800{% endif %}"></i>
-                                    </span>
-                                {% endif %}
-                            </div>
-                            <div id="ajax-icon" class="hidden">
-                                <span title="{% translate "Currently in translation" %}">
-                                    <i icon-name="clock"
-                                       class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
-                                </span>
-                            </div>
-                        </a>
+                                </div>
+                            </a>
+                        {% endif %}
                     {% endfor %}
                 {% endspaceless %}
             </div>

--- a/integreat_cms/cms/templates/pois/poi_list.html
+++ b/integreat_cms/cms/templates/pois/poi_list.html
@@ -62,10 +62,12 @@
                         <div class="lang-grid flags whitespace-nowrap">
                             {% spaceless %}
                                 {% for lang in languages %}
-                                    <a href="{% url 'pois' region_slug=request.region.slug language_slug=lang.slug %}">
-                                        <span class="fp fp-rounded fp-{{ lang.primary_country_code }}"
-                                              title="{{ lang.translated_name }}"></span>
-                                    </a>
+                                    {% if lang != request.region.default_language %}
+                                        <a href="{% url 'pois' region_slug=request.region.slug language_slug=lang.slug %}">
+                                            <span class="fp fp-rounded fp-{{ lang.primary_country_code }}"
+                                                  title="{{ lang.translated_name }}"></span>
+                                        </a>
+                                    {% endif %}
                                 {% endfor %}
                             {% endspaceless %}
                         </div>

--- a/integreat_cms/cms/templates/pois/poi_list_row.html
+++ b/integreat_cms/cms/templates/pois/poi_list_row.html
@@ -36,48 +36,50 @@
     <td class="pr-2 lang-grid">
         {% spaceless %}
             {% for other_language, other_status in poi.translation_states.values %}
-                <a href="{% url 'edit_poi' poi_id=poi.id region_slug=request.region.slug language_slug=other_language.slug %}"
-                   class="{{ other_language.slug }}">
-                    <div id="translation-icon">
-                        {% if other_status == translation_status.MACHINE_TRANSLATED %}
-                            <span title="{% translate "Machine translated" %}">
-                                <i icon-name="bot"
-                                   class="{% if other_language.slug == language.slug %}text-violet-500{% else %}text-gray-800{% endif %}"></i>
-                            </span>
-                        {% elif other_status == translation_status.IN_TRANSLATION %}
+                {% if other_language != request.region.default_language %}
+                    <a href="{% url 'edit_poi' poi_id=poi.id region_slug=request.region.slug language_slug=other_language.slug %}"
+                       class="{{ other_language.slug }}">
+                        <div id="translation-icon">
+                            {% if other_status == translation_status.MACHINE_TRANSLATED %}
+                                <span title="{% translate "Machine translated" %}">
+                                    <i icon-name="bot"
+                                       class="{% if other_language.slug == language.slug %}text-violet-500{% else %}text-gray-800{% endif %}"></i>
+                                </span>
+                            {% elif other_status == translation_status.IN_TRANSLATION %}
+                                <span title="{% translate "Currently in translation" %}">
+                                    <i icon-name="clock"
+                                       class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
+                                </span>
+                            {% elif other_status == translation_status.OUTDATED %}
+                                <span title="{% translate "Translation outdated" %}">
+                                    <i icon-name="alert-triangle"
+                                       class="{% if other_language.slug == language.slug %}text-yellow-500{% else %}text-gray-800{% endif %}"></i>
+                                </span>
+                            {% elif other_status == translation_status.UP_TO_DATE %}
+                                <span title="{% translate "Translation up-to-date" %}">
+                                    <i icon-name="check"
+                                       class="{% if other_language.slug == language.slug %}text-green-500{% else %}text-gray-800{% endif %}"></i>
+                                </span>
+                            {% elif other_status == translation_status.FALLBACK %}
+                                <span title="{% translate "Default language is duplicated" %}">
+                                    <i icon-name="copy"
+                                       class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
+                                </span>
+                            {% elif other_status == translation_status.MISSING %}
+                                <span title="{% translate "Translation missing" %}" class="no-trans">
+                                    <i icon-name="x"
+                                       class="{% if other_language.slug == language.slug %}text-red-500{% else %}text-gray-800{% endif %}"></i>
+                                </span>
+                            {% endif %}
+                        </div>
+                        <div id="ajax-icon" class="hidden">
                             <span title="{% translate "Currently in translation" %}">
                                 <i icon-name="clock"
                                    class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
                             </span>
-                        {% elif other_status == translation_status.OUTDATED %}
-                            <span title="{% translate "Translation outdated" %}">
-                                <i icon-name="alert-triangle"
-                                   class="{% if other_language.slug == language.slug %}text-yellow-500{% else %}text-gray-800{% endif %}"></i>
-                            </span>
-                        {% elif other_status == translation_status.UP_TO_DATE %}
-                            <span title="{% translate "Translation up-to-date" %}">
-                                <i icon-name="check"
-                                   class="{% if other_language.slug == language.slug %}text-green-500{% else %}text-gray-800{% endif %}"></i>
-                            </span>
-                        {% elif other_status == translation_status.FALLBACK %}
-                            <span title="{% translate "Default language is duplicated" %}">
-                                <i icon-name="copy"
-                                   class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
-                            </span>
-                        {% elif other_status == translation_status.MISSING %}
-                            <span title="{% translate "Translation missing" %}" class="no-trans">
-                                <i icon-name="x"
-                                   class="{% if other_language.slug == language.slug %}text-red-500{% else %}text-gray-800{% endif %}"></i>
-                            </span>
-                        {% endif %}
-                    </div>
-                    <div id="ajax-icon" class="hidden">
-                        <span title="{% translate "Currently in translation" %}">
-                            <i icon-name="clock"
-                               class="{% if other_language.slug == language.slug %}text-blue-500{% else %}text-gray-800{% endif %}"></i>
-                        </span>
-                    </div>
-                </a>
+                        </div>
+                    </a>
+                {% endif %}
             {% endfor %}
         {% endspaceless %}
     </td>

--- a/integreat_cms/release_notes/current/unreleased/2389.yml
+++ b/integreat_cms/release_notes/current/unreleased/2389.yml
@@ -1,0 +1,2 @@
+en: Do not show translation status of the root language
+de: Zeige keinen Übersetzungsstatus der Stammsprache an


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR removes the column of the root language in the translation status table in the event/POI list and page tree.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Skip icon display if the language if the root of the region


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- None?


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2389 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
