### PR TITLE
Align eslint pre-commit version with eslintrc version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
         args: [--fix]
         types: [file]
         additional_dependencies:
-          - eslint@8.27.0
+          - eslint@8.51.0
           - "@typescript-eslint/eslint-plugin@5.42.1"
           - "eslint-plugin-prefer-arrow@1.2.3"
   - repo: https://github.com/pre-commit/mirrors-prettier


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This fixes the `Cannot read properties of undefined (reading 'getTokens') Occurred while linting [...].tsx:[...] Rule: "@typescript-eslint/no-empty-function"` error during the eslint pre-commit hook.

### Proposed changes
<!-- Describe this PR in more detail. -->

- as the title says


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: n/a


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
