### PR TITLE
Fix version parsing in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -467,7 +467,7 @@ jobs:
             echo "Current production version: ${CURRENT_VERSION}"
             # Bump version to current alpha version if it is newer
             # Attention: exit(True) in Python means exit(1) which is False in Bash :)
-            if python -c "from looseversion import LooseVersion; exit(LooseVersion('${CURRENT_VERSION}') > LooseVersion('${CURRENT_ALPHA_VERSION}'))"; then
+            if python -c "from bumpver.version import parse_version; exit(parse_version('${CURRENT_VERSION}') > parse_version('${CURRENT_ALPHA_VERSION}'))"; then
               echo "Bump to the currently existing version"
               bumpver update -n --set-version="${CURRENT_ALPHA_VERSION}" --no-commit
             fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,6 @@ dev = [
     "djlint",
     "freezegun",
     "isort",
-    "looseversion",
     "mypy",
     "pre-commit",
     "pyjwt",


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Apparently, f23a3eae4c4be1b393c087e921f2fef3c421eea5 and c7c84d979dfb5f310e68f784a9fbf48f99919020 were not enough to fix the problem.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Use `bumpversion.version.parse_version` instead of `looseversion.LooseVersion`


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2190


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
