### PR TITLE
Fix behavior when cloning region with page based offers

### DIFF
--- a/integreat_cms/cms/constants/duplicate_pbo_behaviors.py
+++ b/integreat_cms/cms/constants/duplicate_pbo_behaviors.py
@@ -1,0 +1,24 @@
+"""
+This module contains all possible behaviors available when cloning regions and having
+to decide how to handle page based offers.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.utils.translation import gettext_lazy as _
+
+if TYPE_CHECKING:
+    from typing import Final
+
+    from django.utils.functional import Promise
+
+
+ACTIVATE: Final = "activate_missing"
+DISCARD: Final = "discard_missing"
+
+CHOICES: Final[list[tuple[str, Promise]]] = [
+    (ACTIVATE, _("Activate all required offers, regardless of choices above")),
+    (DISCARD, _("Discard offer embeddings from offers not activated manually")),
+]

--- a/integreat_cms/cms/forms/regions/region_form.py
+++ b/integreat_cms/cms/forms/regions/region_form.py
@@ -22,7 +22,7 @@ from integreat_cms.cms.utils.linkcheck_utils import replace_links
 from ....gvz_api.utils import GvzRegion
 from ....matomo_api.matomo_api_client import MatomoException
 from ....nominatim_api.nominatim_api_client import NominatimApiClient
-from ...constants import status
+from ...constants import duplicate_pbo_behaviors, status
 from ...models import LanguageTreeNode, OfferTemplate, Page, PageTranslation, Region
 from ...models.regions.region import format_mt_help_text
 from ...utils.slug_utils import generate_unique_slug_helper
@@ -32,6 +32,8 @@ from ..icon_widget import IconWidget
 
 if TYPE_CHECKING:
     from typing import Any
+
+    from django.db.models.query import QuerySet
 
 logger = logging.getLogger(__name__)
 
@@ -109,6 +111,17 @@ class RegionForm(CustomModelForm):
         label=_("Keep publication status of pages"),
         help_text=_(
             "Enable it to keep the initial publication status of the pages and don't overwrite them to draft."
+        ),
+    )
+
+    duplication_pbo_behavior = forms.ChoiceField(
+        choices=duplicate_pbo_behaviors.CHOICES,
+        initial=duplicate_pbo_behaviors.ACTIVATE,
+        widget=forms.Select,
+        required=False,
+        label=_("Page based offers cloning behavior"),
+        help_text=_(
+            "Decide whether offers which have not been activated but are required for embedded content should be auto-activated, or their embeddings be ignored during cloning."
         ),
     )
 
@@ -253,6 +266,25 @@ class RegionForm(CustomModelForm):
         if duplicate_region:
             source_region = self.cleaned_data["duplicated_region"]
             keep_status = self.cleaned_data["duplication_keep_status"]
+
+            # Determine offers to force activate or to skip when cloning pages
+            required_offers = OfferTemplate.objects.filter(pages__region=source_region)
+            if (
+                self.cleaned_data["duplication_pbo_behavior"]
+                == duplicate_pbo_behaviors.ACTIVATE
+            ):
+                region.offers.set(region.offers.union(required_offers))
+                # Even is ACTIVATE behavior was selected, Zammad forms need to be skipped during cloning if no Zammad URL is set
+                offers_to_discard = (
+                    None
+                    if region.zammad_url
+                    else OfferTemplate.objects.filter(is_zammad_form=True)
+                )
+            else:
+                offers_to_discard = required_offers.exclude(
+                    id__in=region.offers.values_list("id", flat=True)
+                )
+
             # Duplicate language tree
             logger.info("Duplicating language tree of %r to %r", source_region, region)
             duplicate_language_tree(source_region, region)
@@ -260,7 +292,12 @@ class RegionForm(CustomModelForm):
             with disable_listeners():
                 # Duplicate pages
                 logger.info("Duplicating page tree of %r to %r", source_region, region)
-                duplicate_pages(source_region, region, keep_status=keep_status)
+                duplicate_pages(
+                    source_region,
+                    region,
+                    keep_status=keep_status,
+                    offers_to_discard=offers_to_discard,
+                )
                 # Duplicate Imprint
                 if source_region.imprint:
                     logger.info(
@@ -375,6 +412,18 @@ class RegionForm(CustomModelForm):
                     _(
                         "Could not retrieve the coordinates automatically, please fill the field manually."
                     ),
+                    code="required",
+                ),
+            )
+
+        # If a region is being cloned but no PBO cloning behavior has been selected, throw an error
+        if cleaned_data.get("duplicated_region") and not cleaned_data.get(
+            "duplication_pbo_behavior"
+        ):
+            self.add_error(
+                "duplication_pbo_behavior",
+                forms.ValidationError(
+                    _("Please choose a behavior for cloning embedded offers."),
                     code="required",
                 ),
             )
@@ -638,6 +687,7 @@ def duplicate_language_tree(
             )
 
 
+# pylint: disable=too-many-locals
 def duplicate_pages(
     source_region: Region,
     target_region: Region,
@@ -645,6 +695,7 @@ def duplicate_pages(
     target_parent: Page | None = None,
     logging_prefix: str = "",
     keep_status: bool = False,
+    offers_to_discard: QuerySet[OfferTemplate] | None = None,
 ) -> None:
     """
     Function to duplicate all non-archived pages from one region to another
@@ -660,6 +711,7 @@ def duplicate_pages(
     :param target_parent: The page of the target region which is the duplicate of the source parent page
     :param logging_prefix: Recursion level to get a pretty log output
     :param keep_status: Parameter to indicate whether the status of the cloned pages should be kept
+    :param offers_to_discard: Offers which might be embedded in the source region, but not in the target region
     """
 
     logger.debug(
@@ -712,7 +764,14 @@ def duplicate_pages(
         # Save duplicated page
         target_page.save()
         # Set embedded offers ManyToMany field
-        target_page.embedded_offers.add(*source_page.embedded_offers.all())
+        embedded_offers = (
+            source_page.embedded_offers.all()
+            if not offers_to_discard
+            else source_page.embedded_offers.exclude(
+                id__in=offers_to_discard.values_list("id", flat=True)
+            )
+        )
+        target_page.embedded_offers.add(*embedded_offers)
         logger.debug(
             "%s Created %r",
             row_logging_prefix + "├─",
@@ -730,6 +789,7 @@ def duplicate_pages(
                 target_page,
                 row_logging_prefix,
                 keep_status,
+                offers_to_discard,
             )
 
 

--- a/integreat_cms/cms/templates/regions/region_form.html
+++ b/integreat_cms/cms/templates/regions/region_form.html
@@ -528,6 +528,13 @@
                     <div class="help-text">
                         {{ form.duplication_keep_status.help_text }}
                     </div>
+                    <label for="{{ form.duplication_pbo_behavior.id_for_label }}">
+                        {{ form.duplication_pbo_behavior.label }}
+                    </label>
+                    {% render_field form.duplication_pbo_behavior %}
+                    <div class="help-text">
+                        {{ form.duplication_pbo_behavior.help_text }}
+                    </div>
                 </div>
             </div>
         {% endif %}

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -1170,6 +1170,15 @@ msgstr "Deutsch (leicht)"
 msgid "Amharic"
 msgstr "Amharisch"
 
+#: cms/constants/duplicate_pbo_behaviors.py
+msgid "Activate all required offers, regardless of choices above"
+msgstr "Aktiviere alle benötigten Angebote, unabhängig von obiger Auswahl"
+
+#: cms/constants/duplicate_pbo_behaviors.py
+msgid "Discard offer embeddings from offers not activated manually"
+msgstr ""
+"Ignoriere Einbindungen von Angeboten, die nicht manuell aktiviert wurden"
+
 #: cms/constants/events_time_range.py
 msgid "Custom time range"
 msgstr "Individueller Zeitraum"
@@ -2113,6 +2122,20 @@ msgstr ""
 "geklont und nicht auf Entwurf gesetzt."
 
 #: cms/forms/regions/region_form.py
+msgid "Page based offers cloning behavior"
+msgstr "Klonverhalten für seitenbasierte Angebote"
+
+#: cms/forms/regions/region_form.py
+msgid ""
+"Decide whether offers which have not been activated but are required for "
+"embedded content should be auto-activated, or their embeddings be ignored "
+"during cloning."
+msgstr ""
+"Festlegen, ob Angebote die nicht aktiviert wurden aber für eingebettete "
+"Inhalte benötigt werden automatisch aktiviert werden sollen, oder ob solche "
+"Einbettungen ignoriert werden sollen."
+
+#: cms/forms/regions/region_form.py
 msgid "Timezone area"
 msgstr "Region der Zeitzone"
 
@@ -2175,6 +2198,10 @@ msgid ""
 msgstr ""
 "Die Koordinaten konnten nicht automatisch abgerufen werden, bitte füllen Sie "
 "das Feld manuell aus."
+
+#: cms/forms/regions/region_form.py
+msgid "Please choose a behavior for cloning embedded offers."
+msgstr "Bitte wählen Sie ein Klonverhalten für eingebettete Angebote."
 
 #: cms/forms/regions/region_form.py
 msgid "'{}' is already selected as administrative division."

--- a/integreat_cms/release_notes/current/unreleased/2665.yml
+++ b/integreat_cms/release_notes/current/unreleased/2665.yml
@@ -1,0 +1,2 @@
+en: Fix bug related to cloning regions with embedded offers
+de: Behebe Fehler im Zusammenhang des Klonens von Regionen mit eingebetteten Angeboten

--- a/tests/cms/test_duplicate_regions.py
+++ b/tests/cms/test_duplicate_regions.py
@@ -53,6 +53,8 @@ def test_duplicate_regions(
             "longitude": 1,
             "latitude": 1,
             "duplicated_region": 1,
+            "duplication_pbo_behavior": "activate_missing",
+            "zammad_url": "https://zammad-test.example.com",
             "timezone": "Europe/Berlin",
             "mt_renewal_month": 6,
         },
@@ -127,10 +129,10 @@ def test_duplicate_regions(
         "number_all_urls": 17,
         "number_email_urls": 0,
         "number_ignored_urls": 0,
-        "number_invalid_urls": 10,
+        "number_invalid_urls": 9,
         "number_phone_urls": 0,
         "number_unchecked_urls": 0,
-        "number_valid_urls": 7,
+        "number_valid_urls": 8,
     }, "Links should be cloned into the new region"
 
     # Check if internal links have been cloned


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

Currently, cloning a region which has embedded offfers into pages can lead to unexpected errors when the newly-created region does not have the same offers enabled.

### Proposed changes
<!-- Describe this PR in more detail. -->

- allow users to choose from two behaviors when cloning a region: either force-activate all required offers\* or discard embeddings for missing offers when cloning pages.
- \* small caveat: if no Zammad URL is provided for the new region, Zammad embeddings are discarded even when force-activation is selected


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none that I could find. As far as I can tell, results are correct in all cases (no cloning, cloning with force-activation or discarding, with/without Zammad URL) 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2665 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
