### PR TITLE
Fix IntegrityError when deleting user

### DIFF
--- a/integreat_cms/cms/views/users/region_user_actions.py
+++ b/integreat_cms/cms/views/users/region_user_actions.py
@@ -36,9 +36,13 @@ def delete_region_user(request, region_slug, user_id):
 
     region = request.region
     user = get_object_or_404(region.region_users, id=user_id)
+
     if user.regions.count() == 1:
-        logger.info("%r deleted %r", request.user, user)
+        # Mark feedback read by the user as unread to prevent IntegrityError
+        user.feedback.update(read_by=None)
+
         user.delete()
+        logger.info("%r deleted %r", request.user, user)
         messages.success(
             request,
             _('Account "{}" was successfully deleted.').format(user.full_user_name),

--- a/integreat_cms/cms/views/users/user_actions.py
+++ b/integreat_cms/cms/views/users/user_actions.py
@@ -32,9 +32,12 @@ def delete_user(request, user_id):
     """
 
     user = get_object_or_404(get_user_model(), id=user_id)
-    logger.info("%r deleted %r", request.user, user)
-    user.delete()
 
+    # Mark feedback read by the user as unread to prevent IntegrityError
+    user.feedback.update(read_by=None)
+
+    user.delete()
+    logger.info("%r deleted %r", request.user, user)
     messages.success(
         request, _('Account "{}" was successfully deleted.').format(user.full_user_name)
     )

--- a/integreat_cms/release_notes/current/unreleased/2408.yml
+++ b/integreat_cms/release_notes/current/unreleased/2408.yml
@@ -1,0 +1,2 @@
+en: Fix IntegrityError on user deletion
+de: Behebe IntegrityError beim Löschen von Benutzern


### PR DESCRIPTION
### Short description
This PR fixes the following case:
1. the user was assigned to more than one region (z.B. A and B)
2. the user read a feedback in the region A
3. the user was removed from the region A (but remained in the region B)

Then, if we try to remove the user from region B (or in general, in "Network management"), IntegrityError will occur.

```
django.db.utils.IntegrityError: update or delete on table "cms_user" violates foreign key constraint "cms_feedback_read_by_id_fbaaab26_fk_cms_user_id" on table "cms_feedback"
DETAIL:  Key (id)=(668) is still referenced from table "cms_feedback".
```

### Proposed changes
- Mark feedback read by the user as unread before deleting the user


### Side effects
- No?


### Resolved issues
Fixes: #2408


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
