### PR TITLE
Use uprounded HIX value

### DIFF
--- a/integreat_cms/cms/models/abstract_content_translation.py
+++ b/integreat_cms/cms/models/abstract_content_translation.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from .regions.region import Region
 
 from ..constants import status, translation_status
+from ..utils.round_hix_score import round_hix_score
 from ..utils.translation_utils import gettext_many_lazy as __
 from .abstract_base_model import AbstractBaseModel
 from .languages.language import Language
@@ -518,6 +519,13 @@ class AbstractContentTranslation(AbstractBaseModel):
         return self.foreign_object.hix_ignore
 
     @cached_property
+    def rounded_hix_score(self) -> float | None:
+        """
+        return rounded-up hix_score
+        """
+        return round_hix_score(self.hix_score)
+
+    @cached_property
     def hix_sufficient_for_mt(self) -> bool:
         """
         Whether this translation has a sufficient HIX value for machine translations.
@@ -525,7 +533,10 @@ class AbstractContentTranslation(AbstractBaseModel):
 
         :return: Wether the HIX value is sufficient for MT
         """
-        return self.hix_score is None or self.hix_score >= settings.HIX_REQUIRED_FOR_MT
+        return (
+            self.hix_score is None
+            or self.rounded_hix_score >= settings.HIX_REQUIRED_FOR_MT
+        )
 
     def __str__(self) -> str:
         """

--- a/integreat_cms/cms/templates/analytics/_page_hix_row.html
+++ b/integreat_cms/cms/templates/analytics/_page_hix_row.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% with page_translation.page.id as page_id %}
-    {% with page_translation.hix_score as hix %}
+    {% with page_translation.rounded_hix_score as hix %}
         <tr class="{% if hix < hix_threshold %} bg-red-100 hover:bg-red-200 text-red-500 hover:text-red-600 border-l-4 border-red-500 {% else %} hover:bg-gray-100 border-l-4 border-white hover:border-gray-400 {% endif %}">
             <td>
                 <a class="block p-1"
@@ -9,7 +9,7 @@
                 </a>
             </td>
             <td>
-                {{ hix|floatformat:2 }}
+                {{ hix }}
             </td>
         </tr>
     {% endwith %}

--- a/integreat_cms/cms/templates/content_versions.html
+++ b/integreat_cms/cms/templates/content_versions.html
@@ -56,7 +56,7 @@
                  data-date="{{ translation.last_updated }}"
                  data-editor="{% firstof translation.creator deleted_user_text %}"
                  data-status="{{ translation.status }}"
-                 data-hix="{{ translation.hix_score|floatformat:2 }}">
+                 data-hix="{{ translation.rounded_hix_score }}">
                 <div class="flex justify-between">
                     <span>
                         <label class="inline-block">
@@ -84,7 +84,7 @@
                                 <label class="inline-block">
                                     {% translate "HIX score" %}:
                                 </label>
-                                {{ translation.hix_score|floatformat:2 }}
+                                {{ translation.rounded_hix_score }}
                             </span>
                         {% endif %}
                         <label class="inline-block">

--- a/integreat_cms/cms/templates/dashboard/todo_dashboard_rows/_low_hix_row.html
+++ b/integreat_cms/cms/templates/dashboard/todo_dashboard_rows/_low_hix_row.html
@@ -17,7 +17,7 @@
 {% block todo_dashboard_description %}
     {% if pages_under_hix_threshold %}
         {% with worst_page=pages_under_hix_threshold.0 %}
-            {% blocktranslate trimmed with worst_page_hix=worst_page.hix_score|floatformat:2 %}
+            {% blocktranslate trimmed with worst_page_hix=worst_page.rounded_hix_score %}
                 The page <b>{{ worst_page }}</b> has a HIX score of {{ worst_page_hix }}. Please adjust the hix score of this page to be able to machine translate it.
             {% endblocktranslate %}
         {% endwith %}

--- a/integreat_cms/cms/templates/hix_widget.html
+++ b/integreat_cms/cms/templates/hix_widget.html
@@ -28,7 +28,7 @@
             </div>
             <div id="hix-container"
                  data-content-changed
-                 data-initial-hix-score="{{ page_translation_form.instance.hix_score|unlocalize }}">
+                 data-initial-hix-score="{{ page_translation_form.instance.rounded_hix_score }}">
                 <div id="hix-bar">
                     <span id="hix-bar-fill">
                         <div id="hix-value">

--- a/integreat_cms/cms/utils/round_hix_score.py
+++ b/integreat_cms/cms/utils/round_hix_score.py
@@ -1,0 +1,8 @@
+def round_hix_score(raw_score: float | None) -> float | None:
+    """
+    Function to round HIX score
+    """
+
+    if raw_score is None:
+        return None
+    return round(raw_score, ndigits=2)

--- a/integreat_cms/cms/views/utils/hix.py
+++ b/integreat_cms/cms/views/utils/hix.py
@@ -17,6 +17,7 @@ from django.views.decorators.http import require_POST
 
 from ....api.decorators import json_response
 from ....textlab_api.textlab_api_client import TextlabClient
+from ...utils.round_hix_score import round_hix_score
 
 if TYPE_CHECKING:
     from typing import Final
@@ -94,5 +95,5 @@ def get_hix_score(request: HttpRequest, region_slug: str) -> JsonResponse:
         return JsonResponse({"error": f"Invalid text: '{text}'"})
 
     if score := lookup_hix_score(text):
-        return JsonResponse({"score": score})
+        return JsonResponse({"score": round_hix_score(score)})
     return JsonResponse({"error": "Could not retrieve hix score"})

--- a/integreat_cms/release_notes/current/unreleased/2756.yml
+++ b/integreat_cms/release_notes/current/unreleased/2756.yml
@@ -1,0 +1,2 @@
+en: Use rounded hix value
+de: Verwende gerundeten Hix-Wert

--- a/integreat_cms/static/src/js/analytics/hix-widget.ts
+++ b/integreat_cms/static/src/js/analytics/hix-widget.ts
@@ -6,11 +6,8 @@ let initialHixValue: number = null;
 
 /* Display the HIX value using a bar chart */
 const updateHixBar = (value: number, setOutdated: boolean) => {
-    const roundedHixValue = Math.round(value * 100) / 100;
-
     const hixValue = document.getElementById("hix-value") as HTMLElement;
-    hixValue.textContent = `HIX ${roundedHixValue}`;
-
+    hixValue.textContent = `HIX ${value}`;
     const hixMaxValue = 20;
     const hixThresholdGood = 15;
     const hixThresholdOk = 7;
@@ -19,7 +16,7 @@ const updateHixBar = (value: number, setOutdated: boolean) => {
     let backgroundColor;
     if (setOutdated) {
         backgroundColor = "rgb(16, 111, 254, 0.3)";
-    } else if (value > hixThresholdGood) {
+    } else if (value >= hixThresholdGood) {
         backgroundColor = "rgb(74, 222, 128)";
     } else if (value > hixThresholdOk) {
         backgroundColor = "rgb(250, 204, 21)";
@@ -28,7 +25,7 @@ const updateHixBar = (value: number, setOutdated: boolean) => {
     }
 
     const hixBarFill = document.getElementById("hix-bar-fill") as HTMLElement;
-    const style = `width:${(roundedHixValue / hixMaxValue) * 100}%;background-color:${backgroundColor};`;
+    const style = `width:${(value / hixMaxValue) * 100}%;background-color:${backgroundColor};`;
     hixBarFill.setAttribute("style", style);
 };
 
@@ -114,7 +111,6 @@ window.addEventListener("load", async () => {
         const mtForm = document.getElementById("machine-translation-form");
         const hixScoreWarning = document.getElementById("hix-score-warning");
         const minimumHix = parseFloat(mtForm?.dataset.minimumHix);
-
         if (hixValue && hixValue < minimumHix) {
             hixScoreWarning?.classList.remove("hidden");
             toggleMTCheckboxes(true);


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adjusts the hix widget and hix score check to align with the score shown in the hix widget.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Use up-rounded value when
     1. toggling the color of HIX bar
     2. toggling the check box for machine translation
     3. checking HIX score for machine translation


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- <s>There are three ways of rounding up HIX value: `|floatformat:2` (existing) in template, `Math.round(hixValue * 100) / 100` (existing) in Typescript and `round(self.hix_score * 100) / 100` in python (new). There might be cases where they do not align each another 🙈 </s>

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2756 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
