### PR TITLE
Deletable media files that are attached to past events only

### DIFF
--- a/integreat_cms/cms/models/media/media_file.py
+++ b/integreat_cms/cms/models/media/media_file.py
@@ -277,7 +277,7 @@ class MediaFile(AbstractBaseModel):
         """
         usage_counts = [
             self.past_event_usages.count(),
-            len(self.icon_usages),
+            (len(self.icon_usages) + self.content_usages.count()),
             self.events.count(),
         ]
 

--- a/integreat_cms/cms/models/media/media_file.py
+++ b/integreat_cms/cms/models/media/media_file.py
@@ -260,6 +260,39 @@ class MediaFile(AbstractBaseModel):
         return Link.objects.filter(url__url=self.url).distinct("object_id")
 
     @cached_property
+    def past_event_usages(self) -> QuerySet:
+        """
+        Count in how many past events this file is used
+
+        :return: count of usages in past events
+        """
+        return self.events.filter(end__lt=timezone.now().date())
+
+    @cached_property
+    def is_only_used_in_past_events(self) -> QuerySet:
+        """
+        Check if a media file is used in past events only
+
+        :return: if a media file is only used in past events
+        """
+        usage_counts = [
+            self.past_event_usages.count(),
+            len(self.icon_usages),
+            self.events.count(),
+        ]
+
+        return all(c == usage_counts[0] for c in usage_counts)
+
+    @cached_property
+    def is_deletable(self) -> bool:
+        """
+        Check if a media file deletable
+
+        :return: Whether a file is deletable
+        """
+        return not self.is_used or self.is_only_used_in_past_events
+
+    @cached_property
     def is_embedded(self) -> bool:
         """
         Check if a media file is embedded in the content
@@ -337,7 +370,7 @@ class MediaFile(AbstractBaseModel):
             "lastModified": localize(timezone.localtime(self.last_modified)),
             "isGlobal": not self.region,
             "isHidden": self.is_hidden,
-            "deletable": not self.is_used,
+            "deletable": self.is_deletable,
         }
 
     @classmethod

--- a/integreat_cms/cms/views/media/media_actions.py
+++ b/integreat_cms/cms/views/media/media_actions.py
@@ -356,7 +356,7 @@ def delete_file_ajax(
     )
 
     # Check if the media file is in use
-    if media_file.is_used:
+    if not media_file.is_deletable:
         return JsonResponse(
             {
                 "messages": [

--- a/tests/cms/models/media/test_media_file.py
+++ b/tests/cms/models/media/test_media_file.py
@@ -1,0 +1,162 @@
+"""
+Test module for RecurrenceRule class
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+import pytest
+from django.utils import timezone
+
+from integreat_cms.cms.models import Event, MediaFile, Organization, Region
+
+
+class TestMediaFile:
+    @pytest.mark.django_db
+    def test_content_usage_count(self) -> None:
+        region = Region.objects.create(name="Testregion")
+
+        file = MediaFile.objects.create(
+            file="example.pdf",
+            thumbnail="example_thumbnail.jpg",
+            file_size=1024,
+            type="PDF",
+            name="Example File",
+            alt_text="This is an example file",
+            last_modified=datetime(2024, 4, 11, 10, 30, 0),
+            is_hidden=False,
+        )
+
+        # Past event
+        file.events.add(
+            Event.objects.create(
+                start=timezone.now() - timedelta(days=2),
+                end=timezone.now() - timedelta(days=1),
+                region=region,
+            )
+        )
+
+        assert file.past_event_usages.count() == 1
+
+    @pytest.mark.django_db
+    def test_only_used_in_past_events(self) -> None:
+        region = Region.objects.create(name="Testregion")
+
+        file = MediaFile.objects.create(
+            file="example.pdf",
+            thumbnail="example_thumbnail.jpg",
+            file_size=1024,
+            type="PDF",
+            name="Example File",
+            alt_text="This is an example file",
+            last_modified=datetime(2024, 4, 11, 10, 30, 0),
+            is_hidden=False,
+        )
+
+        # Past event
+        file.events.add(
+            Event.objects.create(
+                start=timezone.now() - timedelta(days=2),
+                end=timezone.now() - timedelta(days=1),
+                region=region,
+            )
+        )
+
+        assert file.is_only_used_in_past_events
+
+    @pytest.mark.django_db
+    def test_file_is_not_deletable_if_in_use(self) -> None:
+        region = Region.objects.create(name="Testregion")
+
+        file = MediaFile.objects.create(
+            file="example.pdf",
+            thumbnail="example_thumbnail.jpg",
+            file_size=1024,
+            type="PDF",
+            name="Example File",
+            alt_text="This is an example file",
+            last_modified=datetime(2024, 4, 11, 10, 30, 0),
+            is_hidden=False,
+        )
+
+        # Past event
+        file.events.add(
+            Event.objects.create(
+                start=timezone.now() - timedelta(days=2),
+                end=timezone.now() - timedelta(days=1),
+                region=region,
+            )
+        )
+
+        # Upcoming event
+        file.events.add(
+            Event.objects.create(
+                start=timezone.now() + timedelta(days=2),
+                end=timezone.now() + timedelta(days=1),
+                region=region,
+            )
+        )
+
+        assert not file.is_deletable
+
+    @pytest.mark.django_db
+    def test_file_is_deletable_if_only_used_in_past_event(self) -> None:
+        region = Region.objects.create(name="Testregion")
+
+        file = MediaFile.objects.create(
+            file="example.pdf",
+            thumbnail="example_thumbnail.jpg",
+            file_size=1024,
+            type="PDF",
+            name="Example File",
+            alt_text="This is an example file",
+            last_modified=datetime(2024, 4, 11, 10, 30, 0),
+            is_hidden=False,
+        )
+
+        # Past event
+        file.events.add(
+            Event.objects.create(
+                start=timezone.now() - timedelta(days=2),
+                end=timezone.now() - timedelta(days=1),
+                region=region,
+            )
+        )
+
+        assert file.is_deletable
+
+    @pytest.mark.django_db
+    def test_file_is_not_deletable_if_used_as_icon_and_by_past_event(self) -> None:
+        region = Region.objects.create(name="Testregion")
+
+        file = MediaFile.objects.create(
+            file="example.pdf",
+            thumbnail="example_thumbnail.jpg",
+            file_size=1024,
+            type="PDF",
+            name="Example File",
+            alt_text="This is an example file",
+            last_modified=datetime(2024, 4, 11, 10, 30, 0),
+            is_hidden=False,
+        )
+
+        # Past event
+        file.events.add(
+            Event.objects.create(
+                start=timezone.now() - timedelta(days=2),
+                end=timezone.now() - timedelta(days=1),
+                region=region,
+            )
+        )
+
+        # Organization Icon
+        Organization.objects.create(
+            name="Beispiel-Organisation",
+            slug="beispiel-organisation",
+            website="https://example.com",
+            region=region,
+            icon=file,
+        )
+
+        assert not file.is_deletable

--- a/tests/cms/models/media/test_media_file.py
+++ b/tests/cms/models/media/test_media_file.py
@@ -220,7 +220,7 @@ class TestMediaFile:
         )
 
         german_language = Language.objects.create(
-            slug="de",
+            slug="de-testing",
             bcp47_tag="de",
             native_name="Deutsch",
             english_name="German",
@@ -261,7 +261,7 @@ class TestMediaFile:
         )
 
         german_language = Language.objects.create(
-            slug="de",
+            slug="de-testing",
             bcp47_tag="de",
             native_name="Deutsch",
             english_name="German",
@@ -312,7 +312,7 @@ class TestMediaFile:
         )
 
         german_language = Language.objects.create(
-            slug="de",
+            slug="de-testing",
             bcp47_tag="de",
             native_name="Deutsch",
             english_name="German",
@@ -361,7 +361,7 @@ class TestMediaFile:
         )
 
         german_language = Language.objects.create(
-            slug="de",
+            slug="de-testing",
             bcp47_tag="de",
             native_name="Deutsch",
             english_name="German",

--- a/tests/cms/models/media/test_media_file.py
+++ b/tests/cms/models/media/test_media_file.py
@@ -245,4 +245,4 @@ class TestMediaFile:
 
         find_all_links()
 
-        assert file.past_event_usages.count() == 1 and file.is_deletable
+        file.is_deletable

--- a/tests/cms/models/media/test_media_file.py
+++ b/tests/cms/models/media/test_media_file.py
@@ -11,6 +11,8 @@ from django.utils import timezone
 
 from integreat_cms.cms.models import Event, MediaFile, Organization, Region, EventTranslation, Language
 
+from linkcheck.utils import find_all_links
+
 
 class TestMediaFile:
     @pytest.mark.django_db
@@ -212,6 +214,8 @@ class TestMediaFile:
 
         EventTranslation.objects.create(event=upcoming_event, language=german_language, content=f'<p><img src="http://localhost:8000/media/{file.file}"></p>')
 
+        find_all_links()
+
         assert not file.is_deletable
 
     @pytest.mark.django_db
@@ -238,5 +242,7 @@ class TestMediaFile:
         german_language = Language.objects.create(slug="de", bcp47_tag="de", native_name="Deutsch", english_name="German", text_direction="ltr", primary_country_code="DE", table_of_contents="Inhaltsverzeichnis")
 
         EventTranslation.objects.create(event=past_event, language=german_language, content=f'<p><img src="http://localhost:8000/media/{file.file}"></p>')
+
+        find_all_links()
 
         assert file.past_event_usages.count() == 1 and file.is_deletable

--- a/tests/cms/models/media/test_media_file.py
+++ b/tests/cms/models/media/test_media_file.py
@@ -220,7 +220,7 @@ class TestMediaFile:
         )
 
         german_language = Language.objects.create(
-            slug="de-testing",
+            slug="de-test",
             bcp47_tag="de",
             native_name="Deutsch",
             english_name="German",
@@ -261,7 +261,7 @@ class TestMediaFile:
         )
 
         german_language = Language.objects.create(
-            slug="de-testing",
+            slug="de-test",
             bcp47_tag="de",
             native_name="Deutsch",
             english_name="German",
@@ -312,7 +312,7 @@ class TestMediaFile:
         )
 
         german_language = Language.objects.create(
-            slug="de-testing",
+            slug="de-test",
             bcp47_tag="de",
             native_name="Deutsch",
             english_name="German",
@@ -361,7 +361,7 @@ class TestMediaFile:
         )
 
         german_language = Language.objects.create(
-            slug="de-testing",
+            slug="de-test",
             bcp47_tag="de",
             native_name="Deutsch",
             english_name="German",

--- a/tests/cms/models/media/test_media_file.py
+++ b/tests/cms/models/media/test_media_file.py
@@ -8,10 +8,16 @@ from datetime import datetime, timedelta
 
 import pytest
 from django.utils import timezone
-
-from integreat_cms.cms.models import Event, MediaFile, Organization, Region, EventTranslation, Language
-
 from linkcheck.utils import find_all_links
+
+from integreat_cms.cms.models import (
+    Event,
+    EventTranslation,
+    Language,
+    MediaFile,
+    Organization,
+    Region,
+)
 
 
 class TestMediaFile:
@@ -190,7 +196,9 @@ class TestMediaFile:
         assert not file.is_deletable
 
     @pytest.mark.django_db
-    def test_is_not_deletable_if_used_as_within_translation_of_upcoming_event(self) -> None:
+    def test_is_not_deletable_if_used_as_within_translation_of_upcoming_event(
+        self,
+    ) -> None:
         region = Region.objects.create(name="Testregion")
 
         file = MediaFile.objects.create(
@@ -210,9 +218,21 @@ class TestMediaFile:
             region=region,
         )
 
-        german_language = Language.objects.create(slug="de", bcp47_tag="de", native_name="Deutsch", english_name="German", text_direction="ltr", primary_country_code="DE", table_of_contents="Inhaltsverzeichnis")
+        german_language = Language.objects.create(
+            slug="de",
+            bcp47_tag="de",
+            native_name="Deutsch",
+            english_name="German",
+            text_direction="ltr",
+            primary_country_code="DE",
+            table_of_contents="Inhaltsverzeichnis",
+        )
 
-        EventTranslation.objects.create(event=upcoming_event, language=german_language, content=f'<p><img src="http://localhost:8000/media/{file.file}"></p>')
+        EventTranslation.objects.create(
+            event=upcoming_event,
+            language=german_language,
+            content=f'<p><img src="http://localhost:8000/media/{file.file}"></p>',
+        )
 
         find_all_links()
 
@@ -239,9 +259,21 @@ class TestMediaFile:
             region=region,
         )
 
-        german_language = Language.objects.create(slug="de", bcp47_tag="de", native_name="Deutsch", english_name="German", text_direction="ltr", primary_country_code="DE", table_of_contents="Inhaltsverzeichnis")
+        german_language = Language.objects.create(
+            slug="de",
+            bcp47_tag="de",
+            native_name="Deutsch",
+            english_name="German",
+            text_direction="ltr",
+            primary_country_code="DE",
+            table_of_contents="Inhaltsverzeichnis",
+        )
 
-        EventTranslation.objects.create(event=past_event, language=german_language, content=f'<p><img src="http://localhost:8000/media/{file.file}"></p>')
+        EventTranslation.objects.create(
+            event=past_event,
+            language=german_language,
+            content=f'<p><img src="http://localhost:8000/media/{file.file}"></p>',
+        )
 
         find_all_links()
 

--- a/tests/cms/models/media/test_media_file.py
+++ b/tests/cms/models/media/test_media_file.py
@@ -160,3 +160,29 @@ class TestMediaFile:
         )
 
         assert not file.is_deletable
+
+    @pytest.mark.django_db
+    def test_is_not_deletable_if_used_as_organization_icon(self) -> None:
+        region = Region.objects.create(name="Testregion")
+
+        file = MediaFile.objects.create(
+            file="example.pdf",
+            thumbnail="example_thumbnail.jpg",
+            file_size=1024,
+            type="PDF",
+            name="Example File",
+            alt_text="This is an example file",
+            last_modified=datetime(2024, 4, 11, 10, 30, 0),
+            is_hidden=False,
+        )
+
+        # Organization Icon
+        Organization.objects.create(
+            name="Beispiel-Organisation",
+            slug="beispiel-organisation",
+            website="https://example.com",
+            region=region,
+            icon=file,
+        )
+
+        assert not file.is_deletable


### PR DESCRIPTION
### Short description

This pull request changes the `deletable` flag of the [media_file.py](https://github.com/digitalfabrik/integreat-cms/blob/7f9085f9b8eb13d6639aaafd1efaad1625868c77/integreat_cms/cms/models/media/media_file.py#L2) in a such a way that it is true when only used by events in the past.

### Resolved issues
- [Media items used in past event should be deletable](https://github.com/digitalfabrik/integreat-cms/issues/2634)

Fixes:  #2634

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
