### PR TITLE
Don't overwrite city and zip in poi form

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/2444.yml
+++ b/integreat_cms/release_notes/current/unreleased/2444.yml
@@ -1,0 +1,2 @@
+en: Don't automatically overwrite city and zip code in the poi form
+de: Überschreibe nicht mehr automatisch die Stadt und Postleitzahl im Poi-Form

--- a/integreat_cms/static/src/js/pois/poi-actions.ts
+++ b/integreat_cms/static/src/js/pois/poi-actions.ts
@@ -1,7 +1,11 @@
 import { getCsrfToken } from "../utils/csrf-token";
 
-export const updateField = (fieldName: string, value: string) => {
+export const updateField = (fieldName: string, value: string, replace: boolean = true) => {
     const field = document.getElementById(`id_${fieldName}`) as HTMLInputElement;
+    // Don't update the field if it is not empty and replace is false
+    if (field.value && !replace) {
+        return;
+    }
     // Only fill value if it was changed
     if (value && field.value !== value) {
         field.value = value;
@@ -49,8 +53,8 @@ const autoCompleteAddress = async () => {
         return;
     }
 
-    updateField("postcode", data.postcode);
-    updateField("city", data.city);
+    updateField("postcode", data.postcode, false);
+    updateField("city", data.city, false);
     updateField("country", data.country);
 
     if (autoFillCoordinates.checked) {


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr fixes a bug where it was impossible to manually set city or zip code if the wrong values were autofilled.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Don't overwrite city or zip-code if they are already set to something


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->/


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2444


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
