### PR TITLE
Ignore unreachable code for test coverage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -346,6 +346,13 @@ push = false
     'release = "{version}"',
 ]
 
+[tool.coverage.report]
+exclude_also = [
+    "def __repr__",
+    "if TYPE_CHECKING:",
+    "raise NotImplementedError",
+]
+
 [tool.djlint]
 profile="django"
 line_break_after_multiline_tag=true


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
#2459 decreased code coverage pretty significantly, which is not a real problem since the imports are checked during the mypy run.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Ignore the `repr()` functions
- Ignore type checking imports
- Ignore `NotImplementedError` lines

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Part of #2492


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
