### PR TITLE
Add test for language tree node

### DIFF
--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8379,6 +8379,14 @@ msgstr "Der Sprach-Knoten \"{}\" wurde erfolgreich verschoben."
 
 #: cms/views/language_tree/language_tree_actions.py
 msgid ""
+"The language tree node \"{}\" cannot be deleted because it is the source "
+"language of other language(s)."
+msgstr ""
+"Der Sprach-Knoten \"{}\" kann nicht gelöscht werden, da er die Quell-Sprache "
+"anderer Sprachen ist."
+
+#: cms/views/language_tree/language_tree_actions.py
+msgid ""
 "The language tree node \"{}\" and all corresponding translations were "
 "successfully deleted."
 msgstr ""

--- a/tests/cms/test_language.py
+++ b/tests/cms/test_language.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import pytest
+from django.conf import settings
+from django.test.client import Client
+from django.urls import reverse
+
+from integreat_cms.cms.models import Language, LanguageTreeNode, Region
+from tests.conftest import ANONYMOUS, HIGH_PRIV_STAFF_ROLES
+
+
+@pytest.mark.django_db
+def test_create_new_language_node(
+    load_test_data: None,
+    login_role_user: tuple[Client, str],
+) -> None:
+    # Log the user in
+    client, role = login_role_user
+
+    region = Region.objects.filter(slug="nurnberg").first()
+    # Ukrainian will be used for the test because the region Nürnberg does not have it.
+    new_language = Language.objects.filter(slug="uk").first()
+    parent = region.language_tree_root
+
+    # Check the new language does not exist in the region
+    assert not new_language in region.languages
+
+    next_url = url = reverse(
+        "new_languagetreenode", kwargs={"region_slug": region.slug}
+    )
+    response = client.post(
+        url,
+        data={
+            "language": new_language.id,
+            "visible": True,
+            "active": True,
+            "parent": parent.id,
+            "machine_translation_enabled": True,
+        },
+    )
+
+    if role in HIGH_PRIV_STAFF_ROLES:
+        assert response.status_code == 302
+        # Verify the new language node was created
+        assert (
+            LanguageTreeNode.objects.filter(
+                region=region, language=new_language
+            ).count()
+            == 1
+        )
+        # Verify now both Augsburg and Nürnberg have a language node with Ukrainian
+        assert LanguageTreeNode.objects.filter(language=new_language).count() == 2
+    elif role == ANONYMOUS:
+        # For anonymous users, we want to redirect to the login form instead of showing an error
+        assert response.status_code == 302
+        assert (
+            response.headers.get("location") == f"{settings.LOGIN_URL}?next={next_url}"
+        )
+    else:
+        assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_update_language_node(
+    load_test_data: None,
+    login_role_user: tuple[Client, str],
+) -> None:
+    # Log the user in
+    client, role = login_role_user
+
+    # Change the parent of Farsi node from Arabic to German
+    region = Region.objects.filter(slug="nurnberg").first()
+    language = Language.objects.filter(slug="fa").first()
+    language_node = LanguageTreeNode.objects.filter(
+        region=region, language=language
+    ).first()
+    root_language_node = region.language_tree_root
+
+    # Make sure the parent node is not German
+    assert not language_node.parent.id == root_language_node.id
+
+    next_url = url = reverse(
+        "edit_languagetreenode",
+        kwargs={"region_slug": region.slug, "pk": language_node.id},
+    )
+    response = client.post(
+        url,
+        data={
+            "language": language,
+            "visible": True,
+            "active": True,
+            "parent": root_language_node.id,
+            "machine_translation_enabled": True,
+        },
+    )
+
+    if role in HIGH_PRIV_STAFF_ROLES:
+        assert response.status_code == 302
+        # Verify that the parent node is now German
+        assert (
+            LanguageTreeNode.objects.filter(region=region, language=language)
+            .first()
+            .parent.id
+            == root_language_node.id
+        )
+    elif role == ANONYMOUS:
+        # For anonymous users, we want to redirect to the login form instead of showing an error
+        assert response.status_code == 302
+        assert (
+            response.headers.get("location") == f"{settings.LOGIN_URL}?next={next_url}"
+        )
+    else:
+        assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_move_language_node(
+    load_test_data: None,
+    login_role_user: tuple[Client, str],
+) -> None:
+    # Log the user in
+    client, role = login_role_user
+
+    # Use the region Augsburg because it has many language nodes and multiple generations
+    region = Region.objects.filter(slug="augsburg").first()
+    language = Language.objects.filter(slug="ar").first()
+    language_node = LanguageTreeNode.objects.filter(
+        language=language, region=region
+    ).first()
+
+    next_url = url = reverse(
+        "move_languagetreenode",
+        kwargs={
+            "region_slug": region.slug,
+            "pk": language_node.id,
+            "target_id": 9,
+            "target_position": "left",
+        },
+    )
+    response = client.post(url)
+
+    if role in HIGH_PRIV_STAFF_ROLES:
+        assert response.status_code == 302
+        assert (
+            LanguageTreeNode.objects.filter(language=language, region=region)
+            .first()
+            .parent.id
+            == 1
+        )
+    elif role == ANONYMOUS:
+        # For anonymous users, we want to redirect to the login form instead of showing an error
+        assert response.status_code == 302
+        assert (
+            response.headers.get("location") == f"{settings.LOGIN_URL}?next={next_url}"
+        )
+    else:
+        assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_delete_language_node(
+    load_test_data: None,
+    login_role_user: tuple[Client, str],
+) -> None:
+    # Log the user in
+    client, role = login_role_user
+
+    region = Region.objects.filter(slug="augsburg").first()
+    # Choose a node without children to verify the delete function successes
+    deletable_language = Language.objects.filter(slug="ar").first()
+    deletable_language_node = LanguageTreeNode.objects.filter(
+        language=deletable_language, region=region
+    ).first()
+    # Choose a node with children to verify the delete function is cancelled
+    not_deletable_language = Language.objects.filter(slug="en").first()
+    not_deletable_language_node = LanguageTreeNode.objects.filter(
+        language=not_deletable_language, region=region
+    ).first()
+
+    deletable_next_url = deletable_url = reverse(
+        "delete_languagetreenode",
+        kwargs={"region_slug": region.slug, "pk": deletable_language_node.id},
+    )
+    response_success = client.post(deletable_url)
+    not_deletable_next_url = not_deletable_url = reverse(
+        "delete_languagetreenode",
+        kwargs={"region_slug": region.slug, "pk": not_deletable_language_node.id},
+    )
+    response_fail = client.post(not_deletable_url)
+
+    if role in HIGH_PRIV_STAFF_ROLES:
+        # In both cases it should be redirected
+        assert response_success.status_code == 302
+        assert response_fail.status_code == 302
+        # Verify that the language node without children was deleted
+        assert not LanguageTreeNode.objects.filter(
+            language=deletable_language, region=region
+        ).first()
+        # Verify that the language node with child nodes was not deleted
+        assert LanguageTreeNode.objects.filter(
+            language=not_deletable_language, region=region
+        ).first()
+    elif role == ANONYMOUS:
+        # For anonymous users, we want to redirect to the login form instead of showing an error
+        assert response_success.status_code == 302
+        assert response_fail.status_code == 302
+        assert (
+            response_success.headers.get("location")
+            == f"{settings.LOGIN_URL}?next={deletable_next_url}"
+        )
+        assert (
+            response_fail.headers.get("location")
+            == f"{settings.LOGIN_URL}?next={not_deletable_next_url}"
+        )
+    else:
+        assert response_success.status_code == 403
+        assert response_fail.status_code == 403


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds tests for [the language node actions](https://codeclimate.com/github/digitalfabrik/integreat-cms/integreat_cms/cms/views/language_tree/language_tree_actions.py/source)

### Proposed changes
<!-- Describe this PR in more detail. -->
- Test `move_language_tree_node` and `delete_language_tree_node`
- Add `try` and `except ProtectedError` for the deleting action for better user experience (in case the delete button is somehow not deactivated)
- Creating and updating are not included in [the action file](https://codeclimate.com/github/digitalfabrik/integreat-cms/integreat_cms/cms/views/language_tree/language_tree_actions.py/source) and covered by `view_config` but created/updated objects are not checked. So tests for them are added as small aditionals 😸 


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None?


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2582 

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
