### PR TITLE
Limit the maximum number of items displayed in feedback messages

### DIFF
--- a/integreat_cms/cms/utils/stringify_list.py
+++ b/integreat_cms/cms/utils/stringify_list.py
@@ -3,23 +3,37 @@ from collections.abc import Iterable
 from django.utils.translation import gettext_lazy as _
 
 
-def iter_to_string(iterable: Iterable, *, quotation_char: str = '"') -> str:
+def iter_to_string(
+    iterable: Iterable, *, quotation_char: str = '"', max_items: int = 5
+) -> str:
     """
     This is a helper function that turns a list into a string using different delimiters.
 
     :param iterable: List of items
     :param quotation_char: The character that is added around each item in the list
+    :param max_items: The maximum number of items in the iterable to display
     :return: Returns string with the single items separated by comma expect the last item which is separated by 'and'.
     """
     # Convert iterable to list to support querysets etc.
-    lst = list(iterable)
-    # If the list contains more than 1 element, save the last element for later
-    last_element = lst.pop() if len(lst) > 1 else None
+    elements = list(iterable)
+    last_element_to_display = elements.pop() if 1 < len(elements) <= max_items else None
     # Join remaining elements with commas and surrounding quotes
     separator = quotation_char + ", " + quotation_char
-    list_str = quotation_char + separator.join(map(str, lst)) + quotation_char
-    # Append the last element with "and"
-    if last_element:
-        list_str += " " + _("and") + f" {quotation_char}{last_element}{quotation_char}"
-    # Return final string
-    return list_str
+    elements_str = (
+        quotation_char + separator.join(map(str, elements[:max_items])) + quotation_char
+    )
+
+    # Handle the last element with 'and' and note that there are more elements if limited by `max_items`
+    number_elements_over_limit = len(elements) - max_items
+    if number_elements_over_limit == 1:
+        elements_str += " " + _("and 1 other")
+    elif number_elements_over_limit > 1:
+        elements_str += " " + _("and {} others").format(number_elements_over_limit)
+    elif last_element_to_display:
+        elements_str += (
+            " "
+            + _("and")
+            + f" {quotation_char}{last_element_to_display}{quotation_char}"
+        )
+
+    return elements_str

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -7975,6 +7975,14 @@ msgid "Cannot generate slug from {}."
 msgstr "Slug kann nicht aus dem {} abgeleitet werden."
 
 #: cms/utils/stringify_list.py
+msgid "and 1 other"
+msgstr "und 1 weitere"
+
+#: cms/utils/stringify_list.py
+msgid "and {} others"
+msgstr "und {} weitere"
+
+#: cms/utils/stringify_list.py
 msgid "and"
 msgstr "und"
 
@@ -9813,6 +9821,7 @@ msgstr ""
 
 #~ msgid "Allow machine translations into the following languages:"
 #~ msgstr "Folgende Sprachen maschinell übersetzen:"
+
 #~ msgid "No source translation could be found for {} \"{}\"."
 #~ msgstr "Es konnte kein Quelltext für {} \"{}\" gefunden werden."
 

--- a/integreat_cms/release_notes/current/unreleased/2692.yml
+++ b/integreat_cms/release_notes/current/unreleased/2692.yml
@@ -1,0 +1,2 @@
+en: Limit maximum number of items displayed in feedback messages
+de: Begrenze die maximale Anzahl von Objekten, die in Feedbackmeldungen angezeigt werden können


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr limits the maximum number of items displayed in feedback messages in order to avoid visual clutter.

### Proposed changes
<!-- Describe this PR in more detail. -->
Add a parameter to `iter_to_str` to stop after a given number of objects (default 5).
If there are more objects to be displayed, the message will only note that there are more objects. 
 


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR --> 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2692 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
