### PR TITLE
Fix page content comparison

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+FROM mcr.microsoft.com/vscode/devcontainers/python:3.11
+
+RUN apt-get update && \
+    apt-get install -y nodejs npm && \
+    npm install -g n && \
+    n stable && \
+    apt-get purge -y nodejs npm && \
+    ln -sf /usr/local/bin/node /usr/bin/node
+
+RUN apt-get install -y netcat-traditional pcregrep
+
+WORKDIR /workspace
+
+CMD ["sleep", "infinity"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,34 @@
+{
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "devcontainer",
+  "workspaceFolder": "/workspace",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "charliermarsh.ruff",
+        "batisteo.vscode-django",
+        "ms-vscode.vscode-typescript-next",
+        "ms-python.vscode-pylance"
+      ],
+      "settings": {
+        "[python]": {
+          "editor.formatOnSave": true,
+          "editor.defaultFormatter": "charliermarsh.ruff",
+          "editor.codeActionsOnSave": {
+            "source.fixAll": "always",
+            "source.organizeImports": "always"
+          }
+        },
+        "python.defaultInterpreterPath": "${workspaceFolder}/.venv",
+        "python.testing.unittestEnabled": false,
+        "python.testing.pytestEnabled": false,
+        "ruff.enable": true,
+        "ruff.lint.args": ["--config=${workspaceFolder}/pyproject.toml", "--fix"],
+        "ruff.format.args": ["--config=${workspaceFolder}/pyproject.toml", "--preview"]
+      }
+    }
+  },
+  "postCreateCommand": "./tools/install.sh --python python3.11 && ./tools/migrate.sh && ./tools/loadtestdata.sh",
+  "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,26 @@
+version: "3.8"
+
+services:
+  devcontainer:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    volumes:
+      - ..:/workspace:cached
+    network_mode: service:db
+    depends_on:
+      - db
+
+  db:
+    container_name: integreat_django_postgres
+    image: postgres:latest
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: integreat
+      POSTGRES_DB: integreat
+      POSTGRES_PASSWORD: password
+
+volumes:
+  postgres-data:

--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,6 @@ docs/src/templates/footer.html*
 docs/src/templates/breadcrumbs.html*
 
 # Miscellaneous
-.vscode
 .idea
 .directory
 cms-django.iml

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,116 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Run Shell Script",
+      "type": "shell",
+      "command": "sh",
+      "args": ["${file}"],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Run all python tests",
+      "type": "shell",
+      "command": "./tools/test.sh",
+      "problemMatcher": [],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Run current python test",
+      "type": "shell",
+      "command": "./tools/test.sh ${file}",
+      "problemMatcher": [],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Run all frontend tests",
+      "type": "shell",
+      "command": "npm run test",
+      "problemMatcher": [],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Check code style",
+      "type": "shell",
+      "command": "./tools/code_style.sh",
+      "problemMatcher": [],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Run prettier tool",
+      "type": "shell",
+      "command": "./tools/prettier.sh",
+      "problemMatcher": [],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Run mypy tool",
+      "type": "shell",
+      "command": "./tools/prettier.sh",
+      "problemMatcher": [],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Run ruff tool",
+      "type": "shell",
+      "command": "./tools/ruff.sh",
+      "problemMatcher": [],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Run eslint tool",
+      "type": "shell",
+      "command": "./tools/eslint.sh",
+      "problemMatcher": [],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Run devserver",
+      "type": "shell",
+      "command": "./tools/run.sh",
+      "problemMatcher": [],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "Run translation check",
+      "type": "shell",
+      "command": "./tools/check_translations.sh",
+      "problemMatcher": [],
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -12,36 +12,63 @@
 
 This content management system helps local integration experts to provide multilingual information for newcomers.
 
-## TL;DR
+## Development Setup
 
-### Prerequisites
-
-Following packages are required before installing the project (install them with your package manager):
-
-* `npm` version 7 or later
-* `nodejs` version 18 or later
-* `python3` version 3.11 or later
-* `python3-pip` (Debian-based distributions) / `python-pip` (Arch-based distributions)
-* `python3-venv` (only on Debian-based distributions)
-* `gettext` to use the translation features
-* Either `postgresql` **or** `docker` to run a local database server
-
-### Installation
+This section provides a brief overview of setting up the development environment. We support various environments: you can set up everything locally using your preferred package manager, use it as a devcontainer, or utilize the nix-flake ([coming soon](https://github.com/digitalfabrik/integreat-cms/pull/2730)). Please clone the repository with the following snippet before starting to 
+setup your development environment.
 
 ````
 git clone git@github.com:digitalfabrik/integreat-cms.git
 cd integreat-cms
-./tools/install.sh
 ````
+
+### Local Setup
+
+To configure your development environment on your system, please follow these steps carefully.
+
+1. Ensure that the following packages are installed alongside your preferred IDE:
+   - `npm` version 7 or later
+   - `nodejs` version 18 or later
+   - `python3` version 3.11 or later
+   - `python3-pip` (Debian-based distributions) / `python-pip` (Arch-based distributions)
+   - `python3-venv` (only on Debian-based distributions)
+   - `gettext` for translation features
+   - Either `postgresql` **or** `docker` to run a local database server
+2. Execute `tools/install.sh` to download all dependencies.
+3. Execute `tools/migrate.sh` to apply all database schema migrations.
+4. Optionally, run `tools/loadtestdata.sh` to apply a predefined set of test data.
+
+### Devcontainer
+
+To configure your development container, please follow these steps carefully.
+
+1. Make sure you have Docker and VSCode (not VSCodium) installed on your machine.
+2. Open the project in VSCode.
+3. If you're opening VSCode for the first time, you'll be prompted to install the ["Dev Containers" extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers). Click "Install" to proceed.
+4. Open the command palette (Ctrl + Shift + P or Cmd + Shift + P on macOS) and search for "> Remote-Containers: Open Folder in Container".
+5. VSCode will open the project in a new container, install all further required tools and load the testdata.
+
+#### Known Limitations
+
+The perfect is the enemy of the good; thus, this section illuminates aspects of our evolving development setup.
+
+##### Sharing git username and email
+
+A known limitation exists where certain versions of Visual Studio Code (VSCode) may not copy the user's `.gitconfig` file correctly into the Devcontainer environment. In such cases, when you attempt to commit changes within the Devcontainer, you may be prompted to enter your Git username and email every time. This can be inconvenient and disrupt the workflow. However, there is a workaround for this issue. You can resolve it by appending the content of your personal `.gitconfig` file, located at `$HOME/.gitconfig`, to the end of the repository-specific `.git/config` file, which in this case would be `integreat-cms/.git/config`. By doing so, you ensure that the necessary Git configuration settings are correctly applied within the Devcontainer environment, allowing for a smoother development experience.
+
+For more information, refer to [this issue](https://github.com/microsoft/vscode-remote-release/issues/1729) in the VSCode Remote Extension repository.
+
+##### Test discovery 
+
+Testing is not yet fully integrated into our Visual Studio Code Container, but we provide convenient task definitions to facilitate testing. For example, you can simply type `task current python test` and hit enter to run the current Python test file. Take a look at the `.vscode/tasks.json` for more helpful tasks and extend this file as needed.
+
+##### Docker permissions
+
+The user must be in the docker group on linux, VSCode does not allow to optionally enter sudo password.
 
 ### Run development server
 
-````
-./tools/run.sh
-````
-
-* Go to your browser and open the URL `http://localhost:8000`
-* Default user is "root" with password "root1234".
+Run the development server using `/tools/run.sh`, then open your browser and go to `http://localhost:8000`. The default login credentials are username: "root" and password: "root1234".
 
 ## Documentation
 

--- a/integreat_cms/cms/forms/custom_content_model_form.py
+++ b/integreat_cms/cms/forms/custom_content_model_form.py
@@ -10,7 +10,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 from lxml.etree import LxmlError
-from lxml.html import fromstring, tostring
+from lxml.html import fragment_fromstring, tostring
 
 from ..constants import status
 from ..models import MediaFile
@@ -109,7 +109,8 @@ class CustomContentModelForm(CustomModelForm):
         :return: The valid content
         """
         try:
-            content = fromstring(self.cleaned_data["content"])
+            # this returns <div><p>...</p></div> when passed <p>...</p>
+            content = fragment_fromstring(self.cleaned_data["content"])
         except LxmlError:
             # The content is not guaranteed to be valid html, for example it may be empty
             return self.cleaned_data["content"]

--- a/test_data/test_page_content.txt
+++ b/test_data/test_page_content.txt
@@ -1,0 +1,37 @@
+2. Erster-Interview-Termin (Asylantragstellung)
+
+Sie müssen sich nach Ihrem ersten Termin bei der Ausländerbehörde melden.
+
+3. Persönliche Anhörung
+Der zweite Interview-Termin ist die eigentliche Anhörung. Danach entscheidet das BAMF über Ihren Asylantrag und sendet Ihnen einen Bescheid zu. Darin wird die Entscheidung ausführlich begründet.
+
+a) Der Bescheid ist negativ
+
+Wenn der Bescheid negativ ist und Sie ihn anfechten möchten (das heißt, Sie sind nicht einverstanden), gehen Sie sofort zu Ihrer Migrationsberatung der Caritas. Dort bespricht man mit Ihnen, was Sie machen können und man kann Sie an spezialisierte Anwälte vermitteln. Sie können zum Beispiel gegen den Bescheid klagen
+Wenn Sie sich entscheiden, freiwillig auszureisen können Sie finanzielle Unterstützung für Ihren Neuanfang in Ihrem Herkunftsland erhalten
+b) Der Bescheid ist positiv, das heißt Sie sind als schutzberechtigt anerkannt. Die nächsten Schritte sind:
+
+
+Fiktionsbescheinigung / elektronischer Aufenthaltstitel (eAT): Unmittelbar nachdem der positive BAMF-Bescheid zugestellt wurde, müssen Sie sich um ein Ausweisdokument beziehungsweise ein Äquivalent kümmern. Dies erhalten Sie beim Einwohneramt (Ausländerbehörde).
+Jobcenter: Sie bekommen Ihr Geld jetzt nicht mehr vom Sozialamt, sondern müssen beim Jobcenter einen Antrag stellen.
+
+
+
+
+  Öffnungszeiten:
+
+Montag und Dienstag
+08:00-12:00
+15:00-18:00
+15:00-18:00
+Mittwoch
+geschlossen
+10:00-12:00
+geschlossen
+Donnerstag und Freitag
+9:00-11:00
+geschlossen
+geschlossen
+ 
+
+Hier gibt es eine Checkliste für die Erstellung von Seiten

--- a/tests/cms/views/pages/test_page_form_view.py
+++ b/tests/cms/views/pages/test_page_form_view.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from _pytest.logging import LogCaptureFixture
+    from django.test.client import Client
+
+import pytest
+from django.test.client import Client
+from django.urls import reverse
+
+from integreat_cms.cms.models import Language, Page, PageTranslation, Region
+
+
+@pytest.mark.django_db
+def test_save_page_translation(
+    load_test_data: None,
+    login_root_user: tuple[Client, str],
+    caplog: LogCaptureFixture,
+) -> None:
+    # Log the user in
+    client = login_root_user
+
+    # Get a region that already exists and has active languages
+    region = Region.objects.get(slug="testumgebung")
+    german_language = Language.objects.get(slug="de")
+    page = Page.objects.create(region=region, lft=1, rgt=2, tree_id=1, depth=1)
+
+    PageTranslation.objects.create(
+        page=page,
+        slug="testcase",
+        language=german_language,
+        content="<p>testcase</p>",
+    )
+
+    url = reverse(
+        "edit_page",
+        kwargs={
+            "region_slug": region.slug,
+            "language_slug": german_language.slug,
+            "page_id": page.id,
+        },
+    )
+
+    response = client.post(
+        url,
+        data={
+            "content": "test",
+            "mirrored_page_region": "",
+            "title": "My test page",
+            "slug": "my-test-page",
+            "status": "PUBLIC",
+            "_position": "first-child",
+        },
+    )
+
+    assert response.status_code == 302
+
+    response = client.post(
+        url,
+        data={
+            "content": "test123",
+            "mirrored_page_region": "",
+            "title": "My test page",
+            "slug": "my-test-page",
+            "status": "PUBLIC",
+            "_position": "first-child",
+        },
+    )
+
+    assert response.status_code == 302
+
+    mutated_translation = PageTranslation.objects.get(slug="testcase")
+
+    print(PageTranslation.objects.filter(content="test123").count())
+
+    assert mutated_translation.content == "test123"

--- a/tests/cms/views/pages/test_page_form_view.py
+++ b/tests/cms/views/pages/test_page_form_view.py
@@ -27,6 +27,13 @@ def test_save_page_translation(
     german_language = Language.objects.get(slug="de")
     page = Page.objects.create(region=region, lft=1, rgt=2, tree_id=1, depth=1)
 
+    def get_latest_test_content():
+        return (
+            PageTranslation.objects.filter(slug="my-test-page")
+            .latest("version")
+            .content
+        )
+
     PageTranslation.objects.create(
         page=page,
         slug="testcase",
@@ -56,6 +63,7 @@ def test_save_page_translation(
     )
 
     assert response.status_code == 302
+    assert get_latest_test_content() == "<p>test</p>"
 
     response = client.post(
         url,
@@ -70,9 +78,4 @@ def test_save_page_translation(
     )
 
     assert response.status_code == 302
-
-    mutated_translation = PageTranslation.objects.get(slug="testcase")
-
-    print(PageTranslation.objects.filter(content="test123").count())
-
-    assert mutated_translation.content == "test123"
+    assert get_latest_test_content() == "<p>test123</p>"

--- a/tests/cms/views/pages/test_page_form_view.py
+++ b/tests/cms/views/pages/test_page_form_view.py
@@ -62,6 +62,11 @@ def test_save_page_translation(
         },
     )
 
+    # The most straightforward approach to check if the system has detected changes
+    # would be asserting the alert. However, decoding the json_messages cookie and formulating the
+    # test assertion can be quite intricate and support for the messages framework in testing
+    # scenarios begins from Django version 5.0 onwards.
+
     assert response.status_code == 302
     assert get_latest_test_content() == "<p>test</p>"
 

--- a/tests/cms/views/pages/test_page_form_view.py
+++ b/tests/cms/views/pages/test_page_form_view.py
@@ -50,10 +50,12 @@ def test_save_page_translation(
         },
     )
 
+    with open("test_data/test_page_content.txt") as f: file_content = f.read() # noqa: E701
+
     response = client.post(
         url,
         data={
-            "content": "test",
+            "content": file_content,
             "mirrored_page_region": "",
             "title": "My test page",
             "slug": "my-test-page",
@@ -68,19 +70,4 @@ def test_save_page_translation(
     # scenarios begins from Django version 5.0 onwards.
 
     assert response.status_code == 302
-    assert get_latest_test_content() == "<p>test</p>"
-
-    response = client.post(
-        url,
-        data={
-            "content": "test123",
-            "mirrored_page_region": "",
-            "title": "My test page",
-            "slug": "my-test-page",
-            "status": "PUBLIC",
-            "_position": "first-child",
-        },
-    )
-
-    assert response.status_code == 302
-    assert get_latest_test_content() == "<p>test123</p>"
+    assert get_latest_test_content() == file_content

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -100,7 +100,26 @@ def login_role_user(
         with django_db_blocker.unblock():
             user = get_user_model().objects.get(username=request.param.lower())
             client.force_login(user)
-    return client, request.param
+    return client, request.param# pylint: disable=redefined-outer-name
+
+@pytest.fixture(scope="session")
+def login_root_user(
+    load_test_data: None, django_db_blocker: _DatabaseBlocker
+) -> tuple[Client, str]:
+    """
+    Get the root user and force a login.
+
+    :param load_test_data: The fixture providing the test data (see :meth:`~tests.conftest.load_test_data`)
+    :param django_db_blocker: The fixture providing the database blocker
+    :return: The http client and the current role
+    """
+    client = Client()
+
+    with django_db_blocker.unblock():
+        user = get_user_model().objects.get(username="root")
+        client.force_login(user)
+
+    return client
 
 
 # pylint: disable=redefined-outer-name

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -54,9 +54,9 @@ if [[ ! -x "$(command -v pip3)" ]]; then
     echo "Pip for Python3 is not installed. Please install python3-pip manually and run this script again."  | print_error
     exit 1
 fi
-# Check if database backend is installed
-if [[ ! -x "$(command -v docker)" ]] && [[ ! -x "$(command -v psql)" ]]; then
-    echo "In order to run the database, you need either Docker (recommended) or PostgreSQL. Please install at least one of them manually and run this script again." | print_error
+# Check if postgres instance is running on host system or database backend is installed 
+if ! { [[ -x "$(command -v docker)" ]] || [[ -x "$(command -v psql)" ]] || nc -z localhost 5432 > /dev/null 2>&1; }; then
+    echo "In order to run the database, you need either Docker (recommended) or PostgreSQL. Please install at least one of them manually and run this script again."
     exit 1
 fi
 # Define the required npm version


### PR DESCRIPTION
### Short description

This pull request enhances the success message displayed after page edits. Presently, the page refreshes its content upon the second save, even if the document remains unchanged. This behavior stems from the utilization of fromstring, which parses the entire document. Consequently, elements like `<p>...content...</p>` are transformed into` <div><p>...content</p></div>`. To mitigate this issue, this pull request substitutes fromstring with fragment_fromstring, which necessitates only a single element within the HTML, thus resolving the unnecessary content refresh upon subsequent saves.

Reference: https://lxml.de/lxmlhtml.html
Demonstration: https://www.loom.com/share/fc2152f0560b46249e59519351897eab?sid=6c56f491-ac7a-4e16-bce1-67103d5134ea

### Resolved issues
Fixes: #2673 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
