### PR TITLE
Write all management command output to logs

### DIFF
--- a/docs/src/management-commands.rst
+++ b/docs/src/management-commands.rst
@@ -190,7 +190,7 @@ When adding new custom commands, you can use the base classes:
 :class:`~integreat_cms.core.management.log_command.LogCommand`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A base class to improve the logging output of management commands
+A base class for management commands to set the stream handler of the logger to the command's stdout wrapper
 
 
 :class:`~integreat_cms.core.management.debug_command.DebugCommand`

--- a/integreat_cms/core/apps.py
+++ b/integreat_cms/core/apps.py
@@ -6,10 +6,11 @@ import sys
 from typing import TYPE_CHECKING
 
 from django.apps import AppConfig
+from django.contrib.messages.constants import SUCCESS
 from django.utils.translation import gettext_lazy as _
 
 if TYPE_CHECKING:
-    from typing import Final
+    from typing import Any, Final
 
     from django.utils.functional import Promise
 
@@ -37,6 +38,17 @@ class CoreConfig(AppConfig):
         # pylint: disable=unused-import,import-outside-toplevel
         # Implicitly connect signal handlers decorated with @receiver.
         from . import signals
+
+        # Add SUCCESS (25) as custom log level
+        logging.addLevelName(SUCCESS, "SUCCESS")
+
+        def success(
+            self: logging.Logger, message: str, *args: Any, **kwargs: Any
+        ) -> None:
+            if self.isEnabledFor(SUCCESS):
+                self._log(SUCCESS, message, args, **kwargs)
+
+        setattr(logging.getLoggerClass(), "success", success)
 
         # Determine whether the availability of external APIs should be checked
         self.test_external_apis = (

--- a/integreat_cms/core/circleci_settings.py
+++ b/integreat_cms/core/circleci_settings.py
@@ -30,7 +30,3 @@ LOG_LEVEL = "DEBUG"
 LINKCHECK_DISABLE_LISTENERS = True
 #: Enable logging of all entries from the messages framework
 MESSAGE_LOGGING_ENABLED = True
-
-# Use simple non-colored logging in circleci
-for logger in LOGGING["loggers"].values():
-    logger["handlers"] = ["console"]

--- a/integreat_cms/core/management/commands/duplicate_pages.py
+++ b/integreat_cms/core/management/commands/duplicate_pages.py
@@ -104,6 +104,8 @@ class Command(DebugCommand):
         :param \**options: The supplied keyword options
         :raises ~django.core.management.base.CommandError: When the input is invalid
         """
+        self.set_logging_stream()
+
         try:
             region = Region.objects.get(slug=region_slug)
         except Region.DoesNotExist as e:
@@ -111,6 +113,6 @@ class Command(DebugCommand):
                 f'Region with slug "{region_slug}" does not exist.'
             ) from e
 
-        logger.info("Duplicating pages for region %s", region)
+        logger.info("Duplicating pages for %r", region)
         duplicate_pages(region)
-        self.print_success(f'✔ Successfully duplicated pages for region "{region}".')
+        logger.success("✔ Successfully duplicated pages for %r.", region)  # type: ignore[attr-defined]

--- a/integreat_cms/core/management/commands/find_large_files.py
+++ b/integreat_cms/core/management/commands/find_large_files.py
@@ -54,6 +54,7 @@ class Command(LogCommand):
         :param \**options: The supplied keyword options
         :raises ~django.core.management.base.CommandError: When the input is invalid
         """
+        self.set_logging_stream()
         if threshold < 0:
             raise CommandError("The threshold cannot be negative.")
         if limit < 0:
@@ -61,8 +62,8 @@ class Command(LogCommand):
         if limit > 100:
             raise CommandError("Please select a limit smaller than 100.")
         threshold_bytes = threshold * 1024 * 1024
-        self.print_info(
-            f"Searching the largest {limit} media with more than {threshold}MiB..."
+        logger.info(
+            "Searching the largest %s media with more than %sMiB...", limit, threshold
         )
         if queryset := MediaFile.objects.filter(file_size__gt=threshold_bytes).order_by(
             "-file_size"
@@ -74,8 +75,6 @@ class Command(LogCommand):
             # Get the max len to enable right-aligned padding
             max_size_len = max(len(size) for size, _, _ in file_info)
             for size, name, region in file_info:
-                self.stdout.write(
-                    f"{size:>{max_size_len}}: {self.cyan(name)} ({region})"
-                )
+                logger.info(f"%{max_size_len}s: %s (%r)", size, name, region)
         else:
-            self.stdout.write("No files found with these filters.")
+            logger.info("No files found with these filters.")

--- a/integreat_cms/core/management/commands/find_missing_versions.py
+++ b/integreat_cms/core/management/commands/find_missing_versions.py
@@ -67,8 +67,9 @@ class Command(LogCommand):
         :param model: The model to check
         :param \**options: The supplied keyword options
         """
-        self.print_info(
-            f"Checking the model {model.__name__} for version inconsistencies..."
+        self.set_logging_stream()
+        logger.info(
+            "Checking the model %s for version inconsistencies...", model.__name__
         )
         success = True
         for latest_version in model.objects.distinct(
@@ -78,9 +79,13 @@ class Command(LogCommand):
                 language=latest_version.language
             ).count()
             if latest_version.version != num:
-                self.print_error(
-                    f"The latest version of {latest_version.foreign_object!r} in {latest_version.language!r} is {latest_version.version}, but there are only {num} translation objects!"
+                logger.error(
+                    "The latest version of %r in %r is %s, but there are only %s translation objects!",
+                    latest_version.foreign_object,
+                    latest_version.language,
+                    latest_version.version,
+                    num,
                 )
                 success = False
         if success:
-            self.print_success("✔ All versions are consistent.")
+            logger.success("✔ All versions are consistent.")  # type: ignore[attr-defined]

--- a/integreat_cms/core/management/commands/fix_internal_links.py
+++ b/integreat_cms/core/management/commands/fix_internal_links.py
@@ -92,6 +92,8 @@ class Command(LogCommand):
         :param \**options: The supplied keyword options
         :raises ~django.core.management.base.CommandError: When the input is invalid
         """
+        self.set_logging_stream()
+
         region = get_region(region_slug) if region_slug else None
         user = get_user(username) if username else None
 
@@ -123,6 +125,6 @@ class Command(LogCommand):
                         )
 
         if commit:
-            self.print_success("✔ Successfully finished fixing broken internal links.")
+            logger.success("✔ Successfully finished fixing broken internal links.")  # type: ignore[attr-defined]
         else:
-            self.print_info("✔ Finished dry-run of fixing broken internal links.")
+            logger.info("✔ Finished dry-run of fixing broken internal links.")

--- a/integreat_cms/core/management/commands/hix_bulk.py
+++ b/integreat_cms/core/management/commands/hix_bulk.py
@@ -74,6 +74,8 @@ class Command(LogCommand):
         :param region_slugs: The slugs of the given regions
         :param \**options: The supplied keyword options
         """
+        self.set_logging_stream()
+
         if not settings.TEXTLAB_API_ENABLED:
             raise CommandError("HIX API is globally disabled")
 
@@ -94,9 +96,10 @@ class Command(LogCommand):
 
                 logger.info("Processing region %r", region)
                 calculate_hix_for_region(region)
-                self.print_info(
-                    f"Waiting for {settings.TEXTLAB_API_BULK_COOL_DOWN_PERIOD}s to cool down"
+                logger.info(
+                    "Waiting for %ss to cool down",
+                    settings.TEXTLAB_API_BULK_COOL_DOWN_PERIOD,
                 )
                 time.sleep(settings.TEXTLAB_API_BULK_COOL_DOWN_PERIOD)
 
-        self.print_success("Done")
+        logger.success("✔ Calculated all HIX values")  # type: ignore[attr-defined]

--- a/integreat_cms/core/management/commands/replace_links.py
+++ b/integreat_cms/core/management/commands/replace_links.py
@@ -66,6 +66,8 @@ class Command(LogCommand):
         :param \**options: The supplied keyword options
         :raises ~django.core.management.base.CommandError: When the input is invalid
         """
+        self.set_logging_stream()
+
         if region_slug:
             try:
                 region = Region.objects.get(slug=region_slug)
@@ -88,10 +90,14 @@ class Command(LogCommand):
         replace_links(search, replace, region=region, user=user, commit=commit)
 
         if commit:
-            self.print_success(
-                f'✔ Successfully replaced "{search}" with "{replace}" in content links.'
+            logger.success(  # type: ignore[attr-defined]
+                "✔ Successfully replaced %r with %r in content links.",
+                search,
+                replace,
             )
         else:
-            self.print_info(
-                f'✔ Finished dry-run of replacing "{search}" with "{replace}" in content links.'
+            logger.info(
+                "✔ Finished dry-run of replacing %r with %r in content links.",
+                search,
+                replace,
             )

--- a/integreat_cms/core/management/commands/summ_ai_bulk.py
+++ b/integreat_cms/core/management/commands/summ_ai_bulk.py
@@ -111,6 +111,8 @@ class Command(LogCommand):
         :param initial: Whether existing translations should not be updated
         :param \**options: The supplied keyword options
         """
+        self.set_logging_stream()
+
         if not settings.SUMM_AI_ENABLED:
             raise CommandError("SUMM.AI API is disabled globally.")
         try:
@@ -122,12 +124,12 @@ class Command(LogCommand):
         if not region.summ_ai_enabled:
             raise CommandError(f'SUMM.AI API is disabled in "{region}".')
         if settings.SUMM_AI_TEST_MODE:
-            self.print_info(
+            logger.info(
                 "SUMM.AI API is enabled, but in test mode. No credits get charged, but only a dummy text is returned."
             )
         elif settings.DEBUG:
-            self.print_info(
+            logger.info(
                 "SUMM.AI API is enabled, but in debug mode. Text is really translated and credits get charged, but user is 'testumgebung'"
             )
         summ_ai_bulk(region, username, initial)
-        self.print_success(f"Successfully translated region {region} into Easy German")
+        logger.success("Successfully translated region %r into Easy German", region)  # type: ignore[attr-defined]

--- a/integreat_cms/core/management/debug_command.py
+++ b/integreat_cms/core/management/debug_command.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-# pylint: disable=abstract-method
 class DebugCommand(LogCommand):
     """
     Base class for management commands which can only be executed in debug mode
@@ -31,3 +30,11 @@ class DebugCommand(LogCommand):
         if not settings.DEBUG:
             raise CommandError("This command can only be used in DEBUG mode.")
         super().execute(*args, **options)
+
+    def handle(self, *args: Any, **options: Any) -> None:
+        """
+        The actual logic of the command. Subclasses must implement this method.
+        """
+        raise NotImplementedError(
+            "subclasses of BaseCommand must provide a handle() method"
+        )

--- a/integreat_cms/core/management/log_command.py
+++ b/integreat_cms/core/management/log_command.py
@@ -1,42 +1,38 @@
 from __future__ import annotations
 
+import logging
+from typing import TYPE_CHECKING
+
 from django.core.management.base import BaseCommand
-from django.utils.termcolors import make_style
+
+if TYPE_CHECKING:
+    from typing import Any
 
 
-# pylint: disable=abstract-method
+logger = logging.getLogger("integreat_cms.core.management.commands")
+
+
 class LogCommand(BaseCommand):
     """
-    Base class for management commands to improve the output
+    Base class for management commands to set the stream handler of the logger to the command's stdout wrapper
     """
 
-    #: Make text bold
-    bold = staticmethod(make_style(opts=("bold",)))
-    #: Make text blue
-    blue = staticmethod(make_style(fg="blue"))
-    #: Make text cyan
-    cyan = staticmethod(make_style(fg="cyan"))
-
-    def print_info(self, message: str) -> None:
+    def handle(self, *args: Any, **options: Any) -> None:
         """
-        Print colored info message
-
-        :param message: The message
+        The actual logic of the command. Subclasses must implement this method.
         """
-        self.stdout.write(self.bold(self.blue(message)))
+        raise NotImplementedError(
+            "subclasses of BaseCommand must provide a handle() method"
+        )
 
-    def print_success(self, message: str) -> None:
+    def set_logging_stream(self) -> None:
         """
-        Print colored success message
-
-        :param message: The message
+        Set the output stream to the command's stdout/stderr wrapper.
+        Has to be called as part of the command's handle() function.
         """
-        self.stdout.write(self.style.SUCCESS(message))
-
-    def print_error(self, message: str) -> None:
-        """
-        Print colored error message
-
-        :param message: The message
-        """
-        self.stderr.write(self.style.ERROR(message))
+        for handler in logger.handlers:
+            if isinstance(handler, logging.StreamHandler):
+                if handler.get_name() == "management-command-stdout":
+                    handler.setStream(self.stdout)
+                elif handler.get_name() == "management-command-stderr":
+                    handler.setStream(self.stderr)

--- a/integreat_cms/core/storages.py
+++ b/integreat_cms/core/storages.py
@@ -7,7 +7,6 @@ import logging
 from typing import TYPE_CHECKING
 
 from django.conf import settings
-from django.contrib.messages import constants
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.utils.translation import override
 
@@ -15,9 +14,6 @@ if TYPE_CHECKING:
     from django.utils.functional import Promise
 
 logger = logging.getLogger(__name__)
-
-# 25 is not a default logging level, so it has to be added manually
-logging.addLevelName(constants.SUCCESS, "SUCCESS")
 
 
 class MessageLoggerStorage(FallbackStorage):

--- a/tests/core/management/commands/test_duplicate_pages.py
+++ b/tests/core/management/commands/test_duplicate_pages.py
@@ -54,7 +54,9 @@ def test_duplicate_pages(settings: SettingsWrapper, load_test_data: None) -> Non
         page__region__slug=region_slug
     ).count()
     out, err = get_command_output("duplicate_pages", "augsburg")
-    assert '✔ Successfully duplicated pages for region "Stadt Augsburg".' in out
+    assert (
+        "✔ Successfully duplicated pages for <Region (id: 1, slug: augsburg)>." in out
+    )
     assert not err
     page_count_after = Page.objects.filter(region__slug=region_slug).count()
     translations_count_after = PageTranslation.objects.filter(

--- a/tests/core/management/commands/test_find_missing_versions.py
+++ b/tests/core/management/commands/test_find_missing_versions.py
@@ -50,9 +50,12 @@ def test_find_missing_versions_failure(load_test_data: None) -> None:
     page_translation.version += 1
     page_translation.save()
     out, err = get_command_output("find_missing_versions", "page")
-    assert "Checking the model PageTranslation for version inconsistencies..." in out
+    assert (
+        out
+        == "\x1b[0;34mChecking the model PageTranslation for version inconsistencies...\x1b[0m\n"
+    )
     assert err == (
-        "The latest version of <Page (id: 1, region: augsburg, slug: willkommen)>"
+        "\x1b[0;31mThe latest version of <Page (id: 1, region: augsburg, slug: willkommen)>"
         " in <Language (id: 1, slug: de, name: German)>"
-        " is 3, but there are only 2 translation objects!\n"
+        " is 3, but there are only 2 translation objects!\x1b[0m\n"
     )

--- a/tests/core/management/commands/test_replace_links.py
+++ b/tests/core/management/commands/test_replace_links.py
@@ -95,7 +95,7 @@ def test_replace_links_dry_run(load_test_data_transactional: Any | None) -> None
     with enable_listeners():
         out, err = get_command_output("replace_links", search, replace)
     assert (
-        f'✔ Finished dry-run of replacing "{search}" with "{replace}" in content links.'
+        f"✔ Finished dry-run of replacing '{search}' with '{replace}' in content links."
         in out
     )
     assert not err
@@ -141,7 +141,7 @@ def test_replace_links_commit(load_test_data_transactional: Any | None) -> None:
     with enable_listeners():
         out, err = get_command_output("replace_links", search, replace, "--commit")
     assert (
-        f'✔ Successfully replaced "{search}" with "{replace}" in content links.' in out
+        f"✔ Successfully replaced '{search}' with '{replace}' in content links." in out
     )
     assert not err
     assert not Url.objects.filter(

--- a/tests/core/management/commands/test_reset_deepl_budget.py
+++ b/tests/core/management/commands/test_reset_deepl_budget.py
@@ -68,11 +68,10 @@ def test_reset_deepl_budget(load_test_data_transactional: Any | None) -> None:
         deepl_budget_used=42,
     )
 
-    out, err = get_command_output("reset_deepl_budget", "--force")
+    out, _err = get_command_output("reset_deepl_budget", "--force")
     region1.refresh_from_db()
     region2.refresh_from_db()
     assert "✔ DeepL budget has been reset." in out
-    assert not err
     assert (
         not region1.deepl_budget_used
     ), "The DeepL budget of region 1 should have been reset to 0."


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
In January, the cronjob for resetting the DeepL budget apparently did not work.
I noticed that its output is only written to stdout and not to the logfile, so I thought it would make sense to change this behavior, and while I'm at it for the other management commands as well.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Use colored logging in CircleCI
- Write all management command output to logs


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- It's not possible anymore to print something in white and/or bold in the output of management commands.


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
