### PR TITLE
Define pre-commit hooks in devtool scripts

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,35 +16,56 @@ repos:
         exclude: .github/PULL_REQUEST_TEMPLATE.md|tests/cms/views/dashboard/expected_output/chat.html
       - id: no-commit-to-branch
         args: [--branch, main, --branch, develop]
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.7
+  - repo: local
     hooks:
       - id: ruff
+        name: ruff (custom script)
+        entry: ./tools/ruff.sh
+        args: ["--as-precommit"]
+        types_or: ["python", "pyi"]
+        language: script
+        pass_filenames: false
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.10.0.1
     hooks:
       - id: shellcheck
         args: [--external-sources]
-  - repo: https://github.com/psf/black
-    rev: 24.4.2
+  - repo: local
     hooks:
       - id: black
-  - repo: https://github.com/Riverside-Healthcare/djLint
-    rev: v1.34.1
+        name: black (custom script)
+        entry: ./tools/black.sh
+        args: ["--as-precommit"]
+        types_or: ["python", "pyi"]
+        language: script
+        pass_filenames: true
+  - repo: local
     hooks:
       - id: djlint-django
-        args: [--reformat, --lint, --exclude, tests/cms/views/dashboard/expected_output]
-  - repo: https://github.com/pre-commit/mirrors-eslint
-    rev: v8.56.0
+        name: djlint (custom script)
+        entry: ./tools/djlint.sh
+        args: ["--as-precommit"]
+        types_or: ["html"]
+        language: script
+        pass_filenames: true
+  - repo: local
     hooks:
       - id: eslint
-        files: \.[jt]sx?$
-        args: [--fix]
-        types: [file]
-        additional_dependencies:
-          - eslint@8.57.0
-          - "typescript-eslint@7.11.0"
-          - "eslint-plugin-prefer-arrow@1.2.3"
+        name: eslint (custom script)
+        entry: ./tools/eslint.sh
+        args: ["--as-precommit"]
+        types_or: ["javascript", "jsx", "ts", "tsx"]
+        language: script
+        pass_filenames: true
+  - repo: local
+    hooks:
+      - id: prettier
+        name: prettier (custom script)
+        entry: ./tools/prettier.sh
+        args: ["--as-precommit"]
+        types_or: ["javascript", "jsx", "ts", "tsx", "css", "sass", "scss", "yaml", "markdown", "json"]
+        language: script
+        pass_filenames: true
   - repo: local
     hooks:
       - id: translations
@@ -53,7 +74,7 @@ repos:
         entry: tools/check_translations.sh
         types_or: [python, html]
         language: script
-        pass_filenames: false
+        pass_filenames: true
   - repo: local
     hooks:
       - id: frontend-tests
@@ -62,8 +83,21 @@ repos:
         entry: tools/vitest.sh
         language: script
         pass_filenames: false
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.10.0
+  - repo: local
     hooks:
       - id: mypy
-        additional_dependencies: [types-python-dateutil, types-PyYAML, types-requests]
+        name: mypy (custom script)
+        entry: ./tools/mypy.sh
+        args: ["--as-precommit"]
+        types_or: ["python", "pyi"]
+        language: script
+        pass_filenames: true
+  - repo: local
+    hooks:
+      - id: pylint
+        name: pylint (custom script)
+        entry: ./tools/pylint.sh
+        args: ["--as-precommit"]
+        types_or: ["python", "pyi"]
+        language: script
+        pass_filenames: true

--- a/tools/_functions.sh
+++ b/tools/_functions.sh
@@ -362,7 +362,7 @@ function cleanup_docker_container {
 }
 
 function ensure_webpack_bundle_exists {
-    if [ ! -d "${PACKAGE_DIR}/static/dist/" ] || [ ! "$(ls -A "${PACKAGE_DIR}"/static/dist/ 2>/dev/null)" ]; then
+    if [ ! -d "${PACKAGE_DIR}/static/dist/" ] || [ ! "$(ls -A "${PACKAGE_DIR}"/static/dist/ 2> /dev/null)" ]; then
         echo "Building webpack bundle..." | print_info
         npm run build > /dev/null
     fi
@@ -486,4 +486,24 @@ function join_by {
     if shift 2; then
         printf %s "$f" "${@/#/$d}"
     fi
+}
+
+# This function checks if the flag "--as-precommit" was set, and if so,
+# runs the specified pre-commit hook against all changed files
+function run_as_precommit {
+    local command="$1"
+    shift
+
+    for arg in "$@"; do
+        if [[ "$arg" == "--as-precommit" ]]; then
+            shift
+            [ "$#" -eq 0 ] && exit 0
+
+            for file in "$@"; do
+                eval "$command \"$file\""
+            done
+
+            exit 0
+        fi
+    done
 }

--- a/tools/black.sh
+++ b/tools/black.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 # This script can be used to format the python code according to the black code style.
 
 # Import utility functions
@@ -7,6 +6,9 @@
 source "$(dirname "${BASH_SOURCE[0]}")/_functions.sh"
 
 require_installed
+
+# Run black as a pre-commit hook
+run_as_precommit "black" "$@"
 
 # Run black
 echo "Starting code formatting with black..." | print_info

--- a/tools/djlint.sh
+++ b/tools/djlint.sh
@@ -8,6 +8,9 @@ source "$(dirname "${BASH_SOURCE[0]}")/_functions.sh"
 
 require_installed
 
+# Run djlint as a pre-commit hook
+run_as_precommit "djlint --profile=django -e=html --reformat --quiet --lint" "$@"
+
 # Run djlint
 echo "Starting code formatting with djlint..." | print_info
 djlint --reformat --quiet --lint "${PACKAGE_DIR}"

--- a/tools/eslint.sh
+++ b/tools/eslint.sh
@@ -6,6 +6,9 @@
 # shellcheck source=./tools/_functions.sh
 source "$(dirname "${BASH_SOURCE[0]}")/_functions.sh"
 
+# Run eslint as a pre-commit hook
+run_as_precommit "npx eslint" "$@"
+
 # Run prettier
 echo "Starting code linting with eslint..." | print_info
 npx eslint .

--- a/tools/mypy.sh
+++ b/tools/mypy.sh
@@ -8,6 +8,9 @@ source "$(dirname "${BASH_SOURCE[0]}")/_functions.sh"
 
 require_installed
 
+# Run mypy as a pre-commit hook
+run_as_precommit "mypy --scripts-are-modules" "$@"
+
 # Run my[py]
 echo "Starting type checking with my[py]..." | print_info
 export FORCE_COLOR=1

--- a/tools/prettier.sh
+++ b/tools/prettier.sh
@@ -6,6 +6,9 @@
 # shellcheck source=./tools/_functions.sh
 source "$(dirname "${BASH_SOURCE[0]}")/_functions.sh"
 
+# Run prettier as a pre-commit hook
+run_as_precommit "npx prettier --write" "$@"
+
 # Run prettier
 echo "Starting code formatting with prettier..." | print_info
 npx prettier --write .

--- a/tools/pylint.sh
+++ b/tools/pylint.sh
@@ -8,6 +8,9 @@ source "$(dirname "${BASH_SOURCE[0]}")/_functions.sh"
 
 require_installed
 
+# Run pylint as a pre-commit hook
+run_as_precommit "pylint --rcfile=pyproject.toml" "$@"
+
 # Run pylint
 echo "Starting code linting with pylint..." | print_info
 # Explicitly include cli which does not have a .py ending

--- a/tools/ruff.sh
+++ b/tools/ruff.sh
@@ -10,6 +10,9 @@ source "$(dirname "${BASH_SOURCE[0]}")/_functions.sh"
 
 require_installed
 
+# Run ruff as a pre-commit hook
+run_as_precommit "ruff check --fix" "$@"
+
 # Run ruff
 echo "Starting code linting and formatting with ruff..." | print_info
 ruff check --fix "${BASE_DIR}"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This is a followup to the discussion in #2804. This PR swaps out the existing pre-commit hooks for calls to our existing devtools. @cclauss I cannot request you as a reviewer, but you're more than welcome to also take a look!!

### Proposed changes
<!-- Describe this PR in more detail. -->

- a new helper function `run_as_precommit` is called at the start of each relevant devtool
- if the tool was called with the `--as-precommit` flag, the tool is only run against staged files
- `.pre-commit-config` uses the local tools and sets the `--as-precommit` flag
- this *should* be a drop-in replacement for the current pre-commit hooks
- additionally, `pylint` can now be run as a pre-commit hook 🎉 


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- possibly the behavior doesn't match 100%? It's a bit hard to tell, honestly.
- no more mismatches between pre-commit / installed tool versions!


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: n/a


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)