### PR TITLE
Return fallback translations in search

### DIFF
--- a/integreat_cms/cms/models/pois/poi_translation.py
+++ b/integreat_cms/cms/models/pois/poi_translation.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
+from django.db.models import Q
 from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
@@ -12,7 +13,9 @@ from linkcheck.models import Link
 if TYPE_CHECKING:
     from typing import Literal
 
-    from .pois.poi import POI
+    from django.db.models import QuerySet
+
+    from .. import POI, Region
 
 from ...utils.translation_utils import gettext_many_lazy as __
 from ..abstract_content_translation import AbstractContentTranslation
@@ -94,6 +97,29 @@ class POITranslation(AbstractContentTranslation):
                 "region_slug": self.poi.region.slug,
             },
         )
+
+    @classmethod
+    def search(cls, region: Region, language_slug: str, query: str) -> QuerySet:
+        """
+        Searches for all content translations which match the given `query` in their title or slug.
+        :param region: The current region
+        :param language_slug: The language slug
+        :param query: The query string used for filtering the content translations
+        :return: A query for all matching objects
+        """
+        queryset = super().search(region, language_slug, query)
+
+        if region.fallback_translations_enabled:
+            default_language_queryset = (
+                super()
+                .search(region, region.default_language.slug, query)
+                .exclude(poi__translations__language__slug=language_slug)
+            )
+            queryset = cls.objects.filter(
+                Q(id__in=queryset) | Q(id__in=default_language_queryset)
+            )
+
+        return queryset
 
     class Meta:
         #: The verbose name of the model

--- a/integreat_cms/release_notes/current/unreleased/1639.yml
+++ b/integreat_cms/release_notes/current/unreleased/1639.yml
@@ -1,0 +1,2 @@
+en: Enable dynamic linking to fallback translations
+de: Erlaube das Verlinken von Fallback-Übersetzungen


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr modifies the search of pois and events to include fallback translations.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Additionally search for objects in the default language and include them in the result if they don't have a translation in the requested language
- In search_ajax, check if the translation matches the expected language, and if not, use its fallback translation


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- The generated SQL query looks a bit scary :eyes:
- This implementation does not make use of the `fallback_translation_enabled` property and thus adds a bit of overhead if we decide to change for which objects fallback translations are enabled
- Since the `search` method is used in other places too, these will now receive results that are potentially not in the request language. AFAIK this only affects the search functionality of the filter form and I think it is a nice improvement that it is now possible to search for fallback translations there too.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1639


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
