### PR TITLE
Change order of the HIX block and the translation block

### DIFF
--- a/integreat_cms/cms/templates/pages/page_form.html
+++ b/integreat_cms/cms/templates/pages/page_form.html
@@ -187,11 +187,11 @@
                 <div id="left-sidebar-column"
                      class="md:mr-4 md:w-full 3xl:mr-0 md:mt-0 sm:block md:flex sm:mt-4 flex-wrap flex-col 4xl:mr-4"
                      {% if request.user.distribute_sidebar_boxes %}data-enable-automatic-sidebar-distribution{% endif %}>
-                    {% if language.slug in TEXTLAB_API_LANGUAGES and request.region.hix_enabled and TEXTLAB_API_ENABLED %}
-                        {% include "../hix_widget.html" with box_id="hix-widget" %}
-                    {% endif %}
                     {% if page %}
                         {% include "./page_form_sidebar/minor_edit_box.html" with box_id="page-minor-edit" %}
+                    {% endif %}
+                    {% if language.slug in TEXTLAB_API_LANGUAGES and request.region.hix_enabled and TEXTLAB_API_ENABLED %}
+                        {% include "../hix_widget.html" with box_id="hix-widget" %}
                     {% endif %}
                     {% include "./page_form_sidebar/settings_box.html" with box_id="page-setting" %}
                 </div>

--- a/integreat_cms/release_notes/current/unreleased/2689.yml
+++ b/integreat_cms/release_notes/current/unreleased/2689.yml
@@ -1,0 +1,2 @@
+en: Change the order of the HIX block and the translation block
+de: Ändere die Reihenfolge des HIX-Blocks und des Übersetzungsblocks


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Change the order of the HIX and the translation blocks. Bring the translation block above the HIX block so that the municipalities   do not oversee it.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Change their order by bringing the translation block on top of the HIX block

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2689 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
