### PR TITLE
Fix HIX value diff when adding empty lines

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/2577.yml
+++ b/integreat_cms/release_notes/current/unreleased/2577.yml
@@ -1,0 +1,2 @@
+en: Fix HIX value difference when adding empty lines
+de: Behebe die HIX-Wert-Differenz beim Hinzufügen von Leerzeilen

--- a/tests/textlab_api/textlab_api_test.py
+++ b/tests/textlab_api/textlab_api_test.py
@@ -1,0 +1,15 @@
+import pytest
+
+from integreat_cms.cms.views.utils.hix import normalize_text
+from tests.textlab_api.textlab_config import TEXTLAB_NORMALIZE_TEXT
+
+
+@pytest.mark.parametrize("input,output", TEXTLAB_NORMALIZE_TEXT)
+def test_normalize_text(
+    input: str,
+    output: str,
+) -> None:
+    """
+    Test for the text normalization function that is applied before sending text to the TextLab API
+    """
+    assert output == normalize_text(input)

--- a/tests/textlab_api/textlab_config.py
+++ b/tests/textlab_api/textlab_config.py
@@ -1,0 +1,50 @@
+TEXTLAB_NORMALIZE_TEXT = [
+    (
+        "<p>One paragraph</p>",
+        "<div><p>One paragraph</p></div>",
+    ),
+    (
+        "<p>One paragraph</p><p>&nbsp;&nbsp;</p><p>&nbsp;</p>",
+        "<div><p>One paragraph</p></div>",
+    ),
+    (
+        "<div><p>One paragraph</p></div>",
+        "<div><p>One paragraph</p></div>",
+    ),
+    (
+        "<div><p>One paragraph</p><p>&nbsp;&nbsp;</p><p>&nbsp;</p></div>",
+        "<div><p>One paragraph</p></div>",
+    ),
+    (
+        "<p>One paragraph</p><p>Another paragraph</p>",
+        "<div>\r\n<p>One paragraph</p>\r\n<p>Another paragraph</p>\r\n</div>",
+    ),
+    (
+        "<div><p>One paragraph</p><p>Another paragraph</p></div>",
+        "<div>\r\n<p>One paragraph</p>\r\n<p>Another paragraph</p>\r\n</div>",
+    ),
+    (
+        "<p>One paragraph</p><p>Another paragraph</p><p>&nbsp;&nbsp;</p><p>&nbsp;</p>",
+        "<div>\r\n<p>One paragraph</p>\r\n<p>Another paragraph</p>\r\n</div>",
+    ),
+    (
+        "<div><p>One paragraph</p><p>Another paragraph</p><p>&nbsp;&nbsp;</p><p>&nbsp;</p></div>",
+        "<div>\r\n<p>One paragraph</p>\r\n<p>Another paragraph</p>\r\n</div>",
+    ),
+    (
+        "<div>\n<p>One paragraph</p>\n<p>Another paragraph</p>\n</div>",
+        "<div>\r\n<p>One paragraph</p>\r\n<p>Another paragraph</p>\r\n</div>",
+    ),
+    (
+        "<div>\n<p></p></div>",
+        "<div>\r\n</div>",
+    ),
+    (
+        '<div>\n<p><a href="some.url">A link</a></p></div>',
+        '<div>\r\n<p><a href="some.url">A link</a></p>\r\n</div>',
+    ),
+    (
+        '<div><p>An image:</p><p><a href="some.image"><img src="some.image" alt=""></a></p></div>',
+        '<div>\r\n<p>An image:</p>\r\n<p><a href="some.image"><img src="some.image" alt=""></a></p>\r\n</div>',
+    ),
+]


### PR DESCRIPTION
### Short description
Currently HIX value can be manipulated by adding empty lines in a page, because if we send text with empty paragraphs to the TextLab API, it returns a better HIX value.


### Proposed changes
1. Enhance normalize_text function: 
- remove empty paragraphs
- add a div tag as root, if it's not there (it covers the case when the text has one non-empty paragraph + one or more empty paragraphs)
2. Add unit tests for normalize_text function


### Side effects
No?


### Resolved issues
Fixes: #2577


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
