### PR TITLE
Attach region as analytics label to fcm call

### DIFF
--- a/integreat_cms/firebase_api/firebase_api_client.py
+++ b/integreat_cms/firebase_api/firebase_api_client.py
@@ -17,7 +17,6 @@ from ..cms.forms.push_notifications.push_notification_translation_form import (
 from ..cms.models import Region
 
 if TYPE_CHECKING:
-
     from ..cms.models.push_notifications.push_notification import PushNotification
 
 logger = logging.getLogger(__name__)
@@ -135,7 +134,9 @@ class FirebaseApiClient:
                 "android": {
                     "ttl": "86400s",
                 },
-                "fcm_options": {"analytics_label": region.slug},
+                "fcm_options": {
+                    "analytics_label": f"{region.slug}-{pnt.language.slug}"
+                },
             },
         }
         headers = {

--- a/integreat_cms/firebase_api/firebase_api_client.py
+++ b/integreat_cms/firebase_api/firebase_api_client.py
@@ -135,6 +135,7 @@ class FirebaseApiClient:
                 "android": {
                     "ttl": "86400s",
                 },
+                "fcm_options": {"analytics_label": region.slug},
             },
         }
         headers = {


### PR DESCRIPTION
### Short description
To implement ticket #589 and display the number of users who will be reached by a notification (news), I've added the region as an analytics label to all Firebase Cloud Messaging (FCM) calls. The original plan was to call an API that returns the count of subscribed devices per Firebase topic. Unfortunately, Firebase does not offer such an API.

By adding the analytics label, we can leverage the [Firebase Cloud Messaging Data API](https://firebase.google.com/docs/reference/fcmdata/rest) to get an approximate number of delivered messages per topic. It will take some time for users on the live system to send push notifications, and for the API to deliver real data grouped by the analytics label.

Therefore, I propose merging this pull request first so that I can work on the analytics aspect in parallel and hopefully test with real data before merging the next pull request.

##### Resources
- [Blog Post about Analytics Label](https://firebase.blog/posts/2021/09/analytics-labels-app-messaging-campaigns/)
- [Firebase Cloud Messaging Data API](https://firebase.google.com/docs/reference/fcmdata/rest)


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
