### PR TITLE
Fix error when translating links with HTML tags in the link text

### DIFF
--- a/integreat_cms/cms/forms/custom_content_model_form.py
+++ b/integreat_cms/cms/forms/custom_content_model_form.py
@@ -134,7 +134,9 @@ class CustomContentModelForm(CustomModelForm):
                 ):
                     translated_url, translated_text = translation
                     link.set("href", translated_url)
-                    link.text = translated_text
+                    # translated_text might be None if the link tag consists of other tags instead of plain text
+                    if translated_text:
+                        link.text = translated_text
                     self.logger.debug(
                         "Updated link url from %s to %s", href, translated_url
                     )

--- a/integreat_cms/cms/utils/internal_link_utils.py
+++ b/integreat_cms/cms/utils/internal_link_utils.py
@@ -51,13 +51,13 @@ def update_link_language(current_link, link_text, target_language_slug):
         fixed_link = target_translation.full_url
 
         # Update the title if it was previously the translation title or the url
-        title = link_text
-        if source_translation.title.lower() == link_text.strip().lower():
-            title = target_translation.title
-        elif current_link.strip() == link_text.strip():
-            title = fixed_link
+        if link_text:
+            if source_translation.title.lower() == link_text.strip().lower():
+                link_text = target_translation.title
+            elif current_link.strip() == link_text.strip():
+                link_text = fixed_link
 
-        return fixed_link, title
+        return fixed_link, link_text
 
     return None
 

--- a/integreat_cms/release_notes/current/unreleased/2485.yml
+++ b/integreat_cms/release_notes/current/unreleased/2485.yml
@@ -1,0 +1,2 @@
+en: Fix error when translating links with HTML tags in the link text
+de: Behebe Fehler beim Übersetzen von Links mit HTML tags im Link-Text


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fix error when translating links with HTML tags in the link text

### Proposed changes
<!-- Describe this PR in more detail. -->

- Only replace link text if `link.text` is not `None`

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2485


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
