### PR TITLE
Deliver POI title in different languages

### DIFF
--- a/integreat_cms/api/v3/locations.py
+++ b/integreat_cms/api/v3/locations.py
@@ -56,9 +56,6 @@ def transform_poi_translation(poi_translation):
     """
     Function to create a JSON from a single poi_translation object.
 
-    The method returns the title of a location in the default language as the app
-    can currently not display RTL languages on the map.
-
     :param poi_translation: The poi translation object which should be converted
     :type poi_translation: ~integreat_cms.cms.models.pois.poi_translation.POITranslation
 
@@ -75,7 +72,7 @@ def transform_poi_translation(poi_translation):
         "id": poi_translation.id,
         "url": settings.BASE_URL + poi_translation.get_absolute_url(),
         "path": poi_translation.get_absolute_url(),
-        "title": poi.default_public_translation.title,
+        "title": poi_translation.title,
         "modified_gmt": poi_translation.last_updated,  # deprecated field in the future
         "last_updated": timezone.localtime(poi_translation.last_updated),
         "meta_description": poi_translation.meta_description,

--- a/integreat_cms/cms/templates/pois/poi_form.html
+++ b/integreat_cms/cms/templates/pois/poi_form.html
@@ -85,13 +85,6 @@
                                 {% endif %}
                             </div>
                             {% render_field poi_translation_form.title|add_error_class:"border-red-500" class+="mb-2" %}
-                            {% if language != request.region.default_language %}
-                                <div class="bg-yellow-100 border-l-4 border-yellow-500 text-yellow-600 px-4 py-1 mb-2">
-                                    {% blocktranslate trimmed %}
-                                        For technical reasons the name is displayed in the app in the default language.
-                                    {% endblocktranslate %}
-                                </div>
-                            {% endif %}
                             <div id="link-container" class="flex items-center">
                                 <label for="{{ poi_translation_form.slug.id_for_label }}" class="mr-2">
                                     {{ poi_translation_form.slug.label }}:

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -6598,14 +6598,6 @@ msgid "The default translation is not yet published"
 msgstr "Die Standardübersetzung ist noch nicht veröffentlicht"
 
 #: cms/templates/pois/poi_form.html
-msgid ""
-"For technical reasons the name is displayed in the app in the default "
-"language."
-msgstr ""
-"Aus technischen Gründen wird der Name in der App in der Standard-Sprache "
-"angezeigt."
-
-#: cms/templates/pois/poi_form.html
 msgid "SEO section"
 msgstr "SEO-Bereich"
 
@@ -9355,6 +9347,13 @@ msgid "This page belongs to another region ({})."
 msgstr ""
 "Diese Seite konnte nicht importiert werden, da sie zu einer anderen Region "
 "gehört ({})."
+
+#~ msgid ""
+#~ "For technical reasons the name is displayed in the app in the default "
+#~ "language."
+#~ msgstr ""
+#~ "Aus technischen Gründen wird der Name in der App in der Standard-Sprache "
+#~ "angezeigt."
 
 #~ msgid "News was already sent on {}"
 #~ msgstr "Nachricht wurde bereits gesendet am {}"

--- a/integreat_cms/release_notes/current/unreleased/2417.yml
+++ b/integreat_cms/release_notes/current/unreleased/2417.yml
@@ -1,0 +1,2 @@
+en: Deliver POI title in different languages
+de: Liefere POI-Titel in verschiedenen Sprachen

--- a/tests/api/expected-outputs/augsburg_en_locations.json
+++ b/tests/api/expected-outputs/augsburg_en_locations.json
@@ -3,7 +3,7 @@
     "id": 3,
     "url": "http://localhost:8000/augsburg/en/locations/test-location/",
     "path": "/augsburg/en/locations/test-location/",
-    "title": "Test-Ort",
+    "title": "Test location",
     "modified_gmt": "2020-01-22T12:52:56.726Z",
     "last_updated": "2020-01-22T13:52:56.726+01:00",
     "excerpt": "Content of the test location",

--- a/tests/api/expected-outputs/nurnberg_en_locations.json
+++ b/tests/api/expected-outputs/nurnberg_en_locations.json
@@ -3,7 +3,7 @@
     "id": 6,
     "url": "http://localhost:8000/nurnberg/en/locations/test-location/",
     "path": "/nurnberg/en/locations/test-location/",
-    "title": "Test-Ort",
+    "title": "Test location",
     "modified_gmt": "2020-01-22T12:52:56.726Z",
     "last_updated": "2020-01-22T13:52:56.726+01:00",
     "excerpt": "Content of the test location",


### PR DESCRIPTION
### Short description
RTL languages can be displayed on the map in the app now.
So we can deliver the POI title in different languages, not only in the default language.


### Proposed changes
- use poi_translation.title instead of poi.default_public_translation.title
- remove info message from the poi form


### Side effects
No?


### Resolved issues
Fixes: #2417


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
