### PR TITLE
Make input fields of link replacement longer

### DIFF
--- a/integreat_cms/cms/forms/linkcheck/link_replace_form.py
+++ b/integreat_cms/cms/forms/linkcheck/link_replace_form.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from django import forms
+from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 from ...constants.linkcheck import LINK_TYPES
@@ -18,11 +19,13 @@ class LinkReplaceForm(forms.Form):
     """
 
     search = forms.CharField(
-        label=_("Search"), max_length=64, help_text=_("Enter old link to be replaced")
+        label=_("Search"),
+        max_length=settings.LINKCHECK_MAX_URL_LENGTH,
+        help_text=_("Enter old link to be replaced"),
     )
     replace = forms.CharField(
         label=_("Replace"),
-        max_length=64,
+        max_length=settings.LINKCHECK_MAX_URL_LENGTH,
         help_text=_("Enter new link to replace the old link with"),
     )
     link_types = forms.MultipleChoiceField(

--- a/integreat_cms/release_notes/current/unreleased/2714.yml
+++ b/integreat_cms/release_notes/current/unreleased/2714.yml
@@ -1,0 +1,2 @@
+en: Accept longer links while central link replacement
+de: Akzeptiere längerer Links bei zentraler Ersetzung von Links


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the probelem that the central link replacement showed the success message but the replacement was not done as expected.

The cause of reported problem is the length of fields for old and new links: the replacement was conducted successfully but the link was changed only in the first letters.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Make the input fields accept longer links


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- None? 😅 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2714


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
