### PR TITLE
Fix info message after saving page content twice

### DIFF
--- a/integreat_cms/static/src/js/forms/tinymce-init.ts
+++ b/integreat_cms/static/src/js/forms/tinymce-init.ts
@@ -100,6 +100,7 @@ window.addEventListener("load", () => {
             link_default_protocol: "https",
             target_list: false,
             default_link_target: "",
+            indent: false,
             document_base_url: tinymceConfig.getAttribute("data-webapp-url"),
             relative_urls: false,
             remove_script_host: false,


### PR DESCRIPTION
### Short description

This pull request addresses the issue of Tinymce adding whitespace to the content by setting indent: false in the Tinymce configuration. Currently, the added whitespace by Tinymce causes our backend to incorrectly determine whether the content has been edited or not. This is evident when saving a newly created page for the second time, as it erroneously indicates that changes have been saved even when there are none.

Further Explanation: https://stackoverflow.com/a/39489073
Demonstration: https://github.com/digitalfabrik/integreat-cms/assets/13850172/e40e868e-87a5-4972-818d-378c8014aae5

### Proposed changes
- Set indent: false in the Tinymce configuration to prevent the addition of whitespace to the content.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2673


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
