### PR TITLE
Fix output alignment in repair tree command

### DIFF
--- a/integreat_cms/core/management/commands/repair_tree.py
+++ b/integreat_cms/core/management/commands/repair_tree.py
@@ -127,12 +127,9 @@ class Command(LogCommand):
                 logger.error("\tparent_id: %s", orphan.parent_id)
                 if orphan.parent_id:
                     logger.error("\tparent.tree_id: %s", orphan.parent.tree_id)
-                logger.info(
-                    "\tdepth %s\n\tlft: %s\n\trgt: %s",
-                    orphan.depth,
-                    orphan.lft,
-                    orphan.rgt,
-                )
+                logger.info("\tdepth %s", orphan.depth)
+                logger.info("\tlft: %s", orphan.lft)
+                logger.info("\trgt: %s", orphan.rgt)
 
     def calculate_left_right_values(
         self, tree_node: Page, left: int, commit: bool


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
I just noticed the output of the repair tree command looks a bit weird in the log file:

```
Feb 01 15:26:39 INFO    integreat_cms.core.management.commands.repair_tree - Page 34339:
Feb 01 15:26:39 ERROR   integreat_cms.core.management.commands.repair_tree -    parent_id: None
Feb 01 15:26:39 INFO    integreat_cms.core.management.commands.repair_tree -    depth 4
        lft: 1
        rgt: 2
```

Maybe it would be better if all messages were aligned?

```
Feb 01 15:26:39 INFO    integreat_cms.core.management.commands.repair_tree - Page 34339:
Feb 01 15:26:39 ERROR   integreat_cms.core.management.commands.repair_tree -    parent_id: None
Feb 01 15:26:39 INFO    integreat_cms.core.management.commands.repair_tree -    depth 4
Feb 01 15:26:39 INFO    integreat_cms.core.management.commands.repair_tree -    lft: 1
Feb 01 15:26:39 INFO    integreat_cms.core.management.commands.repair_tree -    rgt: 2
```

### Proposed changes
<!-- Describe this PR in more detail. -->

- Start new logging messages instead of `\n` to keep alignment



__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
