### PR TITLE
Make HIX widget more compact

### DIFF
--- a/integreat_cms/cms/templates/hix_widget.html
+++ b/integreat_cms/cms/templates/hix_widget.html
@@ -16,18 +16,6 @@
                 <i icon-name="loader" class="animate-spin"></i> {% translate "Loading..." %}
             </div>
         </div>
-        <label>
-            {% translate "Improve the understandability of the page content" %}
-        </label>
-        <div {% if not request.user.expert_mode %}class="hidden"{% endif %}>
-            {% render_field page_form.hix_ignore %}
-            <label for="{{ page_form.hix_ignore.id_for_label }}" class="secondary">
-                {{ page_form.hix_ignore.label }}
-            </label>
-            <div class="help-text">
-                {{ page_form.hix_ignore.help_text }}
-            </div>
-        </div>
         {% if not request.user.expert_mode and page_form.instance.hix_ignore %}
             <div class="help-text">
                 {% translate "HIX value calculation is disabled for this page." %}
@@ -35,27 +23,39 @@
         {% endif %}
         <div id="hix-block"
              class="{% if page_form.instance.hix_ignore %}hidden{% endif %}">
+            <div class="help-text mt-2">
+                {% translate "Improve the understandability of the page here:" %}
+            </div>
             <div id="hix-container"
                  data-content-changed
                  data-initial-hix-score="{{ page_translation_form.instance.hix_score|unlocalize }}">
-                <canvas id="hix-chart"></canvas>
+                <div id="hix-bar">
+                    <span id="hix-bar-fill">
+                        <div id="hix-value">
+                            HIX
+                        </div>
+                    </span>
+                </div>
             </div>
-            <div class="mb-2">
-                <div data-hix-state="updated" class="bg-green-400 rounded p-2 hidden">
-                    <i icon-name="check-circle"></i>
-                    {% translate "HIX value is up to date." %}
+            <div class="mt-2 mb-2 pb-2 pt-2">
+                <div data-hix-state="updated" class="text-gray-800 hidden">
+                    <i icon-name="check-circle" class="text-green-400 size-6 pr-1"></i>
+                    {% translate "HIX value is up to date" %}
                 </div>
-                <div data-hix-state="outdated" class="bg-yellow-400 rounded p-2 hidden">
-                    <i icon-name="alert-circle"></i>
-                    {% translate "HIX value is outdated." %}
+                <div data-hix-state="outdated"
+                     class="text-gray-800 bg-yellow-300 rounded p-3 hidden">
+                    <i icon-name="alert-circle" class="size-6 pr-1"></i>
+                    {% translate "HIX value is outdated" %}
                 </div>
-                <div data-hix-state="error" class="bg-red-400 rounded p-2 hidden">
-                    <i icon-name="alert-triangle"></i>
+                <div data-hix-state="error"
+                     class="text-gray-800 bg-red-300 rounded p-3 hidden">
+                    <i icon-name="alert-triangle" class="size-6 pr-1"></i>
                     {% translate "HIX value could not be calculated." %} {% translate "Please try again later." %}
                 </div>
-                <div data-hix-state="no-content" class="bg-blue-400 rounded p-2 hidden">
-                    <i icon-name="info"></i>
-                    {% translate "There is no page content." %}
+                <div data-hix-state="no-content"
+                     class="text-gray-800 bg-blue-300 rounded p-3 hidden">
+                    <i icon-name="info" class="size-6 pr-1"></i>
+                    {% translate "There is no page content" %}
                 </div>
             </div>
             <button id="btn-update-hix-value"
@@ -64,11 +64,21 @@
                 <i icon-name="refresh-ccw"></i>
                 {% translate "Update" %}
             </button>
+            <label class="secondary">
+                {% translate "HIX value unexpectedly bad?" %}
+            </label>
             <div class="help-text mt-2">
-                {% translate "Easy words and short sentences can increase the text understandability." %}
-                <br />
-                {% translate "Find more information about this" %}
+                {% translate "Editorial tips and possible reasons can be found " %}
                 <a href="{% translate "https://wiki.tuerantuer.org/write-texts" %}" rel="nooperner noreferrer" target="_blank" class="text-blue-500 underline">{% translate "here" %}</a>.
+            </div>
+        </div>
+        <div {% if not request.user.expert_mode %}class="hidden"{% endif %}>
+            {% render_field page_form.hix_ignore %}
+            <label for="{{ page_form.hix_ignore.id_for_label }}" class="secondary">
+                {{ page_form.hix_ignore.label }}
+            </label>
+            <div class="help-text">
+                {{ page_form.hix_ignore.help_text }}
             </div>
         </div>
     </div>

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -5625,37 +5625,36 @@ msgid "Text understandability"
 msgstr "Textverständlichkeit"
 
 #: cms/templates/hix_widget.html
-msgid "Improve the understandability of the page content"
-msgstr "Verbessern Sie die Textverständlichkeit der Seite"
-
-#: cms/templates/hix_widget.html
 msgid "HIX value calculation is disabled for this page."
 msgstr "Die Berechnung der HIX-Werte ist für diese Seite deaktiviert."
 
 #: cms/templates/hix_widget.html
-msgid "HIX value is up to date."
-msgstr "Der HIX-Wert ist aktuell."
+msgid "Improve the understandability of the page here:"
+msgstr "Verbessern Sie hier die Textverständlichkeit der Seite:"
 
 #: cms/templates/hix_widget.html
-msgid "HIX value is outdated."
-msgstr "Der HIX-Wert ist veraltet."
+msgid "HIX value is up to date"
+msgstr "Der HIX-Wert ist aktuell"
+
+#: cms/templates/hix_widget.html
+msgid "HIX value is outdated"
+msgstr "Der HIX-Wert ist veraltet"
 
 #: cms/templates/hix_widget.html
 msgid "HIX value could not be calculated."
 msgstr "Der HIX-Wert konnte nicht berechnet werden."
 
 #: cms/templates/hix_widget.html
-msgid "There is no page content."
-msgstr "Es gibt keinen Seiteninhalt."
+msgid "There is no page content"
+msgstr "Es gibt keinen Seiteninhalt"
 
 #: cms/templates/hix_widget.html
-msgid "Easy words and short sentences can increase the text understandability."
-msgstr ""
-"Einfache Wörter und kurze Sätze können die Textverständlichkeit verbessern."
+msgid "HIX value unexpectedly bad?"
+msgstr "HIX-Wert unerwartet schlecht?"
 
 #: cms/templates/hix_widget.html
-msgid "Find more information about this"
-msgstr "Mehr Informationen finden Sie"
+msgid "Editorial tips and possible reasons can be found "
+msgstr "Redaktionelle Tipps und mögliche Gründe finden Sie "
 
 #: cms/templates/hix_widget.html
 msgid "https://wiki.tuerantuer.org/write-texts"
@@ -9849,6 +9848,15 @@ msgid "This page belongs to another region ({})."
 msgstr ""
 "Diese Seite konnte nicht importiert werden, da sie zu einer anderen Region "
 "gehört ({})."
+
+#~ msgid "Find more information about this"
+#~ msgstr "Mehr Informationen finden Sie"
+
+#~ msgid ""
+#~ "Easy words and short sentences can increase the text understandability."
+#~ msgstr ""
+#~ "Einfache Wörter und kurze Sätze können die Textverständlichkeit "
+#~ "verbessern."
 
 #~ msgid "The API URL is incorrect. Please contact an administrator."
 #~ msgstr ""

--- a/integreat_cms/release_notes/current/unreleased/2750.yml
+++ b/integreat_cms/release_notes/current/unreleased/2750.yml
@@ -1,0 +1,2 @@
+en: Make HIX widget more compact
+de: Mache HIX-Widget kompakter

--- a/integreat_cms/static/src/css/style.scss
+++ b/integreat_cms/static/src/css/style.scss
@@ -671,3 +671,21 @@ datalist option {
         }
     }
 }
+
+#hix-bar {
+    @apply h-full bg-gray-200 rounded;
+    width: 100%;
+    box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+#hix-bar-fill {
+    @apply rounded;
+    display: block;
+    transition: width 500ms ease-in-out;
+}
+
+#hix-value {
+    @apply p-3 text-lg font-bold text-gray-800;
+    text-align: left;
+    white-space: nowrap;
+}


### PR DESCRIPTION
### Short description
Update the HIX widget according to the [new design](https://www.figma.com/file/6U7R7Xj4wL7sbjxKRmOG9D/CMS-Project?type=design&node-id=1013%3A646&mode=design&t=CoWs1wUEUXzZiKM4-1)
(feedback on the HIX value is not included)

![image](https://github.com/digitalfabrik/integreat-cms/assets/115008338/b6dbb864-e573-4f0d-a095-3c5ae38459a8)
![image](https://github.com/digitalfabrik/integreat-cms/assets/115008338/7eea53f1-9b80-4e15-bcaf-701bff092c7e)

Our current behavior with the "HIX ignore" flag was preserved (as discussed in https://github.com/digitalfabrik/integreat-cms/issues/2358)
I also kept our old update button and old state icons because I think they are nice 🥺
But feel free to object.


### Side effects
- no?


### Resolved issues
Fixes: #2688


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
