### PR TITLE
Use a consistent format for date and time

### DIFF
--- a/integreat_cms/cms/templates/feedback/admin_feedback_list_row.html
+++ b/integreat_cms/cms/templates/feedback/admin_feedback_list_row.html
@@ -78,6 +78,6 @@
         {% endif %}
     </td>
     <td class="pr-2 text-right whitespace-nowrap">
-        {{ feedback.created_date }}
+        {{ feedback.created_date|date:"SHORT_DATE_FORMAT" }}
     </td>
 </tr>

--- a/integreat_cms/cms/templates/feedback/region_feedback_list_row.html
+++ b/integreat_cms/cms/templates/feedback/region_feedback_list_row.html
@@ -72,6 +72,6 @@
         {% endif %}
     </td>
     <td class="pr-2 text-right whitespace-nowrap">
-        {{ feedback.created_date }}
+        {{ feedback.created_date|date:"SHORT_DATE_FORMAT" }}
     </td>
 </tr>

--- a/integreat_cms/cms/templates/generic_auto_save_note.html
+++ b/integreat_cms/cms/templates/generic_auto_save_note.html
@@ -2,5 +2,5 @@
 <span id="auto-save"
       class="{% if form_instance.status != AUTO_SAVE %} hidden {% endif %}">
     <i icon-name="check"></i>
-    {% trans "Automatically saved on:" %} <span id="auto-save-time">{{ form_instance.last_updated }}</span>
+    {% trans "Automatically saved on:" %} <span id="auto-save-time">{{ form_instance.last_updated|date:"SHORT_DATE_FORMAT" }}</span>
 </span>

--- a/integreat_cms/cms/templates/languages/language_list_row.html
+++ b/integreat_cms/cms/templates/languages/language_list_row.html
@@ -25,10 +25,10 @@
         {{ language.get_text_direction_display }}
     </td>
     <td class="pr-2">
-        {{ language.created_date }}
+        {{ language.created_date|date:"SHORT_DATE_FORMAT" }}
     </td>
     <td class="pr-2">
-        {{ language.last_updated }}
+        {{ language.last_updated|date:"SHORT_DATE_FORMAT" }}
     </td>
     <td class="pr-2 text-right">
         {{ language.language_tree_nodes.count }}

--- a/integreat_cms/cms/templates/offertemplates/offertemplate_list_row.html
+++ b/integreat_cms/cms/templates/offertemplates/offertemplate_list_row.html
@@ -13,10 +13,10 @@
         {{ offer_template.url }}
     </td>
     <td class="pr-2">
-        {{ offer_template.last_updated }}
+        {{ offer_template.last_updated|date:"SHORT_DATE_FORMAT" }}
     </td>
     <td class="pr-2">
-        {{ offer_template.created_date }}
+        {{ offer_template.created_date|date:"SHORT_DATE_FORMAT" }}
     </td>
     <td class="pr-2 text-right">
         {{ offer_template.regions.count }}

--- a/integreat_cms/cms/templates/pages/page_tree_archived_node.html
+++ b/integreat_cms/cms/templates/pages/page_tree_archived_node.html
@@ -101,7 +101,7 @@
     </td>
     <td>
         <div class="block py-2 px-2 whitespace-nowrap text-gray-800">
-            {{ page_translation.last_updated }}
+            {{ page_translation.last_updated|date:"SHORT_DATE_FORMAT" }}
         </div>
     </td>
     <td class="pl-2 pr-4 py-2 flex flex-nowrap justify-end gap-2">

--- a/integreat_cms/cms/templates/pages/page_tree_node.html
+++ b/integreat_cms/cms/templates/pages/page_tree_node.html
@@ -137,7 +137,7 @@
     </td>
     <td>
         <div class="block py-1.5 px-2 whitespace-nowrap text-gray-800">
-            {{ page_translation.last_updated }}
+            {{ page_translation.last_updated|date:"SHORT_DATE_FORMAT" }}
         </div>
     </td>
     <td class="pl-2 pr-4 py-1.5 text-right flex flex-nowrap gap-2">

--- a/integreat_cms/cms/templates/regions/region_list_row.html
+++ b/integreat_cms/cms/templates/regions/region_list_row.html
@@ -6,11 +6,11 @@
     </td>
     <td>
         <a href="{% url 'edit_region' slug=region.slug %}"
-           class="block py-3 px-2 text-gray-800">{{ region.created_date }}</a>
+           class="block py-3 px-2 text-gray-800">{{ region.created_date|date:"SHORT_DATE_FORMAT" }}</a>
     </td>
     <td>
         <a href="{% url 'edit_region' slug=region.slug %}"
-           class="block py-3 px-2 text-gray-800">{{ region.last_content_update }}</a>
+           class="block py-3 px-2 text-gray-800">{{ region.last_content_update|date:"SHORT_DATE_FORMAT" }}</a>
     </td>
     <td>
         <a href="{% url 'edit_region' slug=region.slug %}"

--- a/integreat_cms/cms/templates/settings/user_settings.html
+++ b/integreat_cms/cms/templates/settings/user_settings.html
@@ -171,7 +171,7 @@
                                         {{ key.last_usage }}
                                     </td>
                                     <td class="pl-2 whitespace-nowrap">
-                                        {{ key.created_at }}
+                                        {{ key.created_at|date:"SHORT_DATE_FORMAT" }}
                                     </td>
                                     <td class="p-2 text-right">
                                         <a class="btn btn-red"

--- a/integreat_cms/core/formats/en/__init__.py
+++ b/integreat_cms/core/formats/en/__init__.py
@@ -1,0 +1,5 @@
+"""
+This package contains locale formats to override the default ones.
+Put all overrides into the file ``formats.py``.
+See :setting:`django:FORMAT_MODULE_PATH` and :attr:`~integreat_cms.core.settings.FORMAT_MODULE_PATH` for more information.
+"""

--- a/integreat_cms/core/formats/en/formats.py
+++ b/integreat_cms/core/formats/en/formats.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from typing import Final
 
-#: The default formatting to use for displaying datetime fields in any part of the system when using the German locale.
+#: The default formatting to use for displaying datetime fields in any part of the system when using the English locale.
 DATETIME_FORMAT: Final[str] = "d.m.Y, H:i"
 
 #: The short formatting to use for displaying datetime fields when the time is irrelevant

--- a/integreat_cms/release_notes/current/unreleased/2706.yml
+++ b/integreat_cms/release_notes/current/unreleased/2706.yml
@@ -1,0 +1,2 @@
+en: Use a consistent format for date and time
+de: Verwende ein einheitliches Format für Datums- und Zeitangaben


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Change current timestamp format for last update ( I realized that we also need to change all timestamps as well like `created` `last login`, `last usage`, and `date added`) to make a quick overview easier and not so cluttered with long date string. It might be better to remove time for not so relevant components like pages, languages, regions, feedback and include time to chat, user last login, events, and content versions. 

### Proposed changes
<!-- Describe this PR in more detail. -->

- Change timestamp format for short and remove time for not relevant components
- Change timestamp format for short and add time for relevant components, like chat, content versions, events and user's last login


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

None?

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2706 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
