### PR TITLE
Add tests for untested management commands

### DIFF
--- a/tests/core/management/commands/test_repair_tree.py
+++ b/tests/core/management/commands/test_repair_tree.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+
+from integreat_cms.cms.models import Page, Region
+
+from ..utils import get_command_output
+
+
+@pytest.mark.django_db
+def test_check_clean_tree_fields(load_test_data: None) -> None:
+    """
+    Ensure no errors are found in default test data
+    """
+    for region in Region.objects.all():
+        for root in Page.get_root_pages(region.slug):
+            out, err = get_command_output("repair_tree", root.id)
+            assert f"Detecting problems in tree with id {root.tree_id}..." in out
+            assert not err
+
+
+@pytest.mark.django_db
+def test_fix_clean_tree_fields(load_test_data: None) -> None:
+    """
+    Ensure no errors need to be fixed in default test data
+    """
+    for region in Region.objects.all():
+        for root in Page.get_root_pages(region.slug):
+            out, err = get_command_output("repair_tree", root.id, commit=True)
+            assert f"Fixing tree with id {root.tree_id}..." in out
+            assert not err
+
+
+@pytest.mark.django_db
+def test_check_broken_tree_fields(load_test_data: None) -> None:
+    """
+    Ensure error is found in faulty test data
+    """
+    page = Page.objects.get(id=18)
+    page.lft = 2
+    page.save()
+
+    out, err = get_command_output("repair_tree", page.id)
+    assert f"Detecting problems in tree with id {page.tree_id}..." in out
+    assert "lft: 2 → 1" in err
+
+
+@pytest.mark.django_db
+def test_fix_broken_tree_fields(load_test_data: None) -> None:
+    """
+    Ensure error is fixed in faulty test data
+    """
+    page = Page.objects.get(id=18)
+    page.lft = 2
+    page.save()
+
+    out, err = get_command_output("repair_tree", page.id, commit=True)
+    assert f"Fixing tree with id {page.tree_id}..." in out
+    assert "lft: 2 → 1" in err

--- a/tests/core/management/commands/test_send_push_notifications.py
+++ b/tests/core/management/commands/test_send_push_notifications.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+import pytest
+from django.core.management.base import CommandError
+from pytest_django.fixtures import SettingsWrapper
+
+from ..utils import get_command_output
+
+
+@pytest.mark.django_db
+def test_push_notifications_disabled(settings: SettingsWrapper) -> None:
+    """
+    Ensure that disabled push notifications cause an error
+    """
+    settings.FCM_ENABLED = False
+    with pytest.raises(CommandError) as exc_info:
+        assert not any(get_command_output("send_push_notifications"))
+    assert str(exc_info.value) == "Push notifications are disabled"
+
+
+@pytest.mark.django_db
+def test_push_notifications_nonexisting_testregion(settings: SettingsWrapper) -> None:
+    """
+    Ensure that an error is caused when the system runs in debug mode but the test region does not exist
+    """
+    settings.TEST_REGION_SLUG = "non-existing"
+    settings.DEBUG = True
+    with pytest.raises(CommandError) as exc_info:
+        assert not any(get_command_output("send_push_notifications"))
+    assert (
+        str(exc_info.value)
+        == f"The system runs with DEBUG=True but the region with TEST_REGION_SLUG={settings.TEST_REGION_SLUG} does not exist."
+    )


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Add some tests for the `repair_tree` and `send_push_notifications` management commands.

### Proposed changes
<!-- Describe this PR in more detail. -->

- check that `repair_tree` does not find/fix anything in healthy trees
- check that `repair_tree` does find/fix errors in faulty trees
- check that `send_push_notifications` only available when FCM enabled
- check that `send_push_notifications` not available when in DEBUG mode and the test region does not exist

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- `repair_tree`: 0% -> 75%
- `send_push_notifications`: 0% -> 54%


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: (partially) #2492

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
