### PR TITLE
Add devcontainer definition

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/vscode/devcontainers/python:3.11
+
+RUN apt-get update && \
+    apt-get install -y nodejs npm && \
+    npm install -g n && \
+    n stable && \
+    apt-get purge -y nodejs npm && \
+    ln -sf /usr/local/bin/node /usr/bin/node
+
+RUN apt-get install -y netcat-traditional pcregrep
+
+WORKDIR /workspace
+
+CMD ["sleep", "infinity"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,33 @@
+{
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "devcontainer",
+  "workspaceFolder": "/workspace",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "charliermarsh.ruff",
+        "batisteo.vscode-django",
+        "ms-vscode.vscode-typescript-next",
+        "ms-python.vscode-pylance"
+      ],
+      "settings": {
+        "[python]": {
+          "editor.formatOnSave": true,
+          "editor.defaultFormatter": "charliermarsh.ruff",
+          "editor.codeActionsOnSave": {
+            "source.fixAll": "always",
+            "source.organizeImports": "always"
+          }
+        },
+        "python.testing.unittestEnabled": false,
+        "python.testing.pytestEnabled": false,
+        "ruff.enable": true,
+        "ruff.lint.args": ["--config=${workspaceFolder}/pyproject.toml", "--fix"],
+        "ruff.format.args": ["--config=${workspaceFolder}/pyproject.toml", "--preview"]
+      }
+    }
+  },
+  "postCreateCommand": "./tools/install.sh --python python3.11 && ./tools/migrate.sh && ./tools/loadtestdata.sh",
+  "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.8"
+
+services:
+  devcontainer:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ..:/workspace:cached
+    network_mode: service:db
+    depends_on:
+      - db
+
+  db:
+    container_name: integreat_django_postgres
+    image: postgres:latest
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: integreat
+      POSTGRES_DB: integreat
+      POSTGRES_PASSWORD: password
+
+volumes:
+  postgres-data:

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,6 @@ docs/src/templates/footer.html*
 docs/src/templates/breadcrumbs.html*
 
 # Miscellaneous
-.vscode
 .idea
 .directory
 cms-django.iml

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,116 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Run Shell Script",
+      "type": "shell",
+      "command": "sh",
+      "args": ["${file}"],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Run all python tests",
+      "type": "shell",
+      "command": "./tools/test.sh",
+      "problemMatcher": [],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Run current python test",
+      "type": "shell",
+      "command": "./tools/test.sh ${file}",
+      "problemMatcher": [],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Run all frontend tests",
+      "type": "shell",
+      "command": "npm run test",
+      "problemMatcher": [],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Check code style",
+      "type": "shell",
+      "command": "./tools/code_style.sh",
+      "problemMatcher": [],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Run prettier tool",
+      "type": "shell",
+      "command": "./tools/prettier.sh",
+      "problemMatcher": [],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Run mypy tool",
+      "type": "shell",
+      "command": "./tools/prettier.sh",
+      "problemMatcher": [],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Run ruff tool",
+      "type": "shell",
+      "command": "./tools/ruff.sh",
+      "problemMatcher": [],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Run eslint tool",
+      "type": "shell",
+      "command": "./tools/eslint.sh",
+      "problemMatcher": [],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Run devserver",
+      "type": "shell",
+      "command": "./tools/run.sh",
+      "problemMatcher": [],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Run translation check",
+      "type": "shell",
+      "command": "./tools/check_translations.sh",
+      "problemMatcher": [],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -12,36 +12,63 @@
 
 This content management system helps local integration experts to provide multilingual information for newcomers.
 
-## TL;DR
+## Development Setup
 
-### Prerequisites
-
-Following packages are required before installing the project (install them with your package manager):
-
-* `npm` version 7 or later
-* `nodejs` version 18 or later
-* `python3` version 3.11 or later
-* `python3-pip` (Debian-based distributions) / `python-pip` (Arch-based distributions)
-* `python3-venv` (only on Debian-based distributions)
-* `gettext` to use the translation features
-* Either `postgresql` **or** `docker` to run a local database server
-
-### Installation
+This section provides a brief overview of setting up the development environment. We support various environments: you can set up everything locally using your preferred package manager, use it as a devcontainer, or utilize the nix-flake ([coming soon](https://github.com/digitalfabrik/integreat-cms/pull/2730)). Please clone the repository with the following snippet before starting to 
+setup your development environment.
 
 ````
 git clone git@github.com:digitalfabrik/integreat-cms.git
 cd integreat-cms
-./tools/install.sh
 ````
+
+### Local Setup
+
+To configure your development environment on your system, please follow these steps carefully.
+
+1. Ensure that the following packages are installed alongside your preferred IDE:
+   - `npm` version 7 or later
+   - `nodejs` version 18 or later
+   - `python3` version 3.11 or later
+   - `python3-pip` (Debian-based distributions) / `python-pip` (Arch-based distributions)
+   - `python3-venv` (only on Debian-based distributions)
+   - `gettext` for translation features
+   - Either `postgresql` **or** `docker` to run a local database server
+2. Execute `tools/install.sh` to download all dependencies.
+3. Execute `tools/migrate.sh` to apply all database schema migrations.
+4. Optionally, run `tools/loadtestdata.sh` to apply a predefined set of test data.
+
+### Devcontainer
+
+To configure your development container, please follow these steps carefully.
+
+1. Make sure you have Docker and VSCode (not VSCodium) installed on your machine.
+2. Open the project in VSCode.
+3. If you're opening VSCode for the first time, you'll be prompted to install the ["Dev Containers" extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers). Click "Install" to proceed.
+4. Open the command palette (Ctrl + Shift + P or Cmd + Shift + P on macOS) and search for "> Remote-Containers: Open Folder in Container".
+5. VSCode will open the project in a new container, install all further required tools and load the testdata.
+
+#### Known Limitations
+
+The perfect is the enemy of the good; thus, this section illuminates aspects of our evolving development setup.
+
+##### Sharing git username and email
+
+A known limitation exists where certain versions of Visual Studio Code (VSCode) may not copy the user's `.gitconfig` file correctly into the Devcontainer environment. In such cases, when you attempt to commit changes within the Devcontainer, you may be prompted to enter your Git username and email every time. This can be inconvenient and disrupt the workflow. However, there is a workaround for this issue. You can resolve it by appending the content of your personal `.gitconfig` file, located at `$HOME/.gitconfig`, to the end of the repository-specific `.git/config` file, which in this case would be `integreat-cms/.git/config`. By doing so, you ensure that the necessary Git configuration settings are correctly applied within the Devcontainer environment, allowing for a smoother development experience.
+
+For more information, refer to [this issue](https://github.com/microsoft/vscode-remote-release/issues/1729) in the VSCode Remote Extension repository.
+
+##### Test discovery 
+
+Testing is not yet fully integrated into our Visual Studio Code Container, but we provide convenient task definitions to facilitate testing. For example, you can simply type `task current python test` and hit enter to run the current Python test file. Take a look at the `.vscode/tasks.json` for more helpful tasks and extend this file as needed.
+
+##### Docker permissions
+
+The user must be in the docker group on linux, VSCode does not allow to optionally enter sudo password.
 
 ### Run development server
 
-````
-./tools/run.sh
-````
-
-* Go to your browser and open the URL `http://localhost:8000`
-* Default user is "root" with password "root1234".
+Run the development server using `/tools/run.sh`, then open your browser and go to `http://localhost:8000`. The default login credentials are username: "root" and password: "root1234".
 
 ## Documentation
 

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -54,9 +54,9 @@ if [[ ! -x "$(command -v pip3)" ]]; then
     echo "Pip for Python3 is not installed. Please install python3-pip manually and run this script again."  | print_error
     exit 1
 fi
-# Check if database backend is installed
-if [[ ! -x "$(command -v docker)" ]] && [[ ! -x "$(command -v psql)" ]]; then
-    echo "In order to run the database, you need either Docker (recommended) or PostgreSQL. Please install at least one of them manually and run this script again." | print_error
+# Check if postgres instance is running on host system or database backend is installed 
+if ! { [[ -x "$(command -v docker)" ]] || [[ -x "$(command -v psql)" ]] || nc -z localhost 5432 > /dev/null 2>&1; }; then
+    echo "In order to run the database, you need either Docker (recommended) or PostgreSQL. Please install at least one of them manually and run this script again."
     exit 1
 fi
 # Define the required npm version


### PR DESCRIPTION
### Short description

This Pull Request adds a devcontainer definition to make the project setup easier and streamline the onboarding process of new devs.

### Proposed changes

I encountered some difficulties during onboarding and initial setup of the project, which I aim to automate with this addition. Through discussions in the chat, I learned that most people here develop with VSCode, so I thought that a devcontainer would be the appropriate solution.

#### Challenges Encountered:

- Initially, I installed a too-new patch of Python 3.11, which caused some issues and required downgrading.
- The translate.sh script expects the GNU variant of sed, which needs to be installed separately on macOS. Additionally, it needs to be either changed in the script to gsed instead of sed or overridden with an alias. The base image of the devcontainer includes the correct sed directly.
- The project requires the programs gettext and libmagic as native dependencies, which are also included in the base image of the devcontainer.
- After starting the project for the first time, I couldn't log in because the database was still empty. The devcontainer automatically loads the test data.

### Side effects

There should be no major side effects besides that we might need to take care of both the nix-flake (#2730) and the devcontainer definition.

### Optimizations

The Docker image built for running the devcontainer is currently quite large, at 2.1 GB, and it contains a nested Docker installation. I propose we create our own Dockerfile that utilizes a native PostgreSQL setup and  implementing image caching if this feature is utilized by a significant number of users.

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
