### PR TITLE
Fix HIX value display in the HIX widget

### DIFF
--- a/integreat_cms/cms/templates/hix_widget.html
+++ b/integreat_cms/cms/templates/hix_widget.html
@@ -28,7 +28,7 @@
             </div>
             <div id="hix-container"
                  data-content-changed
-                 data-initial-hix-score="{{ page_translation_form.instance.rounded_hix_score }}"
+                 data-initial-hix-score="{{ page_translation_form.instance.rounded_hix_score|safe }}"
                  data-initial-hix-feedback="{{ page_translation_form.instance.hix_feedback }}">
                 <div id="hix-bar">
                     <span id="hix-bar-fill">

--- a/integreat_cms/release_notes/current/unreleased/2853.yml
+++ b/integreat_cms/release_notes/current/unreleased/2853.yml
@@ -1,0 +1,2 @@
+en: Fix HIX value display in the HIX widget
+de: Korrigiere die Darstellung des HIX-Wertes im HIX-Widget


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the problem that HIX score in the hix widget was shown with decimals cut off if German is chosen in the settings (form example, 14 instead of 14, 99). 

### Proposed changes
<!-- Describe this PR in more detail. -->
- No change in the calculation logic
- Replace `,` to `.` so `parseFloat` works well.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- HIX score is shown with `.` even in German (Currenlty in German 14,99 with comma, but now 14.99 with point). If this is too bad I'll do something for that 😅 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2853 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
