### PR TITLE
Hide permission section in page form during page creation

### DIFF
--- a/integreat_cms/cms/templates/pages/page_form_sidebar/settings_box.html
+++ b/integreat_cms/cms/templates/pages/page_form_sidebar/settings_box.html
@@ -90,12 +90,16 @@
                 <label>
                     {% translate "Additional permissions for this page" %}
                 </label>
-                <p class="italic">
-                    {% translate "This affects only users, who don't have the permission to change arbitrary pages anyway." %}
-                </p>
-                <div id="page_permission_table">
-                    {% include "pages/_page_permission_table.html" %}
-                </div>
+                {% if page_id %}
+                    <p class="italic">
+                        {% translate "This only affects users who do not have permission to edit arbitrary pages." %}
+                    </p>
+                    <div id="page_permission_table">
+                        {% include "pages/_page_permission_table.html" %}
+                    </div>
+                {% else %}
+                    <i icon-name="alert-triangle" class="pb-1"></i> {% translate "Page permissions can only be set after the page has been saved as draft or published for the first time." %}
+                {% endif %}
             </div>
         {% endif %}
     {% endif %}

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -6328,11 +6328,18 @@ msgstr "Zusätzliche Berechtigungen für diese Seite"
 
 #: cms/templates/pages/page_form_sidebar/settings_box.html
 msgid ""
-"This affects only users, who don't have the permission to change arbitrary "
-"pages anyway."
+"This only affects users who do not have permission to edit arbitrary pages."
 msgstr ""
-"Dies betrifft nur Benutzer:innen, die nicht ohnehin die Berechtigung haben, "
+"Dies betrifft nur Benutzer:innen, die nicht sowieso die Berechtigung haben, "
 "beliebige Seiten zu ändern."
+
+#: cms/templates/pages/page_form_sidebar/settings_box.html
+msgid ""
+"Page permissions can only be set after the page has been saved as draft or "
+"published for the first time."
+msgstr ""
+"Sie müssen die Seite erst als Entwurf speichern oder veröffentlichen, bevor "
+"Sie die Berechtigungen für diese Seite ändern können."
 
 #: cms/templates/pages/page_form_sidebar/translator_view_box.html
 msgid "Translator view"

--- a/integreat_cms/release_notes/current/unreleased/2482.yml
+++ b/integreat_cms/release_notes/current/unreleased/2482.yml
@@ -1,0 +1,2 @@
+en: Hide permission section in page form during page creation to fix bug
+de: Blende den Berechtigungsabschnitt im Seitenformular während der Seitenerstellung aus, um einen Fehler zu beheben


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the issue that authors and observers can't be assigned during the page creation.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Hide the permission section during the time that there is not a page id yet (for example page creation)
- Add help text for page creation to inform about this behavior


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

I think none


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2482 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
