### PR TITLE
Fix `IntegrityError` when deleting region with multiple feedback

### DIFF
--- a/integreat_cms/cms/views/regions/region_actions.py
+++ b/integreat_cms/cms/views/regions/region_actions.py
@@ -91,6 +91,8 @@ def delete_region(request, *args, **kwargs):
     region.events.update(location=None)
     # Prevent ProtectedError when media files get deleted before their usages as organization logo
     region.organizations.all().delete()
+    # Prevent IntegrityError when multiple feedback objects exist
+    region.feedback.all().delete()
     # Delete region and cascade delete all contents
     deleted_objects = region.delete()
     logger.info(

--- a/integreat_cms/release_notes/current/unreleased/2462.yml
+++ b/integreat_cms/release_notes/current/unreleased/2462.yml
@@ -1,0 +1,2 @@
+en: Fix error when deleting regions with multiple feedback
+de: Behebe Fehler beim Löschen von Regionen mit verschiedenem Feedback


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fix `IntegrityError` when deleting region with multiple feedback.

#### Steps that previously worked to reproduce the issue:
1. Submit at least *2 feedback forms of differing types*, for example:
```
curl --location --request POST 'http://localhost:8000/api/augsburg/de/feedback/imprint-page' --form 'comment="test"'
curl --location --request POST 'http://localhost:8000/api/augsburg/de/feedback/map' --form 'comment="test"'
```
2. It does not matter whether these are read or remain unread, but they **cannot** be for the same endpoint (e.g. two feedback submissions for the map)
3. Attempt to delete the region "Stadt Augsburg" and receive the following error:
```
django.db.utils.IntegrityError: update or delete on table "cms_feedback" violates foreign key constraint "
cms_imprintpagefeedb_feedback_ptr_id_8eb10618_fk_cms_feedb" on table "cms_imprintpagefeedback"
DETAIL:  Key (id)=(1) is still referenced from table "cms_imprintpagefeedback".
```
This should now no longer "work", i.e. be fixed.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Explicitly delete all feedback before deleting the region


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none, I think


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2462 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
