### PR TITLE
Fix page content comparison

### DIFF
--- a/integreat_cms/cms/forms/custom_content_model_form.py
+++ b/integreat_cms/cms/forms/custom_content_model_form.py
@@ -10,7 +10,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 from lxml.etree import LxmlError
-from lxml.html import fromstring, tostring
+from lxml.html import fragment_fromstring, tostring
 
 from ..constants import status
 from ..models import MediaFile
@@ -109,7 +109,7 @@ class CustomContentModelForm(CustomModelForm):
         :return: The valid content
         """
         try:
-            content = fromstring(self.cleaned_data["content"])
+            content = fragment_fromstring(self.cleaned_data["content"])
         except LxmlError:
             # The content is not guaranteed to be valid html, for example it may be empty
             return self.cleaned_data["content"]

--- a/tests/cms/views/pages/test_page_form_view.py
+++ b/tests/cms/views/pages/test_page_form_view.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from _pytest.logging import LogCaptureFixture
+    from django.test.client import Client
+
+import pytest
+from django.test.client import Client
+from django.urls import reverse
+
+from integreat_cms.cms.models import Language, Page, PageTranslation, Region
+
+
+@pytest.mark.django_db
+def test_page_form_view_does_not_mutate_valid_html(
+    load_test_data: None,
+    login_root_user: Client,
+    caplog: LogCaptureFixture,
+) -> None:
+    client = login_root_user
+
+    region = Region.objects.get(slug="testumgebung")
+    german_language = Language.objects.get(slug="de")
+    page = Page.objects.create(region=region, lft=1, rgt=2, tree_id=1, depth=1)
+    content = "<p>line1\r\nline2<p>"
+
+    def get_latest_test_content() -> str:
+        return (
+            PageTranslation.objects.filter(slug="my-test-page")
+            .latest("version")
+            .content
+        )
+
+    PageTranslation.objects.create(
+        page=page,
+        slug="testcase",
+        language=german_language,
+        content=content,
+    )
+
+    url = reverse(
+        "edit_page",
+        kwargs={
+            "region_slug": region.slug,
+            "language_slug": german_language.slug,
+            "page_id": page.id,
+        },
+    )
+
+    response = client.post(
+        url,
+        data={
+            "content": content,
+            "mirrored_page_region": "",
+            "title": "My test page",
+            "slug": "my-test-page",
+            "status": "PUBLIC",
+            "_position": "first-child",
+        },
+    )
+
+    # The most straightforward approach to check if the system has detected changes
+    # would be asserting the alert. However, decoding the json_messages cookie and formulating the
+    # test assertion can be quite intricate and support for the messages framework in testing
+    # scenarios begins from Django version 5.0 onwards.
+
+    assert response.status_code == 302
+
+    assert get_latest_test_content() == content

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,6 +105,25 @@ def login_role_user(
     return client, request.param
 
 
+@pytest.fixture(scope="session")
+def login_root_user(
+    load_test_data: None, django_db_blocker: _DatabaseBlocker
+) -> Client:
+    """
+    Get the root user and force a login.
+    :param load_test_data: The fixture providing the test data (see :meth:`~tests.conftest.load_test_data`)
+    :param django_db_blocker: The fixture providing the database blocker
+    :return: The http client and the current role
+    """
+    client = Client()
+
+    with django_db_blocker.unblock():
+        user = get_user_model().objects.get(username="root")
+        client.force_login(user)
+
+    return client
+
+
 # pylint: disable=redefined-outer-name
 @pytest.fixture(scope="session", params=ALL_ROLES)
 def login_role_user_async(


### PR DESCRIPTION
### Short description

This pull request enhances the success message displayed after page edits. Presently, the page refreshes its content upon the second save, even if the document remains unchanged. This behavior stems from the utilization of fromstring, which parses the entire document. Consequently, elements like `<p>...content...</p>` are transformed into` <div><p>...content</p></div>`. To mitigate this issue, this pull request substitutes fromstring with fragment_fromstring, which necessitates only a single element within the HTML, thus resolving the unnecessary content refresh upon subsequent saves.

Reference: https://lxml.de/lxmlhtml.html
Demonstration: https://www.loom.com/share/fc2152f0560b46249e59519351897eab?sid=6c56f491-ac7a-4e16-bce1-67103d5134ea

### Resolved issues
Fixes: #2673 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
