### PR TITLE
Fix quotes in GitHub release description

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -511,7 +511,7 @@ jobs:
       - run:
           name: Get release notes
           command: |
-            RELEASE_NOTES=$(./tools/make_release_notes.sh --format=raw --no-heading --no-subheading)
+            RELEASE_NOTES=$(./tools/make_release_notes.sh --format=raw --no-heading --no-subheading | sed "s/\"/'/g")
             echo "export RELEASE_NOTES=\"${RELEASE_NOTES}\"" >> $BASH_ENV
       - run:
           name: Get contributors


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fix quotes in GitHub release description

### Proposed changes
<!-- Describe this PR in more detail. -->

- Replace double quotes with single quotes in the release notes of GitHub releases
__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
