### PR TITLE
Validate slugs against reserved patterns

### DIFF
--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -64,6 +64,26 @@ IMPRINT_SLUG: Final[str] = os.environ.get("INTEGREAT_CMS_IMPRINT_SLUG", "disclai
 
 TEST_REGION_SLUG: Final[str] = "testumgebung"
 
+#: Reserved region slugs, that are used in the webapp
+RESERVED_REGION_SLUGS: Final[list[str]] = [
+    "landing",
+    "recommend",
+    "licenses",
+    "main-disclaimer",
+    "jpal",
+    "not-found",
+]
+
+#: Reserved region page patterns
+RESERVED_REGION_PAGE_PATTERNS: Final[list[str]] = [
+    IMPRINT_SLUG,
+    "news",
+    "events",
+    "locations",
+    "offers",
+    "search",
+]
+
 #: URL to the Integreat Website
 WEBSITE_URL: Final[str] = os.environ.get(
     "INTEGREAT_CMS_WEBSITE_URL", "https://integreat-app.de"

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -7906,9 +7906,8 @@ msgid "The PDF could not be successfully generated."
 msgstr "PDF-Datei konnte nicht erfolgreich erzeugt werden."
 
 #: cms/utils/slug_utils.py
-#, python-format
-msgid "Cannot generate slug from %(fallback)s."
-msgstr "Slug kann nicht aus dem %(fallback)s abgeleitet werden."
+msgid "Cannot generate slug from {}."
+msgstr "Slug kann nicht aus dem {} abgeleitet werden."
 
 #: cms/utils/welcome_mail_utils.py
 msgid "activation mail"

--- a/integreat_cms/release_notes/current/unreleased/1792.yml
+++ b/integreat_cms/release_notes/current/unreleased/1792.yml
@@ -1,0 +1,2 @@
+en: Disallow using region and page slugs with reserved patterns.
+de: Verbiete das Verwenden von reservierten URL-Parametern.

--- a/tests/cms/utils/test_slug_utils.py
+++ b/tests/cms/utils/test_slug_utils.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from django.core.exceptions import ValidationError
+
+from integreat_cms.cms.models import PageTranslation, Region
+from integreat_cms.cms.utils.slug_utils import generate_unique_slug
+
+if TYPE_CHECKING:
+    from pytest_django.fixtures import SettingsWrapper
+
+    from integreat_cms.cms.utils.slug_utils import SlugKwargs
+
+
+@pytest.mark.django_db
+def test_generate_unique_slug_fallback(
+    settings: SettingsWrapper, load_test_data: None
+) -> None:
+    """
+    Test whether the :meth:`~integreat_cms.cms.utils.slug_utils.generate_unique_slug_helper` function correctly uses the fallback property
+    when no slug is provided
+    """
+    region = Region.objects.get(slug="augsburg")
+    kwargs: SlugKwargs = {
+        "cleaned_data": {"name": "unique_slug_fallback"},
+        "manager": Region.objects,
+        "object_instance": region,
+        "foreign_model": "region",
+        "fallback": "name",
+    }
+    assert (
+        generate_unique_slug(**kwargs) == "unique_slug_fallback"
+    ), "Name is not used as fallback when slug is missing"
+
+
+@pytest.mark.django_db
+def test_generate_unique_slug_reserved_region_slug(
+    settings: SettingsWrapper, load_test_data: None
+) -> None:
+    """
+    Test whether the :meth:`~integreat_cms.cms.utils.slug_utils.generate_unique_slug_helper` function returns the correct unique slug
+    when the new region slug is a reserved slug
+    """
+    region = Region.objects.get(slug="augsburg")
+    kwargs: SlugKwargs = {
+        "slug": "landing",
+        "cleaned_data": {},
+        "manager": Region.objects,
+        "object_instance": region,
+        "foreign_model": "region",
+        "fallback": "name",
+    }
+    assert (
+        generate_unique_slug(**kwargs) == "landing-2"
+    ), "Reserved region slug is not prevented"
+
+
+@pytest.mark.django_db
+def test_generate_unique_slug_reserved_page_slug(
+    settings: SettingsWrapper, load_test_data: None
+) -> None:
+    """
+    Test whether the :meth:`~integreat_cms.cms.utils.slug_utils.generate_unique_slug_helper` function  function returns the correct unique slug
+    when the new page slug is a reserved slug
+    """
+    page = PageTranslation.objects.filter(page__region__slug="augsburg").first()
+    kwargs: SlugKwargs = {
+        "slug": "disclaimer",
+        "cleaned_data": {},
+        "manager": PageTranslation.objects,
+        "language": page.language,
+        "object_instance": page,
+        "foreign_model": "page",
+    }
+    assert (
+        generate_unique_slug(**kwargs) == "disclaimer-2"
+    ), "Reserved imprint slug is not prevented for pages"
+
+
+def test_generate_unique_slug_no_fallback() -> None:
+    """
+    Test whether the :meth:`~integreat_cms.cms.utils.slug_utils.generate_unique_slug_helper` throws a :class:`django.core.exceptions.ValidationError`,
+    while the fallback property does not exist
+    """
+    kwargs: SlugKwargs = {
+        "cleaned_data": {},
+        "manager": [],
+        "object_instance": Region(),
+        "foreign_model": "region",
+        "fallback": "name",
+    }
+    with pytest.raises(ValidationError):
+        generate_unique_slug(**kwargs)


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Currently regions can be created with slugs that are already in use in the webapp. The same goes for page patterns that should be reserved.

Some changes in this PR are required for #2391.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Validate against reserved region patterns
- Validate against page patterns


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1792 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
