### PR TITLE
Fix HIX value difference

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/2630.yml
+++ b/integreat_cms/release_notes/current/unreleased/2630.yml
@@ -1,0 +1,2 @@
+en: Fix HIX value difference after adding lines without text
+de: Behebe HIX-Wert-Differenz nach Hinzufügen von Zeilen ohne Text

--- a/tests/textlab_api/textlab_config.py
+++ b/tests/textlab_api/textlab_config.py
@@ -1,19 +1,35 @@
 TEXTLAB_NORMALIZE_TEXT = [
     (
         "<p>One paragraph</p>",
-        "<div><p>One paragraph</p></div>",
+        "<p>One paragraph</p>",
+    ),
+    (
+        "<p><strong>One</strong> paragraph</p>",
+        "<p><strong>One</strong> paragraph</p>",
     ),
     (
         "<p>One paragraph</p><p>&nbsp;&nbsp;</p><p>&nbsp;</p>",
-        "<div><p>One paragraph</p></div>",
+        "<p>One paragraph</p>",
     ),
     (
         "<div><p>One paragraph</p></div>",
-        "<div><p>One paragraph</p></div>",
+        "<p>One paragraph</p>",
     ),
     (
         "<div><p>One paragraph</p><p>&nbsp;&nbsp;</p><p>&nbsp;</p></div>",
-        "<div><p>One paragraph</p></div>",
+        "<p>One paragraph</p>",
+    ),
+    (
+        "<h2>Some header</h2>",
+        "<h2>Some header</h2>",
+    ),
+    (
+        "<h2>Some header</h2><h2>&nbsp;&nbsp;</h2><h2>&nbsp;</h2>",
+        "<h2>Some header</h2>",
+    ),
+    (
+        "<h2>Some header</h2><p>&nbsp;&nbsp;</p>",
+        "<h2>Some header</h2>",
     ),
     (
         "<p>One paragraph</p><p>Another paragraph</p>",
@@ -36,15 +52,23 @@ TEXTLAB_NORMALIZE_TEXT = [
         "<div>\r\n<p>One paragraph</p>\r\n<p>Another paragraph</p>\r\n</div>",
     ),
     (
-        "<div>\n<p></p></div>",
-        "<div>\r\n</div>",
+        '<div>\n<p><a href="some.url">Some link</a></p></div>',
+        '<p><a href="some.url">Some link</a></p>',
     ),
     (
-        '<div>\n<p><a href="some.url">A link</a></p></div>',
-        '<div>\r\n<p><a href="some.url">A link</a></p>\r\n</div>',
+        '<div><p>Some image</p><p><a href="some.image"><img src="some.image" alt=""></a></p></div>',
+        "<p>Some image</p>",
     ),
     (
-        '<div><p>An image:</p><p><a href="some.image"><img src="some.image" alt=""></a></p></div>',
-        '<div>\r\n<p>An image:</p>\r\n<p><a href="some.image"><img src="some.image" alt=""></a></p>\r\n</div>',
+        '<p><a href="some.image"><img src="some.image" alt=""></a></p>',
+        "<p></p>",
+    ),
+    (
+        '<div><p>Some video</p><p><video controls="controls" width="300" height="150"><source src="some.video" /></video></p></div>',
+        "<p>Some video</p>",
+    ),
+    (
+        '<p><video controls="controls" width="300" height="150"><source src="some.video" /></video></p>',
+        "<p></p>",
     ),
 ]


### PR DESCRIPTION
### Short description
Fix another portion of cases with HIX value difference problem:

1. Adding an empty paragraph to a 1-paragraph text increased the HIX value
2. Adding empty headers increased the HIX value
3. Adding images increased the HIX value


### Proposed changes
- refactoring of the normalize_text function


### Side effects
No?


### Resolved issues
In follow-up to #2577


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
