### PR TITLE
Fix upload file behavior on set icon form

### DIFF
--- a/integreat_cms/cms/views/media/media_context_mixin.py
+++ b/integreat_cms/cms/views/media/media_context_mixin.py
@@ -105,6 +105,9 @@ class MediaContextMixin(ContextMixin):
                     map(str, dict(allowed_media.UPLOAD_CHOICES).values())
                 ),
             },
+            "mediaTypes": {
+                "allowedMediaTypes": ", ".join(dict(allowed_media.UPLOAD_CHOICES)),
+            },
             "expertMode": self.request.user.expert_mode,
             "allowedMediaTypes": ", ".join(dict(allowed_media.UPLOAD_CHOICES)),
             "canDeleteFile": self.request.user.has_perm("cms.delete_mediafile"),

--- a/integreat_cms/release_notes/current/unreleased/2623.yml
+++ b/integreat_cms/release_notes/current/unreleased/2623.yml
@@ -1,0 +1,2 @@
+en: Show only files of allowed data types when uploading a new file in the content icon setting
+de: Zeige beim Hochladen einer neuen Datei in der Einstellung für das Inhaltsicon nur Dateien zulässiger Datentypen an

--- a/integreat_cms/static/src/js/media-management/component/upload-file.tsx
+++ b/integreat_cms/static/src/js/media-management/component/upload-file.tsx
@@ -13,8 +13,8 @@ type Props = {
     directory: Directory;
     setUploadFile: StateUpdater<boolean>;
     apiEndpoints: MediaApiPaths;
-    allowedMediaTypes: string;
     mediaTranslations: any;
+    mediaTypes: { allowedMediaTypes: string };
     submitForm: (event: Event, successCallback: () => void) => any;
     /* eslint-disable-next-line react/no-unused-prop-types */
     isLoading: boolean;
@@ -25,8 +25,8 @@ const UploadFile = ({
     directory,
     setUploadFile,
     apiEndpoints,
-    allowedMediaTypes,
     mediaTranslations,
+    mediaTypes,
     submitForm,
     refreshState,
 }: Props) => {
@@ -42,7 +42,7 @@ const UploadFile = ({
             headers: { "X-CSRFToken": getCsrfToken() },
             dictDefaultMessage: mediaTranslations.text_upload_area,
             dictInvalidFileType: `${mediaTranslations.text_error_invalid_file_type} ${mediaTranslations.text_allowed_media_types}`,
-            acceptedFiles: allowedMediaTypes,
+            acceptedFiles: `${mediaTypes.allowedMediaTypes}`,
             parallelUploads: 1,
         });
         dropZone.on("queuecomplete", () => {

--- a/integreat_cms/static/src/js/media-management/index.tsx
+++ b/integreat_cms/static/src/js/media-management/index.tsx
@@ -82,7 +82,7 @@ type Props = {
     onlyImage?: boolean;
     globalEdit?: boolean;
     expertMode?: boolean;
-    allowedMediaTypes?: string;
+    mediaTypes: { allowedMediaTypes: string };
     selectionMode?: boolean;
     selectMedia?: (file: File) => any;
     canDeleteFile: boolean;

--- a/integreat_cms/static/src/js/media-management/library.tsx
+++ b/integreat_cms/static/src/js/media-management/library.tsx
@@ -35,7 +35,7 @@ export type LibraryProps = {
     mediaTranslations: any;
     globalEdit?: boolean;
     expertMode?: boolean;
-    allowedMediaTypes?: string;
+    mediaTypes: { allowedMediaTypes: string };
     selectionMode?: boolean;
     onlyImage?: boolean;
     selectMedia?: (file: File) => any;
@@ -62,9 +62,9 @@ const Library = ({
     sidebarFileState,
     apiEndpoints,
     mediaTranslations,
+    mediaTypes,
     globalEdit,
     expertMode,
-    allowedMediaTypes,
     selectionMode,
     onlyImage,
     showMessage,
@@ -320,7 +320,7 @@ const Library = ({
                             directory={directory}
                             mediaTranslations={mediaTranslations}
                             apiEndpoints={apiEndpoints}
-                            allowedMediaTypes={allowedMediaTypes}
+                            mediaTypes={mediaTypes}
                             submitForm={submitForm}
                             setUploadFile={setUploadFile}
                             isLoading={isLoading}

--- a/integreat_cms/static/src/js/media-management/select-media.tsx
+++ b/integreat_cms/static/src/js/media-management/select-media.tsx
@@ -13,6 +13,7 @@ type Props = {
     selectMedia: (file: File) => any;
     apiEndpoints: MediaApiPaths;
     mediaTranslations: any;
+    mediaTypes: { allowedMediaTypes: string };
     canDeleteFile: boolean;
     canReplaceFile: boolean;
     canDeleteDirectory: boolean;
@@ -22,6 +23,7 @@ const SelectMedia = ({
     cancel,
     onlyImage,
     selectMedia,
+    mediaTypes,
     apiEndpoints,
     mediaTranslations,
     canDeleteFile,
@@ -39,6 +41,7 @@ const SelectMedia = ({
                     selectMedia={selectMedia}
                     apiEndpoints={apiEndpoints}
                     mediaTranslations={mediaTranslations}
+                    mediaTypes={mediaTypes}
                     canDeleteFile={canDeleteFile}
                     canReplaceFile={canReplaceFile}
                     canDeleteDirectory={canDeleteDirectory}


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Currently the upload form on icon set on the editor form of pages does not correctly validate the accepted uploaded files. If the unaccepted file is uploaded, it is removed after 5 seconds. The expected behaviour is that it shouldn't be removed from the upload input and should show type error on mouse over.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Create an object called mediaTypes with a key "allowedMediaTypes" and set the type "any" to it (it was undefined when it was set to string and seems like directly assigning it in a component resulted in an undefined property value)
- Fix importing of mediaTypes in other files and components
- File types filter on file select can be left as it is because based on the browser it behaves differently (Firefox shows now filters with accepted types, Chrome only shows filters like Customised files and all files)


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- should be none

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2623 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
