### PR TITLE
Fix underlined space in To-Do dashboard

### DIFF
--- a/integreat_cms/cms/templates/dashboard/_todo_dashboard_row.html
+++ b/integreat_cms/cms/templates/dashboard/_todo_dashboard_row.html
@@ -6,11 +6,8 @@
                icon-name="{% spaceless %}{% block todo_dashboard_icon %}{% endblock todo_dashboard_icon %}{% endspaceless %}"></i>
         </div>
         <div>
-            <a href="{% spaceless %}{% block todo_dashboard_title_link %}{% endblock todo_dashboard_title_link %}{% endspaceless %}"
-               class="text-blue-500 font-bold underline">
-                {% block todo_dashboard_title %}
-                {% endblock todo_dashboard_title %}
-            </a>
+            {# djlint:off #}<a href="{% spaceless %}{% block todo_dashboard_title_link %}{% endblock todo_dashboard_title_link %}{% endspaceless %}"
+            class="text-blue-500 font-bold underline">{% spaceless %}{% block todo_dashboard_title %}{% endblock todo_dashboard_title %}{% endspaceless %}</a>{# djlint:on #}
             {% block todo_dashboard_number %}
                 <span>({% translate "in total" %} {{ total }})</span>
             {% endblock todo_dashboard_number %}


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
FIx underlined space in To-Do dashboard

### Proposed changes
<!-- Describe this PR in more detail. -->

- wrap the `todo_dashboard_title` in `spaceless` and turn off linitng for the `a` tag to prevent surrounding spaces 


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2521 

This is a really unsatisfying solution to the problem, but the only one I could find.
__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
