### PR TITLE
Fix nonexistant language MT provider leading to error in tests

### DIFF
--- a/integreat_cms/cms/forms/translations/translations_management_form.py
+++ b/integreat_cms/cms/forms/translations/translations_management_form.py
@@ -136,7 +136,7 @@ class TranslationsManagementForm(CustomModelForm):
 
         # Iterate over all machine translatable languages and toggle them based on the checkbox value
         for lang, language_options in self.languages_dict.items():
-            if provider_name := self.uncleaned_data[lang]:
+            if provider_name := self.uncleaned_data.get(lang, None):
                 if provider_name in language_options.providers:
                     language_options.language_tree_node.preferred_mt_provider = (
                         language_options.providers[provider_name]


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
For a while now, I've been getting test failures relating to the MT management view. I'm not entirely sure *why* those happen (esp. since they do not *always* happen, and apparently never happens on CircleCI), but if they do happen, it's due to a key error when querying for the MT provider for a given language.

If someone has a idea how to fix the root cause of this, I am all ears 😄 

### Proposed changes
<!-- Describe this PR in more detail. -->

- instead of directly accessing the dict value via `[]`, `get()` it with fallback `None`


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: n/a


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
