### PR TITLE
Don't send news when they're overdue

### DIFF
--- a/integreat_cms/cms/models/push_notifications/push_notification.py
+++ b/integreat_cms/cms/models/push_notifications/push_notification.py
@@ -162,7 +162,7 @@ class PushNotification(AbstractBaseModel):
             return False
 
         retention_time = timezone.now() - timedelta(
-            hours=settings.NOTIFICATION_RETAIN_TIME_IN_HOURS
+            hours=settings.FCM_NOTIFICATION_RETAIN_TIME_IN_HOURS
         )
         return timezone.localtime(self.scheduled_send_date) <= retention_time
 

--- a/integreat_cms/cms/templates/push_notifications/push_notification_list_row.html
+++ b/integreat_cms/cms/templates/push_notifications/push_notification_list_row.html
@@ -50,6 +50,8 @@
     <td class="pl-2 pr-4 whitespace-nowrap">
         {% if push_notification.sent_date %}
             <i icon-name="check" class="text-green-500 align-text-top"></i> {{ push_notification.sent_date }}
+        {% elif push_notification.is_overdue %}
+            <i icon-name="x" class="text-red-500 align-text-top"></i> {% translate "Message is overdue and will not be sent" %}
         {% else %}
             <i icon-name="x" class="text-red-500 align-text-top"></i> {% translate "Message not sent yet" %}
         {% endif %}

--- a/integreat_cms/core/management/commands/send_push_notifications.py
+++ b/integreat_cms/core/management/commands/send_push_notifications.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from django.conf import settings
@@ -55,6 +56,8 @@ class Command(LogCommand):
             sent_date__isnull=True,
             draft=False,
             scheduled_send_date__lte=timezone.now(),
+            scheduled_send_date__gte=timezone.now()
+            - timedelta(hours=settings.NOTIFICATION_RETAIN_TIME_IN_HOURS),
         )
         if total := len(pending_push_notifications):
             for counter, push_notification in enumerate(pending_push_notifications):

--- a/integreat_cms/core/management/commands/send_push_notifications.py
+++ b/integreat_cms/core/management/commands/send_push_notifications.py
@@ -57,7 +57,7 @@ class Command(LogCommand):
             draft=False,
             scheduled_send_date__lte=timezone.now(),
             scheduled_send_date__gte=timezone.now()
-            - timedelta(hours=settings.NOTIFICATION_RETAIN_TIME_IN_HOURS),
+            - timedelta(hours=settings.FCM_NOTIFICATION_RETAIN_TIME_IN_HOURS),
         )
         if total := len(pending_push_notifications):
             for counter, push_notification in enumerate(pending_push_notifications):

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -1310,3 +1310,8 @@ USER_CHAT_WINDOW_LIMIT: Final[int] = 50
 
 #: Zammad ticket group used for Integreat chat messages
 USER_CHAT_TICKET_GROUP: Final[str] = "integreat-chat"
+
+#: Duration (in hours) that we retain pending push notifications for retry attempts before discarding them
+NOTIFICATION_RETAIN_TIME_IN_HOURS: Final[int] = int(
+    os.environ.get("INTEGREAT_CMS_NOTIFICATION_RETAIN_TIME_IN_HOURS", 24)
+)

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -227,6 +227,11 @@ assert (
     not 60 % FCM_SCHEDULE_INTERVAL_MINUTES
 ), "Interval must be <= 60 and a divisor of 60"
 
+#: Duration (in hours) that we retain pending push notifications for retry attempts before discarding them
+FCM_NOTIFICATION_RETAIN_TIME_IN_HOURS: Final[int] = int(
+    os.environ.get("INTEGREAT_CMS_NOTIFICATION_RETAIN_TIME_IN_HOURS", 24)
+)
+
 ###########
 # GVZ API #
 ###########
@@ -1310,8 +1315,3 @@ USER_CHAT_WINDOW_LIMIT: Final[int] = 50
 
 #: Zammad ticket group used for Integreat chat messages
 USER_CHAT_TICKET_GROUP: Final[str] = "integreat-chat"
-
-#: Duration (in hours) that we retain pending push notifications for retry attempts before discarding them
-NOTIFICATION_RETAIN_TIME_IN_HOURS: Final[int] = int(
-    os.environ.get("INTEGREAT_CMS_NOTIFICATION_RETAIN_TIME_IN_HOURS", 24)
-)

--- a/integreat_cms/firebase_api/firebase_api_client.py
+++ b/integreat_cms/firebase_api/firebase_api_client.py
@@ -17,7 +17,6 @@ from ..cms.forms.push_notifications.push_notification_translation_form import (
 from ..cms.models import Region
 
 if TYPE_CHECKING:
-
     from ..cms.models.push_notifications.push_notification import PushNotification
 
 logger = logging.getLogger(__name__)

--- a/integreat_cms/firebase_api/firebase_api_client.py
+++ b/integreat_cms/firebase_api/firebase_api_client.py
@@ -17,6 +17,7 @@ from ..cms.forms.push_notifications.push_notification_translation_form import (
 from ..cms.models import Region
 
 if TYPE_CHECKING:
+
     from ..cms.models.push_notifications.push_notification import PushNotification
 
 logger = logging.getLogger(__name__)

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -7437,6 +7437,10 @@ msgid "Title not available"
 msgstr "Titel nicht verfügbar"
 
 #: cms/templates/push_notifications/push_notification_list_row.html
+msgid "Message is overdue and will not be sent"
+msgstr "Nachricht ist überfällig und wird nicht mehr gesendet"
+
+#: cms/templates/push_notifications/push_notification_list_row.html
 msgid "Message not sent yet"
 msgstr "Nachricht noch nicht gesendet"
 
@@ -10229,6 +10233,7 @@ msgstr ""
 
 #~ msgid "Chinese simplified"
 #~ msgstr "Vereinfachtes Chinesisch"
+
 #~ msgid "The requested chat does not exist. Did you delete it?"
 #~ msgstr "Der angeforderte chat existiert nicht. Hast du ihn gelöscht?"
 

--- a/tests/core/management/commands/test_send_push_notifications.py
+++ b/tests/core/management/commands/test_send_push_notifications.py
@@ -1,33 +1,155 @@
 from __future__ import annotations
 
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import requests
+
+if TYPE_CHECKING:
+    from typing import Any
+
 import pytest
+from django.core.management import call_command
 from django.core.management.base import CommandError
 from pytest_django.fixtures import SettingsWrapper
+from requests_mock.mocker import Mocker
+
+from integreat_cms.cms.models import (
+    Language,
+    LanguageTreeNode,
+    PushNotification,
+    PushNotificationTranslation,
+    Region,
+)
+from integreat_cms.firebase_api.firebase_api_client import FirebaseApiClient
 
 from ..utils import get_command_output
 
 
-@pytest.mark.django_db
-def test_push_notifications_disabled(settings: SettingsWrapper) -> None:
+class TestSendPushNotification:
     """
-    Ensure that disabled push notifications cause an error
+    Test that cover the send_push_notification management command and its filter mechanisms
     """
-    settings.FCM_ENABLED = False
-    with pytest.raises(CommandError) as exc_info:
-        assert not any(get_command_output("send_push_notifications"))
-    assert str(exc_info.value) == "Push notifications are disabled"
 
+    @pytest.mark.django_db
+    def test_push_notifications_disabled(self, settings: SettingsWrapper) -> None:
+        """
+        Ensure that disabled push notifications cause an error
+        """
+        settings.FCM_ENABLED = False
+        with pytest.raises(CommandError) as exc_info:
+            assert not any(get_command_output("send_push_notifications"))
+        assert str(exc_info.value) == "Push notifications are disabled"
 
-@pytest.mark.django_db
-def test_push_notifications_nonexisting_testregion(settings: SettingsWrapper) -> None:
-    """
-    Ensure that an error is caused when the system runs in debug mode but the test region does not exist
-    """
-    settings.TEST_REGION_SLUG = "non-existing"
-    settings.DEBUG = True
-    with pytest.raises(CommandError) as exc_info:
-        assert not any(get_command_output("send_push_notifications"))
-    assert (
-        str(exc_info.value)
-        == f"The system runs with DEBUG=True but the region with TEST_REGION_SLUG={settings.TEST_REGION_SLUG} does not exist."
-    )
+    @pytest.mark.django_db
+    def test_push_notifications_nonexisting_testregion(
+        self,
+        settings: SettingsWrapper,
+    ) -> None:
+        """
+        Ensure that an error is caused when the system runs in debug mode but the test region does not exist
+        """
+        settings.TEST_REGION_SLUG = "non-existing"
+        settings.DEBUG = True
+        with pytest.raises(CommandError) as exc_info:
+            assert not any(get_command_output("send_push_notifications"))
+        assert (
+            str(exc_info.value)
+            == f"The system runs with DEBUG=True but the region with TEST_REGION_SLUG={settings.TEST_REGION_SLUG} does not exist."
+        )
+
+    patch: Any = None
+
+    def setup_method(self) -> None:
+        self.patch = patch.object(
+            FirebaseApiClient, "_get_access_token", return_value="secret access token"
+        )
+        self.patch.start()
+
+    def teardown_method(self) -> None:
+        self.patch.stop()
+        self.patch = None
+
+    @pytest.mark.django_db
+    def test_ignore_overdue_notification(
+        self, settings: SettingsWrapper, requests_mock: Mocker
+    ) -> None:
+        called = 0
+
+        def json_func(
+            _request: requests.PreparedRequest, _context: Any
+        ) -> dict[str, str | int]:
+            nonlocal called
+            called += 1
+
+            return {
+                "name": "projects/integreat-2020/messages/1",
+                "status_code": 200,
+            }
+
+        requests_mock.post(
+            "https://fcm.googleapis.com/v1/projects/integreat-2020/messages:send",
+            json=json_func,
+            status_code=200,
+        )
+
+        german_language = Language.objects.create(
+            slug="de-test",
+            bcp47_tag="de",
+            native_name="Deutsch",
+            english_name="German",
+            text_direction="ltr",
+            primary_country_code="DE",
+            table_of_contents="Inhaltsverzeichnis",
+        )
+
+        region = Region.objects.create(name="unit-test-region")
+
+        LanguageTreeNode.objects.create(
+            language=german_language, lft=1, rgt=2, tree_id=1, depth=1, region=region
+        )
+
+        push_notification = PushNotification.objects.create(
+            channel="default",
+            draft=False,
+            sent_date=None,
+            scheduled_send_date=datetime.now(),
+            mode="ONLY_AVAILABLE",
+            is_template=False,
+            template_name=None,
+        )
+
+        overdue_push_notification = PushNotification.objects.create(
+            channel="default",
+            draft=False,
+            sent_date=None,
+            scheduled_send_date=datetime.now() - timedelta(days=2),
+            mode="ONLY_AVAILABLE",
+            is_template=False,
+            template_name=None,
+        )
+
+        PushNotificationTranslation.objects.create(
+            title="Test Push Notification",
+            text="Test Push Notification",
+            push_notification=push_notification,
+            language=german_language,
+        )
+
+        PushNotificationTranslation.objects.create(
+            title="Test (Overdue) Push Notification",
+            text="Test Push Notification",
+            push_notification=overdue_push_notification,
+            language=german_language,
+        )
+
+        push_notification.regions.add(region)
+        push_notification.save()
+
+        overdue_push_notification.regions.add(region)
+        overdue_push_notification.save()
+
+        call_command("send_push_notifications")
+
+        assert called == 1

--- a/tests/core/management/commands/test_send_push_notifications.py
+++ b/tests/core/management/commands/test_send_push_notifications.py
@@ -32,6 +32,18 @@ class TestSendPushNotification:
     Test that cover the send_push_notification management command and its filter mechanisms
     """
 
+    patch: Any = None
+
+    def setup_method(self) -> None:
+        self.patch = patch.object(
+            FirebaseApiClient, "_get_access_token", return_value="secret access token"
+        )
+        self.patch.start()
+
+    def teardown_method(self) -> None:
+        self.patch.stop()
+        self.patch = None
+
     @pytest.mark.django_db
     def test_push_notifications_disabled(self, settings: SettingsWrapper) -> None:
         """
@@ -58,18 +70,6 @@ class TestSendPushNotification:
             str(exc_info.value)
             == f"The system runs with DEBUG=True but the region with TEST_REGION_SLUG={settings.TEST_REGION_SLUG} does not exist."
         )
-
-    patch: Any = None
-
-    def setup_method(self) -> None:
-        self.patch = patch.object(
-            FirebaseApiClient, "_get_access_token", return_value="secret access token"
-        )
-        self.patch.start()
-
-    def teardown_method(self) -> None:
-        self.patch.stop()
-        self.patch = None
 
     @pytest.mark.django_db
     def test_ignore_overdue_notification(


### PR DESCRIPTION
### Short Description

This pull request introduces a new setting to control the retention time for notifications. Notifications that exceed the specified retention time will no longer be sent and will be marked accordingly in the user interface.

### Proposed Changes

- Add `NOTIFICATION_RETAIN_TIME_IN_HOURS` that can also be set through environment variables as recommended in [The Twelve-Factor App](https://12factor.net/config)
- Implement `is_overdue` function in the PushNotification class to be used by the HTML template
- Add new case to the [push_notification_list_row.html](https://github.com/digitalfabrik/integreat-cms/pull/2861/files#diff-83cf1391d28d5cc93fd2655748cb3664e7ac4fcffe32b7fc71aa0542ec13c402)
- Add retention time filter to [send_push_notifications.py](https://github.com/digitalfabrik/integreat-cms/pull/2861/files#diff-1b2c44019336467e050fd926f3c8ce9a8dccdb4bef702b8b064d3afb1a42b193)
- Implement unit test

### Resolved Issues

- #2645



__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
