### PR TITLE
Widen hix box

### DIFF
--- a/integreat_cms/cms/templates/_collapsible_box.html
+++ b/integreat_cms/cms/templates/_collapsible_box.html
@@ -1,5 +1,5 @@
 {# Set collapsed=True when including this template to show the box collapsed in the beginning #}
-<div class="rounded shadow-2xl border border-blue-500 bg-white mb-4">
+<div class="rounded {% if 2_cols %} 2xl:col-span-2 {% endif %} shadow-2xl border border-blue-500 bg-white mb-4">
     <div {% if box_id %}id="{{ box_id }}"{% endif %}
          class="collapsible cursor-pointer rounded p-4 bg-water-500 text-black font-bold flex justify-between"
          {% if collapsed %}data-collapsed{% endif %}>

--- a/integreat_cms/cms/templates/analytics/translation_coverage.html
+++ b/integreat_cms/cms/templates/analytics/translation_coverage.html
@@ -111,7 +111,7 @@
                 </div>
             </div>
             {% if TEXTLAB_API_ENABLED and request.region.hix_enabled and worst_hix_translations %}
-                {% include "analytics/_page_hix_widget.html" with box_id="hix-overview" %}
+                {% include "analytics/_page_hix_widget.html" with box_id="hix-overview" 2_cols="True" %}
             {% endif %}
         </div>
     </div>

--- a/integreat_cms/release_notes/current/unreleased/2523.yml
+++ b/integreat_cms/release_notes/current/unreleased/2523.yml
@@ -1,0 +1,2 @@
+en: Widen box of text understandibility
+de: Verbreitere die Box von Text-Verständlichkeit


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR changes the width of the "text understandibilty" box from one to two columns and adds an additional parameter for the collapsible boxes template to allow boxes to also span two columns. 

### Proposed changes
<!-- Describe this PR in more detail. -->

- Change width of "text understandibilty" box from one to two columns
- Add parameter to enable boxes to also span two columns


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

I hope none


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2523


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
