### PR TITLE
Fix crashing dashboard when region has no default language

### DIFF
--- a/integreat_cms/cms/templates/dashboard/dashboard.html
+++ b/integreat_cms/cms/templates/dashboard/dashboard.html
@@ -11,7 +11,9 @@
             <div class="xl:w-1/2">
                 <!-- Task Widget -->
                 {% if perms.cms.change_page or perms.cms.change_feedback %}
-                    {% include "dashboard/_todo_dashboard_widget.html" with no_padding=True %}
+                    {% if request.region.default_language %}
+                        {% include "dashboard/_todo_dashboard_widget.html" with no_padding=True %}
+                    {% endif %}
                 {% endif %}
                 <!-- Statistic Widget -->
                 {% if request.region.statistics_enabled and perms.cms.view_statistics %}

--- a/integreat_cms/cms/views/dashboard/dashboard_view.py
+++ b/integreat_cms/cms/views/dashboard/dashboard_view.py
@@ -85,6 +85,9 @@ class DashboardView(TemplateView, ChatContextMixin):
         :return: Dictionary containing the context for unreviewed pages
         :rtype: dict
         """
+        if not self.request.region.default_language:
+            return {}
+
         unreviewed_pages = PageTranslation.objects.filter(
             language__slug=self.request.region.default_language.slug,
             id__in=self.latest_version_ids,
@@ -103,6 +106,9 @@ class DashboardView(TemplateView, ChatContextMixin):
         :return: Dictionary containing the context for auto saved pages
         :rtype: dict
         """
+        if not self.request.region.default_language:
+            return {}
+
         automatically_saved_pages = PageTranslation.objects.filter(
             language__slug=self.request.region.default_language.slug,
             id__in=self.latest_version_ids,
@@ -155,18 +161,19 @@ class DashboardView(TemplateView, ChatContextMixin):
         :return: Dictionary containing the context for pages with low hix value
         :rtype: dict
         """
-        if settings.TEXTLAB_API_ENABLED and self.request.region.hix_enabled:
-            translations_under_hix_threshold = PageTranslation.objects.filter(
-                language__slug__in=settings.TEXTLAB_API_LANGUAGES,
-                id__in=self.latest_version_ids,
-                page__hix_ignore=False,
-                hix_score__lt=settings.HIX_REQUIRED_FOR_MT,
-            )
+        if not settings.TEXTLAB_API_ENABLED or not self.request.region.hix_enabled:
+            return {}
 
-            return {
-                "pages_under_hix_threshold": translations_under_hix_threshold,
-            }
-        return {}
+        translations_under_hix_threshold = PageTranslation.objects.filter(
+            language__slug__in=settings.TEXTLAB_API_LANGUAGES,
+            id__in=self.latest_version_ids,
+            page__hix_ignore=False,
+            hix_score__lt=settings.HIX_REQUIRED_FOR_MT,
+        )
+
+        return {
+            "pages_under_hix_threshold": translations_under_hix_threshold,
+        }
 
     def get_outdated_pages_context(self):
         r"""
@@ -175,6 +182,9 @@ class DashboardView(TemplateView, ChatContextMixin):
         :return: Dictionary containing the context for outdated pages
         :rtype: dict
         """
+        if not self.request.region.default_language:
+            return {}
+
         OUTDATED_THRESHOLD_DATE = datetime.now() - relativedelta(
             days=settings.OUTDATED_THRESHOLD_DAYS
         )


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

Fixes a bug when the newly introduced dashboard (#2348) would cause a regression before a new region could be set up, because it assumed regions always have a default language. When trying to access its slug, it crashed, ironically preventing anyone from setting up the language tree through the CMS.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add checks to detect when there is no default language and don't display the items in that case


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

I couldn't think of any yet


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2518

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
