### PR TITLE
Fix filter reset function

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/1589.yml
+++ b/integreat_cms/release_notes/current/unreleased/1589.yml
@@ -1,0 +1,2 @@
+en: Fix filter reset function
+de: Repariere die "Filter zurücksetzen"-Funktion

--- a/integreat_cms/static/src/js/filter-form.ts
+++ b/integreat_cms/static/src/js/filter-form.ts
@@ -14,6 +14,9 @@ const resetToDefaultValue = (node: HTMLSelectElement | HTMLInputElement) => {
         // Non-checkbox input marked to have a default value
         /* eslint-disable-next-line no-param-reassign */
         node.value = node.getAttribute("data-default-value");
+    } else if (node.matches("select")) {
+        const inputElement = document.getElementById(node.id) as HTMLInputElement;
+        inputElement.value = "";
     }
 };
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the reset function for filter. 

### Proposed changes
<!-- Describe this PR in more detail. -->
- Set `value` of `select` Objects to "" (default).
- I decided against `HTMLFormElement.reset()` because this sets the choices back to the latest chosen values not the default.

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- None?


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1589 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
