### PR TITLE
Add LTR marker to `notranslate` texts and do not translate phone numbers

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/2854.yml
+++ b/integreat_cms/release_notes/current/unreleased/2854.yml
@@ -1,0 +1,2 @@
+en: Prevent phone numbers from being rearranged in RTL languages
+de: Verhindere, dass Telefonnummern in RTL Sprachen umgruppiert werden

--- a/integreat_cms/static/src/css/tinymce_custom.css
+++ b/integreat_cms/static/src/css/tinymce_custom.css
@@ -5,4 +5,6 @@
 
 [translate="no"] {
     background-color: rgb(239, 68, 68);
+    direction: ltr;
+    display: inline-block;
 }

--- a/integreat_cms/static/src/js/tinymce-plugins/autolink_tel/plugin.js
+++ b/integreat_cms/static/src/js/tinymce-plugins/autolink_tel/plugin.js
@@ -85,7 +85,10 @@
         }
         /* eslint-enable no-magic-numbers */
 
-        return [`${countryCode} (0) ${phoneNumberBody}`, `tel:${phoneNumberCallable}`];
+        return [
+            `<span class="notranslate" translate="no">${countryCode} (0) ${phoneNumberBody}</span>`,
+            `tel:${phoneNumberCallable}`,
+        ];
     };
     const parseCurrentLine = (editor, endOffset, delimiter) => {
         let end;


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Add LTR marker to `notranslate` texts and do not translate phone numbers

### Proposed changes
<!-- Describe this PR in more detail. -->

- add `dir="ltr"` to the existing `toggleNoTranslate` function
- add the wrapping `span` to phone numbers
- add class to overwrite the red background. IMO it's confusing when applied to phone numbers, esp. since it's applied automatically and might lead users to assume that something is wrong with the phone number they just entered.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2854


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
