### PR TITLE
Fix error when deleting regions with organization logos

### DIFF
--- a/integreat_cms/cms/views/regions/region_actions.py
+++ b/integreat_cms/cms/views/regions/region_actions.py
@@ -89,6 +89,8 @@ def delete_region(request, *args, **kwargs):
     region.files.update(parent_directory=None)
     # Prevent ProtectedError when location gets deleted before their events
     region.events.update(location=None)
+    # Prevent ProtectedError when media files get deleted before their usages as organization logo
+    region.organizations.all().delete()
     # Delete region and cascade delete all contents
     deleted_objects = region.delete()
     logger.info(

--- a/integreat_cms/release_notes/current/unreleased/2452.yml
+++ b/integreat_cms/release_notes/current/unreleased/2452.yml
@@ -1,0 +1,2 @@
+en: Fix error when deleting regions with organization logos
+de: Behebe Fehler beim Löschen von Regionen mit Organisations-Logos


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fix error when deleting regions with organization logos

### Proposed changes
<!-- Describe this PR in more detail. -->

- Delete region's organizations before the region itself (including the region's media library)


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- If an error occurs during `region.delete()`, the organization objects can not be recovered


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2452


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
