### PR TITLE
Perform link replacement as background task

### DIFF
--- a/integreat_cms/core/circleci_settings.py
+++ b/integreat_cms/core/circleci_settings.py
@@ -30,3 +30,5 @@ LOG_LEVEL = "DEBUG"
 LINKCHECK_DISABLE_LISTENERS = True
 #: Enable logging of all entries from the messages framework
 MESSAGE_LOGGING_ENABLED = True
+# Disable background tasks during testing
+BACKGROUND_TASKS_ENABLED = False

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -185,6 +185,9 @@ CUSTOM_LOCALE_PATH: Final[str] = os.environ.get(
 #: The number of regions that are available via the dropdown
 NUM_REGIONS_QUICK_ACCESS: Final[int] = 15
 
+BACKGROUND_TASKS_ENABLED = bool(
+    strtobool(os.environ.get("INTEGREAT_CMS_BACKGROUND_TASKS_ENABLED", "True"))
+)
 
 ##############################################################
 # Firebase Push Notifications (Firebase Cloud Messaging FCM) #

--- a/integreat_cms/release_notes/current/unreleased/2343.yml
+++ b/integreat_cms/release_notes/current/unreleased/2343.yml
@@ -1,0 +1,2 @@
+en: When duplicating a region, perform internal link replacement as background task
+de: Beim Duplizieren des Inhalts einer Region werden interne Verlinkungen nun im Hintergrund ausgetauscht

--- a/tests/cms/test_duplicate_regions.py
+++ b/tests/cms/test_duplicate_regions.py
@@ -127,10 +127,10 @@ def test_duplicate_regions(
         "number_all_urls": 17,
         "number_email_urls": 0,
         "number_ignored_urls": 0,
-        "number_invalid_urls": 5,
+        "number_invalid_urls": 10,
         "number_phone_urls": 0,
         "number_unchecked_urls": 0,
-        "number_valid_urls": 12,
+        "number_valid_urls": 7,
     }, "Links should be cloned into the new region"
 
     # Check if internal links have been cloned
@@ -139,9 +139,16 @@ def test_duplicate_regions(
     assert Link.objects.filter(
         url__url=test_url, page_translation__page__region=source_region
     ).exists(), "The internal test URL should exist in the source region"
-    assert Link.objects.filter(
+    assert not Link.objects.filter(
         url__url=test_url, page_translation__page__region=target_region
-    ).exists(), "The internal test URL should exist in the target region"
+    ).exists(), "The internal test URL should not exist in the target region"
+    replaced_url = test_url.replace(source_region.slug, target_region.slug)
+    assert not Link.objects.filter(
+        url__url=replaced_url, page_translation__page__region=source_region
+    ).exists(), "The replaced internal URL not should exist in the source region"
+    assert Link.objects.filter(
+        url__url=replaced_url, page_translation__page__region=target_region
+    ).exists(), "The replaced internal URL should exist in the target region"
 
     # Check if all cloned language tree nodes exist and are identical
     source_language_tree = source_region.language_tree_nodes.all()

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -22,6 +22,9 @@ export INTEGREAT_CMS_DEEPL_AUTH_KEY="dummy"
 # Disable linkcheck listeners during testing
 export INTEGREAT_CMS_LINKCHECK_DISABLE_LISTENERS=1
 
+# Disable background tasks during testing
+export INTEGREAT_CMS_BACKGROUND_TASKS_ENABLED=0
+
 TESTS=()
 
 # Parse given command line arguments


### PR DESCRIPTION
### Short description
Reverts #2344.


### Proposed changes
<!-- Describe this PR in more detail. -->

- ~add a global task queue (implemetation almost identical to [django-linkcheck task queue](https://github.com/DjangoAdminHackers/django-linkcheck/blob/3d6188e5053469a36fedd307b75ecb02b15d0087/linkcheck/listeners.py#L19))~ Instead just create a thread where the links are replaced
- replace links when cloning content
- readd checks in the tests


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Technically there should be no multithread issue here, as django-linkcheck creates a lock when doing sth. like this, but I also did not explicitly test for side effects.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2343 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
