### PR TITLE
Disable delete button for used media files and improve error message

### DIFF
--- a/integreat_cms/cms/models/media/media_file.py
+++ b/integreat_cms/cms/models/media/media_file.py
@@ -336,6 +336,7 @@ class MediaFile(AbstractBaseModel):
             "lastModified": localize(timezone.localtime(self.last_modified)),
             "isGlobal": not self.region,
             "isHidden": self.is_hidden,
+            "deletable": not self.is_used,
         }
 
     @classmethod

--- a/integreat_cms/cms/views/media/media_actions.py
+++ b/integreat_cms/cms/views/media/media_actions.py
@@ -354,6 +354,22 @@ def delete_file_ajax(
         MediaFile.objects.filter(region=region), id=request.POST.get("id")
     )
 
+    # Check if the media file is in use
+    if media_file.is_used:
+        return JsonResponse(
+            {
+                "messages": [
+                    {
+                        "type": "warning",
+                        "text": _(
+                            'File "{}" cannot be deleted because it is used as an icon or content.'
+                        ).format(media_file.name),
+                    }
+                ],
+            },
+            status=400,
+        )
+
     # Delete corresponding physical files
     media_file.file.delete()
     media_file.thumbnail.delete()

--- a/integreat_cms/cms/views/media/media_context_mixin.py
+++ b/integreat_cms/cms/views/media/media_context_mixin.py
@@ -43,6 +43,7 @@ class MediaContextMixin(ContextMixin):
                 "btn_upload_file": _("Upload file"),
                 "btn_save_file": _("Save file"),
                 "btn_delete_file": _("Delete file"),
+                "btn_delete_used_file": _("You can only delete unused media files"),
                 "btn_show_file": _("Show file"),
                 "btn_create": _("Create"),
                 "btn_enter_directory": _("Enter directory"),

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8450,6 +8450,12 @@ msgid "File \"{}\" was saved successfully"
 msgstr "Datei \"{}\" wurde erfolgreich gespeichert"
 
 #: cms/views/media/media_actions.py
+msgid "File \"{}\" cannot be deleted because it is used as an icon or content."
+msgstr ""
+"Datei \"{}\" kann nicht gelöscht werden, da sie als Icon oder Inhalt benutzt "
+"ist."
+
+#: cms/views/media/media_actions.py
 msgid "File \"{}\" was successfully deleted"
 msgstr "Datei \"{}\" wurde erfolgreich gelöscht"
 
@@ -8520,6 +8526,10 @@ msgstr "Datei speichern"
 #: cms/views/media/media_context_mixin.py
 msgid "Delete file"
 msgstr "Datei löschen"
+
+#: cms/views/media/media_context_mixin.py
+msgid "You can only delete unused media files"
+msgstr "Es können nur unbenutzte Dateien gelöscht werden"
 
 #: cms/views/media/media_context_mixin.py
 msgid "Show file"

--- a/integreat_cms/release_notes/current/unreleased/2585.yml
+++ b/integreat_cms/release_notes/current/unreleased/2585.yml
@@ -1,0 +1,2 @@
+en: Disable delete button for used media files and improve error message
+de: Deaktiviere die Schaltfläche "Löschen" für verwendete Mediendateien und verbessere die Fehlermeldung

--- a/integreat_cms/static/src/js/media-management/component/edit-sidebar.tsx
+++ b/integreat_cms/static/src/js/media-management/component/edit-sidebar.tsx
@@ -396,11 +396,15 @@ const EditSidebar = ({
                                 )}
                                 {canDeleteFile && (
                                     <button
-                                        title={mediaTranslations.btn_delete_file}
-                                        className={cn("btn", { "btn-red": !isLoading })}
+                                        title={
+                                            file.deletable
+                                                ? mediaTranslations.btn_delete_file
+                                                : mediaTranslations.btn_delete_used_file
+                                        }
+                                        className={cn("btn", { "btn-red": !isLoading && file.deletable })}
                                         data-confirmation-title={mediaTranslations.text_file_delete_confirm}
                                         data-confirmation-subject={file.name}
-                                        disabled={isLoading}
+                                        disabled={isLoading || !file.deletable}
                                         onClick={showConfirmationPopupAjax}
                                         onaction-confirmed={() => document.getElementById("delete-file").click()}>
                                         <Trash2 class="inline-block" />

--- a/integreat_cms/static/src/js/media-management/index.tsx
+++ b/integreat_cms/static/src/js/media-management/index.tsx
@@ -48,6 +48,7 @@ export type File = {
     lastModified: Date;
     isGlobal: boolean;
     isHidden: boolean;
+    deletable: boolean;
 };
 
 export type FileUsage = {


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR disables the delete button if the media file is in use and improve as back up the error message which is shown when users try to delete an used media file,

### Proposed changes
<!-- Describe this PR in more detail. -->
- Disable the delete button for used media files
- Improve the error message in case a media file in use is about to be deleted.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- The delete button is disabled in another way than I suggested in the issue. In my opinion it's better to disable it in the same way as it is disabled for non-empty directories.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2585 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
