### PR TITLE
Fix DeepL budget year start not being shown in the case of January

### DIFF
--- a/integreat_cms/cms/forms/regions/region_form.py
+++ b/integreat_cms/cms/forms/regions/region_form.py
@@ -210,8 +210,8 @@ class RegionForm(CustomModelForm):
             self.fields["summ_ai_enabled"].disabled = True
         if not settings.TEXTLAB_API_ENABLED and not self.instance.hix_enabled:
             self.fields["hix_enabled"].disabled = True
-        self.fields["deepl_midyear_start_enabled"].initial = bool(
-            self.instance.deepl_midyear_start_month
+        self.fields["deepl_midyear_start_enabled"].initial = (
+            self.instance.deepl_midyear_start_month is not None
         )
         self.disabled_offer_options = (
             OfferTemplate.objects.filter(pages__region=self.instance)

--- a/integreat_cms/release_notes/current/unreleased/2598.yml
+++ b/integreat_cms/release_notes/current/unreleased/2598.yml
@@ -1,0 +1,2 @@
+en: Fix the differing DeepL budget year start not being shown in the case of January
+de: Behebe, dass der unterjährige Start des DeepL Abrechnungszeitraums im Fall von Januar nicht angezeigt wurde


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fixes the budget year start not being shown in case it was set to january

### Proposed changes
<!-- Describe this PR in more detail. -->

- explicitly check if the month is `None`, rather than truthy, because January is saved as `0`


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2598 

(Sorry for taking a `good first issue`, just saw that its prio had been upped to high this morning)
__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
