### PR TITLE
Fix different HIX value calculation

### DIFF
--- a/integreat_cms/core/signals/hix_signals.py
+++ b/integreat_cms/core/signals/hix_signals.py
@@ -35,16 +35,19 @@ def page_translation_save_handler(instance, **kwargs):
         instance.hix_score = None
         return
 
-    if identical_version := instance.all_versions.filter(
-        content=instance.content, hix_score__isnull=False
-    ).first():
+    latest_version = instance.latest_version
+
+    if (
+        latest_version
+        and latest_version.hix_score
+        and latest_version.content == instance.content
+    ):
         logger.debug(
-            "Content of %r is identical to %r, copying HIX score %r",
+            "Content of %r was not changed, copying the HIX score from the previous version: %r",
             instance,
-            identical_version,
-            identical_version.hix_score,
+            latest_version.hix_score,
         )
-        instance.hix_score = identical_version.hix_score
+        instance.hix_score = latest_version.hix_score
         return
 
     if score := lookup_hix_score(instance.content):

--- a/integreat_cms/release_notes/current/unreleased/2224.yml
+++ b/integreat_cms/release_notes/current/unreleased/2224.yml
@@ -1,0 +1,2 @@
+en: Fix different HIX value calculation
+de: Behebe unterschiedliche HIX-Wert-Berechnung


### PR DESCRIPTION
### Short description
There are still cases where we got different HIX values for the same content.
For example:
1. Create new page with the following content:
```
<p>Eine sehr schwierige Zeile</p>
<p>Eine weitere sehr schwierige Zeile</p>
```
2. Save or Publish it --> HIX is **19.17**
3. Press "Publish" again with no changes --> HIX is **19.86**

The behavior will be the same if step 3 is "Press Ctrl+A and reload the HIX value".


### Proposed changes
-  Rework text normalization before sending request to Textlab API


### Side effects
- Hope none, but careful testing is welcomed


### Resolved issues
Fixes: #2224


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
