### PR TITLE
Improve test coverage of search, publishing multiple objects and region deletion

### DIFF
--- a/integreat_cms/cms/fixtures/test_data.json
+++ b/integreat_cms/cms/fixtures/test_data.json
@@ -67,28 +67,6 @@
   },
   {
     "model": "cms.user",
-    "pk": 9,
-    "fields": {
-      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
-      "last_login": null,
-      "is_superuser": false,
-      "username": "author",
-      "first_name": "Region",
-      "last_name": "Author",
-      "email": "author@example.com",
-      "is_staff": false,
-      "is_active": true,
-      "date_joined": "2019-11-13T09:21:34.960Z",
-      "groups": [8],
-      "user_permissions": [],
-      "organization": null,
-      "regions": [1],
-      "expert_mode": true,
-      "page_tree_tutorial_seen": true
-    }
-  },
-  {
-    "model": "cms.user",
     "pk": 4,
     "fields": {
       "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
@@ -102,28 +80,6 @@
       "is_active": true,
       "date_joined": "2019-11-13T09:21:34.960Z",
       "groups": [3],
-      "user_permissions": [],
-      "organization": null,
-      "regions": [1],
-      "expert_mode": true,
-      "page_tree_tutorial_seen": true
-    }
-  },
-  {
-    "model": "cms.user",
-    "pk": 10,
-    "fields": {
-      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
-      "last_login": null,
-      "is_superuser": false,
-      "username": "observer",
-      "first_name": "Region",
-      "last_name": "Observer",
-      "email": "observer@example.com",
-      "is_staff": false,
-      "is_active": true,
-      "date_joined": "2019-11-13T09:21:34.960Z",
-      "groups": [9],
       "user_permissions": [],
       "organization": null,
       "regions": [1],
@@ -215,6 +171,72 @@
       "user_permissions": [],
       "organization": null,
       "regions": [],
+      "expert_mode": true,
+      "page_tree_tutorial_seen": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 9,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": false,
+      "username": "author",
+      "first_name": "Region",
+      "last_name": "Author",
+      "email": "author@example.com",
+      "is_staff": false,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [8],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [1],
+      "expert_mode": true,
+      "page_tree_tutorial_seen": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 10,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": false,
+      "username": "observer",
+      "first_name": "Region",
+      "last_name": "Observer",
+      "email": "observer@example.com",
+      "is_staff": false,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [9],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [1],
+      "expert_mode": true,
+      "page_tree_tutorial_seen": true
+    }
+  },
+  {
+    "model": "cms.user",
+    "pk": 11,
+    "fields": {
+      "password": "pbkdf2_sha256$150000$6GBOYJT9gM6Z$fUrVoa16jJuWcG5G/cEjEGUZ14e9DWJAus8ygWHN4nk=",
+      "last_login": null,
+      "is_superuser": false,
+      "username": "management_artland",
+      "first_name": "Artland",
+      "last_name": "Manager",
+      "email": "management_artland@example.com",
+      "is_staff": false,
+      "is_active": true,
+      "date_joined": "2019-11-13T09:21:34.960Z",
+      "groups": [1],
+      "user_permissions": [],
+      "organization": null,
+      "regions": [4],
       "expert_mode": true,
       "page_tree_tutorial_seen": true
     }
@@ -4314,6 +4336,18 @@
     }
   },
   {
+    "model": "cms.pushnotification",
+    "pk": 7,
+    "fields": {
+      "regions": [4],
+      "channel": "news",
+      "draft": false,
+      "sent_date": "2022-03-05T10:32:33.118Z",
+      "created_date": "2022-03-05T10:31:33.118Z",
+      "mode": "USE_MAIN_LANGUAGE"
+    }
+  },
+  {
     "model": "cms.pushnotificationtranslation",
     "pk": 1,
     "fields": {
@@ -4387,6 +4421,17 @@
       "text": "Test DE Inhalt",
       "language": 1,
       "push_notification": 6,
+      "last_updated": "2022-03-05T10:31:33.130Z"
+    }
+  },
+  {
+    "model": "cms.pushnotificationtranslation",
+    "pk": 8,
+    "fields": {
+      "title": "Test",
+      "text": "Test",
+      "language": 1,
+      "push_notification": 7,
       "last_updated": "2022-03-05T10:31:33.130Z"
     }
   },

--- a/integreat_cms/cms/models/push_notifications/push_notification_translation.py
+++ b/integreat_cms/cms/models/push_notifications/push_notification_translation.py
@@ -57,7 +57,7 @@ class PushNotificationTranslation(AbstractBaseModel):
         :return: A query for all matching objects
         """
         return cls.objects.filter(
-            push_notification__regions__contains=region,
+            push_notification__regions=region,
             language__slug=language_slug,
             title__icontains=query,
         )

--- a/integreat_cms/release_notes/current/unreleased/2542.yml
+++ b/integreat_cms/release_notes/current/unreleased/2542.yml
@@ -1,0 +1,2 @@
+en: Fix push notification search
+de: Behebe Push-Benachrichtigungssuche

--- a/tests/cms/views/view_config.py
+++ b/tests/cms/views/view_config.py
@@ -15,6 +15,7 @@ from integreat_cms.cms.models.pois.poi import get_default_opening_hours
 from ...conftest import (
     ALL_ROLES,
     AUTHOR,
+    CMS_TEAM,
     EDITOR,
     HIGH_PRIV_STAFF_ROLES,
     MANAGEMENT,
@@ -22,6 +23,7 @@ from ...conftest import (
     PRIV_STAFF_ROLES,
     ROLES,
     ROOT,
+    SERVICE_TEAM,
     STAFF_ROLES,
     WRITE_ROLES,
 )
@@ -329,12 +331,32 @@ VIEWS: list[
                 {"selected_ids[]": [1, 2, 3]},
             ),
             (
+                "publish_multiple_pages",
+                PRIV_STAFF_ROLES + [MANAGEMENT, EDITOR, AUTHOR],
+                {"selected_ids[]": [1]},
+            ),
+            (
+                "draft_multiple_pages",
+                PRIV_STAFF_ROLES + [MANAGEMENT, EDITOR, AUTHOR],
+                {"selected_ids[]": [1]},
+            ),
+            (
                 "bulk_archive_events",
                 PRIV_STAFF_ROLES + WRITE_ROLES,
                 {"selected_ids[]": [1]},
             ),
             (
                 "bulk_restore_events",
+                PRIV_STAFF_ROLES + WRITE_ROLES,
+                {"selected_ids[]": [1]},
+            ),
+            (
+                "publish_multiple_events",
+                PRIV_STAFF_ROLES + WRITE_ROLES,
+                {"selected_ids[]": [1]},
+            ),
+            (
+                "draft_multiple_events",
                 PRIV_STAFF_ROLES + WRITE_ROLES,
                 {"selected_ids[]": [1]},
             ),
@@ -348,9 +370,159 @@ VIEWS: list[
                 PRIV_STAFF_ROLES + WRITE_ROLES,
                 {"selected_ids[]": [4]},
             ),
+            (
+                "publish_multiple_pois",
+                PRIV_STAFF_ROLES + WRITE_ROLES,
+                {"selected_ids[]": [4]},
+            ),
+            (
+                "draft_multiple_pois",
+                PRIV_STAFF_ROLES + WRITE_ROLES,
+                {"selected_ids[]": [4]},
+            ),
+            (
+                "search_content_ajax",
+                ROLES,
+                json.dumps(
+                    {
+                        "query_string": "Test-Veranstaltung",
+                        "object_types": ["event"],
+                        "archived": False,
+                    }
+                ),
+            ),
+            (
+                "search_content_ajax",
+                ROLES,
+                json.dumps(
+                    {
+                        "query_string": "Test-Ort",
+                        "object_types": ["poi"],
+                        "archived": False,
+                    }
+                ),
+            ),
+            (
+                "search_content_ajax",
+                STAFF_ROLES + [MANAGEMENT, EDITOR, AUTHOR, OBSERVER],
+                json.dumps(
+                    {
+                        "query_string": "Willkommen",
+                        "object_types": ["page"],
+                        "archived": False,
+                    }
+                ),
+            ),
+            (
+                "search_content_ajax",
+                STAFF_ROLES + [MANAGEMENT],
+                json.dumps(
+                    {
+                        "query_string": "Test",
+                        "object_types": ["feedback"],
+                        "archived": False,
+                    }
+                ),
+            ),
+            (
+                "search_content_ajax",
+                STAFF_ROLES + [MANAGEMENT],
+                json.dumps(
+                    {
+                        "query_string": "Test",
+                        "object_types": ["push_notification"],
+                        "archived": False,
+                    }
+                ),
+            ),
+            (
+                "search_content_ajax",
+                STAFF_ROLES,
+                json.dumps(
+                    {
+                        "query_string": "Augsburg",
+                        "object_types": ["region"],
+                        "archived": False,
+                    }
+                ),
+            ),
+            (
+                "search_content_ajax",
+                STAFF_ROLES + [MANAGEMENT],
+                json.dumps(
+                    {
+                        "query_string": "root",
+                        "object_types": ["user"],
+                        "archived": False,
+                    }
+                ),
+            ),
+            (
+                "search_content_ajax",
+                ROLES,
+                json.dumps(
+                    {
+                        "query_string": "Test",
+                        "object_types": ["media"],
+                        "archived": False,
+                    }
+                ),
+            ),
         ],
         # The kwargs for these views
         {"region_slug": "augsburg", "language_slug": "de"},
+    ),
+    (
+        [
+            (
+                "slugify_ajax",
+                PRIV_STAFF_ROLES + WRITE_ROLES,
+                json.dumps(
+                    {
+                        "title": "Slugify event",
+                    }
+                ),
+            ),
+        ],
+        {"region_slug": "augsburg", "language_slug": "de", "model_type": "event"},
+    ),
+    (
+        [
+            (
+                "slugify_ajax",
+                PRIV_STAFF_ROLES + WRITE_ROLES,
+                json.dumps(
+                    {
+                        "title": "Slugify poi",
+                    }
+                ),
+            ),
+        ],
+        {"region_slug": "augsburg", "language_slug": "de", "model_type": "poi"},
+    ),
+    (
+        [
+            (
+                "slugify_ajax",
+                PRIV_STAFF_ROLES + [MANAGEMENT, EDITOR, AUTHOR],
+                json.dumps(
+                    {
+                        "title": "Slugify page",
+                    }
+                ),
+            ),
+        ],
+        {"region_slug": "augsburg", "language_slug": "de", "model_type": "page"},
+    ),
+    (
+        [
+            (
+                "publish_multiple_pages",
+                PRIV_STAFF_ROLES + [MANAGEMENT, EDITOR, AUTHOR],
+                {"selected_ids[]": [5]},
+            ),
+        ],
+        {"region_slug": "augsburg", "language_slug": "ar"},
     ),
     (
         [
@@ -510,6 +682,18 @@ VIEWS: list[
         ],
         # The kwargs for these views
         {"slug": "augsburg"},
+    ),
+    (
+        [
+            (
+                "delete_region",
+                [ROOT, SERVICE_TEAM, CMS_TEAM],
+                {
+                    "slug": "artland",
+                },
+            ),
+        ],
+        {"slug": "artland"},
     ),
     (
         [


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR improves the test coverage.

### Proposed changes
<!-- Describe this PR in more detail. -->
Add tests for the following views:
- integreat_cms/cms/views/utils/translation_status.py (34%->91%)
- integreat_cms/cms/views/utils/search_content_ajax.py (22%->88%)
- integreat_cms/cms/views/regions/region_actions.py (37%->90%)
- integreat_cms/cms/views/utils/slugify_ajax.py (33%->89%)

Some lines are left unchecked. Is the coverage of 100% a must?:
- `PermissionDenied` at events and POIs in `search_content_ajax`: these lines won't be called because all the roles can veiw events and POIs in the current implementation.
- `AttributeError` in `search_content_ajax`: when this is called (even in a correct context), the test fails and won't complete.
- Error by mirorred pages in region deletion: the (intended) error message "Region could not be deleted, because the following pages are mirrored in other regions:" causes a failing assertion at `assert_no_error_messages`


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- if-conditions in `search_content_ajax` are modified to raise `PermissionDenied` when users have no appropriate permission but valid `content_types`. Before the change they landed on `AttributeError` even when the problem was permissions.
- A bug was found in the search function of push notifications and is fixed (see #2542 )


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2542 (partially #2492)


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
