### PR TITLE
 Replace the reference to django-mptt with a reference to django-treebeard in the docstring

### DIFF
--- a/integreat_cms/cms/models/languages/language_tree_node.py
+++ b/integreat_cms/cms/models/languages/language_tree_node.py
@@ -22,8 +22,8 @@ if TYPE_CHECKING:
 class LanguageTreeNode(AbstractTreeNode):
     """
     Data model representing a region's language tree. Each tree node is a single object instance and the whole tree is
-    identified by the root node. The base functionality inherits from the package `django-mptt
-    <https://django-mptt.readthedocs.io/en/latest/index.html>`_ (Modified Preorder Tree Traversal).
+    identified by the root node. The base functionality inherits from the package `django-treebeard
+    <https://django-treebeard.readthedocs.io/en/latest/>`.
     """
 
     language = models.ForeignKey(


### PR DESCRIPTION
### Short description

This modifies the docstring to reference django-treebeard instead of django-mptt. Earlier today, I read the documentation and was puzzled by why the passing classes import from treebeard. Subsequently, I discovered this [release note](https://github.com/digitalfabrik/integreat-cms/blob/develop/integreat_cms/release_notes/2022/2022.2.0-beta/1088.yml).
__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
