### PR TITLE
Require the title field for all region default languages in push notification form

### DIFF
--- a/integreat_cms/cms/models/push_notifications/push_notification.py
+++ b/integreat_cms/cms/models/push_notifications/push_notification.py
@@ -107,6 +107,14 @@ class PushNotification(AbstractBaseModel):
         return self.translations.filter(language__slug=get_language()).first()
 
     @property
+    def default_language(self) -> Language:
+        """
+        This property returns the default language of this push notification
+        :return: The default language of the first region
+        """
+        return self.regions.first().default_language
+
+    @property
     def default_translation(self) -> PushNotificationTranslation:
         """
         This function returns the translation of this push notification in the region's default language.
@@ -115,9 +123,7 @@ class PushNotification(AbstractBaseModel):
 
         :return: The default translation of a push notification
         """
-        return self.translations.filter(
-            language=self.regions.first().default_language
-        ).first()
+        return self.translations.filter(language=self.default_language).first()
 
     @property
     def best_translation(self) -> PushNotificationTranslation:

--- a/integreat_cms/firebase_api/firebase_api_client.py
+++ b/integreat_cms/firebase_api/firebase_api_client.py
@@ -47,7 +47,7 @@ class FirebaseApiClient:
         self.prepared_pnts = []
         self.primary_pnt = PushNotificationTranslation.objects.get(
             push_notification=push_notification,
-            language=push_notification.regions.first().default_language,
+            language=push_notification.default_language,
         )
         if self.primary_pnt.title:
             self.prepared_pnts.append(self.primary_pnt)

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -9251,6 +9251,22 @@ msgstr ""
 "kontaktieren Sie eine:n Administrator:in."
 
 #: cms/views/push_notifications/push_notification_form_view.py
+msgid "updated"
+msgstr "aktualisiert"
+
+#: cms/views/push_notifications/push_notification_form_view.py
+msgid "created"
+msgstr "erstellt"
+
+#: cms/views/push_notifications/push_notification_form_view.py
+msgid "Template \"{}\" was successfully {}"
+msgstr "Vorlage \"{}\" wurde erfolgreich {}"
+
+#: cms/views/push_notifications/push_notification_form_view.py
+msgid "News \"{}\" was successfully {}"
+msgstr "Nachricht \"{}\" wurde erfolgreich {}"
+
+#: cms/views/push_notifications/push_notification_form_view.py
 msgid "This news is also assigned to regions you don't have access to: {}."
 msgstr ""
 "Diese Nachricht ist auch Regionen zugewiesen, auf die Sie keinen Zugriff "
@@ -9267,22 +9283,6 @@ msgid ""
 msgstr ""
 "Bitte wenden Sie sich an denjenigen, der für all diese Regionen zuständig "
 "ist oder kontaktieren Sie eine:n Administrator:in."
-
-#: cms/views/push_notifications/push_notification_form_view.py
-msgid "updated"
-msgstr "aktualisiert"
-
-#: cms/views/push_notifications/push_notification_form_view.py
-msgid "created"
-msgstr "erstellt"
-
-#: cms/views/push_notifications/push_notification_form_view.py
-msgid "Template \"{}\" was successfully {}"
-msgstr "Vorlage \"{}\" wurde erfolgreich {}"
-
-#: cms/views/push_notifications/push_notification_form_view.py
-msgid "News \"{}\" was successfully {}"
-msgstr "Nachricht \"{}\" wurde erfolgreich {}"
 
 #: cms/views/push_notifications/push_notification_form_view.py
 msgid "News \"{}\" is not a template"

--- a/integreat_cms/release_notes/current/unreleased/2722.yml
+++ b/integreat_cms/release_notes/current/unreleased/2722.yml
@@ -1,0 +1,2 @@
+en: Fix bug where sent push notifications cannot be updated sometimes
+de: Behebe Fehler, wobei manche Push-Benachrichtigungen nicht mehr aktualisiert werden können, nachdem sie gesendet wurden


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr makes the title field in the push notification form required for every language that is a default language in one of the push notifications regions. This fixes two issues:
- Previously, only the title field of the first language of the query was required, even if it differed from the primary regions language.
- With the first problem fixed, it was still undefined what happened if a push notification was assigned to two regions with different default languages. The title was arbitrarily required for the language of either region, but not both.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Require the title field for all region default languages in push notification form
- Do a small refactor on the push notification form view post handler, to make it easier to add this functionality


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
It is still arbitrary what will be used as the default language if a push notification without title and text gets send. Maybe we should always use the default language of the region from which the push notification was sent?

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2722 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
