### PR TITLE
Fix outdated references to FCM_KEY

### DIFF
--- a/docs/src/prod-server.rst
+++ b/docs/src/prod-server.rst
@@ -69,7 +69,7 @@ Integreat CMS Package
         [integreat-cms]
 
         SECRET_KEY = <your-secret-key>
-        FCM_KEY = <your-firebase-key>
+        FCM_CREDENTIALS = <path-your-firebase-credentials-file>
         BASE_URL = https://cms.integreat-app.de
         LOGFILE = /var/integreat-cms.log
 

--- a/example-configs/integreat-cms.ini
+++ b/example-configs/integreat-cms.ini
@@ -37,8 +37,8 @@ IMPRINT_SLUG = imprint
 [secrets]
 # The secret key for this installation [required]
 SECRET_KEY = <your-secret-key>
-# If you want to send push notification to your app users, set your firebase key here [optional, defaults to None]
-FCM_KEY = <your-firebase-key>
+# If you want to send push notification to your app users, set a path to your firebase credentials file here [optional, defaults to None]
+FCM_CREDENTIALS = <your-firebase-key>
 # If you want to use automatic translations via DeepL, set your API auth key here [optional, defaults to None]
 DEEPL_AUTH_KEY = <your-deepl-auth-key>
 

--- a/integreat_cms/core/circleci_settings.py
+++ b/integreat_cms/core/circleci_settings.py
@@ -15,8 +15,8 @@ from .settings import *
 
 #: Set a dummy secret key for CircleCI build even if it's not in debug mode
 SECRET_KEY = "dummy"
-#: Set dummy key to test push notifications
-FCM_KEY = "dummy"
+#: Set dummy credentials path to test push notifications
+FCM_CREDENTIALS = "dummy"
 #: Enable manually because existing setting derives from the unset env var
 FCM_ENABLED = True
 #: Set dummy SUMM.AI API key to test translations into Easy German

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -200,10 +200,10 @@ FCM_URL: Final[str] = (
 )
 
 #: Path to the saved credential json file
-FCM_CREDENTIALS: Final[str | None] = os.environ.get("INTEGREAT_CMS_FCM_CREDENTIALS")
+FCM_CREDENTIALS: str | None = os.environ.get("INTEGREAT_CMS_FCM_CREDENTIALS")
 
 #: Whether push notifications via Firebase are enabled.
-#: This is ``True`` if :attr:`~integreat_cms.core.settings.FCM_KEY` is set, ``False`` otherwise.
+#: This is ``True`` if :attr:`~integreat_cms.core.settings.FCM_CREDENTIALS` is set, ``False`` otherwise.
 FCM_ENABLED: bool = bool(FCM_CREDENTIALS)
 
 #: The available push notification channels

--- a/tools/_functions.sh
+++ b/tools/_functions.sh
@@ -181,9 +181,9 @@ function require_installed {
             INTEGREAT_CMS_DEBUG=1
             export INTEGREAT_CMS_DEBUG
             # Set dummy FCM key to test functionality
-            if [[ -z "${INTEGREAT_CMS_FCM_KEY}" ]]; then
-                INTEGREAT_CMS_FCM_KEY="dummy"
-                export INTEGREAT_CMS_FCM_KEY
+            if [[ -z "${INTEGREAT_CMS_FCM_CREDENTIALS}" ]]; then
+                INTEGREAT_CMS_FCM_CREDENTIALS="dummy"
+                export INTEGREAT_CMS_FCM_CREDENTIALS
             fi
         fi
     fi


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
In #2759 I forgot to update references to `FCM_KEY` which got renamed in that pr. 

### Proposed changes
<!-- Describe this PR in more detail. -->
- Rename all occurences of `FCM_KEY` to `FCM_CREDENTIALS`, which is the new name


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
