### PR TITLE
Feature/add bulk action to reset currently in translation

### DIFF
--- a/integreat_cms/cms/templates/pages/page_tree.html
+++ b/integreat_cms/cms/templates/pages/page_tree.html
@@ -252,6 +252,11 @@
                         {% endblocktranslate %}
                     </option>
                 {% endif %}
+                {% if has_pages_in_translation %}
+                    <option data-bulk-action="{% url 'cancel_translation_process' region_slug=request.region.slug language_slug=language.slug %}">
+                        {% translate "Cancel translation process" %}
+                    </option>
+                {% endif %}
             </select>
             <button id="bulk-action-execute" class="btn" disabled>
                 {% translate "Execute" %}

--- a/integreat_cms/cms/urls/protected.py
+++ b/integreat_cms/cms/urls/protected.py
@@ -896,6 +896,13 @@ urlpatterns: list[URLPattern] = [
                                             name="draft_multiple_pages",
                                         ),
                                         path(
+                                            "bulk-cancel-translation-process/",
+                                            pages.CancelTranslationProcess.as_view(
+                                                model=Page,
+                                            ),
+                                            name="cancel_translation_process",
+                                        ),
+                                        path(
                                             "<int:page_id>/",
                                             include(
                                                 [

--- a/integreat_cms/cms/views/pages/__init__.py
+++ b/integreat_cms/cms/views/pages/__init__.py
@@ -19,6 +19,7 @@ from .page_actions import (
     upload_xliff,
 )
 from .page_bulk_actions import (
+    CancelTranslationProcess,
     ExportMultiLanguageXliffView,
     ExportXliffView,
     GeneratePdfView,

--- a/integreat_cms/cms/views/pages/page_actions.py
+++ b/integreat_cms/cms/views/pages/page_actions.py
@@ -289,7 +289,9 @@ def cancel_translation_process_ajax(
     if not (page_translation := page.get_translation(language_slug)):
         return JsonResponse(
             {
-                "error": f"Page {page} does not have a translation for language '{language_slug}'"
+                "error": _(
+                    'Page "{}" does not have a translation for language "{}"'
+                ).format(page, language_slug)
             },
             status=404,
         )
@@ -301,7 +303,9 @@ def cancel_translation_process_ajax(
     translation_state = page.get_translation_state(language_slug)
     return JsonResponse(
         {
-            "success": f"Cancelled translation process for page {page} and language {page_translation.language}",
+            "success": _(
+                'Cancelled translation process for page "{}" and language "{}"'
+            ).format(page, page_translation.language),
             "languageSlug": page_translation.language.slug,
             "translationState": translation_state,
         }

--- a/integreat_cms/cms/views/pages/page_tree_view.py
+++ b/integreat_cms/cms/views/pages/page_tree_view.py
@@ -133,6 +133,7 @@ class PageTreeView(TemplateView, PageContextMixin, MachineTranslationContextMixi
 
         # Filter pages according to given filters, if any
         pages = filter_form.apply(pages, language_slug)
+
         return render(
             request,
             self.template_name,
@@ -147,5 +148,11 @@ class PageTreeView(TemplateView, PageContextMixin, MachineTranslationContextMixi
                 "filter_form": filter_form,
                 "XLIFF_EXPORT_VERSION": settings.XLIFF_EXPORT_VERSION,
                 "hix_threshold": settings.HIX_REQUIRED_FOR_MT,
+                "has_pages_in_translation": PageTranslation.objects.filter(
+                    page__in=request.region.non_archived_pages,
+                    language=language,
+                    currently_in_translation=True,
+                ).count()
+                > 0,
             },
         )

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -6746,7 +6746,7 @@ msgstr "Neue Seite erstellen"
 msgid "Translation in progress"
 msgstr "Übersetzung wird durchgeführt"
 
-#: cms/templates/pages/page_form.html
+#: cms/templates/pages/page_form.html cms/templates/pages/page_tree.html
 msgid "Cancel translation process"
 msgstr "Übersetzungsprozess abbrechen"
 
@@ -9243,6 +9243,14 @@ msgid "Page was successfully deleted"
 msgstr "Seite wurde erfolgreich gelöscht"
 
 #: cms/views/pages/page_actions.py
+msgid "Page \"{}\" does not have a translation for language \"{}\""
+msgstr "Die Seite \"{}\" hat keine Übersetzung für die Sprache \"{}\""
+
+#: cms/views/pages/page_actions.py
+msgid "Cancelled translation process for page \"{}\" and language \"{}\""
+msgstr "Übersetzungsprozess für Seite \"{}\" und Sprache \"{}\" abgebrochen"
+
+#: cms/views/pages/page_actions.py
 msgid "File \"{}\" is neither a ZIP archive nor an XLIFF file."
 msgstr "Die Datei \"{}\" ist weder ein ZIP-Archiv noch eine XLIFF-Datei."
 
@@ -9293,6 +9301,47 @@ msgid "XLIFF file for translation to selected languages successfully created."
 msgstr ""
 "XLIFF Datei für die Übersetzung in die ausgewählten Sprachen wurde "
 "erfolgreich erstellt."
+
+#: cms/views/pages/page_bulk_actions.py
+#, python-brace-format
+msgid "{model_name} {object_names} was not in translation process."
+msgid_plural ""
+"The following {model_name_plural} were not in translation process: "
+"{object_names}"
+msgstr[0] "{model_name} {object_names} war nicht im Übersetzungsprozess"
+msgstr[1] ""
+"Die folgenden {model_name_plural} waren nicht im Übersetzungsprozess: "
+"{object_names}"
+
+#: cms/views/pages/page_bulk_actions.py
+#, python-brace-format
+msgid ""
+"Translation process was successfully cancelled for {model_name} "
+"{object_names}."
+msgid_plural ""
+"Translation process was successfully cancelled for the following "
+"{model_name_plural}: {object_names}"
+msgstr[0] ""
+"Der Übersetzungsprozess für {model_name} {object_names} wurde erfolgreich "
+"abgebrochen."
+msgstr[1] ""
+"Der Übersetzungsprozess für die folgenden {model_name_plural} wurde "
+"erfolgreich abgebrochen: {object_names}."
+
+#: cms/views/pages/page_bulk_actions.py
+#, python-brace-format
+msgid ""
+"Translation process could not be successfully cancelled for {model_name} "
+"{object_names}."
+msgid_plural ""
+"Translation process could not be successfully cancelled for the following "
+"{model_name_plural}: {object_names}"
+msgstr[0] ""
+"Der Übersetzungsprozess konnte nicht erfolgreich abgebrochen werden für die "
+"{model_name} {object_names}."
+msgstr[1] ""
+"Der Übersetzungsprozess für die folgenden {model_name_plural} wurde "
+"erfolgreich abgebrochen: {object_names}"
 
 #: cms/views/pages/page_context_mixin.py
 msgid "Please confirm that you really want to archive this page"
@@ -10299,6 +10348,11 @@ msgstr ""
 "Diese Seite konnte nicht importiert werden, da sie zu einer anderen Region "
 "gehört ({})."
 
+#~ msgid "\"{} {}\" was not in translation process."
+#~ msgid_plural "The following \"{}\" were not in translation process: \"{}\""
+#~ msgstr[0] "\"{} {}\" war nicht im Überestzungsprozess"
+#~ msgstr[1] "Die folgenden\"{} {}\" waren nicht im Übersetzungsprozess"
+
 #~ msgid "Contents"
 #~ msgstr "Inhalte"
 
@@ -10307,6 +10361,16 @@ msgstr ""
 
 #~ msgid "Loading process for this row is still ongoing."
 #~ msgstr "Der Ladevorgang für diese Zeile ist noch nicht abgeschlossen."
+
+#~ msgid ""
+#~ "Cancelled translation process for page \"{page}\" and language "
+#~ "\"{page_translation.language}\""
+#~ msgstr ""
+#~ "Überestzungsprozess für Seite \"{page}\" und Sprache \"{page_translation."
+#~ "language}\" abgebrochen"
+
+#~ msgid "You cannot translate into the default language"
+#~ msgstr "Sie können nicht in die Standard-Sprache übersetzen"
 
 #~ msgid "Find more information about this"
 #~ msgstr "Mehr Informationen finden Sie"
@@ -10737,9 +10801,6 @@ msgstr ""
 
 #~ msgid "File is hidden:"
 #~ msgstr "Datei ist verborgen:"
-
-#~ msgid "You cannot translate into the default language"
-#~ msgstr "Sie können nicht in die Standard-Sprache übersetzen"
 
 #~ msgid "Barrier free"
 #~ msgstr "Barrierefrei"
@@ -12362,9 +12423,6 @@ msgstr ""
 
 #~ msgid "POI Translation was successfully created and published."
 #~ msgstr "POI Übersetzung wurde erfolgreich erstellt und veröffentlicht."
-
-#~ msgid "POI Translation was successfully created."
-#~ msgstr "POI Übersetzung wurde erfolgreich erstellt."
 
 #~ msgid "POI Translation was successfully published."
 #~ msgstr "POI Übersetzung wurde erfolgreich veröffentlicht."

--- a/integreat_cms/release_notes/current/unreleased/2865.yml
+++ b/integreat_cms/release_notes/current/unreleased/2865.yml
@@ -1,0 +1,2 @@
+en: Bulk action for canceling translation process
+de: Mehrfachaktion zum abbrechen vom Übersetzungsprozess


### PR DESCRIPTION
### Short description
Add bulk action to reset translation status after exporting pages as XLIFF but rejecting the translation offer.


### Proposed changes

- Add bulk action that only shows when there are pages that are currently in translation
- Bulk action cancels translation process utilizing 'cancel_translation_process_ajax'
- Succes/Error messages are shown for every page that is cancelled


### Side effects

- Since 'cancel_translation_process_ajax' is changed to get Succes/Error Messages, other times this method is used can be affected


### Resolved issues

Fixes: #2007 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
