### PR TITLE
Add `.sh` tool to load database dump

### DIFF
--- a/docs/src/tools.rst
+++ b/docs/src/tools.rst
@@ -63,6 +63,10 @@ Delete all database content with :github-source:`tools/prune_database.sh`::
 
     ./tools/prune_database.sh
 
+Load database dump with :github-source:`tools/prune_database.sh`::
+
+    ./tools/load_database_dump.sh
+
 
 .. _translations:
 

--- a/tools/load_database_dump.sh
+++ b/tools/load_database_dump.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# This script can be used to load downloaded database dump.
+
+# Import utility functions
+# shellcheck source=./tools/_functions.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_functions.sh"
+require_installed
+
+SQL_DATA_PATH=$1
+
+bash "${DEV_TOOL_DIR}/prune_database.sh"
+
+docker run -d --name "${DOCKER_CONTAINER_NAME}" -e "POSTGRES_USER=integreat" -e "POSTGRES_PASSWORD=password" -e "POSTGRES_DB=integreat" -v "${BASE_DIR}/.postgres:/var/lib/postgresql" -p "${INTEGREAT_CMS_DOCKER_LISTEN_PORT}":"${INTEGREAT_CMS_DB_PORT}" postgres > /dev/null
+wait_for_docker_container
+
+docker exec -i "${DOCKER_CONTAINER_NAME}" psql -U integreat < "${SQL_DATA_PATH}"
+
+bash "${DEV_TOOL_DIR}/migrate.sh"
+
+bash "${DEV_TOOL_DIR}/create_superuser.sh"
+
+echo -e "✔ Done😻" | print_success
+echo -e "Use ./tools/run.sh as always" | print_info


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
It seems we will need more and more often testing with database dump, so I would like to share this small tool I made after forgetting how to do it and comming back to the instruction again and again.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Gather all the steps in [this instruction](https://github.com/digitalfabrik/integreat-cms/pull/2832#issuecomment-2182293775)

- Use it just like other tools with the path to the extracted SQL data. Ex: `./tools/load_database_dump.sh ../integreat-2024-05-25.sql`

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- The error `rm: cannot remove '/home/xxxxxxx/integreat-cms/.postgres/data': Permission denied` will appear. You can just use `sudo rm -r .postgres/data`. If you know how to overcome this inconvenience, let me know please in the review 👀 
- I'm not familier with thema Docker etc and not sure whether this tool can work in others' environment.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: # (related to #2516 )


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
