### PR TITLE
Update media file paths

### DIFF
--- a/integreat_cms/cms/models/media/media_file.py
+++ b/integreat_cms/cms/models/media/media_file.py
@@ -7,6 +7,7 @@ are used to determine the file system path to which the files should be uploaded
 from __future__ import annotations
 
 import logging
+import time
 from os.path import splitext
 from time import strftime
 from typing import TYPE_CHECKING
@@ -41,6 +42,7 @@ def upload_path(instance: MediaFile, filename: str) -> str:
     """
     This function calculates the path for a file which is uploaded to the media library.
     It contains the region id, the current year and month as subdirectories and the filename.
+    It also contains the current epoch time to make sure that no path will be used twice.
     It is just the provisionally requested path for the media storage.
     If it already exists, Django will automatically append a random string to make sure the file name is unique.
 
@@ -48,21 +50,11 @@ def upload_path(instance: MediaFile, filename: str) -> str:
     :param filename: The filename of media library object
     :return: The upload path of the file
     """
-    # If the instance already exists in the database, make sure the upload path doesn't change
-    if instance.id:
-        original_instance = MediaFile.objects.get(id=instance.id)
-        if original_instance.file:
-            logger.debug(
-                "%r already exists in the database, keeping original upload path: %r",
-                instance,
-                original_instance.file.name,
-            )
-            return original_instance.file.name
-
     # If the media file is uploaded to a specific region, prepend a region id subdirectory
     subdirectory = f"regions/{instance.region.id}" if instance.region else "global"
     # Calculate the remaining upload path
-    path = f"{subdirectory}/{strftime('%Y/%m')}/{filename}"
+    path = f"{subdirectory}/{strftime('%Y/%m')}/{int(time.time())}_{filename}"
+
     logger.debug("Upload path for media file %r: %r", instance.file, path)
     return path
 
@@ -82,17 +74,6 @@ def upload_path_thumbnail(instance: MediaFile, filename: str) -> str:
     :param filename: The (unused) initial filename of thumbnail
     :return: The upload path of the thumbnail
     """
-    # If the instance already exists in the database, make sure the upload path doesn't change
-    if instance.id:
-        original_instance = MediaFile.objects.get(id=instance.id)
-        if original_instance.thumbnail:
-            logger.debug(
-                "%r already exists in the database, keeping original thumbnail upload path: %r",
-                instance,
-                original_instance.thumbnail.name,
-            )
-            return original_instance.thumbnail.name
-
     # Derive the thumbnail name from the original file name
     name, extension = splitext(instance.file.name)
     path = f"{name}_thumbnail{extension}"

--- a/integreat_cms/cms/views/media/media_actions.py
+++ b/integreat_cms/cms/views/media/media_actions.py
@@ -305,7 +305,7 @@ def replace_file_ajax(
     )
 
     media_file_form = ReplaceMediaFileForm(
-        data=request.POST, instance=media_file, files=request.FILES
+        user=request.user, data=request.POST, instance=media_file, files=request.FILES
     )
 
     if not media_file_form.is_valid():


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Update media file paths when uploading a new file in order to avoid caching problems.

### Proposed changes
<!-- Describe this PR in more detail. -->
Instead of making sure that a path gets reused when a media file is replaced, always create a new path for the new file, so that no caching problems occur.
This is done by prepending the epoch time to the filename.

Then replace all internal links to the old path with links to the new
path.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- Hopfully none, old file paths should still work


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1168


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
