### PR TITLE
pre-commit: Remove prettier because the repo is now archived

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,12 +49,6 @@ repos:
           - eslint@8.56.0
           - "@typescript-eslint/eslint-plugin@6.21.0"
           - "eslint-plugin-prefer-arrow@1.2.3"
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
-    hooks:
-      - id: prettier
-        additional_dependencies:
-          - prettier@3.2.5
   - repo: local
     hooks:
       - id: translations


### PR DESCRIPTION
https://github.com/pre-commit/mirrors-prettier
* prettier/prettier#16229

One of the other options could be used:
* https://github.com/prettier/prettier/blob/main/docs/precommit.md

```diff
  - repo: https://github.com/pre-commit/mirrors-prettier
    rev: v4.0.0-alpha.8
    hooks:
      - id: prettier
        additional_dependencies:
          - prettier@3.2.5
```

- - -

Unrelated CodeQL warnings: https://github.blog/changelog/2024-01-23-codeql-2-16-python-dependency-installation-disabled-new-queries-and-bug-fixes/

### Short description
<!-- Describe this PR in one or two sentences. -->

### Proposed changes
<!-- Describe this PR in more detail. -->

- 
- 


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- 
- 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
