### PR TITLE
Do not refresh outdated translations

### DIFF
--- a/integreat_cms/cms/views/pages/page_actions.py
+++ b/integreat_cms/cms/views/pages/page_actions.py
@@ -790,7 +790,7 @@ def refresh_date(
     language_slug: str,
 ) -> HttpResponseRedirect:
     """
-    Refresh the date for all translations of a corresponding page
+    Refresh the date for up-to-date translations of a corresponding page
 
     :param request: The current request
     :param page_id: The id of the page of the current page form
@@ -820,8 +820,14 @@ def refresh_date(
             page_translation.language
         ),
     )
-    # Update timestamps of all translations
-    for page_translation in page_translations:
+    translations_to_update = [
+        page_translation
+        for page_translation in page_translations
+        if page_translation.language.slug == language_slug
+        or page_translation.is_up_to_date
+    ]
+    # Update timestamps of up-to-date translations
+    for page_translation in translations_to_update:
         page_translation.save()
 
     messages.success(request, _("Marked all translations of this page as up-to-date"))

--- a/integreat_cms/release_notes/current/unreleased/2511.yml
+++ b/integreat_cms/release_notes/current/unreleased/2511.yml
@@ -1,0 +1,2 @@
+en: Do not refresh outdated translations
+de: Aktualisiere keine veralteten Übersetzungen


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR modifies the function `refresh_date` so outdated translations of the page will not be refreshed

### Proposed changes
<!-- Describe this PR in more detail. -->
- Filter outdated translations out before refreshing the translation time stamp.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- One additional loop: I think this is safer (avoiding that translations are counted accidentally as outdated due to the order of date refreshing) than checking the status by `is_outdated` or `is_up_to_date` here:
https://github.com/digitalfabrik/integreat-cms/blob/21d735c41312a475c7a16e2f3acc6f792283590d/integreat_cms/cms/views/pages/page_actions.py#L823-L825

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2511 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
