### PR TITLE
Use rounded HIX score for dashboard

### DIFF
--- a/integreat_cms/cms/views/analytics/translation_coverage_view.py
+++ b/integreat_cms/cms/views/analytics/translation_coverage_view.py
@@ -148,7 +148,7 @@ class TranslationCoverageView(TemplateView):
 
         # Get the number of translations which are not ready for MT
         not_ready_for_mt_count = sum(
-            pt.hix_score < settings.HIX_REQUIRED_FOR_MT
+            pt.rounded_hix_score < settings.HIX_REQUIRED_FOR_MT
             for pt in hix_translations_with_score
         )
 

--- a/integreat_cms/cms/views/dashboard/dashboard_view.py
+++ b/integreat_cms/cms/views/dashboard/dashboard_view.py
@@ -160,7 +160,7 @@ class DashboardView(TemplateView, ChatContextMixin):
             "relevant_url": invalid_url,
         }
 
-    def get_low_hix_value_context(self) -> dict[str, QuerySet]:
+    def get_low_hix_value_context(self) -> dict[str, list[PageTranslation]]:
         r"""
         Extend context by info on pages with low hix value
 
@@ -169,12 +169,18 @@ class DashboardView(TemplateView, ChatContextMixin):
         if not settings.TEXTLAB_API_ENABLED or not self.request.region.hix_enabled:
             return {}
 
-        translations_under_hix_threshold = PageTranslation.objects.filter(
+        translations = PageTranslation.objects.filter(
             language__slug__in=settings.TEXTLAB_API_LANGUAGES,
             id__in=self.latest_version_ids,
             page__hix_ignore=False,
             hix_score__lt=settings.HIX_REQUIRED_FOR_MT,
         )
+
+        translations_under_hix_threshold = [
+            translation
+            for translation in translations
+            if not translation.hix_sufficient_for_mt
+        ]
 
         return {
             "pages_under_hix_threshold": translations_under_hix_threshold,

--- a/tests/cms/utils/test_rounded_hix_value.py
+++ b/tests/cms/utils/test_rounded_hix_value.py
@@ -1,0 +1,23 @@
+import pytest
+
+from integreat_cms.cms.utils.round_hix_score import round_hix_score
+
+raw_hix_expected_rounding = [
+    (14.995187697427333, 15.00),
+    (15.002092699342697, 15.00),
+    (9.72960372960373, 9.73),
+    (12.474861615283503, 12.47),
+]
+
+
+# pylint:disable=redefined-outer-name
+@pytest.mark.django_db
+@pytest.mark.parametrize("raw_hix_expected_rounding", raw_hix_expected_rounding)
+def test_rounded_hix_value(raw_hix_expected_rounding: tuple[float, float]) -> None:
+    """
+    Test to check HIX scores are rounded correctly
+    """
+
+    raw_hix, expected_rounding = raw_hix_expected_rounding
+
+    assert round_hix_score(raw_hix) == expected_rounding


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This is a follow up PR for #2760, in which still raw HIX score is used in the dashboard/analytics view.

How to reproduce:
1. Enable HIX in Augsburg and fill its pages with HIX value by `hix_bulk`.
2. Go to Augsburg, find 9 in "Pages with low hix score" in ToDo list and "Overview of the text understandability of the pages".
3. Add the two pages listed in the Issue #2756 
4. See 10 instead of 9 in "Pages with low hix score" and "Overview of the text understandability of the pages", while both the pages shuold be good enough in the HIX score check.


### Proposed changes
<!-- Describe this PR in more detail. -->
- Use rounded HIX score


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- Tell me please if you find other points that are to be adjusted too 👀 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
