### PR TITLE
Fix HIX block display when toggling a checkbox

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/2517.yml
+++ b/integreat_cms/release_notes/current/unreleased/2517.yml
@@ -1,0 +1,2 @@
+en: Fix HIX block display when HIX-ignore checkbox is toggled
+de: Behebe die Anzeige des HIX-Blocks, wenn das Kontrollkästchen HIX-ignore umgeschaltet wird

--- a/integreat_cms/static/src/js/analytics/hix-widget.ts
+++ b/integreat_cms/static/src/js/analytics/hix-widget.ts
@@ -209,10 +209,10 @@ window.addEventListener("load", async () => {
         if (hixIgnore.checked) {
             hixBlock.classList.add("hidden");
             toggleMTCheckboxes(true);
-            mtForm.classList.add("hidden");
+            mtForm?.classList.add("hidden");
         } else {
             toggleMTCheckboxes(false);
-            mtForm.classList.remove("hidden");
+            mtForm?.classList.remove("hidden");
             hixBlock.classList.remove("hidden");
         }
     };


### PR DESCRIPTION
### Short description
When MT are disabled, checking the "Ignore HIX value" checkbox does not cause the HIX block to expand, because of TS errors:
```
caught (in promise) TypeError: Cannot read properties of null (reading 'classList')
    at _callee4$ (hix-widget.ts:212:20)
    at tryCatch (.*\.svg$:51:1)
    at Generator.<anonymous> (.*\.svg$:51:1)
    at Generator.next (.*\.svg$:51:1)
    at .*\.svg$:51:1
    at new Promise (<anonymous>)
    at __webpack_modules__../integreat_cms/static/src/js/analytics/hix-widget.ts.__awaiter (.*\.svg$:51:1)
    at HTMLInputElement.toggleHixIgnore (hix-widget.ts:205:40)
_
```


### Proposed changes
- Use TS optional chaining to access MT-form element


### Side effects
No?


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
