### PR TITLE
Ensure that webpack bundle exists before running tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "private": true,
   "scripts": {
     "dev": "NODE_ENV=development webpack watch --mode development --color --stats=errors-warnings",
-    "prod": "NODE_ENV=production webpack --mode production"
+    "prod": "NODE_ENV=production webpack --mode production",
+    "build": "webpack build"
   },
   "devDependencies": {
     "@babel/cli": "^7.23.9",

--- a/tools/_functions.sh
+++ b/tools/_functions.sh
@@ -340,6 +340,15 @@ function cleanup_docker_container {
     fi
 }
 
+function ensure_webpack_bundle_exists {
+    if [ ! -d "${PACKAGE_DIR}/static/dist/" ] || [ ! "$(ls -A ${PACKAGE_DIR}/static/dist/ 2>/dev/null)" ]; then
+        echo "Building webpack bundle..." | print_info
+        npm run build > /dev/null
+    fi
+
+    echo "✔ Webpack bundle is in place" | print_success
+}
+
 # This function makes sure a postgres database docker container is running
 function ensure_docker_container_running {
     # Make sure script has the permission to run docker

--- a/tools/_functions.sh
+++ b/tools/_functions.sh
@@ -341,7 +341,7 @@ function cleanup_docker_container {
 }
 
 function ensure_webpack_bundle_exists {
-    if [ ! -d "${PACKAGE_DIR}/static/dist/" ] || [ ! "$(ls -A ${PACKAGE_DIR}/static/dist/ 2>/dev/null)" ]; then
+    if [ ! -d "${PACKAGE_DIR}/static/dist/" ] || [ ! "$(ls -A "${PACKAGE_DIR}"/static/dist/ 2>/dev/null)" ]; then
         echo "Building webpack bundle..." | print_info
         npm run build > /dev/null
     fi

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -11,6 +11,9 @@ CODE_COVERAGE_DIR="${BASE_DIR:?}/htmlcov"
 rm -rf "${CODE_COVERAGE_DIR}"
 
 require_installed
+
+ensure_webpack_bundle_exists
+
 require_database
 
 # Set dummy key to enable SUMM.AI during testing


### PR DESCRIPTION
### Description

This pull request introduces a precondition to the `test.sh` tool, ensuring that the webpack output is available. This precaution is necessary because otherwise, the tests would fail when someone runs `./tools/test.sh` in an environment where the application hasn't been initialized.

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
