### PR TITLE
Set the automatic translation to unchecked by default

### DIFF
--- a/integreat_cms/cms/forms/custom_content_model_form.py
+++ b/integreat_cms/cms/forms/custom_content_model_form.py
@@ -43,9 +43,10 @@ class CustomContentModelForm(CustomModelForm):
         # Instantiate CustomModelForm
         super().__init__(**kwargs)
 
-        # Always set the minor edit to unchecked to make sure it does not influence future versions
-        # (unless manually enabled)
+        # Always set the minor edit and the automatic translation to unchecked
+        # to make sure it does not influence future versions (unless manually enabled)
         self.initial["minor_edit"] = False
+        self.initial["automatic_translation"] = False
 
         # The slug is not required because it will be auto-generated if left blank
         if "slug" in self.fields:

--- a/integreat_cms/release_notes/current/unreleased/2691.yml
+++ b/integreat_cms/release_notes/current/unreleased/2691.yml
@@ -1,0 +1,2 @@
+en: Set the automatic translation checkbox to unchecked by default
+de: Deaktiviere das Kontrollkästchen für die automatische Übersetzung standardmäßig

--- a/integreat_cms/static/src/js/forms/autosave.ts
+++ b/integreat_cms/static/src/js/forms/autosave.ts
@@ -21,6 +21,10 @@ export const autosaveEditor = async () => {
     formData.append("status", "AUTO_SAVE");
     // Override minor edit field to keep translation status
     formData.set("minor_edit", "on");
+    // Do not create or update automatic translations on autosave
+    formData.delete("automatic_translation");
+    formData.delete("mt_translations_to_create");
+    formData.delete("mt_translations_to_update");
     // Show auto save remark
     const autoSaveNote = document.getElementById("auto-save");
     autoSaveNote.classList.remove("hidden");
@@ -39,7 +43,7 @@ export const autosaveEditor = async () => {
     // Set the form action to the url of the server response to make sure new pages aren't created multiple times
     form.action = data.url;
 
-    // mark the content as saved
+    // Mark the content as saved
     document.querySelectorAll("[data-unsaved-warning]").forEach((element) => {
         element.dispatchEvent(new Event("autosave"));
     });


### PR DESCRIPTION
### Short description
This PR fixes 2 issues:
1. Since we kept the state of automatic translation checkbox, some automatic translations were made accidentally (details in #2691)
2. When the automatic translation checkbox was checked, autosave did not work. It caused an error "The options "automatic translation" and "minor edit" are mutually exclusive"


### Proposed changes
- Set the automatic translation to unchecked by default unless manually enabled (the same behavior as for minor edit)
- Delete automatic translation attributes from the form data on autosave


### Side effects
No?


### Resolved issues
Fixes: #2691


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
