### PR TITLE
Add empty tag to empty pages with only archived subpages

### DIFF
--- a/integreat_cms/cms/models/pages/page_translation.py
+++ b/integreat_cms/cms/models/pages/page_translation.py
@@ -266,7 +266,7 @@ class PageTranslation(AbstractBasePageTranslation):
         This functions returns a list of translated tags which apply to this function.
         Supported tags:
         * Live content: if the page of this translation has live content
-        * Empty: if the page contains no text and has no subpages (TODO: Can also be empty if subpages are archived)
+        * Empty: if the page contains no text and has no non-archived subpages
 
         :return: A list of tags which apply to this translation
         """
@@ -275,7 +275,10 @@ class PageTranslation(AbstractBasePageTranslation):
         if self.page.mirrored_page:
             tags.append(_("Live content"))
 
-        if self.is_empty and self.page.is_leaf():
+        if self.is_empty and (
+            self.page.is_leaf()
+            or not self.page.children.filter(explicitly_archived=False).exists()
+        ):
             tags.append(_("Empty"))
 
         return tags

--- a/integreat_cms/release_notes/current/unreleased/1175.yml
+++ b/integreat_cms/release_notes/current/unreleased/1175.yml
@@ -1,0 +1,2 @@
+en: Add empty tag for empty pages with only archived subpages
+de: Füge "Leer" Tag zu leeren Seiten mit nur archivierten Unterseiten hinzu


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds an empty tag to empty pages whose subpages are all archived.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add to the condition for the empty tag the case where all the subpages are archived 
- Adjust `get_non_archived_children` to choose whether the parent page should be included or not.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- I hope none
- but I may have misunderstood the desired behaviour 🙈 

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1175 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
