### PR TITLE
Fix HIX value diff when page content has nested tags

### DIFF
--- a/integreat_cms/cms/views/utils/hix.py
+++ b/integreat_cms/cms/views/utils/hix.py
@@ -42,7 +42,7 @@ def normalize_text(text: str) -> str:
         root = fromstring(text)
 
         # Remove paragraphs without text (e.g. empty paragraphs or with an image only)
-        for node in root.iter():
+        for node in list(root):
             node_text = node.text_content()
             if not node_text or not node_text.strip():
                 node.getparent().remove(node)

--- a/integreat_cms/release_notes/current/unreleased/2621.yml
+++ b/integreat_cms/release_notes/current/unreleased/2621.yml
@@ -1,0 +1,2 @@
+en: Mark HIX value as outdated when changes are undone in the editor
+de: Markiere HIX-Wert als veraltet, wenn Änderungen im Editor rückgängig gemacht werden

--- a/integreat_cms/release_notes/current/unreleased/2652.yml
+++ b/integreat_cms/release_notes/current/unreleased/2652.yml
@@ -1,0 +1,2 @@
+en: Fix HIX value diff when page content has nested tags
+de: Behebe HIX-Wert-Differenz, wenn Seiteninhalt verschachtelte Tags hat

--- a/integreat_cms/static/src/js/forms/tinymce-init.ts
+++ b/integreat_cms/static/src/js/forms/tinymce-init.ts
@@ -229,7 +229,7 @@ window.addEventListener("load", () => {
                     });
                 });
                 // Create an event every time the content changes
-                editor.on("keyup", () =>
+                editor.on("keyup undo redo", () =>
                     document.querySelectorAll("[data-content-changed]").forEach((element) => {
                         element.dispatchEvent(new Event("contentChanged"));
                     })

--- a/tests/textlab_api/textlab_config.py
+++ b/tests/textlab_api/textlab_config.py
@@ -8,8 +8,8 @@ TEXTLAB_NORMALIZE_TEXT = [
         "<p><strong>One</strong> paragraph</p>",
     ),
     (
-        "<p>One paragraph</p><p>&nbsp;&nbsp;</p><p>&nbsp;</p>",
-        "<p>One paragraph</p>",
+        "<p><strong>One</strong> paragraph</p><p>&nbsp;&nbsp;</p><p>&nbsp;</p>",
+        "<p><strong>One</strong> paragraph</p>",
     ),
     (
         "<div><p>One paragraph</p></div>",
@@ -56,7 +56,7 @@ TEXTLAB_NORMALIZE_TEXT = [
         '<p><a href="some.url">Some link</a></p>',
     ),
     (
-        '<div><p>Some image</p><p><a href="some.image"><img src="some.image" alt=""></a></p></div>',
+        '<div><p>Some image</p><p><a href="some.image"><img src="some.image" alt=""></a></p><p>&nbsp;</p></div>',
         "<p>Some image</p>",
     ),
     (


### PR DESCRIPTION
### Short description
Using root.iter() was not a good choice to iterate over the paragraphs, because it goes "one-way" deep into the nested elements.
For example, if a page has the following structure:
`<div><p>Some image</p><p><a href="some.image"><img src="some.image" alt=""></a></p><p>&nbsp;</p></div>`
The iteration will proceed as follows:
```
<div>
<p>
<p>
<a>
<img>
--> end of iteration
```
And the last p-node will not be processed.


### Proposed changes
Use list(root) instead of root.iter()


### Side effects
No?


### Resolved issues
Another follow-up to #2577

**UPD**: added another small HIX-related fix
Fixes: #2621


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
