### PR TITLE
Add `location_url` to event endpoint response

### DIFF
--- a/docs/src/api-docs.rst
+++ b/docs/src/api-docs.rst
@@ -429,6 +429,7 @@ RESPONSE
             "latitude": Number | null,      // The latitude of this location
             "longitude": Number | null,     // The longitude of this location
          },
+         "location_url": String | null,     // The url to the location for this event translation
          "event": {
             "id": Number | null,            // The id of this event. Null if this is a recurrence of an event
             "start": String,                // The start date&time of this event

--- a/integreat_cms/release_notes/current/unreleased/2294.yml
+++ b/integreat_cms/release_notes/current/unreleased/2294.yml
@@ -1,0 +1,2 @@
+en: Add location url to event API endpoint
+de: Füge Ort-URL zur Event API-Antwort hinzu

--- a/tests/api/expected-outputs/augsburg_ar_events.json
+++ b/tests/api/expected-outputs/augsburg_ar_events.json
@@ -38,6 +38,7 @@
       "latitude": null,
       "longitude": null
     },
+    "location_url": null,
     "event": {
       "id": null,
       "start": "2030-01-01T13:00:00+01:00",
@@ -92,6 +93,7 @@
       "latitude": null,
       "longitude": null
     },
+    "location_url": null,
     "event": {
       "id": null,
       "start": "2030-01-03T13:00:00+01:00",
@@ -146,6 +148,7 @@
       "latitude": null,
       "longitude": null
     },
+    "location_url": null,
     "event": {
       "id": null,
       "start": "2030-01-15T13:00:00+01:00",
@@ -200,6 +203,7 @@
       "latitude": null,
       "longitude": null
     },
+    "location_url": null,
     "event": {
       "id": null,
       "start": "2030-01-17T13:00:00+01:00",
@@ -254,6 +258,7 @@
       "latitude": null,
       "longitude": null
     },
+    "location_url": null,
     "event": {
       "id": null,
       "start": "2030-01-29T13:00:00+01:00",
@@ -308,6 +313,7 @@
       "latitude": null,
       "longitude": null
     },
+    "location_url": null,
     "event": {
       "id": null,
       "start": "2030-01-31T13:00:00+01:00",

--- a/tests/api/expected-outputs/augsburg_de_events.json
+++ b/tests/api/expected-outputs/augsburg_de_events.json
@@ -38,6 +38,7 @@
       "latitude": null,
       "longitude": null
     },
+    "location_url": null,
     "event": {
       "id": null,
       "start": "2030-01-01T13:00:00+01:00",
@@ -92,6 +93,7 @@
       "latitude": null,
       "longitude": null
     },
+    "location_url": null,
     "event": {
       "id": null,
       "start": "2030-01-03T13:00:00+01:00",
@@ -146,6 +148,7 @@
       "latitude": null,
       "longitude": null
     },
+    "location_url": null,
     "event": {
       "id": null,
       "start": "2030-01-15T13:00:00+01:00",
@@ -200,6 +203,7 @@
       "latitude": null,
       "longitude": null
     },
+    "location_url": null,
     "event": {
       "id": null,
       "start": "2030-01-17T13:00:00+01:00",
@@ -254,6 +258,7 @@
       "latitude": null,
       "longitude": null
     },
+    "location_url": null,
     "event": {
       "id": null,
       "start": "2030-01-29T13:00:00+01:00",
@@ -308,6 +313,7 @@
       "latitude": null,
       "longitude": null
     },
+    "location_url": null,
     "event": {
       "id": null,
       "start": "2030-01-31T13:00:00+01:00",

--- a/tests/api/expected-outputs/augsburg_de_events_combine_recurring.json
+++ b/tests/api/expected-outputs/augsburg_de_events_combine_recurring.json
@@ -38,6 +38,7 @@
       "latitude": null,
       "longitude": null
     },
+    "location_url": null,
     "event": {
       "id": 1,
       "start": "2030-01-01T13:00:00+01:00",

--- a/tests/api/expected-outputs/augsburg_en_events.json
+++ b/tests/api/expected-outputs/augsburg_en_events.json
@@ -38,6 +38,7 @@
       "latitude": null,
       "longitude": null
     },
+    "location_url": null,
     "event": {
       "id": null,
       "start": "2030-01-01T13:00:00+01:00",
@@ -92,6 +93,7 @@
       "latitude": null,
       "longitude": null
     },
+    "location_url": null,
     "event": {
       "id": null,
       "start": "2030-01-03T13:00:00+01:00",
@@ -146,6 +148,7 @@
       "latitude": null,
       "longitude": null
     },
+    "location_url": null,
     "event": {
       "id": null,
       "start": "2030-01-15T13:00:00+01:00",
@@ -200,6 +203,7 @@
       "latitude": null,
       "longitude": null
     },
+    "location_url": null,
     "event": {
       "id": null,
       "start": "2030-01-17T13:00:00+01:00",
@@ -254,6 +258,7 @@
       "latitude": null,
       "longitude": null
     },
+    "location_url": null,
     "event": {
       "id": null,
       "start": "2030-01-29T13:00:00+01:00",
@@ -308,6 +313,7 @@
       "latitude": null,
       "longitude": null
     },
+    "location_url": null,
     "event": {
       "id": null,
       "start": "2030-01-31T13:00:00+01:00",

--- a/tests/api/expected-outputs/nurnberg_de_events.json
+++ b/tests/api/expected-outputs/nurnberg_de_events.json
@@ -28,6 +28,7 @@
       "latitude": 1,
       "longitude": 1
     },
+    "location_url": "http://localhost:8000/nurnberg/de/locations/test-ort/",
     "event": {
       "id": null,
       "start": "2031-01-01T15:00:00+01:00",
@@ -72,6 +73,7 @@
       "latitude": 1,
       "longitude": 1
     },
+    "location_url": "http://localhost:8000/nurnberg/de/locations/test-ort/",
     "event": {
       "id": null,
       "start": "2031-01-03T15:00:00+01:00",
@@ -116,6 +118,7 @@
       "latitude": 1,
       "longitude": 1
     },
+    "location_url": "http://localhost:8000/nurnberg/de/locations/test-ort/",
     "event": {
       "id": null,
       "start": "2031-01-15T15:00:00+01:00",
@@ -160,6 +163,7 @@
       "latitude": 1,
       "longitude": 1
     },
+    "location_url": "http://localhost:8000/nurnberg/de/locations/test-ort/",
     "event": {
       "id": null,
       "start": "2031-01-17T15:00:00+01:00",
@@ -204,6 +208,7 @@
       "latitude": 1,
       "longitude": 1
     },
+    "location_url": "http://localhost:8000/nurnberg/de/locations/test-ort/",
     "event": {
       "id": null,
       "start": "2031-01-29T15:00:00+01:00",
@@ -248,6 +253,7 @@
       "latitude": 1,
       "longitude": 1
     },
+    "location_url": "http://localhost:8000/nurnberg/de/locations/test-ort/",
     "event": {
       "id": null,
       "start": "2031-01-31T15:00:00+01:00",

--- a/tests/api/expected-outputs/nurnberg_en_events.json
+++ b/tests/api/expected-outputs/nurnberg_en_events.json
@@ -28,6 +28,7 @@
       "latitude": 1,
       "longitude": 1
     },
+    "location_url": "http://localhost:8000/nurnberg/en/locations/test-location/",
     "event": {
       "id": null,
       "start": "2031-01-01T15:00:00+01:00",
@@ -72,6 +73,7 @@
       "latitude": 1,
       "longitude": 1
     },
+    "location_url": "http://localhost:8000/nurnberg/en/locations/test-location/",
     "event": {
       "id": null,
       "start": "2031-01-03T15:00:00+01:00",
@@ -116,6 +118,7 @@
       "latitude": 1,
       "longitude": 1
     },
+    "location_url": "http://localhost:8000/nurnberg/en/locations/test-location/",
     "event": {
       "id": null,
       "start": "2031-01-15T15:00:00+01:00",
@@ -160,6 +163,7 @@
       "latitude": 1,
       "longitude": 1
     },
+    "location_url": "http://localhost:8000/nurnberg/en/locations/test-location/",
     "event": {
       "id": null,
       "start": "2031-01-17T15:00:00+01:00",
@@ -204,6 +208,7 @@
       "latitude": 1,
       "longitude": 1
     },
+    "location_url": "http://localhost:8000/nurnberg/en/locations/test-location/",
     "event": {
       "id": null,
       "start": "2031-01-29T15:00:00+01:00",
@@ -248,6 +253,7 @@
       "latitude": 1,
       "longitude": 1
     },
+    "location_url": "http://localhost:8000/nurnberg/en/locations/test-location/",
     "event": {
       "id": null,
       "start": "2031-01-31T15:00:00+01:00",


### PR DESCRIPTION
### Short description
This adds the `location_url` to the event endpoint. I decided against adding the url in the `transform_poi` function, as it is also used in the poi endpoint and there this information would be duplicated.


### Proposed changes
<!-- Describe this PR in more detail. -->

- add attribute `location_url` to event endpoint

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2294 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
