### PR TITLE
Add option to translate into Plain German

### DIFF
--- a/example-configs/integreat-cms.ini
+++ b/example-configs/integreat-cms.ini
@@ -143,6 +143,9 @@ SUMM_AI_EASY_GERMAN_LANGUAGE_SLUG = "de-si"
 SUMM_AI_SEPARATOR = "hyphen"
 # Whether the SUMM.AI translations are initial by default [optional, defaults to True]
 SUMM_AI_IS_INITIAL = True
+# Slugs of regions that prefer Plain German over Easy German in the management command
+SUMM_AI_PLAIN_GERMAN_REGIONS = "augsburg
+testregion"
 
 [MT global]
 # The amount of yearly translation credits each region receives for free

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -1011,6 +1011,14 @@ SUMM_AI_IS_INITIAL: Final[bool] = bool(
     strtobool(os.environ.get("INTEGREAT_CMS_SUMM_AI_IS_INITIAL", "True"))
 )
 
+# Slugs of regions that prefer Plain German over Easy German in the management command
+SUMM_AI_PLAIN_GERMAN_REGIONS: Final[list[str]] = [
+    x.strip()
+    for x in os.environ.get(
+        "INTEGREAT_CMS_SUMM_AI_PLAIN_GERMAN_REGIONS", ""
+    ).splitlines()
+]
+
 
 ################
 # STATIC FILES #

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -9835,6 +9835,15 @@ msgstr ""
 #~ msgid "The DeepL budget has been exceeded."
 #~ msgstr "Das DeepL-Budget wurde überschritten."
 
+#~ msgid "German (Plain)"
+#~ msgstr "Deutsch (leicht)"
+
+#~ msgid ""
+#~ "Machine translate %(content_type)s via %(provider)s to German (Plain)"
+#~ msgstr ""
+#~ "%(content_type)s maschinell via %(provider)s auf Deutsch (einfach) "
+#~ "übersetzen"
+
 #~ msgid "Language Selection"
 #~ msgstr "Sprachauswahl"
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
 

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add a new environment variable `SUMM_AI_PLAIN_GERMAN_REGIONS` to list regions that want to use plain German in the bulk MT action.
- Set `output_language_level` to `plain` if the region is listed in `SUMM_AI_PLAIN_GERMAN_REGIONS` **and** the MT translation request is made per bulk action.
- Change the language name in the description of bulk SUMM.AI translation to `German (plain)` if it is the case of `output_language_level = "plain"`.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- None? 🙈 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2670


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
