### PR TITLE
Fix page order not being editable after changing the page parent

### DIFF
--- a/integreat_cms/cms/views/pages/page_actions.py
+++ b/integreat_cms/cms/views/pages/page_actions.py
@@ -745,6 +745,7 @@ def get_page_order_table_ajax(
         {
             "page": page,
             "siblings": siblings,
+            "can_edit_page": request.user.has_perm("cms.change_page_object", page),
         },
     )
 

--- a/integreat_cms/release_notes/current/unreleased/2627.yml
+++ b/integreat_cms/release_notes/current/unreleased/2627.yml
@@ -1,0 +1,2 @@
+en: Fix page order not being editable after changing the page parent
+de: Behebe, dass die Seitenreihenfolge nach Änderung der übergeordneten Seite nicht bearbeitbar war


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

Fix page order not being editable after changing the page's parent in the page form sidebar

### Proposed changes
<!-- Describe this PR in more detail. -->

- this was caused by the `can_edit_page` variable being set in the parent template, which isn't utilized in the ajax call. Now the permission check is handled in the ajax call and the passed along from there.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none I am aware of


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2627


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
