### PR TITLE
Configure dependabot for devcontainer, pip and npm

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
-# Keep GitHub Actions up to date with GitHub's Dependabot.
-# https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot
-# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem
+# Keep dependencies up to date with GitHub's Dependabot.
+# https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates
+
 version: 2
 updates:
   - package-ecosystem: github-actions
@@ -8,6 +8,33 @@ updates:
     groups:
       github-actions:
         patterns:
-          - "*" # Group all Actions updates into a single larger pull request
+          - "*"
     schedule:
-      interval: weekly
+      interval: monthly
+
+  - package-ecosystem: npm
+    directory: "/"
+    groups:
+      frontend:
+        patterns:
+          - "*"
+    schedule:
+      interval: monthly
+
+  - package-ecosystem: pip
+    directory: "/"
+    groups:
+      python:
+        patterns:
+          - "*"
+    schedule:
+      interval: monthly
+
+  - package-ecosystem: devcontainers
+    directory: "/"
+    groups:
+      devcontainers:
+        patterns:
+          - "*"
+    schedule:
+      interval: monthly

--- a/docs/src/documentation.rst
+++ b/docs/src/documentation.rst
@@ -50,7 +50,7 @@ Cross-referencing
 =================
 
 Whenever you want to reference another module, class or function inside a static documentation page or within a
-docstring, use the according :doc:`sphinx:usage/domains/index` and have a look at :ref:`sphinx:python-xref-roles`.
+docstring, use the according :doc:`sphinx:usage/restructuredtext/domains` and have a look at :ref:`sphinx:python-xref-roles`.
 
 Example:
 ``:class:`~integreat_cms.cms.models.regions.region.Region``` becomes :class:`~integreat_cms.cms.models.regions.region.Region`


### PR DESCRIPTION
### Short description

This pull request extends the existing dependabot configuration by adding support for `devcontainers`, `pip`, and `npm`. Dependabot is a tool that continuously monitors our repository for available updates across various ecosystems. It automatically creates weekly pull requests to update dependencies, organized by their respective ecosystems.

### Resolved issues
Fixes: #2812 #2347


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
