### PR TITLE
Fix push notification bug

### DIFF
--- a/integreat_cms/cms/fixtures/test_data.json
+++ b/integreat_cms/cms/fixtures/test_data.json
@@ -4451,6 +4451,17 @@
     }
   },
   {
+    "model": "cms.pushnotificationtranslation",
+    "pk": 9,
+    "fields": {
+      "title": "",
+      "text": "English translation without title",
+      "language": 2,
+      "push_notification": 7,
+      "last_updated": "2022-03-05T10:31:33.130Z"
+    }
+  },
+  {
     "model": "cms.mediafile",
     "pk": 1,
     "fields": {

--- a/integreat_cms/cms/models/push_notifications/push_notification.py
+++ b/integreat_cms/cms/models/push_notifications/push_notification.py
@@ -127,10 +127,11 @@ class PushNotification(AbstractBaseModel):
 
         :return: The "best" translation of a push notification for displaying in the backend
         """
+        backend_translation = self.backend_translation
         return (
-            self.backend_translation
-            or self.default_translation
-            or self.translations.first()
+            backend_translation
+            if backend_translation and backend_translation.title
+            else (self.default_translation or self.translations.first())
         )
 
     @cached_property

--- a/integreat_cms/release_notes/current/unreleased/2726.yml
+++ b/integreat_cms/release_notes/current/unreleased/2726.yml
@@ -1,0 +1,2 @@
+en: Fix title of push notification not being displayed if it has no translation available in the users language
+de: Behebe Fehler, wobei der Titel von Push-Benachrichtigungen nicht dargestellt wird, wenn sie nicht in der Benutzeroberflächensprache verfügbar sind.

--- a/tests/cms/models/push_notifications/test_push_notification.py
+++ b/tests/cms/models/push_notifications/test_push_notification.py
@@ -1,0 +1,31 @@
+import pytest
+from django.utils import translation
+
+from integreat_cms.cms.models import (
+    Language,
+    PushNotification,
+    PushNotificationTranslation,
+)
+
+
+@pytest.mark.django_db
+def test_best_translation(load_test_data: None) -> None:
+    """
+    Test whether the `best_translation` method functions correctly. This is to prevent the following bug: https://github.com/digitalfabrik/integreat-cms/issues/2726
+    :param load_test_data: The fixture providing the test data (see :meth:`~tests.conftest.load_test_data`)
+    """
+    pn = PushNotification.objects.get(translations__title="Test")
+
+    with translation.override("de"):
+        assert pn.best_translation.title == "Test"
+
+    with translation.override("en"):
+        # This push notification has no other translations than the German one and should thus always return
+        # the German translation as the best translation
+        assert pn.best_translation.title == "Test"
+
+    PushNotificationTranslation.objects.filter(
+        push_notification=pn, language__slug="en"
+    ).update(title="English test")
+    with translation.override("en"):
+        assert pn.best_translation.title == "English test"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr fixes a problem that the `best_translation` method of push notifications prefers translations without title over translations with title.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Only return the backend translation if it has a title


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- 
- 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2726


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
