### PR TITLE
Keep internal chat messages internal

### DIFF
--- a/integreat_cms/api/v3/chat/zammad_api.py
+++ b/integreat_cms/api/v3/chat/zammad_api.py
@@ -144,14 +144,17 @@ class ZammadChatAPI:
     # pylint: disable=method-hidden
     def get_messages(self, chat: UserChat) -> dict[str, dict | list[dict]]:
         """
-        Get all messages for a given ticket
+        Get all non-internal messages for a given ticket
 
         :param chat: UserChat instance for the relevant Zammad ticket
         """
-        response = self._parse_response(
-            self._attempt_call(self.client.ticket.articles, chat.zammad_id)
-        )
+        raw_response = self._attempt_call(self.client.ticket.articles, chat.zammad_id)
+        if not isinstance(raw_response, list):
+            return self._parse_response(raw_response)  # type: ignore[return-value]
 
+        response = self._parse_response(
+            [article for article in raw_response if not article.get("internal")]
+        )
         for message in response:
             if "attachments" in message:
                 message["attachments"] = [


### PR DESCRIPTION
### Short description
Do not return internal Zammad messages as chat responses to app users.


### Proposed changes
Filter messages by internal attribute.

### Side effects
- None

### Resolved issues

Fixes: #2843


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
