### PR TITLE
Deactivate PDF export for some languages

### DIFF
--- a/example-configs/integreat-cms.ini
+++ b/example-configs/integreat-cms.ini
@@ -187,3 +187,7 @@ GOOGLE_CREDENTIALS = <path-to-credential-json>
 GOOGLE_PROJECT_ID = <project-id>
 # Location
 GOOGLE_TRANSLATE_LOCATION = <location>
+
+[xhtml2pdf]
+# Slugs of languages for which PDF export should be deactivated
+PDF_DEACTIVATED_LANGUAGES = <pdf-deactivated-languages>

--- a/integreat_cms/cms/models/languages/language.py
+++ b/integreat_cms/cms/models/languages/language.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from cacheops import invalidate_obj
+from django.conf import settings
 from django.core.validators import MinLengthValidator
 from django.db import models
 
@@ -191,6 +192,15 @@ class Language(AbstractBaseModel):
             language_tree_nodes__active=True,
             language_tree_nodes__visible=True,
         )
+
+    @cached_property
+    def can_be_pdf_exported(self) -> bool:
+        """
+        Returns whether PDF export is allowed for the language
+
+        :return: whether PDF export is allowed for the language
+        """
+        return self.slug not in settings.PDF_DEACTIVATED_LANGUAGES
 
     def save(self, *args: Any, **kwargs: Any) -> None:
         r"""

--- a/integreat_cms/cms/templates/pages/page_tree.html
+++ b/integreat_cms/cms/templates/pages/page_tree.html
@@ -193,12 +193,19 @@
                         </option>
                     {% endif %}
                 {% endif %}
-                <option id="pdf-export-option"
-                        data-bulk-action="{% url 'export_pdf' region_slug=request.region.slug language_slug=language.slug %}"
-                        data-target="_blank"
-                        data-language-slug="{{ language.slug }}">
-                    {% translate "Export published pages as PDF" %}
-                </option>
+                {% if language.can_be_pdf_exported %}
+                    <option id="pdf-export-option"
+                            data-bulk-action="{% url 'export_pdf' region_slug=request.region.slug language_slug=language.slug %}"
+                            data-target="_blank"
+                            data-language-slug="{{ language.slug }}">
+                        {% translate "Export published pages as PDF" %}
+                    </option>
+                {% else %}
+                    <option disabled
+                            title="{% translate "Currently PDF-Export is not available in this language." %}">
+                        {% translate "Export published pages as PDF" %}
+                    </option>
+                {% endif %}
                 {% if request.user.expert_mode %}
                     {% with language_translated_name=language.translated_name %}
                         {% blocktranslate trimmed asvar xliff_export_public %}

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -1250,6 +1250,12 @@ PDF_ROOT: Final[str] = os.environ.get(
 PDF_URL: Final[str] = "/pdf/"
 
 
+#: Slugs of languages for which PDF export should be deactivated
+PDF_DEACTIVATED_LANGUAGES: Final[str | list[str]] = os.environ.get(
+    "INTEGREAT_CMS_PDF_DEACTIVATED_LANGUAGES", []
+)
+
+
 #######################
 # XLIFF SERIALIZATION #
 #######################

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -6960,6 +6960,10 @@ msgid "Export published pages as PDF"
 msgstr "Veröffentlichte Seiten als PDF exportieren"
 
 #: cms/templates/pages/page_tree.html
+msgid "Currently PDF-Export is not available in this language."
+msgstr "Derzeit ist der PDF-Export in dieser Sprache nicht verfügbar."
+
+#: cms/templates/pages/page_tree.html
 #, python-format
 msgid "Export published pages for %(language_translated_name)s translation"
 msgstr ""

--- a/integreat_cms/release_notes/current/unreleased/2890.yml
+++ b/integreat_cms/release_notes/current/unreleased/2890.yml
@@ -1,0 +1,2 @@
+en: Deactivate PDF export for languages for which it is not working
+de: Deaktiviere den PDF-Export für Sprachen, für die er nicht funktioniert


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR deactivates PDF ecport for languages that are specified in the newly introuced variable `PDF_DEACTIVATED_LANGUAGES`.

I know there is an ongoing discussion about the in-browser PDF function as alternative, but opened this PR because the implementation for deactivating was already done before it started 😅 We can of course discard this if we decide for the in-browser PDF function and it can be implemented quickly, or use this as temporary bridge until it comes into the production.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add a new variable in which slugs of languages can be listed for which the PDF function should be deactivated
- Gray out the PDF bulk action if it is disabled for the current language and show an warning as tooltip


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- None?


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2890 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
