### PR TITLE
Add tools/prune_pdf_cache.sh

### DIFF
--- a/docs/src/tools.rst
+++ b/docs/src/tools.rst
@@ -101,6 +101,10 @@ Run tests and generate coverage report with :github-source:`tools/test.sh`::
   Notice that if none are specified, we automatically pass ``--quiet``
   and run tests on multiple CPUs using xdist, resulting in much shorter wait times.
 
+If tests comparing the contents of PDF files fail repeatedly despite you not touching anything related to it, you can try to prune the PDF cache::
+
+    ./tools/prune_pdf_cache.sh
+
 
 .. _management-command-tool:
 

--- a/tools/prune_pdf_cache.sh
+++ b/tools/prune_pdf_cache.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# This script can be used to prune the pdf file cache.
+
+# Import utility functions
+# shellcheck source=./tools/_functions.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_functions.sh"
+
+rm -rfv "${PACKAGE_DIR:?}/pdf"
+echo "Removed PDF cache" | print_info

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -104,6 +104,8 @@ if [[ -n "${KW_EXPR}" ]] || [[ -n "${MARKER}" ]] || (( ${#TESTS[@]} )); then
     TEST_MESSAGE=" in ${TEST_MESSAGE}"
 fi
 
+"$(dirname "${BASH_SOURCE[0]}")/prune_pdf_cache.sh"
+
 echo -e "Running all tests${TEST_MESSAGE}${CHANGED_MESSAGE}..." | print_info
 deescalate_privileges pytest "${PYTEST_ARGS[@]}"
 echo "✔ Tests successfully completed " | print_success


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds a helpful tool to prune the pdf file cache so you don't have to remember the which directory to delete whenever PDF tests fail but probably not because of you.

### Proposed changes
<!-- Describe this PR in more detail. -->

- adds `tools/prune_pdf_cache.sh` which essentially just runs `rm -rfv "integreat_cms/pdf"`
- list the tool in the documentation
- prune pdf cache before running tests


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- pruning the PDF cache deletes the whole cache, not only the files specific to the tests

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
