### PR TITLE
Hide links from old versions in link checker

### DIFF
--- a/integreat_cms/cms/utils/linkcheck_utils.py
+++ b/integreat_cms/cms/utils/linkcheck_utils.py
@@ -9,13 +9,19 @@ from typing import TYPE_CHECKING
 from urllib.parse import ParseResult, unquote, urlparse
 
 from django.conf import settings
-from django.db.models import Prefetch, Q
+from django.db.models import Prefetch, Q, Subquery
 from linkcheck import update_lock
 from linkcheck.listeners import tasks_queue
 from linkcheck.models import Link, Url
 from lxml.html import rewrite_links
 
-from ..models import EventTranslation, PageTranslation, POITranslation
+from integreat_cms.cms.models import (
+    EventTranslation,
+    ImprintPageTranslation,
+    PageTranslation,
+    POITranslation,
+    Region,
+)
 
 if TYPE_CHECKING:
     from typing import Any
@@ -31,7 +37,7 @@ def get_urls(
     prefetch_content_objects: bool = True,
 ) -> list[Url]:
     """
-    Count all urls by status, either of a specific region or globally
+    Collect all the urls which appear in the latest versions of the contents of the region, filtered by ID or region if given.
 
     :param region_slug: The slug of the current region
     :param url_ids: The list of requested url ids
@@ -43,15 +49,39 @@ def get_urls(
         # If the results should be limited to specific ids, filter the queryset
         urls = urls.filter(id__in=url_ids)
     if region_slug:
+        region = Region.objects.get(slug=region_slug)
+        latest_pagetranslation_versions = Subquery(
+            PageTranslation.objects.filter(
+                page__id__in=Subquery(region.non_archived_pages.values("pk")),
+            )
+            .distinct("page__id", "language__id")
+            .values_list("pk", flat=True)
+        )
+        latest_poitranslation_versions = Subquery(
+            POITranslation.objects.filter(poi__region=region)
+            .distinct("poi__id", "language__id")
+            .values_list("pk", flat=True)
+        )
+        latest_eventtranslation_versions = Subquery(
+            EventTranslation.objects.filter(event__region=region)
+            .distinct("event__id", "language__id")
+            .values_list("pk", flat=True)
+        )
+        latest_imprinttranslation_versions = Subquery(
+            ImprintPageTranslation.objects.filter(page__region=region)
+            .distinct("page__id", "language__id")
+            .values_list("pk", flat=True)
+        )
         # Get all link objects of the requested region
         region_links = Link.objects.filter(
-            Q(page_translation__page__region__slug=region_slug)
-            | Q(imprint_translation__page__region__slug=region_slug)
-            | Q(event_translation__event__region__slug=region_slug)
-            | Q(poi_translation__poi__region__slug=region_slug)
+            Q(page_translation__id__in=latest_pagetranslation_versions)
+            | Q(imprint_translation__id__in=latest_imprinttranslation_versions)
+            | Q(event_translation__id__in=latest_eventtranslation_versions)
+            | Q(poi_translation__id__in=latest_poitranslation_versions)
         ).order_by("id")
+
         if prefetch_content_objects:
-            region_links = region_links.prefetch_related("content_object")
+            region_links = region_links.prefetch_related("content_object__language")
         # Prefetch all link objects of the requested region
         urls = urls.prefetch_related(
             Prefetch(

--- a/integreat_cms/release_notes/current/unreleased/2466.yml
+++ b/integreat_cms/release_notes/current/unreleased/2466.yml
@@ -1,0 +1,2 @@
+en: Hide links from old versions in link checker
+de: Blende Links aus alten Versionen im Link-Checker aus


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds an apropriate message when a link from old versions is about to be replaced

### Proposed changes
<!-- Describe this PR in more detail. -->
- Chekck whether all the queried tranlations are the latest of each translation
- Show the new detailed message


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- I know the loop `for translation in translations` is doubled in the function. This is to prevent  it that replacement is successfull in some of the translations but not in the others, so either the link will be replaced in all of the related translations or not at all.
- I left the utility function `replace_links` unchanged, for this works only on the latest versions.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2466 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
