### PR TITLE
Fix review submission notification

### DIFF
--- a/integreat_cms/cms/forms/custom_content_model_form.py
+++ b/integreat_cms/cms/forms/custom_content_model_form.py
@@ -239,28 +239,20 @@ class CustomContentModelForm(CustomModelForm):
 
         :param request: The current request submitting the translation form
         """
+        status_messages = {
+            status.AUTO_SAVE: _('{} "{}" was saved automatically'),
+            status.REVIEW: _('{} "{}" was successfully submitted for review'),
+            status.DRAFT: _('{} "{}" was successfully saved as draft'),
+            status.PUBLIC: (
+                _('{} "{}" was successfully published')
+                if "status" in self.changed_data
+                else _('{} "{}" was successfully updated')
+            ),
+        }
+
         model_name = type(self.instance.foreign_object)._meta.verbose_name.title()
-        if not self.instance.status == status.PUBLIC:
-            messages.success(
-                request,
-                _('{} "{}" was successfully saved as draft').format(
-                    model_name, self.instance.title
-                ),
-            )
-        elif "status" not in self.changed_data:
-            messages.success(
-                request,
-                _('{} "{}" was successfully updated').format(
-                    model_name, self.instance.title
-                ),
-            )
-        else:
-            messages.success(
-                request,
-                _('{} "{}" was successfully published').format(
-                    model_name, self.instance.title
-                ),
-            )
+        if message := status_messages.get(self.instance.status):
+            messages.success(request, message.format(model_name, self.instance.title))
 
     class Meta:
         fields = [

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -1694,16 +1694,24 @@ msgstr ""
 "schließen sich gegenseitig aus."
 
 #: cms/forms/custom_content_model_form.py
+msgid "{} \"{}\" was saved automatically"
+msgstr "{} \"{}\" wurde automatisch gespeichert"
+
+#: cms/forms/custom_content_model_form.py
+msgid "{} \"{}\" was successfully submitted for review"
+msgstr "{} \"{}\" wurde erfolgreich zur Überprüfung eingereicht"
+
+#: cms/forms/custom_content_model_form.py
 msgid "{} \"{}\" was successfully saved as draft"
 msgstr "{} \"{}\" wurde erfolgreich als Entwurf gespeichert"
 
 #: cms/forms/custom_content_model_form.py
-msgid "{} \"{}\" was successfully updated"
-msgstr "{} \"{}\" wurde erfolgreich aktualisiert"
-
-#: cms/forms/custom_content_model_form.py
 msgid "{} \"{}\" was successfully published"
 msgstr "{} \"{}\" wurde erfolgreich veröffentlicht"
+
+#: cms/forms/custom_content_model_form.py
+msgid "{} \"{}\" was successfully updated"
+msgstr "{} \"{}\" wurde erfolgreich aktualisiert"
 
 #: cms/forms/custom_model_form.py
 msgid "Enter {} here"

--- a/integreat_cms/release_notes/current/unreleased/2605.yml
+++ b/integreat_cms/release_notes/current/unreleased/2605.yml
@@ -1,0 +1,2 @@
+en: Fix notification shown to user when submitting pages for review
+de: Korrigiere die dem Nutzer nach Abschicken einer Seite zur Überprüfung angezeigte Benachrichtigung


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

Instead of showing the message meant for saving drafts, submitting pages for review now has its own success message.

### Proposed changes
<!-- Describe this PR in more detail. -->

- check if the to-be-saved content object is a Page and the user has permission to edit the page; if not, show the new success message
- tbh I am not super happy with the way checking the content type is done (against a hardcoded string), if someone has a better idea, I am all ears


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none afaik 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2605 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
