### PR TITLE
Ensure node_modules are in place before running vitest

### DIFF
--- a/tools/_functions.sh
+++ b/tools/_functions.sh
@@ -372,14 +372,8 @@ function ensure_webpack_bundle_exists {
 
 function ensure_node_modules_exist {
     if [ ! -d "${BASE_DIR}/node_modules" ]; then
-        echo "Missing node_modules - running npm install..." | print_info
-
-        if ! npm install > /dev/null 2>&1; then
-            echo "Error during npm install" | print_error
-            exit 1
-        fi
-
-        echo "✔ npm install completed successfully" | print_success
+        echo "Missing node_modules - please run ./tools/install.sh" | print_info
+        exit 1
     else
         echo "✔ node_modules is in place" | print_info
     fi

--- a/tools/_functions.sh
+++ b/tools/_functions.sh
@@ -371,7 +371,7 @@ function ensure_webpack_bundle_exists {
 }
 
 function ensure_node_modules_exist {
-    if [ ! -d "node_modules" ]; then
+    if [ ! -d "${BASE_DIR}/node_modules" ]; then
         echo "Missing node_modules - running npm install..." | print_info
 
         if ! npm install > /dev/null 2>&1; then

--- a/tools/_functions.sh
+++ b/tools/_functions.sh
@@ -370,6 +370,21 @@ function ensure_webpack_bundle_exists {
     echo "✔ Webpack bundle is in place" | print_success
 }
 
+function ensure_node_modules_exist {
+    if [ ! -d "node_modules" ]; then
+        echo "Missing node_modules - running npm install..." | print_info
+
+        if ! npm install > /dev/null 2>&1; then
+            echo "Error during npm install" | print_error
+            exit 1
+        fi
+
+        echo "✔ npm install completed successfully" | print_success
+    else
+        echo "✔ node_modules is in place" | print_info
+    fi
+}
+
 # This function makes sure a postgres database docker container is running
 function ensure_docker_container_running {
     # Make sure script has the permission to run docker

--- a/tools/_functions.sh
+++ b/tools/_functions.sh
@@ -372,7 +372,7 @@ function ensure_webpack_bundle_exists {
 
 function ensure_node_modules_exist {
     if [ ! -d "${BASE_DIR}/node_modules" ]; then
-        echo "Missing node_modules - please run ./tools/install.sh" | print_info
+        echo "Missing node_modules - please run ./tools/install.sh" | print_error
         exit 1
     else
         echo "✔ node_modules is in place" | print_info

--- a/tools/vitest.sh
+++ b/tools/vitest.sh
@@ -6,6 +6,8 @@
 # shellcheck source=./tools/_functions.sh
 source "$(dirname "${BASH_SOURCE[0]}")/_functions.sh"
 
+ensure_node_modules_exist
+
 # Run prettier
 echo "Starting frontend tests with vitest..." | print_info
 npm run test


### PR DESCRIPTION
### Short description

This pull request addresses the issue where the Vitest tools fail if the node_modules directory is missing.

### Proposed changes
- If node_modules is not found, npm install is executed silently (with output redirected to /dev/null).

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
