### PR TITLE
Fix blocked HIX request

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/2893.yml
+++ b/integreat_cms/release_notes/current/unreleased/2893.yml
@@ -1,0 +1,2 @@
+en: Fix blocked HIX request
+de: Behebe blockierte HIX-Anfrage

--- a/integreat_cms/textlab_api/textlab_api_client.py
+++ b/integreat_cms/textlab_api/textlab_api_client.py
@@ -95,5 +95,6 @@ class TextlabClient:
         if auth_token:
             request.add_header("authorization", f"Bearer {auth_token}")
         request.add_header("Content-Type", "application/json")
+        request.add_header("User-Agent", "")
         with urlopen(request) as response:
             return json.loads(response.read().decode("utf-8"))


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR wants to solve the problem that HIX feature is currently not working in Integreat (and in Malte too?).

So far as I googled, the value which will be set as `User-Agent` to requests without `User-Agent` setting in the header, is causing TextLab to reject our requests
 

### Proposed changes
<!-- Describe this PR in more detail. -->
- Set `User-Agent` into the header


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- None?
- Suggestion for a better value setting for `User-Agent` will be welcomed :)


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2893 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
