### PR TITLE
Allow the central link replacement of URLs with UTF-8 characters

### DIFF
--- a/integreat_cms/cms/utils/linkcheck_utils.py
+++ b/integreat_cms/cms/utils/linkcheck_utils.py
@@ -278,6 +278,9 @@ def replace_links(
                         logger.debug(
                             "Replacing %r with %r in %r", url, fixed_url, translation
                         )
+                new_translation.content = fix_content_link_encoding(
+                    new_translation.content
+                )
                 if new_translation.content != translation.content and commit:
                     save_new_version(translation, new_translation, user)
     # Wait until all post-save signals have been processed

--- a/integreat_cms/cms/views/linkcheck/linkcheck_list_view.py
+++ b/integreat_cms/cms/views/linkcheck/linkcheck_list_view.py
@@ -21,7 +21,7 @@ from lxml.html import rewrite_links
 
 from ...decorators import permission_required
 from ...forms.linkcheck.edit_url_form import EditUrlForm
-from ...utils.linkcheck_utils import filter_urls, get_urls
+from ...utils.linkcheck_utils import filter_urls, fix_content_link_encoding, get_urls
 
 if TYPE_CHECKING:
     from typing import Any
@@ -170,6 +170,9 @@ class LinkcheckListView(ListView):
                     new_translation.content = rewrite_links(
                         new_translation.content,
                         partial(self.replace_link, self.instance.url, new_url),
+                    )
+                    new_translation.content = fix_content_link_encoding(
+                        new_translation.content
                     )
                     # Save translation with replaced content as new minor version
                     new_translation.id = None

--- a/integreat_cms/release_notes/current/unreleased/2646.yml
+++ b/integreat_cms/release_notes/current/unreleased/2646.yml
@@ -1,0 +1,2 @@
+en: Allow the central link replacement of URLs with UTF-8 characters in the domain name
+de: Erlaube das zentrale Ersetzen von URLs mit UTF-8 Zeichen im Domainnamen im Link-Checker


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Allow the central link replacement of URLs with UTF-8 characters in the domain name

### Proposed changes
<!-- Describe this PR in more detail. -->

- Apply the new `fix_content_link_encoding()` function not only in the forms, but also in the link checker

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2646


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
