### PR TITLE
Reduce logging verbosity in `link_callback()`

### DIFF
--- a/integreat_cms/cms/utils/pdf_utils.py
+++ b/integreat_cms/cms/utils/pdf_utils.py
@@ -151,8 +151,11 @@ def link_callback(uri, rel):
     :rtype: str
     """
     parsed_uri = urlparse(uri)
-    # When the uri is an absolute URL to an allowed host, convert it to an absolute local path
-    if parsed_uri.hostname in settings.ALLOWED_HOSTS:
+    if parsed_uri.hostname:
+        # When the uri is an absolute URL to an external host, return the uri unchanged.
+        if parsed_uri.hostname not in settings.ALLOWED_HOSTS:
+            return uri
+        # When the uri is an absolute URL to an allowed host, convert it to an absolute local path
         uri = parsed_uri.path
         # When the url contains the legacy media url, replace it with the new pattern
         if (LEGACY_MEDIA_URL := "/wp-content/uploads/sites/") in uri:


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
We get a lot of logging entries like this:

```
Oct 08 02:01:20 WARNING integreat_cms.cms.utils.pdf_utils - The file 'https://www.vhs-bodenseekreis.de/f/cmx512f766acfdb9/cmx_4bbc75f45e264/cmx51e7ea767a9de/FS51e7eccb691ce.png' is not inside the static directories '/static/' and '/media/'.
```

but I think this "warning" is irrelevant - external images work just fine in pdfs.

Thus I suggest to only log the error when it's really a relative URL and not an external one.

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
