### PR TITLE
Add link checker to the `to-do-board`

### DIFF
--- a/integreat_cms/cms/templates/dashboard/_todo_dashboard_row.html
+++ b/integreat_cms/cms/templates/dashboard/_todo_dashboard_row.html
@@ -1,15 +1,24 @@
 {% load i18n %}
-<div class="flex justify-between border-t-2 border-zinc-600 p-4 w-full">
+{% load tagifnotempty %}
+<div class="flex justify-between w-full p-4 border-t-2 border-zinc-600"
+     {% filter tagifnotempty:'data-url' %}
+     {% block todo_dashboard_ajax_url %}
+     {% endblock todo_dashboard_ajax_url %}
+     {% endfilter %}
+     {% filter tagifnotempty:'id' %}
+     {% block todo_dashboard_id %}
+     {% endblock todo_dashboard_id %}
+     {% endfilter %}>
     <div class="flex items-center basis-full">
         <div class="mr-6">
-            <i class="h-8 w-8"
+            <i class="w-8 h-8"
                icon-name="{% spaceless %}{% block todo_dashboard_icon %}{% endblock todo_dashboard_icon %}{% endspaceless %}"></i>
         </div>
         <div>
             {# djlint:off #}<a href="{% spaceless %}{% block todo_dashboard_title_link %}{% endblock todo_dashboard_title_link %}{% endspaceless %}"
-            class="text-blue-500 font-bold underline">{% spaceless %}{% block todo_dashboard_title %}{% endblock todo_dashboard_title %}{% endspaceless %}</a>{# djlint:on #}
+            class="font-bold text-blue-500 underline">{% spaceless %}{% block todo_dashboard_title %}{% endblock todo_dashboard_title %}{% endspaceless %}</a>{# djlint:on #}
             {% block todo_dashboard_number %}
-                <span>({% translate "in total" %} {{ total }})</span>
+                <span class="total-results">({% translate "in total" %} <span>{{ total }}</span>)</span>
             {% endblock todo_dashboard_number %}
             <p>
                 {% block todo_dashboard_description %}
@@ -17,7 +26,7 @@
             </p>
         </div>
     </div>
-    <div class="flex items-center text-center whitespace-nowrap ml-6 justify-center w-48">
+    <div class="flex items-center justify-center w-48 ml-6 text-center whitespace-nowrap">
         {% block todo_dashboard_button_link %}
         {% endblock todo_dashboard_button_link %}
     </div>

--- a/integreat_cms/cms/templates/dashboard/_todo_dashboard_widget.html
+++ b/integreat_cms/cms/templates/dashboard/_todo_dashboard_widget.html
@@ -13,11 +13,9 @@
                 Every day you can find a list of ideas on how you can improve the content of your pages.
             {% endblocktranslate %}
         </p>
-        {% comment "Temporarily disable linkcheck widget for performance reasons" %}
         {% if perms.cms.change_page and perms.cms.view_broken_links %}
             {% include "dashboard/todo_dashboard_rows/_broken_links_row.html" %}
         {% endif %}
-        {% endcomment %}
         {% if perms.cms.change_page %}
             {% include "dashboard/todo_dashboard_rows/_outdated_pages_row.html" %}
         {% endif %}

--- a/integreat_cms/cms/templates/dashboard/todo_dashboard_rows/_broken_links_row.html
+++ b/integreat_cms/cms/templates/dashboard/todo_dashboard_rows/_broken_links_row.html
@@ -1,5 +1,11 @@
 {% extends "../_todo_dashboard_row.html" %}
 {% load i18n %}
+{% block todo_dashboard_ajax_url %}
+    {{ broken_link_ajax }}
+{% endblock todo_dashboard_ajax_url %}
+{% block todo_dashboard_id %}
+    broken-links
+{% endblock todo_dashboard_id %}
 {% block todo_dashboard_icon %}
     link
 {% endblock todo_dashboard_icon %}
@@ -10,28 +16,36 @@
     {% translate "Broken links" %}
 {% endblock todo_dashboard_title %}
 {% block todo_dashboard_number %}
-    {% with total=broken_links|length %}
+    {% with total="?" %}
         {{ block.super }}
     {% endwith %}
 {% endblock todo_dashboard_number %}
 {% block todo_dashboard_description %}
-    {% if broken_links %}
+    <div class="hidden todo-message">
+        {# djlint:off #}
         {% blocktranslate trimmed %}
-            The page <b>{{ relevant_translation }}</b> has a broken link. Please replace it by a functional link.
+            The page <b></b> has a broken link. Please replace it by a functional link.
         {% endblocktranslate %}
-    {% else %}
+        {# djlint:on #}
+    </div>
+    <div class="hidden success-message">
         {% blocktranslate trimmed %}
             At the moment there are no broken links. Good job!
         {% endblocktranslate %}
-    {% endif %}
+    </div>
+    <div class="waiting-message">
+        {% blocktranslate trimmed %}
+            Loading...
+        {% endblocktranslate %}
+    </div>
 {% endblock todo_dashboard_description %}
 {% block todo_dashboard_button_link %}
-    {% if broken_links %}
-        <a class="btn !rounded-full"
-           href="{% url 'edit_url' region_slug=request.region.slug url_filter='invalid' url_id=relevant_url.id %}#replace-url">
+    <div class="hidden todo-button">
+        <a class="btn !rounded-full" href="">
             {% translate "Go to link" %}
         </a>
-    {% else %}
-        <i class="h-8 w-8 text-green-500" icon-name="check-circle-2"></i>
-    {% endif %}
+    </div>
+    <div class="hidden success-icon">
+        <i class="w-8 h-8 text-green-500" icon-name="check-circle-2"></i>
+    </div>
 {% endblock todo_dashboard_button_link %}

--- a/integreat_cms/cms/templatetags/tagifnotempty.py
+++ b/integreat_cms/cms/templatetags/tagifnotempty.py
@@ -1,0 +1,18 @@
+from django import template
+from django.template.defaultfilters import stringfilter
+from django.utils.safestring import SafeString
+
+register = template.Library()
+
+
+@register.filter
+@stringfilter
+def tagifnotempty(value: SafeString, args: SafeString) -> str:
+    """
+    Helper function for template to display property if it's not left empty
+    :param value: url where that is being investigated
+    :param args: properties that might be left empty
+    :return: Correctly formatted properties
+    """
+    value = value.strip()
+    return f'{str(args)}="{value}"' if value else value

--- a/integreat_cms/cms/urls/protected.py
+++ b/integreat_cms/cms/urls/protected.py
@@ -524,6 +524,18 @@ urlpatterns: list[URLPattern] = [
                     "ajax/",
                     include(
                         [
+                            path(
+                                "dashboard/",
+                                include(
+                                    [
+                                        path(
+                                            "broken-links/",
+                                            dashboard.DashboardView.get_broken_links_context,
+                                            name="get_broken_links_ajax",
+                                        )
+                                    ]
+                                ),
+                            ),
                             path("", include(media_ajax_urlpatterns)),
                             path(
                                 "<slug:language_slug>/",

--- a/integreat_cms/cms/views/dashboard/dashboard_view.py
+++ b/integreat_cms/cms/views/dashboard/dashboard_view.py
@@ -7,9 +7,12 @@ from typing import TYPE_CHECKING
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.db.models import Q, Subquery
+from django.http import JsonResponse
+from django.urls import reverse
 from django.utils import translation
 from django.views.generic import TemplateView
 
+from ....api.decorators import json_response
 from ...constants import status
 from ...models import Feedback, PageTranslation
 from ...utils.linkcheck_utils import filter_urls
@@ -19,6 +22,7 @@ if TYPE_CHECKING:
     from typing import Any
 
     from django.db.models.query import QuerySet
+    from django.http import HttpRequest
     from linkcheck.models import Url
 
     from ...models.abstract_content_translation import AbstractContentTranslation
@@ -56,14 +60,16 @@ class DashboardView(TemplateView, ChatContextMixin):
                 "feed_url": settings.RSS_FEED_URLS.get(
                     language_slug, settings.DEFAULT_RSS_FEED_URL
                 ),
+                "broken_link_ajax": reverse(
+                    "get_broken_links_ajax",
+                    kwargs={"region_slug": self.request.region.slug},
+                ),
             }
         )
 
         context.update(self.get_unreviewed_pages_context())
         context.update(self.get_automatically_saved_pages())
         context.update(self.get_unread_feedback_context())
-        # Temporarily disable linkcheck todo for performance reasons
-        # context.update(self.get_broken_links_context())
         context.update(self.get_low_hix_value_context())
         context.update(self.get_outdated_pages_context())
         context.update(self.get_drafted_pages())
@@ -140,26 +146,43 @@ class DashboardView(TemplateView, ChatContextMixin):
             "unread_feedback": unread_feedback,
         }
 
+    @json_response
+    # pylint: disable=unused-argument, disable=no-self-argument
     def get_broken_links_context(
-        self,
-    ) -> dict[str, list[Url] | Url | AbstractContentTranslation]:
+        request: HttpRequest, region_slug: str
+    ) -> JsonResponse:
         r"""
         Extend context by info on broken links
 
         :return: Dictionary containing the context for broken links
         """
-        invalid_urls = filter_urls(self.request.region.slug, "invalid")[0]
+        invalid_urls = filter_urls(request.region.slug, "invalid")[0]
         invalid_url = invalid_urls[0] if invalid_urls else None
 
         relevant_translation = (
             invalid_url.region_links[0].content_object if invalid_url else None
         )
 
-        return {
-            "broken_links": invalid_urls,
-            "relevant_translation": relevant_translation,
-            "relevant_url": invalid_url,
-        }
+        edit_url = (
+            reverse(
+                "edit_url",
+                kwargs={
+                    "region_slug": request.region.slug,
+                    "url_filter": "invalid",
+                    "url_id": invalid_url.pk,
+                },
+            )
+            if invalid_url
+            else ""
+        )
+
+        return JsonResponse(
+            data={
+                "broken_links": len(invalid_urls),
+                "relevant_translation": str(relevant_translation),
+                "edit_url": f"{edit_url}#replace-url" if len(edit_url) > 0 else "",
+            }
+        )
 
     def get_low_hix_value_context(self) -> dict[str, list[PageTranslation]]:
         r"""

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -4714,7 +4714,9 @@ msgid "Please contact the administrator."
 msgstr "Bitte kontaktieren Sie eine:n Administrator:in."
 
 #: cms/templates/analytics/_broken_links_widget.html
-#: cms/templates/dashboard/_news_widget.html cms/templates/hix_widget.html
+#: cms/templates/dashboard/_news_widget.html
+#: cms/templates/dashboard/todo_dashboard_rows/_broken_links_row.html
+#: cms/templates/hix_widget.html
 #: cms/templates/pois/poi_form_sidebar/position_box.html
 #: cms/templates/statistics/_statistics_widget.html
 #: cms/templates/statistics/statistics_overview.html
@@ -5170,13 +5172,11 @@ msgid "Broken links"
 msgstr "Fehlerhafte Links"
 
 #: cms/templates/dashboard/todo_dashboard_rows/_broken_links_row.html
-#, python-format
 msgid ""
-"The page <b>%(relevant_translation)s</b> has a broken link. Please replace "
-"it by a functional link."
+"The page <b></b> has a broken link. Please replace it by a functional link."
 msgstr ""
-"Auf der Seite <b>%(relevant_translation)s</b> befindet sich ein fehlerhafter "
-"Link. Tauschen Sie diesen bitte aus."
+"Auf der Seite <b></b> befindet sich ein fehlerhafter Link. Tauschen Sie "
+"diesen bitte aus."
 
 #: cms/templates/dashboard/todo_dashboard_rows/_broken_links_row.html
 msgid "At the moment there are no broken links. Good job!"
@@ -10259,6 +10259,9 @@ msgid "This page belongs to another region ({})."
 msgstr ""
 "Diese Seite konnte nicht importiert werden, da sie zu einer anderen Region "
 "gehört ({})."
+
+#~ msgid "Loading process for this row is still ongoing."
+#~ msgstr "Der Ladevorgang für diese Zeile ist noch nicht abgeschlossen."
 
 #~ msgid "Find more information about this"
 #~ msgstr "Mehr Informationen finden Sie"

--- a/integreat_cms/release_notes/2024/2024.7.0/2824.yml
+++ b/integreat_cms/release_notes/2024/2024.7.0/2824.yml
@@ -1,0 +1,2 @@
+en: Add link checker row to todo-dashboard
+de: Füge Zeile für fehlerhafte Links zum ToDo-Dashboard hinzu

--- a/integreat_cms/static/src/index.ts
+++ b/integreat_cms/static/src/index.ts
@@ -102,6 +102,7 @@ import "./js/pois/opening-hours/index";
 import "./js/menu";
 
 import "./js/poi-categories/poicategory-colors-icons";
+import "./js/dashboard/broken-links";
 
 // IE11: fetch
 /* eslint-disable-next-line @typescript-eslint/no-var-requires */

--- a/integreat_cms/static/src/js/dashboard/broken-links.ts
+++ b/integreat_cms/static/src/js/dashboard/broken-links.ts
@@ -1,0 +1,75 @@
+import { getCsrfToken } from "../utils/csrf-token";
+
+type Content = {
+    broken_links: number;
+    relevant_translation: string;
+    edit_url: string;
+};
+
+const getContent = async (url: string): Promise<Content> => {
+    const response = await fetch(url, {
+        method: "POST",
+        headers: {
+            "X-CSRFToken": getCsrfToken(),
+        },
+    });
+    return response.json();
+};
+
+window.addEventListener("load", async () => {
+    const brokenLinksElement = document.getElementById("broken-links");
+
+    if (!brokenLinksElement) {
+        return;
+    }
+
+    const url = brokenLinksElement.dataset.url;
+    const hideWaitingMessage = () => {
+        brokenLinksElement.querySelector(".waiting-message").classList.add("hidden");
+    };
+
+    const showSuccessMessage = () => {
+        brokenLinksElement.querySelector(".success-message").classList.remove("hidden");
+    };
+
+    const showSuccessIcon = () => {
+        brokenLinksElement.querySelector(".success-icon").classList.remove("hidden");
+    };
+
+    const showDescription = (affectedPageTitle: string) => {
+        brokenLinksElement.querySelector(".todo-message").classList.remove("hidden");
+        (brokenLinksElement.querySelector(".todo-message b") as HTMLElement).innerText = affectedPageTitle;
+    };
+
+    const showNumberOfPagesElement = () => {
+        brokenLinksElement.querySelector(".total-results").classList.remove("hidden");
+    };
+
+    const updateNumberOfPages = (numberOfPages: number) => {
+        (brokenLinksElement.querySelector(".total-results span") as HTMLElement).innerText = numberOfPages.toString();
+    };
+
+    const setLink = (editURL: string) => {
+        (brokenLinksElement.querySelector(".todo-button a") as HTMLAnchorElement).href = editURL;
+    };
+
+    const showButton = (editURL: string) => {
+        brokenLinksElement.querySelector(".todo-button").classList.remove("hidden");
+        setLink(editURL);
+    };
+
+    if (url) {
+        const json = await getContent(url);
+        hideWaitingMessage();
+        showNumberOfPagesElement();
+        if (json.broken_links > 0) {
+            showDescription(json.relevant_translation);
+            updateNumberOfPages(json.broken_links);
+            showButton(json.edit_url);
+        } else {
+            showSuccessMessage();
+            showSuccessIcon();
+            updateNumberOfPages(0);
+        }
+    }
+});

--- a/tests/cms/views/dashboard/test_dashboard.py
+++ b/tests/cms/views/dashboard/test_dashboard.py
@@ -169,7 +169,7 @@ def test_number_of_outdated_pages_is_correct(
 
     assert response.status_code == 200
     match = re.search(
-        rf'<a href="{pages}\?(|[^"]+&)exclude_pages_without_content=on(|&[^"]+)"[^<>]*>Veraltete Seiten</a>\s*<span>\(Insgesamt ([0-9]+)\)</span>',
+        rf'<a href="{pages}\?(|[^"]+&)exclude_pages_without_content=on(|&[^"]+)"[^<>]*>Veraltete Seiten</a>\s*<span[^>]*>\(Insgesamt <span>([0-9]+)</span>\)</span>',
         response.content.decode("utf-8"),
     )
     assert match, "Number of outdated pages not displayed"
@@ -267,7 +267,7 @@ def test_number_of_drafted_pages_is_correct(
 
     assert response.status_code == 200
     match = re.search(
-        rf'<a href="{pages}\?(|[^"]+&)status=DRAFT(|&[^"]+)"[^<>]*>Seiten im Entwurf</a>\s*<span>\(Insgesamt ([0-9]+)\)</span>',
+        rf'<a href="{pages}\?(|[^"]+&)status=DRAFT(|&[^"]+)"[^<>]*>Seiten im Entwurf</a>\s*<span[^>]*>\(Insgesamt <span>([0-9]+)</span>\)</span>',
         response.content.decode("utf-8"),
     )
     assert match, "Number of drafted pages not displayed"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds an AJAX call for the link checker row on our To-Do-Board in order to hopefully increase the loading times so we can enable the row on our system.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add an AJAX call for the broken link context
- Add additional optional properties to the HTML template


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- The loading times were normal for 1200+ pages in one region (but only 7 regions and not a lot of pages in the other regions). Is there a way to test this more reliably before merging it and testing it on the test system? 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2824


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
