### PR TITLE
Auto add `link external` in backend

### DIFF
--- a/integreat_cms/cms/forms/custom_content_model_form.py
+++ b/integreat_cms/cms/forms/custom_content_model_form.py
@@ -96,6 +96,7 @@ class CustomContentModelForm(CustomModelForm):
 
         return cleaned_data
 
+    # pylint: disable=too-many-branches
     def clean_content(self) -> str:
         """
         Validate the content field (see :ref:`overriding-modelform-clean-method`) and applies changes
@@ -125,6 +126,21 @@ class CustomContentModelForm(CustomModelForm):
             self.logger.debug(
                 "Replaced %r tag with p tag: %r", tag_type, tostring(monospaced)
             )
+
+        # Set link-external as class for external links
+        for link in content.iter("a"):
+            if href := link.get("href"):
+                is_external = not any(url in href for url in settings.INTERNAL_URLS)
+                if "link-external" not in link.classes and is_external:
+                    link.classes.add("link-external")
+                    self.logger.debug(
+                        "Added class 'link-external' to %r", tostring(link)
+                    )
+                elif "link-external" in link.classes and not is_external:
+                    link.classes.remove("link-external")
+                    self.logger.debug(
+                        "Removed class 'link-external' from %r", tostring(link)
+                    )
 
         # Remove external links
         for link in content.iter("a"):

--- a/integreat_cms/cms/templates/_tinymce_config.html
+++ b/integreat_cms/cms/templates/_tinymce_config.html
@@ -18,7 +18,6 @@
 {% firstof font_style|add:"del { background-color: rgb(252 165 165); } ins { background-color: rgb(134 239 172); text-decoration-line: none; }" as content_style %}
 <div id="tinymce-config-options"
      data-webapp-url="{% get_webapp_url %}"
-     data-internal-urls="{% get_internal_urls %}"
      data-language="{{ LANGUAGE_CODE|slice:'0:2' }}"
      data-directionality="{% if right_to_left %}rtl{% else %}ltr{% endif %}"
      data-no-translate-tooltip='{% translate "Do not translate the selected text." %}'

--- a/integreat_cms/cms/templatetags/settings_tags.py
+++ b/integreat_cms/cms/templatetags/settings_tags.py
@@ -3,8 +3,6 @@ This contains tags for accessing settings
 """
 from __future__ import annotations
 
-import re
-
 from django import template
 from django.conf import settings
 
@@ -29,15 +27,3 @@ def get_base_url() -> str:
     :return: The base url of the current web application
     """
     return settings.BASE_URL
-
-
-@register.simple_tag
-def get_internal_urls() -> str:
-    """
-    This tag returns the stringified list of url names
-    which should be treated as internal
-
-    :return: stringified list of internal url names
-    """
-    stringified = " ".join(settings.INTERNAL_URLS)
-    return re.sub(r"https?://(www)?", "", stringified)

--- a/integreat_cms/release_notes/current/unreleased/2453.yml
+++ b/integreat_cms/release_notes/current/unreleased/2453.yml
@@ -1,0 +1,2 @@
+en: Mark all external urls in content as external
+de: Markiere alle externen Urls in Inhalten als extern

--- a/integreat_cms/static/src/js/tinymce-plugins/custom_link_input/plugin.js
+++ b/integreat_cms/static/src/js/tinymce-plugins/custom_link_input/plugin.js
@@ -2,7 +2,6 @@ import { getCsrfToken } from "../../utils/csrf-token";
 
 (() => {
     const tinymceConfig = document.getElementById("tinymce-config-options");
-    const internalUrls = tinymceConfig.getAttribute("data-internal-urls");
 
     const getCompletions = async (query, id) => {
         const url = tinymceConfig.getAttribute("data-link-ajax-url");
@@ -35,8 +34,6 @@ import { getCsrfToken } from "../../utils/csrf-token";
         }
         return url;
     };
-
-    const isExternalUrl = (url) => !internalUrls.split(" ").some((e) => url.includes(e));
 
     const updateLink = (editor, anchorElm, text, linkAttrs) => {
         if (text !== null) {
@@ -263,15 +260,10 @@ import { getCsrfToken } from "../../utils/csrf-token";
                     // Either insert a new link or update the existing one
                     const anchor = getAnchor();
                     if (!anchor) {
-                        if (isExternalUrl(realUrl)) {
-                            editor.insertContent(`<a href=${realUrl} class="link-external">${text}</a>`);
-                        } else {
-                            editor.insertContent(`<a href=${realUrl}>${text}</a>`);
-                        }
+                        editor.insertContent(`<a href=${realUrl}>${text}</a>`);
                     } else {
                         updateLink(editor, anchor, text, {
                             href: realUrl,
-                            class: isExternalUrl(realUrl) ? "link-external" : "",
                         });
                     }
                 },
@@ -320,7 +312,6 @@ import { getCsrfToken } from "../../utils/csrf-token";
                             const anchor = getAnchor();
                             updateLink(editor, anchor, null, {
                                 href: realUrl,
-                                class: isExternalUrl(realUrl) ? "link-external" : "",
                             });
                         }
                         formApi.hide();


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr moves the code that marks external links as external from autolink plugin to python in order to ensure that all external links get correctly marked as such.
This pr does not automatically fix all links from content translations that already exist. I have opened a separate issue for that: #2491


### Proposed changes
<!-- Describe this PR in more detail. -->
- Add additional step to `clean_content`
- Remove functionality related to `link-external` from the frontend


### Side effects
/

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2453


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
