### PR TITLE
Update page link before submitting page form

### DIFF
--- a/integreat_cms/cms/models/users/user.py
+++ b/integreat_cms/cms/models/users/user.py
@@ -26,6 +26,7 @@ from ...utils.translation_utils import gettext_many_lazy as __
 from ..abstract_base_model import AbstractBaseModel
 from ..chat.chat_message import ChatMessage
 from ..decorators import modify_fields
+from ..pages.page import Page
 from ..regions.region import Region
 from .organization import Organization
 
@@ -208,6 +209,19 @@ class User(AbstractUser, AbstractBaseModel):
             self.chat_last_visited.strftime("%Y-%m-%d %H:%M:%S"),
         )
         return previous_chat_last_visited
+
+    def access_granted_pages(self, region: Region) -> QuerySet[Page]:
+        """
+        Get a list of all pages the user has been given explicit rights to edit
+        """
+        access_granted_pages = Page.objects.filter(
+            models.Q(authors=self) | models.Q(editors=self)
+        ).filter(region=region)
+        if self.organization:
+            access_granted_pages = access_granted_pages.union(
+                Page.objects.filter(organization=self.organization)
+            )
+        return access_granted_pages
 
     def __str__(self) -> str:
         """

--- a/integreat_cms/cms/templates/events/event_form.html
+++ b/integreat_cms/cms/templates/events/event_form.html
@@ -41,10 +41,14 @@
                     <div class="flex flex-wrap gap-4 ml-auto mr-0 items-center">
                         {% include "generic_auto_save_note.html" with form_instance=event_form.instance %}
                         {% if perms.cms.publish_event %}
-                            <button name="status" value="{{ DRAFT }}" class="btn btn-outline">
+                            <button name="status"
+                                    value="{{ DRAFT }}"
+                                    class="btn btn-outline no-premature-submission">
                                 {% translate "Save as draft" %}
                             </button>
-                            <button name="status" value="{{ PUBLIC }}" class="btn">
+                            <button name="status"
+                                    value="{{ PUBLIC }}"
+                                    class="btn no-premature-submission">
                                 {% if event_translation_form.instance.status == PUBLIC %}
                                     {% translate "Update" %}
                                 {% else %}
@@ -52,7 +56,9 @@
                                 {% endif %}
                             </button>
                         {% else %}
-                            <button name="status" value="{{ REVIEW }}" class="btn">
+                            <button name="status"
+                                    value="{{ REVIEW }}"
+                                    class="btn no-premature-submission">
                                 {% translate "Submit for approval" %}
                             </button>
                         {% endif %}
@@ -67,7 +73,8 @@
                     <div class="w-full p-4 flex flex-col flex-auto">
                         <div class="flex justify-between">
                             <label for="{{ event_translation_form.title.id_for_label }}"
-                                   data-slugify-url="{% url 'slugify_ajax' region_slug=request.region.slug language_slug=language.slug model_type='event' %}{% if event_form.instance.id %}?model_id={{ event_form.instance.id }}{% endif %}">
+                                   data-slugify-url="{% url 'slugify_ajax' region_slug=request.region.slug language_slug=language.slug model_type='event' %}"
+                                   {% if event_form.instance.id %}data-model-id="{{ event_form.instance.id }}"{% endif %}>
                                 {{ event_translation_form.title.label }}
                             </label>
                             {% if event_translation_form.instance.id %}

--- a/integreat_cms/cms/templates/imprint/imprint_form.html
+++ b/integreat_cms/cms/templates/imprint/imprint_form.html
@@ -43,8 +43,7 @@
                 <div class="w-full rounded border border-blue-500 bg-white flex flex-col flex-auto">
                     <div class="w-full p-4 flex flex-col flex-auto">
                         <div class="flex justify-between mr-2">
-                            <label for="{{ page_translation_form.title.id_for_label }}"
-                                   data-slugify-url="{% url 'slugify_ajax' region_slug=request.region.slug language_slug=language.slug model_type='page' %}{% if page_form.instance.id %}?model_id={{ page_form.instance.id }}{% endif %}">
+                            <label for="{{ page_translation_form.title.id_for_label }}">
                                 {{ imprint_translation_form.title.label }}
                             </label>
                             {% if imprint_translation_form.instance.id %}

--- a/integreat_cms/cms/templates/pages/page_form.html
+++ b/integreat_cms/cms/templates/pages/page_form.html
@@ -52,10 +52,14 @@
                     </button>
                     {% has_perm 'cms.publish_page_object' request.user page as can_publish_page %}
                     {% if can_publish_page %}
-                        <button name="status" value="{{ DRAFT }}" class="btn btn-outline">
+                        <button name="status"
+                                value="{{ DRAFT }}"
+                                class="btn btn-outline no-premature-submission">
                             {% translate "Save as draft" %}
                         </button>
-                        <button name="status" value="{{ PUBLIC }}" class="btn whitespace-nowrap">
+                        <button name="status"
+                                value="{{ PUBLIC }}"
+                                class="btn whitespace-nowrap no-premature-submission">
                             {% if page_translation_form.instance.status == PUBLIC %}
                                 {% translate "Update" %}
                             {% else %}
@@ -63,7 +67,9 @@
                             {% endif %}
                         </button>
                     {% elif can_edit_page %}
-                        <button name="status" value="{{ REVIEW }}" class="btn">
+                        <button name="status"
+                                value="{{ REVIEW }}"
+                                class="btn no-premature-submission">
                             {% translate "Submit for approval" %}
                         </button>
                     {% endif %}
@@ -92,7 +98,8 @@
                         {% endif %}
                         <div class="flex justify-between mr-2">
                             <label for="{{ page_translation_form.title.id_for_label }}"
-                                   data-slugify-url="{% url 'slugify_ajax' region_slug=request.region.slug language_slug=language.slug model_type='page' %}{% if page_form.instance.id %}?model_id={{ page_form.instance.id }}{% endif %}">
+                                   data-slugify-url="{% url 'slugify_ajax' region_slug=request.region.slug language_slug=language.slug model_type='page' %}"
+                                   {% if page_form.instance.id %}data-model-id="{{ page_form.instance.id }}"{% endif %}>
                                 {{ page_translation_form.title.label }}
                             </label>
                             {% if page_translation_form.instance.id %}

--- a/integreat_cms/cms/templates/pois/poi_form.html
+++ b/integreat_cms/cms/templates/pois/poi_form.html
@@ -35,12 +35,14 @@
             {% if not poi_form.instance.archived and perms.cms.change_poi %}
                 <div class="flex flex-wrap items-center gap-4 ml-auto mr-0">
                     {% include "generic_auto_save_note.html" with form_instance=poi_translation_form.instance %}
-                    <button name="status" value="{{ DRAFT }}" class="btn btn-outline">
+                    <button name="status"
+                            value="{{ DRAFT }}"
+                            class="btn btn-outline no-premature-submission">
                         {% translate "Save as draft" %}
                     </button>
                     <button name="status"
                             value="{{ PUBLIC }}"
-                            class="btn"
+                            class="btn no-premature-submission"
                             {% if language != request.region.default_language and not poi_form.instance.default_public_translation %} title="{% translate "The default translation is not yet published" %}" disabled {% endif %}>
                         {% if poi_translation_form.instance.status == PUBLIC %}
                             {% translate "Update" %}
@@ -59,7 +61,8 @@
                         <div class="flex flex-col flex-auto w-full p-4">
                             <div class="flex justify-between">
                                 <label for="{{ poi_translation_form.title.id_for_label }}"
-                                       data-slugify-url="{% url 'slugify_ajax' region_slug=request.region.slug language_slug=language.slug model_type='poi' %}{% if poi_form.instance.id %}?model_id={{ poi_form.instance.id }}{% endif %}">
+                                       data-slugify-url="{% url 'slugify_ajax' region_slug=request.region.slug language_slug=language.slug model_type='poi' %}"
+                                       {% if poi_form.instance.id %}data-model-id="{{ poi_form.instance.id }}"{% endif %}>
                                     {{ poi_translation_form.title.label }}
                                 </label>
                                 {% if poi_translation_form.instance.id %}

--- a/integreat_cms/cms/views/pages/page_tree_view.py
+++ b/integreat_cms/cms/views/pages/page_tree_view.py
@@ -5,7 +5,6 @@ from typing import TYPE_CHECKING
 
 from django.conf import settings
 from django.contrib import messages
-from django.db.models import Q
 from django.shortcuts import redirect, render
 from django.utils.decorators import method_decorator
 from django.utils.html import format_html, format_html_join
@@ -14,7 +13,7 @@ from django.views.generic import TemplateView
 
 from ...decorators import permission_required
 from ...forms import PageFilterForm
-from ...models import Page, PageTranslation
+from ...models import PageTranslation
 from ..mixins import MachineTranslationContextMixin
 from .page_context_mixin import PageContextMixin
 
@@ -89,13 +88,7 @@ class PageTreeView(TemplateView, PageContextMixin, MachineTranslationContextMixi
             )
 
         if not request.user.has_perm("cms.change_page"):
-            access_granted_pages = Page.objects.filter(
-                Q(authors=request.user) | Q(editors=request.user)
-            ).filter(region=request.region)
-            if request.user.organization:
-                access_granted_pages = access_granted_pages.union(
-                    Page.objects.filter(organization=request.user.organization)
-                )
+            access_granted_pages = request.user.access_granted_pages(request.region)
             if len(access_granted_pages) > 0:
                 messages.info(
                     request,

--- a/integreat_cms/static/src/js/forms/prevent-premature-submission.ts
+++ b/integreat_cms/static/src/js/forms/prevent-premature-submission.ts
@@ -1,0 +1,34 @@
+/**
+ * We sometimes want to perform a background task when an input element looses focus.
+ * If the focus loss is due to the user clicking on a submission button however, the
+ * corresponding form will be submitted before the background task is initiated.
+ * This class is a convenient wrapper for preventing this.
+ *
+ * See here for more: https://github.com/digitalfabrik/integreat-cms/pull/2636
+ */
+export default class SubmissionPrevention {
+    watchedElements: HTMLElement[] = [];
+    mostRecentlyClicked: HTMLElement = null;
+
+    preventSubmission = (e: Event) => {
+        e.preventDefault();
+        this.mostRecentlyClicked = e.target as HTMLElement;
+    };
+
+    constructor(identifier: string) {
+        const elements = document.querySelectorAll<HTMLElement>(identifier);
+        elements.forEach((element) => {
+            element.addEventListener("click", this.preventSubmission);
+        });
+        this.watchedElements = Array.from(elements);
+    }
+
+    release() {
+        this.watchedElements.forEach((element) => {
+            element.removeEventListener("click", this.preventSubmission);
+        });
+        if (this.mostRecentlyClicked !== null) {
+            this.mostRecentlyClicked.click();
+        }
+    }
+}

--- a/integreat_cms/static/src/js/forms/update-permalink.ts
+++ b/integreat_cms/static/src/js/forms/update-permalink.ts
@@ -4,6 +4,7 @@ or when the user clicks the permalinks edit button */
 
 import { getCsrfToken } from "../utils/csrf-token";
 import { copyToClipboard } from "../copy-clipboard";
+import SubmissionPrevention from "./prevent-premature-submission";
 
 const slugify = async (url: string, data: any) => {
     const response = await fetch(url, {
@@ -44,13 +45,16 @@ window.addEventListener("load", () => {
         (document.querySelector('[for="id_title"]') as HTMLElement)?.dataset?.slugifyUrl
     ) {
         document.getElementById("id_title").addEventListener("focusout", ({ target }) => {
+            const submissionLock = new SubmissionPrevention(".no-premature-submission");
             const currentTitle = (target as HTMLInputElement).value;
-            const url = (document.querySelector('[for="id_title"]') as HTMLElement).dataset.slugifyUrl;
-            slugify(url, { title: currentTitle }).then((response) => {
-                /* on success write response to both slug field and permalink */
-                slugField.value = response.unique_slug;
-                updatePermalink(response.unique_slug);
-            });
+            const dataset = (document.querySelector('[for="id_title"]') as HTMLElement).dataset;
+            slugify(dataset.slugifyUrl, { title: currentTitle, model_id: dataset.modelId })
+                .then((response) => {
+                    /* on success write response to both slug field and permalink */
+                    slugField.value = response.unique_slug;
+                    updatePermalink(response.unique_slug);
+                })
+                .finally(() => submissionLock.release());
         });
     }
 

--- a/tests/cms/views/view_config.py
+++ b/tests/cms/views/view_config.py
@@ -601,6 +601,7 @@ VIEWS: ViewConfig = [
                 json.dumps(
                     {
                         "title": "Slugify event",
+                        "model_id": 1,
                     }
                 ),
             ),
@@ -615,6 +616,7 @@ VIEWS: ViewConfig = [
                 json.dumps(
                     {
                         "title": "Slugify poi",
+                        "model_id": 4,
                     }
                 ),
             ),
@@ -629,6 +631,7 @@ VIEWS: ViewConfig = [
                 json.dumps(
                     {
                         "title": "Slugify page",
+                        "model_id": 1,
                     }
                 ),
             ),


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

I had a bit of trouble reproducing the issue. The only way I could trigger it was by entering Firefox's Responsive Design Mode and enabling Touch Simulation (though I suspect this might also happen on real touch devices).

I don't think this is worth an entry in the change log, this really is an edge case.

### Proposed changes
<!-- Describe this PR in more detail. -->

- if the content form is submitted while we're still waiting on a response for `slugify`, prevent the submission, then trigger it again once the previous call completed.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- hopefully not


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2624


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
