### PR TITLE
Display helpful message when deleting POICategory fails

### DIFF
--- a/integreat_cms/cms/urls/protected.py
+++ b/integreat_cms/cms/urls/protected.py
@@ -362,9 +362,7 @@ urlpatterns: list[URLPattern] = [
                             ),
                             path(
                                 "delete/",
-                                delete_views.CustomDeleteView.as_view(
-                                    model=POICategory,
-                                ),
+                                poi_categories.POICategoryDeleteView.as_view(),
                                 name="delete_poicategory",
                             ),
                         ]

--- a/integreat_cms/cms/views/poi_categories/__init__.py
+++ b/integreat_cms/cms/views/poi_categories/__init__.py
@@ -4,4 +4,8 @@ This package contains all views related to POI categories
 
 from __future__ import annotations
 
-from .poi_category_form_view import POICategoryCreateView, POICategoryUpdateView
+from .poi_category_form_view import (
+    POICategoryCreateView,
+    POICategoryDeleteView,
+    POICategoryUpdateView,
+)

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -6832,6 +6832,7 @@ msgid "No POI categories available yet."
 msgstr "Noch keine POI Kategorien vorhanden."
 
 #: cms/templates/poicategories/poicategory_list_row.html
+#: cms/views/poi_categories/poi_category_form_view.py
 msgid ""
 "You cannot delete a location category that is used in at least one location."
 msgstr ""


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Deleting a POICategory still in use by POIs is discouraged by disabling the delete button in the list view. If a request reaches the delete endpoint anyways, an internal server error is displayed. This PR catches the exception and displays a helpful message instead.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Implement a custom `POICategoryDeleteView` which subclasses `CustomDeleteView` and acts as a simple wrapper around its `post()` logic:
- If a `ProtectedError` is raised, a helpful message is added to the request context and the browser is redirected back to the list view.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- If in the future there are other reasons how a `ProtectedError` could arise, the current message might be misleading.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2733


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
