### PR TITLE
Store integreat-cms.log as an artifact after test run in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -303,6 +303,12 @@ jobs:
           paths:
             - cc-test-reporter
             - coverage
+      - run:
+          name: Copy CMS log
+          command: cp integreat_cms/integreat-cms.log integreat-cms.log
+          when: on_fail
+      - store_artifacts:
+          path: integreat-cms.log
   upload-test-coverage:
     docker:
       - image: cimg/base:stable

--- a/integreat_cms/core/circleci_settings.py
+++ b/integreat_cms/core/circleci_settings.py
@@ -25,11 +25,75 @@ SUMM_AI_ENABLED = True
 DEEPL_AUTH_KEY = "dummy"
 #: Enable manually because existing setting derives from the unset env var
 DEEPL_ENABLED = True
-#: Use debug logging on CircleCI
-LOG_LEVEL = "DEBUG"
 #: Disable linkcheck listeners on CircleCI
 LINKCHECK_DISABLE_LISTENERS = True
-#: Enable logging of all entries from the messages framework
-MESSAGE_LOGGING_ENABLED = True
 # Disable background tasks during testing
 BACKGROUND_TASKS_ENABLED = False
+#: Enable logging of all entries from the messages framework
+MESSAGE_LOGGING_ENABLED = True
+#: Use debug logging on CircleCI
+LOG_LEVEL = "DEBUG"
+#: Logging configuration dictionary (see :setting:`django:LOGGING`)
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "formatters": {
+        "management-command": {
+            "()": ColorFormatter,
+            "format": "{message}",
+            "style": "{",
+        },
+        "logfile": {
+            "()": RequestFormatter,
+            "format": "{asctime} {levelname:7} {name} - {message}",
+            "datefmt": "%b %d %H:%M:%S",
+            "style": "{",
+        },
+    },
+    "filters": {
+        "only_stdout": {
+            "()": "django.utils.log.CallbackFilter",
+            "callback": lambda record: record.levelno <= SUCCESS,
+        },
+    },
+    "handlers": {
+        # Send DEBUG, INFO and SUCCESS to stdout
+        "management-command-stdout": {
+            "class": "logging.StreamHandler",
+            "filters": ["only_stdout"],
+            "formatter": "management-command",
+            "level": "DEBUG",
+            "stream": sys.stdout,
+        },
+        # Send WARNING, ERROR and CRITICAL to stderr
+        "management-command-stderr": {
+            "class": "logging.StreamHandler",
+            "formatter": "management-command",
+            "level": "WARNING",
+        },
+        "logfile": {
+            "class": "logging.FileHandler",
+            "filename": LOGFILE,
+            "formatter": "logfile",
+        },
+    },
+    "loggers": {
+        "integreat_cms": {
+            "handlers": ["logfile"],
+            "level": LOG_LEVEL,
+        },
+        "integreat_cms.core.management.commands": {
+            "handlers": [
+                "management-command-stdout",
+                "management-command-stderr",
+                "logfile",
+            ],
+            "level": LOG_LEVEL,
+            "propagate": False,
+        },
+        "auth": {
+            "handlers": ["logfile"],
+            "level": "INFO",
+        },
+    },
+}

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -577,7 +577,7 @@ MESSAGE_LOGGING_ENABLED: bool = bool(
 )
 
 #: Logging configuration dictionary (see :setting:`django:LOGGING`)
-LOGGING: Final[dict[str, Any]] = {
+LOGGING: dict[str, Any] = {
     "version": 1,
     "disable_existing_loggers": False,
     "formatters": {


### PR DESCRIPTION
### Short description
Sometimes we encounter test failures in CI that are not reproduced locally.
We can see some pieces of the log in the test output, but sometimes it's not enough to localize the problem.
To make the analysis a bit easier, I suggest attaching full integreat-cms.log as a job artifact.
It will only be available when there are test failures:
![image](https://github.com/digitalfabrik/integreat-cms/assets/115008338/cfe29f8c-0c08-414b-b800-a6b383bdb3ea)



### Proposed changes
- add step "Copy CMS log" to the test job in CI



### Side effects
No?

I think it would also be useful to set the logging level to DEBUG, but I couldn't find how to do that :(
I thought this was supposed to be managed by
```
#: Use debug logging on CircleCI
LOG_LEVEL = "DEBUG"
```
in circleci_settings.py, but no. 
The actual log level in CI is currently INFO.
[log example](https://circleci-tasks-prod.s3.us-east-1.amazonaws.com/storage/artifacts/ffe45036-8130-48f0-859b-fdbbd73624f0/d33f030f-843c-4fe9-9236-fb30e2df5321/8/integreat-cms.log?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIAQVFQINEODBOYVHHO%2F20240227%2Fus-east-1%2Fs3%2Faws4_request&X-Amz-Date=20240227T180803Z&X-Amz-Expires=60&X-Amz-Security-Token=IQoJb3JpZ2luX2VjEPL%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLWVhc3QtMSJIMEYCIQDERqy6qMSyvzkzOirUJa4%2BA86r%2Ftj2jgE%2Fe17y7ceK%2FgIhALx35xifoC0K3JE1%2BWW14kRlVpPMmfmxhh%2Fz5lt5urReKrQCCNv%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEQAxoMMDQ1NDY2ODA2NTU2IgxZlrYmmmEDPJL2H5UqiALmVtxmXyNn88CQuFNU6AHQTP3E3R%2BaB1RSNus9AjSjzYMCrScGaanF1XVaJKRvM00DJGtd%2Bhd6qRPXua%2Fdq7ZKHmNuFWK5BJhD8p6oaiqV09pbPlQ1C4MP6thK9MmuRYdwT1X1Q1s4gNJmP43QdjtqL8iEmIGnyaDo74y%2F1MnM7qEA4RGNExp2SWwVXvHhrssFqn6A6W%2FlsxQz4%2FcM3U3lFECT6qu%2FkUmW7bSoUSy71QO0MmH3Eb4kdwM76ff7AyoJfcwmvCJOhy6kLlMBBWvX63nePnXXUDIXT4JTzfElOOiq0qPHEs79SkNmkuX5FSZ%2FHb8%2F%2FPUTRMH7OV%2FHd6khsU7%2FSO2gfqUwosf4rgY6nAGCyKk%2BJj%2FlddzVOTbbNNpirwW%2F3zDwX0dAlKpp8NA6zgSZIiEuWTmpRQE%2BYn1emKm4XWzwEWIWr5vOresrAn07tzHgMz%2BpBHvg3XTpvfOAkkqff1z2IcqM6xObjZccYZ%2FZYzzWmZO4NCxeBk1nWRXYlHKrwxLIjzguIR5UjONTMJuBS%2FGLH7yoRcWvVx4WWLxEcTpD%2FFxAnjy7J1k%3D&X-Amz-SignedHeaders=host&x-id=GetObject&X-Amz-Signature=2389c6ca85c1b0bb66052310471bae348f682509f44cd4819f540e35855e917f)
Maybe someone has some ideas on how to change this?



### Resolved issues
Fixes: #2256


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
