### PR TITLE
Prevent `ValueError` when accessing language tree of unsaved regions

### DIFF
--- a/integreat_cms/cms/models/regions/region.py
+++ b/integreat_cms/cms/models/regions/region.py
@@ -457,11 +457,14 @@ class Region(AbstractBaseModel):
     @cached_property
     def language_tree(self) -> list[LanguageTreeNode]:
         """
-        This property returns a QuerySet of all
+        This property returns a list of all
         :class:`~integreat_cms.cms.models.languages.language_tree_node.LanguageTreeNode` objects of this region.
 
-        :return: A QuerySet of all active language tree nodes of this region
+        :return: A list of all language tree nodes of this region
         """
+        # Prevent ValueError for unsaved regions
+        if not self.pk:
+            return []
         try:
             # Try to get the prefetched language tree
             return self.prefetched_language_tree_nodes

--- a/integreat_cms/release_notes/current/unreleased/2674.yml
+++ b/integreat_cms/release_notes/current/unreleased/2674.yml
@@ -1,0 +1,2 @@
+en: Fix error when creating regions with the administrative division being included in the name
+de: Behebe Fehler beim Erstellen von Regionen, wenn die Verwaltungseinheit dem Namen hinzugefügt wird


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

Fix error when creating regions with the administrative division being included in the name

### Proposed changes
<!-- Describe this PR in more detail. -->

- Prevent `ValueError` when accessing language tree of unsaved regions


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2674


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
