### PR TITLE
Keep content edit lock release request alive

### DIFF
--- a/integreat_cms/cms/views/utils/content_edit_lock.py
+++ b/integreat_cms/cms/views/utils/content_edit_lock.py
@@ -61,7 +61,7 @@ def content_edit_lock_release(request, region_slug=None):
     :return: Json object containing `success: true` if the content object could be unlocked
     :rtype: ~django.http.JsonResponse
     """
-    body = json.loads(request.body.decode("utf-8"))
+    body = json.loads(request.POST.get("body"))
     id_, type_ = body
 
     success = unlock_content(id_, type_, request.user)


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr tries to fix the log spam caused by many content-edit-lock-release requests being aborted.
An error will still be logged if a request gets aborted, but I hope that this should only happen very rarely after this pr.
Unfortunately I cannot reproduce the actual issue locally, does someone know how to do that?

### Proposed changes
<!-- Describe this PR in more detail. -->
- Use the `navigator.sendBeacon` api which does not cancel requests
- use the `pagehide` event instead of `unload` (https://developer.mozilla.org/en-US/docs/Web/API/Window/unload_event#usage_notes)


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- Ideally none


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2283


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
