### PR TITLE
Dynamic export formats

### DIFF
--- a/integreat_cms/cms/templates/feedback/region_feedback_list.html
+++ b/integreat_cms/cms/templates/feedback/region_feedback_list.html
@@ -119,7 +119,7 @@
                             {% translate "Delete" %}
                         </option>
                     {% endif %}
-                    <option data-bulk-action="{% url 'export_region_feedback' region_slug=request.region.slug %}">
+                    <option data-bulk-action="{% url 'export_region_feedback' region_slug=request.region.slug file_format='csv' %}">
                         {% translate "Export to CSV" %}
                     </option>
                 </select>

--- a/integreat_cms/cms/urls/protected.py
+++ b/integreat_cms/cms/urls/protected.py
@@ -1334,7 +1334,7 @@ urlpatterns: list[URLPattern] = [
                                 name="delete_region_feedback",
                             ),
                             path(
-                                "export/",
+                                "export/<str:file_format>/",
                                 feedback.export_region_feedback,
                                 name="export_region_feedback",
                             ),

--- a/tests/cms/views/feedback/test_region_feedback_actions.py
+++ b/tests/cms/views/feedback/test_region_feedback_actions.py
@@ -262,7 +262,9 @@ def test_csv_export_feedback(
 ) -> None:
     client, role = login_role_user
 
-    csv_export = reverse("export_region_feedback", kwargs=region_slug_param)
+    csv_export = reverse(
+        "export_region_feedback", kwargs={**region_slug_param, "file_format": "csv"}
+    )
     csv_to_export_ids = [7, 8]
     response = client.post(csv_export, data={"selected_ids[]": csv_to_export_ids})
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Allow export to other formats supported by tablib / django-import-export
We were troubleshooting what looked like an encoding problem with feedback exported as CSV, and by the time we found that EXCEL was at fault and our CSVs were flawless, this was already half done. I figured I might as well clean it up and submit it as a low prio PR.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Extend feedback export URL endpoint by `format` parameter
- Check if requested format is available through the dependency library
- Automatically determine mime type


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- We just throw a ValueError if the format is not available. This is likely not the most elegant solution, but at the moment we hard-code which format can be requested through the UI anyway.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

none


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
