### PR TITLE
Remove duplicate 'x' in search fields

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/2604.yml
+++ b/integreat_cms/release_notes/current/unreleased/2604.yml
@@ -1,0 +1,2 @@
+en: Remove duplicate 'x' in search fields in Chromium-based browsers
+de: Entferne doppeltes 'x' in Suchfeldern in Chromium-basierten Browsern

--- a/integreat_cms/static/src/css/style.scss
+++ b/integreat_cms/static/src/css/style.scss
@@ -305,6 +305,17 @@ label:not([for]) {
     @apply mb-2 text-gray-600;
 }
 
+::-ms-clear {
+    display: none;
+}
+
+::-webkit-search-decoration,
+::-webkit-search-cancel-button,
+::-webkit-search-results-button,
+::-webkit-search-results-decoration {
+    display: none;
+}
+
 .table-listing {
     overflow-x: auto;
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

In Chromium-based browsers, a duplicate 'x' for clearing search fields was inserted by the browser itself. This PR adds styling to hide this element.

### Proposed changes
<!-- Describe this PR in more detail. -->

- apply `display: none` to the duplicate 'x'


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2604 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
