### PR TITLE
Lint Python code with ruff

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,6 +85,22 @@ jobs:
       - run:
           name: Run pylint
           command: ./tools/pylint.sh
+  ruff:
+    docker:
+      - image: cimg/python:3.11.7
+    resource_class: small
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          name: Enable virtual environment
+          command: echo "source .venv/bin/activate" >> $BASH_ENV
+      - run:
+          name: Run ruff
+          command: |
+            ruff check
+            # ruff format
   mypy:
     docker:
       - image: cimg/python:3.11.7
@@ -661,6 +677,9 @@ workflows:
           requires:
             - pip-install
       - pylint:
+          requires:
+            - pip-install
+      - ruff:
           requires:
             - pip-install
       - mypy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,10 @@ repos:
         exclude: .github/PULL_REQUEST_TEMPLATE.md
       - id: no-commit-to-branch
         args: [--branch, main, --branch, develop]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.3.5
+    hooks:
+      - id: ruff
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.9.0.6
     hooks:

--- a/integreat_cms/cms/decorators.py
+++ b/integreat_cms/cms/decorators.py
@@ -99,7 +99,7 @@ def modify_mfa_authenticated(function: Callable) -> Callable:
         :param \**kwargs: The supplied kwargs
         :return: the decorated function
         """
-        if not "modify_mfa_authentication_time" in request.session or request.session[
+        if "modify_mfa_authentication_time" not in request.session or request.session[
             "modify_mfa_authentication_time"
         ] < (time.time() - 5 * 60):
             request.session["mfa_redirect_url"] = request.path

--- a/integreat_cms/cms/models/events/recurrence_rule.py
+++ b/integreat_cms/cms/models/events/recurrence_rule.py
@@ -167,7 +167,7 @@ class RecurrenceRule(AbstractBaseModel):
         i = 0
         end_date = self.recurrence_end_date or date.max
         while True:
-            for _ in advance():
+            for _recurrence in advance():
                 if next_recurrence > end_date:
                     return
                 if not i % self.interval:

--- a/integreat_cms/cms/templatetags/page_filters.py
+++ b/integreat_cms/cms/templatetags/page_filters.py
@@ -24,7 +24,7 @@ def get_depth_in(node: Page, pageset: PageQuerySet) -> int:
     :param pageset: The pages (all pages or pages chosen by filter)
     :return: the depth of node within the tree/pages in pageset
     """
-    if not node.parent in pageset:
+    if node.parent not in pageset:
         return 0
     return node.depth - get_highest_anscentor_in(node, pageset).depth
 

--- a/integreat_cms/core/circleci_settings.py
+++ b/integreat_cms/core/circleci_settings.py
@@ -9,6 +9,8 @@ For the full list of settings and their values, see :doc:`django:ref/settings`.
 # pylint: disable=unused-wildcard-import
 from __future__ import annotations
 
+import sys
+
 from .settings import *
 
 #: Set a dummy secret key for CircleCI build even if it's not in debug mode

--- a/integreat_cms/core/signals/auth_signals.py
+++ b/integreat_cms/core/signals/auth_signals.py
@@ -48,7 +48,7 @@ def user_logged_in_callback(
 # pylint: disable=unused-argument
 @receiver(user_logged_out)
 def user_logged_out_callback(
-    sender: ModelBase, request: HttpRequest | HttpRequest, user: User, **kwargs: Any
+    sender: ModelBase, request: HttpRequest, user: User, **kwargs: Any
 ) -> None:
     r"""
     Log a logout event

--- a/integreat_cms/matomo_api/matomo_api_client.py
+++ b/integreat_cms/matomo_api/matomo_api_client.py
@@ -288,9 +288,9 @@ class MatomoApiClient:
             if TYPE_CHECKING:
 
                 def is_dict_list(
-                    l: list[dict[str, Any] | list[int]]
+                    lst: list[dict[str, Any] | list[int]]
                 ) -> TypeGuard[list[dict[str, Any]]]:
-                    return all(isinstance(d, dict) for d in l)
+                    return all(isinstance(d, dict) for d in lst)
 
                 assert is_dict_list(result)
             return result

--- a/integreat_cms/sitemap/sitemaps.py
+++ b/integreat_cms/sitemap/sitemaps.py
@@ -243,9 +243,7 @@ class OfferSitemap(WebappSitemap):
         :param item: Objects passed from items() method
         :return: The absolute path of the given offer object
         """
-        return "/" + "/".join(
-            [self.region.slug, self.language.slug, "offers", item.slug]
-        )
+        return f"/{self.region.slug}/{self.language.slug}/offers/{item.slug}"
 
     def sitemap_alternates(self, obj: OfferTemplate) -> list[dict[str, str]]:
         """

--- a/integreat_cms/summ_ai_api/summ_ai_api_client.py
+++ b/integreat_cms/summ_ai_api/summ_ai_api_client.py
@@ -337,5 +337,5 @@ class SummAiApiClient(MachineTranslationApiClient):
                 "SUMM.AI translation is waiting for %ss because the rate limit has been exceeded",
                 settings.SUMM_AI_RATE_LIMIT_COOLDOWN,
             )
-            raise SummAiRateLimitingExceeded()
+            raise SummAiRateLimitingExceeded
         return False

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ dev = [
     "pytest-testmon<=1.4.5",
     "pytest-xdist",
     "requests-mock",
+    "ruff",
     "shellcheck-py",
     "sphinx",
     "sphinx-last-updated-by-git",
@@ -287,6 +288,7 @@ dev-pinned = [
     "requests-toolbelt==1.0.0",
     "rfc3986==2.0.0",
     "rich==13.7.0",
+    "ruff==0.3.5",
     "SecretStorage==3.3.3",
     "shellcheck-py==0.9.0.6",
     "snowballstemmer==2.2.0",
@@ -426,3 +428,115 @@ disallow_untyped_defs = true
 ignore_missing_imports = true
 warn_redundant_casts = true
 strict_equality = true
+
+[tool.ruff]
+line-length = 279
+target-version = "py311"
+
+[tool.ruff.lint]
+select = [
+  "A",      # flake8-builtins
+  "AIR",    # Airflow
+  "ASYNC",  # flake8-async
+  "BLE",    # flake8-blind-except
+  "C4",   # flake8-comprehensions
+  "C90",    # McCabe cyclomatic complexity
+  "DJ",     # flake8-django
+  "E",      # pycodestyle
+  "EXE",    # flake8-executable
+  "F",      # Pyflakes
+  "FA",     # flake8-future-annotations
+  "FIX",    # flake8-fixme
+  "FLY",    # flynt
+  "G",      # flake8-logging-format
+  "ICN",    # flake8-import-conventions
+  "INP",    # flake8-no-pep420
+  "INT",    # flake8-gettext
+  "ISC",    # flake8-implicit-str-concat
+  "LOG",    # flake8-logging
+  "NPY",    # NumPy-specific rules
+  "PD",     # pandas-vet
+  "PERF",   # Perflint
+  "PGH",    # pygrep-hooks
+  "PIE",    # flake8-pie
+  "PL",     # Pylint
+  "PYI",    # flake8-pyi
+  "RSE",    # flake8-raise
+  "SLOT",   # flake8-slots
+  "T10",    # flake8-debugger
+  "TRIO",   # flake8-trio
+  "W",      # pycodestyle
+  "YTT",    # flake8-2020
+  # "ANN",  # flake8-annotations
+  # "ARG",  # flake8-unused-arguments
+  # "B",    # flake8-bugbear
+  # "COM",  # flake8-commas
+  # "CPY",  # flake8-copyright
+  # "D",    # pydocstyle
+  # "DTZ",  # flake8-datetimez
+  # "EM",   # flake8-errmsg
+  # "ERA",  # eradicate
+  # "FBT",  # flake8-boolean-trap
+  # "FURB", # refurb
+  # "I",    # isort
+  # "N",    # pep8-naming
+  # "PT",   # flake8-pytest-style
+  # "PTH",  # flake8-use-pathlib
+  # "Q",    # flake8-quotes
+  # "RET",  # flake8-return
+  # "RUF",  # Ruff-specific rules
+  # "S",    # flake8-bandit
+  # "SIM",  # flake8-simplify
+  # "SLF",  # flake8-self
+  # "T20",  # flake8-print
+  # "TCH",  # flake8-type-checking
+  # "TD",   # flake8-todos
+  # "TID",  # flake8-tidy-imports
+  # "TRY",  # tryceratops
+  # "UP",   # pyupgrade
+]
+ignore = [
+  "F401",
+  "INP001",
+]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 23  # default is 10
+
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401", "F403"]
+"docs/src/conf.py" = ["A001"]
+"integreat_cms/api/v3/*" = ["PERF401"]
+"integreat_cms/cms/forms/custom_model_form.py" = ["G003", "PERF401"]
+"integreat_cms/cms/forms/linkcheck/link_replace_form.py" = ["W605"]
+"integreat_cms/cms/forms/pages/page_form.py" = ["PLR5501"]
+"integreat_cms/cms/forms/regions/region_form.py" = ["FIX002"]
+"integreat_cms/cms/models/abstract_base_model.py" = ["BLE001", "DJ012"]
+"integreat_cms/cms/models/poi_categories/poi_category.py" = ["DJ001"]
+"integreat_cms/cms/models/push_notifications/push_notification.py" = ["DJ001"]
+"integreat_cms/cms/models/users/user.py" = ["DJ001"]
+"integreat_cms/cms/views/*" = ["PIE804"]
+"integreat_cms/cms/views/analytics/app_size_view.py" = ["FIX002"]
+"integreat_cms/core/*_settings.py" = ["F403"]
+"integreat_cms/core/circleci_settings.py" = ["F405"]
+"integreat_cms/core/management/commands/find_large_files.py" = ["G004"]
+"integreat_cms/core/sphinx_settings.py" = ["F405"]
+"integreat_cms/google_translate_api/apps.py" = ["BLE001"]
+"integreat_cms/google_translate_api/google_translate_api_client.py" = ["BLE001"]
+"integreat_cms/nominatim_api/nominatim_api_client.py" = ["PERF401"]
+"tests/*" = ["S101"]
+"tests/core/management/commands/test_summ_ai_bulk.py" = ["FIX002"]
+"tests/deepl_api/deepl_api_test.py" = ["PIE804"]
+"tests/pdf/test_pdf_export.py" = ["PLW2901"]
+"tests/summ_ai_api/summ_ai_test.py" = ["PLW0603"]
+"tests/textlab_api/textlab_api_test.py" = ["A002"]
+
+[tool.ruff.lint.pylint]
+allow-magic-value-types = ["float", "int", "str"]
+max-args = 8  # default is 5
+max-bool-expr = 5  # default is 5
+max-branches = 22  # default is 12
+max-locals = 15  # default is 15
+max-positional-args = 5  # default is 5
+max-returns = 12  # default is 6
+max-statements = 64  # default is 50

--- a/tests/cms/test_language.py
+++ b/tests/cms/test_language.py
@@ -23,7 +23,7 @@ def test_create_new_language_node(
     parent = region.language_tree_root
 
     # Check the new language does not exist in the region
-    assert not new_language in region.languages
+    assert new_language not in region.languages
 
     next_url = url = reverse(
         "new_languagetreenode", kwargs={"region_slug": region.slug}

--- a/tests/cms/test_media_library.py
+++ b/tests/cms/test_media_library.py
@@ -40,7 +40,7 @@ def test_directory_path(
         assert response.status_code == 200
         # Check contents in the response
         assert "Test Directory" in response.content.decode("utf-8")
-        assert not "Empty Directory" in response.content.decode("utf-8")
+        assert "Empty Directory" not in response.content.decode("utf-8")
     elif role == ANONYMOUS:
         # For anonymous users, we want to redirect to the login form instead of showing an error
         assert response.status_code == 302
@@ -73,7 +73,7 @@ def test_get_directory_content(
         assert response.status_code == 200
         # Check contents in the response
         assert "Test Logo" in response.content.decode("utf-8")
-        assert not "Test Logo 2" in response.content.decode("utf-8")
+        assert "Test Logo 2" not in response.content.decode("utf-8")
     elif role == ANONYMOUS:
         # For anonymous users, we want to redirect to the login form instead of showing an error
         assert response.status_code == 302
@@ -433,7 +433,7 @@ def test_get_file_usages(
         assert response.status_code == 200
         # Check contents in the response
         assert "Test Organization" in response.content.decode("utf-8")
-        assert not "Welcome" in response.content.decode("utf-8")
+        assert "Welcome" not in response.content.decode("utf-8")
     elif role == ANONYMOUS:
         # For anonymous users, we want to redirect to the login form instead of showing an error
         assert response.status_code == 302
@@ -467,7 +467,7 @@ def test_get_search_result(
         # Check contents in the response
         assert "Test Directory" in response.content.decode("utf-8")
         assert "Test Logo" in response.content.decode("utf-8")
-        assert not "Empty Directory" in response.content.decode("utf-8")
+        assert "Empty Directory" not in response.content.decode("utf-8")
 
     elif role == ANONYMOUS:
         # For anonymous users, we want to redirect to the login form instead of showing an error

--- a/tests/cms/views/feedback/test_admin_feedback_actions.py
+++ b/tests/cms/views/feedback/test_admin_feedback_actions.py
@@ -92,7 +92,7 @@ def test_mark_admin_feedback_as_unread(
 
         # Check that feedback has been marked as unread by the user in the database
         feedback = Feedback.objects.get(id=test_feedback_id)
-        assert feedback.read_by == None
+        assert feedback.read_by is None
 
     elif role == ANONYMOUS:
         # For anonymous users, we want to redirect to the login form instead of showing an error
@@ -135,7 +135,7 @@ def test_archive_admin_feedback(
 
         # Check that feedback has been archived by the user in the database
         feedback = Feedback.objects.get(id=test_feedback_id)
-        assert feedback.archived == True
+        assert feedback.archived is True
 
     elif role == ANONYMOUS:
         # For anonymous users, we want to redirect to the login form instead of showing an error
@@ -178,7 +178,7 @@ def test_restore_admin_feedback(
 
         # Check that feedback has been restored by the user in the database
         feedback = Feedback.objects.get(id=test_feedback_id)
-        assert feedback.archived == False
+        assert feedback.archived is False
 
     elif role == ANONYMOUS:
         # For anonymous users, we want to redirect to the login form instead of showing an error

--- a/tests/cms/views/feedback/test_region_feedback_actions.py
+++ b/tests/cms/views/feedback/test_region_feedback_actions.py
@@ -107,7 +107,7 @@ def test_mark_region_feedback_as_unread(
 
         # Check that feedback has been marked as unread by the user in the database
         feedback = Feedback.objects.get(id=test_feedback_id)
-        assert feedback.read_by == None
+        assert feedback.read_by is None
 
     elif role == ANONYMOUS:
         # For anonymous users, we want to redirect to the login form instead of showing an error
@@ -152,7 +152,7 @@ def test_archive_region_feedback(
 
         # Check that feedback has been archived by the user in the database
         feedback = Feedback.objects.get(id=test_feedback_id)
-        assert feedback.archived == True
+        assert feedback.archived is True
 
     elif role == ANONYMOUS:
         # For anonymous users, we want to redirect to the login form instead of showing an error
@@ -197,7 +197,7 @@ def test_restore_region_feedback(
 
         # Check that feedback has been restored by the user in the database
         feedback = Feedback.objects.get(id=test_feedback_id)
-        assert feedback.archived == False
+        assert feedback.archived is False
 
     elif role == ANONYMOUS:
         # For anonymous users, we want to redirect to the login form instead of showing an error


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Lint Python code with [`ruff`](https://docs.astral.sh/ruff) which is a superset of `black`, `isort`, `mccabe`, `pylint`, `pylint-django`, and numerous other Python linting tools.  It is written in Rust to be able to consistently lint and format the repo in well under one second.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Lint Python code with ruff.
- Make minor fixes to enable several linters.
- Put `ruff format` in place but disable it until a follow-on pull request.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2442


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
