### PR TITLE
Improve the date display of the German locale

### DIFF
--- a/integreat_cms/cms/templates/pages/page_tree_archived_node.html
+++ b/integreat_cms/cms/templates/pages/page_tree_archived_node.html
@@ -101,7 +101,7 @@
     </td>
     <td>
         <div class="block py-2 px-2 whitespace-nowrap text-gray-800">
-            {{ page_translation.last_updated|date:"d.m.Y, H:i" }}
+            {{ page_translation.last_updated }}
         </div>
     </td>
     <td class="pl-2 pr-4 py-2 flex flex-nowrap justify-end gap-2">

--- a/integreat_cms/cms/templates/pages/page_tree_node.html
+++ b/integreat_cms/cms/templates/pages/page_tree_node.html
@@ -137,7 +137,7 @@
     </td>
     <td>
         <div class="block py-1.5 px-2 whitespace-nowrap text-gray-800">
-            {{ page_translation.last_updated|date:"d.m.Y, H:i" }}
+            {{ page_translation.last_updated }}
         </div>
     </td>
     <td class="pl-2 pr-4 py-1.5 text-right flex flex-nowrap gap-2">

--- a/integreat_cms/core/formats/__init__.py
+++ b/integreat_cms/core/formats/__init__.py
@@ -1,0 +1,5 @@
+"""
+This package contains locale formats to override the default ones.
+Create one file ``formats.py`` per locale directory.
+See :setting:`django:FORMAT_MODULE_PATH` and :attr:`~integreat_cms.core.settings.FORMAT_MODULE_PATH` for more information.
+"""

--- a/integreat_cms/core/formats/de/__init__.py
+++ b/integreat_cms/core/formats/de/__init__.py
@@ -1,0 +1,5 @@
+"""
+This package contains locale formats to override the default ones.
+Put all overrides into the file ``formats.py``.
+See :setting:`django:FORMAT_MODULE_PATH` and :attr:`~integreat_cms.core.settings.FORMAT_MODULE_PATH` for more information.
+"""

--- a/integreat_cms/core/formats/de/formats.py
+++ b/integreat_cms/core/formats/de/formats.py
@@ -1,0 +1,7 @@
+"""
+This file contains locale formats to override the default ones.
+See :setting:`django:FORMAT_MODULE_PATH` and :attr:`~integreat_cms.core.settings.FORMAT_MODULE_PATH` for more information.
+"""
+
+#: The default formatting to use for displaying datetime fields in any part of the system when using the German locale.
+DATETIME_FORMAT = "d. F Y \\u\\m H:i \\U\\h\\r"

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -762,6 +762,12 @@ USE_L10N = True
 #: (see :setting:`django:USE_TZ` and :doc:`django:topics/i18n/index`)
 USE_TZ = True
 
+#: A full Python path to a Python package that contains custom format definitions for project locales.
+#: (see :setting:`django:FORMAT_MODULE_PATH`)
+FORMAT_MODULE_PATH = [
+    "integreat_cms.core.formats",
+]
+
 
 ##########################
 # AUTOMATIC TRANSLATIONS #

--- a/integreat_cms/release_notes/current/unreleased/2446.yml
+++ b/integreat_cms/release_notes/current/unreleased/2446.yml
@@ -1,0 +1,2 @@
+en: Improve the date display of the German locale
+de: Verbessere die Datums-Anzeige der Deutschen Locale


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Improve the date display of the German locale.
See docs: https://docs.djangoproject.com/en/3.2/ref/settings/#format-module-path

### Proposed changes
<!-- Describe this PR in more detail. -->

- Instead of `09. Oktober 2023 22:15` write `09. Oktober 2023 um 22:15 Uhr`

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
