### PR TITLE
Add a select-all button to language selection in page form

### DIFF
--- a/integreat_cms/cms/forms/machine_translation_form.py
+++ b/integreat_cms/cms/forms/machine_translation_form.py
@@ -28,7 +28,9 @@ class MachineTranslationForm(CustomContentModelForm):
     """
 
     mt_translations_to_create = forms.ModelMultipleChoiceField(
-        widget=forms.CheckboxSelectMultiple(),
+        widget=forms.CheckboxSelectMultiple(
+            attrs={"class": "bulk-select-language", "name": "selected_language_slugs[]"}
+        ),
         queryset=LanguageTreeNode.objects.none(),
         required=False,
         label=_("Create new translations:"),

--- a/integreat_cms/cms/templates/pages/page_form_sidebar/minor_edit_box.html
+++ b/integreat_cms/cms/templates/pages/page_form_sidebar/minor_edit_box.html
@@ -28,7 +28,7 @@
                 {{ page_translation_form.automatic_translation.label }}
             </label>
             <div id="hix-score-warning"
-                 class="hidden bg-yellow-100 border-l-4 border-yellow-500 text-orange-700  px-4 py-3 mb-2">
+                 class="hidden px-4 py-3 mb-2 text-orange-700 bg-yellow-100 border-l-4 border-yellow-500">
                 <p>
                     {% blocktranslate trimmed %}
                         Increase the HIX score to at least {{ minimum_hix }} to enable automatic translations.
@@ -38,7 +38,7 @@
             <div class="help-text">
                 {{ page_translation_form.automatic_translation.help_text }}
             </div>
-            <div id="language-options" class="pl-2 hidden">
+            <div id="language-options" class="hidden pl-2">
                 {% if page_translation_form.mt_translations_to_update.field.queryset.exists %}
                     <label for="{{ page_translation_form.mt_translations_to_update.id_for_label }}"
                            class="secondary">
@@ -52,6 +52,12 @@
                         {{ page_translation_form.mt_translations_to_create.label }}
                     </label>
                     {% render_field page_translation_form.mt_translations_to_create %}
+                    <div class="mt-4 font-bold">
+                        <input id="select-all-languages" type="checkbox" />
+                        <label for="select-all-languages">
+                            {% translate "Select all languages" %}
+                        </label>
+                    </div>
                 {% endif %}
             </div>
         </div>

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -6794,6 +6794,10 @@ msgstr ""
 "Um automatische Übersetzungen nutzen zu können, muss der HIX-Wert mindestens "
 "%(minimum_hix)s betragen."
 
+#: cms/templates/pages/page_form_sidebar/minor_edit_box.html
+msgid "Select all languages"
+msgstr "Alle Sprachen auswählen"
+
 #: cms/templates/pages/page_form_sidebar/settings_box.html
 msgid "Settings of the page"
 msgstr "Einstellungen der Seite"
@@ -10229,6 +10233,7 @@ msgstr ""
 
 #~ msgid "Chinese simplified"
 #~ msgstr "Vereinfachtes Chinesisch"
+
 #~ msgid "The requested chat does not exist. Did you delete it?"
 #~ msgstr "Der angeforderte chat existiert nicht. Hast du ihn gelöscht?"
 

--- a/integreat_cms/release_notes/current/unreleased/2838.yml
+++ b/integreat_cms/release_notes/current/unreleased/2838.yml
@@ -1,0 +1,2 @@
+en: Add select all box for machine translations in page form
+de: Füge Option hinzu mehrere Sprachen im Seitenformular für maschinelle Übersetzungen auszuwählen

--- a/integreat_cms/static/src/js/pages/xliff-export-overlay.ts
+++ b/integreat_cms/static/src/js/pages/xliff-export-overlay.ts
@@ -2,7 +2,9 @@ const toggleXliffBulkActionButton = () => {
     // Only activate button if at least one language item is selected
     const selectLanguages = <HTMLInputElement[]>Array.from(document.getElementsByClassName("bulk-select-language"));
     const multiLanguageXliffButton = document.getElementById("xliff-overlay-bulk-action-execute") as HTMLButtonElement;
-    multiLanguageXliffButton.disabled = !selectLanguages.some((el) => el.checked);
+    if (multiLanguageXliffButton) {
+        multiLanguageXliffButton.disabled = !selectLanguages.some((el) => el.checked);
+    }
 };
 
 const closeXliffExportOverlay = (overlay: HTMLElement) => {


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds the option to "select all languages" when creating a new page / creating new translations.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add option to select multiple languages in the page form at once


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- In order to reuse the existing code I now had to twist my way around it. Maybe this is too much spaghetti already. If you have any suggestions on how to make this cleaner, I'm very interested to know! :)

### How to test this

- It might be necessary to add more language nodes to the default language first, as our unchanged test data provides only one child language for our default language
- It's a bit easier to test this when creating a new page than when updating a new page 

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2838


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
