### PR TITLE
Adapt package dist naming to PEP-625

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -375,7 +375,7 @@ jobs:
           command: echo "source .venv/bin/activate" >> $BASH_ENV
       - run:
           name: Publish integreat-cms package to (Test-)PyPI
-          command: twine upload --non-interactive ./dist/integreat-cms-*.tar.gz
+          command: twine upload --non-interactive ./dist/integreat_cms-*.tar.gz
   build-documentation:
     docker:
       - image: cimg/python:3.11.7
@@ -563,7 +563,7 @@ jobs:
             echo "export CONTRIBUTORS=\"${CONTRIBUTORS}\"" >> $BASH_ENV
       - run:
           name: Create release as Deliverino app
-          command: ./.circleci/scripts/create_release.py "${DELIVERINO_ACCESS_TOKEN}" "${CIRCLE_TAG}" "${PREV_TAG}" "${RELEASE_NOTES}" "${CONTRIBUTORS}" ./dist/integreat-cms-*.tar.gz
+          command: ./.circleci/scripts/create_release.py "${DELIVERINO_ACCESS_TOKEN}" "${CIRCLE_TAG}" "${PREV_TAG}" "${RELEASE_NOTES}" "${CONTRIBUTORS}" ./dist/integreat_cms-*.tar.gz
   notify-mattermost:
     docker:
       - image: cimg/base:stable

--- a/docs/src/packaging.rst
+++ b/docs/src/packaging.rst
@@ -34,6 +34,6 @@ Publish package
 
 You can publish the package to a python repository like e.g. `PyPI <https://pypi.org/>`__ with :doc:`twine:index`::
 
-    twine upload ./dist/integreat-cms-*.tar.gz
+    twine upload ./dist/integreat_cms-*.tar.gz
 
 See the :doc:`Twine documentation <twine:index>` for all configuration options of this command.


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
I hope this fixes our publishing of the dev packages to TestPyPI which is failing since last week.

I assume the build fails are due to this change in setuptools:

- Support [PEP 625](https://peps.python.org/pep-0625/) by canonicalizing package name and version in filenames. ([#3593](https://github.com/pypa/setuptools/issues/3593))

https://setuptools.pypa.io/en/latest/history.html#v69-3-0

So my hope is that by adapting the new package name to the canonical form, everything should be fine. I guess the actual package name on PyPI probably remains the same.


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
