### PR TITLE
Adjust Textlab benchmark ID

### DIFF
--- a/docs/src/index.rst
+++ b/docs/src/index.rst
@@ -43,11 +43,15 @@ Project Architecture / Reference
   - :doc:`ref/integreat_cms.api`: This app provides wrapper functions around all API routes and classes mapping the cms models to API JSON responses.
   - :doc:`ref/integreat_cms.cms`: This app contains all database models, views, forms and templates forming the content management system for backend users.
   - :doc:`ref/integreat_cms.core`: This is the project’s main app which contains all configuration files.
+  - :doc:`ref/integreat_cms.deepl_api`: This app provides wrapper functions around the DeepL API for providing translations.
   - :doc:`ref/integreat_cms.firebase_api`: This app provides wrapper functions around the Firebase API to send push notifications.
+  - :doc:`ref/integreat_cms.google_translate_api`: This app provides wrapper functions around the Google Cloud Translate API for providing translations.
   - :doc:`ref/integreat_cms.gvz_api`: This app provides wrapper functions around our Gemeindeverzeichnis API to automatically import coordinates and region aliases.
+  - :doc:`ref/integreat_cms.matomo_api`: This app provides wrapper functions around the Matomo API, for gathering statistics like those in the region dashboard.
   - :doc:`ref/integreat_cms.nominatim_api`: This app provides wrapper functions around our Nominatim API to automatically import region bounding boxes.
   - :doc:`ref/integreat_cms.sitemap`: This app dynamically generates a sitemap.xml for the webapp.
   - :doc:`ref/integreat_cms.summ_ai_api`: This app provides wrapper functions around the SUMM.AI API for automatic translations into Easy German.
+  - :doc:`ref/integreat_cms.textlab_api`: This app provides wrapper functions around the Textlab API to evaluate texts and determine their HIX value.
   - :doc:`ref/integreat_cms.xliff`: This app allows (de-)serialization of translations from/to XLIFF (XML Localization Interchange File Format) for standardised exchange with translation agencies.
 
 * :doc:`ref/tests`: This app contains all tests to verify integreat-cms works as intended

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -285,6 +285,11 @@ TEXTLAB_API_BULK_COOL_DOWN_PERIOD: Final[float] = float(
     os.environ.get("INTEGREAT_CMS_TEXTLAB_API_BULK_COOL_DOWN_PERIOD", 60)
 )
 
+#: Which text type / benchmark id to default to
+TEXTLAB_API_DEFAULT_BENCHMARK_ID: Final[int] = int(
+    os.environ.get("INTEGREAT_CMS_TEXTLAB_API_DEFAULT_BENCHMARK_ID", 420)
+)
+
 #: The minimum HIX score required for machine translation
 HIX_REQUIRED_FOR_MT: Final[float] = float(
     os.environ.get("INTEGREAT_CMS_HIX_REQUIRED_FOR_MT", 15.0)

--- a/integreat_cms/textlab_api/textlab_api_client.py
+++ b/integreat_cms/textlab_api/textlab_api_client.py
@@ -43,15 +43,25 @@ class TextlabClient:
         response = self.post_request("/user/login", data)
         self.token = response["token"]
 
-    def benchmark(self, text: str) -> float | None:
+    def benchmark(
+        self, text: str, text_type: int = settings.TEXTLAB_API_DEFAULT_BENCHMARK_ID
+    ) -> float | None:
         """
         Retrieves the hix score of the given text.
 
         :param text: The text to calculate the score for
+        :param text_type: The id of the text type ("Textsorte") or, in terms of the api, benchmark to query.
+            A benchmark is a pre-defined set of modules producing various metrics.
+            They can have threshold/target values, depending on the type of text the benchmark is trying to represent.
+            The available text types activated for the logged in account can be queried by sending a simple
+            GET request to the ``/benchmark`` endpoint, complete with all metrics that get included for it.
+            You can find the not so helpful API "documentation" here: https://comlab-ulm.github.io/swagger-V8/
+            But since for now we are only interested in the HIX score anyway, we just use the benchmark
+            "Letter Demo Integreat" with ID ``420`` by default.
         :return: The score, or None if an error occurred
         """
         data = {"text": unescape(text), "locale_name": "de_DE"}
-        path = "/benchmark/5"
+        path = f"/benchmark/{text_type}"
         response = self.post_request(path, data, self.token)
         return response.get("formulaHix")
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Adjust the benchmark ("Textsorte") ID to ask of the Textlab API, improve documentation

### Proposed changes
<!-- Describe this PR in more detail. -->

- Make the ID a parameter rather than hardcoded
- Previously we used an ID of `5` (whatever that might have been). Since Textlab implemented proper checks and we are only able to use `420` through `424`, and all of those provide the HIX value and we discard the rest anyway, just use `420` as the default
    - Maybe the default should be in the settings instead?
    - Or furthermore, in theory, robust business logic should query all available benchmarks containing the HIX value from the `/benchmark` endpoint of the API (with a query string) and select the one with the fewest / least costly other metrics. But this is likely overkill.
- Improve the documentation a bit
- Update the Project Architecture (in the landing page of the documentation)


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- The hardcoded ID has been manually altered on the production system as a quick fix. We should keep that in mind for any deployments before one containing the changes of this PR.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
