### PR TITLE
Fix missing venv activation in update script

### DIFF
--- a/tools/update_dependencies.sh
+++ b/tools/update_dependencies.sh
@@ -73,6 +73,8 @@ rm -rf .venv.tmp
 
 # Install updated versions in the real venv
 if [[ -d ".venv" ]]; then
+    # Activate virtual environment
+    source .venv/bin/activate
     # shellcheck disable=SC2102
     pip install -e .[dev-pinned,pinned]
 else


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
I noticed a small bug in the depencency script which causes an error `error: externally-managed-environment` on systems which comply to [PEP 668](https://peps.python.org/pep-0668/).

### Proposed changes
<!-- Describe this PR in more detail. -->

- Activate venv before installing upgraded versions



__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
