### PR TITLE
Improve performance when deleting regions

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/2336.yml
+++ b/integreat_cms/release_notes/current/unreleased/2336.yml
@@ -1,0 +1,2 @@
+en: Improve performance when deleting regions
+de: Verbessere die Performance beim Löschen von Regionen


### PR DESCRIPTION

### Short description
<!-- Describe this PR in one or two sentences. -->

This pr suppresses most linkcheck deletion listeners when deleting regions, which hopefully improves performance enough that deleting big regions will be possible again.
Currently the `Link` post_delete handlers from linkcheck will still run, which is unnecessary. However this is hopefully not a big problem, since those only run per link and not per page translation. 


### Proposed changes
<!-- Describe this PR in more detail. -->
- Delete regions with the `disable_listeners` context manager


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- The db may be in an inconsistent state after deleting a region. However, this should only result in internal links to content of the deleted region not being flagged as broken. Also the db will be fixed after the next run of the `findlinks` management command.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

fixes: #2336


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
