### PR TITLE
Speed up CSV export by instantiating dataset with data and headers

### DIFF
--- a/integreat_cms/cms/views/feedback/region_feedback_actions.py
+++ b/integreat_cms/cms/views/feedback/region_feedback_actions.py
@@ -199,14 +199,10 @@ def export_region_feedback(
     )
 
     resource = FeedbackResource()
-    dataset = Dataset()
-
-    headers = resource.export().headers
-    dataset.headers = headers
-
-    for obj in selected_feedback:
-        data = resource.export_resource(obj)
-        dataset.append(data)
+    dataset = Dataset(
+        *(resource.export_resource(obj) for obj in selected_feedback),
+        headers=resource.export().headers,
+    )
 
     if file_format in (f.title for f in format_registry.formats()):
         blob = getattr(dataset, file_format)


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fixes #2650
* #2650

https://tablib.readthedocs.io/en/stable/api.html suggests that:
> You can also set rows and headers upon instantiation.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Instantiate the `Dataset` with all data up front instead of repeatedly calling `Dataset.append()`
- Also, use [`Dataset.export("csv")`](https://tablib.readthedocs.io/en/stable/api.html#tablib.Dataset.export) which is documented instead of `Dataset.csv` which is not.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- I do not know how to test or benchmark this beyond the current pytests.
- 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2650


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
