### PR TITLE
Start docker container without -t flag on macOS

### DIFF
--- a/tools/_functions.sh
+++ b/tools/_functions.sh
@@ -317,14 +317,14 @@ function wait_for_docker_container {
         DOCKER_EXEC_FLAGS="-it"
     fi
 
-    echo "Waiting for Docker container ${DOCKER_CONTAINER_NAME} to be ready..."
+    echo "Waiting for Docker container ${DOCKER_CONTAINER_NAME} to be ready..." | print_info
     # Wait until container is ready and accepts database connections
     until docker exec ${DOCKER_EXEC_FLAGS} "${DOCKER_CONTAINER_NAME}" psql -U integreat -d integreat -c "select 1" > /dev/null 2>&1; do
-        echo "Container not ready yet, sleeping..."
+        echo "Container not ready yet, sleeping..." | print_info
         sleep 0.1
     done
 
-    echo "Docker container ${DOCKER_CONTAINER_NAME} is ready!"
+    echo "Docker container ${DOCKER_CONTAINER_NAME} is ready!" | print_success
 }
 
 # This function creates a new postgres database docker container

--- a/tools/_functions.sh
+++ b/tools/_functions.sh
@@ -310,10 +310,21 @@ function migrate_database {
 
 # This function waits for the docker database container
 function wait_for_docker_container {
+    # Set flags based on operating system because the t flag does not work on macOS
+    if [[ "$(uname)" == "Darwin" ]]; then
+        DOCKER_EXEC_FLAGS="-i"
+    else
+        DOCKER_EXEC_FLAGS="-it"
+    fi
+
+    echo "Waiting for Docker container ${DOCKER_CONTAINER_NAME} to be ready..."
     # Wait until container is ready and accepts database connections
-    until docker exec -it "${DOCKER_CONTAINER_NAME}" psql -U integreat -d integreat -c "select 1" > /dev/null 2>&1; do
+    until docker exec ${DOCKER_EXEC_FLAGS} "${DOCKER_CONTAINER_NAME}" psql -U integreat -d integreat -c "select 1" > /dev/null 2>&1; do
+        echo "Container not ready yet, sleeping..."
         sleep 0.1
     done
+
+    echo "Docker container ${DOCKER_CONTAINER_NAME} is ready!"
 }
 
 # This function creates a new postgres database docker container

--- a/tools/_functions.sh
+++ b/tools/_functions.sh
@@ -310,16 +310,10 @@ function migrate_database {
 
 # This function waits for the docker database container
 function wait_for_docker_container {
-    # Set flags based on operating system because the t flag does not work on macOS
-    if [[ "$(uname)" == "Darwin" ]]; then
-        DOCKER_EXEC_FLAGS="-i"
-    else
-        DOCKER_EXEC_FLAGS="-it"
-    fi
-
     echo "Waiting for Docker container ${DOCKER_CONTAINER_NAME} to be ready..." | print_info
+
     # Wait until container is ready and accepts database connections
-    until docker exec ${DOCKER_EXEC_FLAGS} "${DOCKER_CONTAINER_NAME}" psql -U integreat -d integreat -c "select 1" > /dev/null 2>&1; do
+    until docker exec "${DOCKER_CONTAINER_NAME}" psql -U integreat -d integreat -c "select 1" > /dev/null 2>&1; do
         echo "Container not ready yet, sleeping..." | print_info
         sleep 0.1
     done


### PR DESCRIPTION
### Short description

This pull request updates the `wait_for_docker_container` function in our shell script to fix the waiting mechanism on macOS, which currently hangs forever, as demonstrated in the attached video.

### Proposed changes

- Removed the docker run flags, as the waiting mechanism works without them.
- Added echo statements to provide feedback during the waiting period.

### Testing
The script was tested on macOS to ensure it does not hang and correctly waits for the Docker container to be ready. It'd be nice if someone can test the script on a Linux environment to verify that it maintains compatibility.


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
