### PR TITLE
Use the correct default language for pnt forms

### DIFF
--- a/integreat_cms/cms/views/push_notifications/push_notification_form_view.py
+++ b/integreat_cms/cms/views/push_notifications/push_notification_form_view.py
@@ -234,7 +234,14 @@ class PushNotificationFormView(TemplateView):
             ],
         )
         # Make title of default language required
-        pnt_formset[0].fields["title"].required = True
+        default_language = region.language_tree_root
+        assert default_language
+        default_language_form = [
+            form
+            for form in pnt_formset
+            if form.instance.language.slug == default_language.slug
+        ][0]
+        default_language_form.fields["title"].required = True
 
         if details["disable_edit"]:
             not_accessible_regions_warning = __(

--- a/integreat_cms/release_notes/current/unreleased/2722.yml
+++ b/integreat_cms/release_notes/current/unreleased/2722.yml
@@ -1,0 +1,2 @@
+en: Fix bug where sent push notifications cannot be updated sometimes
+de: Behebe Fehler, wobei manche Push-Benachrichtigungen nicht mehr aktualisiert werden können, nachdem sie gesendet wurden


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr fixes a bug where sometimes sent push notifications cannot be updated, because the cms incorrectly calculates the default language, which causes the wrong field to be required in the push notification translation formset.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Don't assume that the default language is the first language in the query
- Explicitly filter for the default language


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
/


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2722


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
