### PR TITLE
Fix feedback filtering errors

### DIFF
--- a/integreat_cms/cms/forms/feedback/region_feedback_filter_form.py
+++ b/integreat_cms/cms/forms/feedback/region_feedback_filter_form.py
@@ -69,20 +69,19 @@ class RegionFeedbackFilterForm(CustomFilterForm):
     query = forms.CharField(required=False)
 
     def apply(
-        self, feedback: CascadeDeletePolymorphicQuerySet, region: Region | None
+        self, feedback: CascadeDeletePolymorphicQuerySet
     ) -> tuple[CascadeDeletePolymorphicQuerySet, None]:
         """
         Filter the feedback list according to the given filter data
 
         :param feedback: The list of feedback
-        :param region: The current region
         :return: The filtered feedback list and the search query
         """
         if not self.is_enabled:
             return feedback, None
 
         if query := self.cleaned_data["query"]:
-            feedback = Feedback.search(region=region, query=query)
+            feedback = feedback.filter(comment__icontains=query)
 
         # Filter feedback for region
         if self.cleaned_data.get("region", None):

--- a/integreat_cms/cms/templates/feedback/admin_feedback_list.html
+++ b/integreat_cms/cms/templates/feedback/admin_feedback_list.html
@@ -20,7 +20,7 @@
                 </a>
             </div>
             <div class="flex justify-between">
-                {% include "search_input_form.html" with object_type="feedback" related_form="admin-feedback-filter-form" %}
+                {% include "_search_input.html" with object_type="feedback" related_form="admin-feedback-filter-form" %}
                 <button id="filter-toggle" class="btn btn-ghost">
                     <span class="filter-toggle-text {% if filters_visible %}hidden{% endif %}">{% translate "Show filters" %}</span>
                     <span class="filter-toggle-text {% if not filters_visible %}hidden{% endif %}">{% translate "Hide filters" %}</span>
@@ -111,7 +111,7 @@
                             <i icon-name="minus" class="pr-1"></i>
                         {% else %}
                             <div class="table-cell-truncate">
-                                <span class="table-cell-content ">{{ feedback.comment }}</span>
+                                <span class="table-cell-content">{{ feedback.comment }}</span>
                                 <a class="toggle-table-cell">
                                     <i icon-name="chevron-down" class="more"></i>
                                     <i icon-name="chevron-up" class="less"></i>

--- a/integreat_cms/cms/templates/feedback/admin_feedback_list_archived.html
+++ b/integreat_cms/cms/templates/feedback/admin_feedback_list_archived.html
@@ -19,7 +19,7 @@
                 </a>
             </div>
             <div class="flex justify-between">
-                {% include "search_input_form.html" with object_type="feedback" related_form="admin-feedback-filter-form" %}
+                {% include "_search_input.html" with object_type="feedback" object_archived=True related_form="admin-feedback-filter-form" %}
                 <button id="filter-toggle" class="btn btn-ghost">
                     <span class="filter-toggle-text {% if filters_visible %}hidden{% endif %}">{% translate "Show filters" %}</span>
                     <span class="filter-toggle-text {% if not filters_visible %}hidden{% endif %}">{% translate "Hide filters" %}</span>
@@ -109,9 +109,9 @@
                         {% if not feedback.comment %}
                             <i icon-name="minus" class="pr-1"></i>
                         {% else %}
-                            <div class="feedback-entry">
-                                <span class="feedback-entry-content ">{{ feedback.comment }}</span>
-                                <a class="toggle-feedback-entry">
+                            <div class="table-cell-truncate">
+                                <span class="table-cell-content">{{ feedback.comment }}</span>
+                                <a class="toggle-table-cell">
                                     <i icon-name="chevron-down" class="more"></i>
                                     <i icon-name="chevron-up" class="less"></i>
                                 </a>

--- a/integreat_cms/cms/templates/feedback/region_feedback_list_archived.html
+++ b/integreat_cms/cms/templates/feedback/region_feedback_list_archived.html
@@ -19,7 +19,7 @@
                 </a>
             </div>
             <div class="flex justify-between">
-                {% include "_search_input.html" with object_type="feedback" region_slug=request.region.slug related_form="region-feedback-filter-form" %}
+                {% include "_search_input.html" with object_type="feedback" object_archived=True region_slug=request.region.slug related_form="region-feedback-filter-form" %}
                 <button id="filter-toggle" class="btn btn-ghost">
                     <span class="filter-toggle-text {% if filters_visible %}hidden{% endif %}">{% translate "Show filters" %}</span>
                     <span class="filter-toggle-text {% if not filters_visible %}hidden{% endif %}">{% translate "Hide filters" %}</span>
@@ -106,9 +106,9 @@
                         {% if not feedback.comment %}
                             <i icon-name="minus" class="pr-1"></i>
                         {% else %}
-                            <div class="feedback-entry">
-                                <span class="feedback-entry-content">{{ feedback.comment }}</span>
-                                <a class="toggle-feedback-entry">
+                            <div class="table-cell-truncate">
+                                <span class="table-cell-content">{{ feedback.comment }}</span>
+                                <a class="toggle-table-cell">
                                     <i icon-name="chevron-down" class="more"></i>
                                     <i icon-name="chevron-up" class="less"></i>
                                 </a>

--- a/integreat_cms/cms/views/feedback/admin_feedback_list_view.py
+++ b/integreat_cms/cms/views/feedback/admin_feedback_list_view.py
@@ -60,7 +60,7 @@ class AdminFeedbackListView(TemplateView):
 
         # Filter pages according to given filters, if any
         filter_form = AdminFeedbackFilterForm(data=request.GET)
-        admin_feedback, query = filter_form.apply(admin_feedback, region=None)
+        admin_feedback, query = filter_form.apply(admin_feedback)
 
         admin_feedback = admin_feedback.select_related("region", "language")
 

--- a/integreat_cms/cms/views/feedback/region_feedback_list_view.py
+++ b/integreat_cms/cms/views/feedback/region_feedback_list_view.py
@@ -61,7 +61,7 @@ class RegionFeedbackListView(TemplateView):
         )
 
         filter_form = RegionFeedbackFilterForm(data=request.GET)
-        region_feedback, query = filter_form.apply(region_feedback, region)
+        region_feedback, query = filter_form.apply(region_feedback)
 
         region_feedback = region_feedback.select_related("region", "language")
 

--- a/integreat_cms/cms/views/utils/search_content_ajax.py
+++ b/integreat_cms/cms/views/utils/search_content_ajax.py
@@ -112,7 +112,9 @@ def search_content_ajax(
                 "url": None,
                 "type": "feedback",
             }
-            for feedback in Feedback.search(region, query)
+            for feedback in Feedback.search(region, query).filter(
+                archived=archived_flag
+            )
         )
 
     if "page" in object_types:

--- a/integreat_cms/release_notes/current/unreleased/2587.yml
+++ b/integreat_cms/release_notes/current/unreleased/2587.yml
@@ -1,0 +1,2 @@
+en: Fix feedback filtering issues
+de: Behebe Fehler im Feedback-Filter


### PR DESCRIPTION
### Short description
Fix a few small bugs in feedback filtering


### Proposed changes
1. Fix the defect described in #2587
2. Fix the more-less buttons in archived feedback forms
![image](https://github.com/digitalfabrik/integreat-cms/assets/115008338/cd962fb0-5aae-46e0-b002-35b1d25e7320)
3. Fix the following issue:
When a query search is applied, it ignores the "archived" attribute.
For example, this is a form for active feedback.
![image](https://github.com/digitalfabrik/integreat-cms/assets/115008338/4fa38658-d326-4fb2-a6fb-b2cd2f1bf64a)
But if I try to search for a feedback by comment, it also adds archived feedback to the output (the first one is actually archived).
![image](https://github.com/digitalfabrik/integreat-cms/assets/115008338/8602d17a-1958-4c4f-988a-0e55d82f9d67)


### Side effects
No?


### Resolved issues
Fixes: #2587


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
