### PR TITLE
docs: fix `WARNING: undefined label: 'sphinx:python-roles'`

### DIFF
--- a/docs/src/documentation.rst
+++ b/docs/src/documentation.rst
@@ -50,7 +50,7 @@ Cross-referencing
 =================
 
 Whenever you want to reference another module, class or function inside a static documentation page or within a
-docstring, use the according :doc:`sphinx:usage/restructuredtext/domains` and have a look at :ref:`sphinx:python-roles`.
+docstring, use the according :doc:`sphinx:usage/domains/index` and have a look at :ref:`sphinx:python-xref-roles`.
 
 Example:
 ``:class:`~integreat_cms.cms.models.regions.region.Region``` becomes :class:`~integreat_cms.cms.models.regions.region.Region`


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Building docs suddenly failed with `WARNING: undefined label: 'sphinx:python-roles'` apparently caused by a restructuring (no pun intended) of the docs about sphinx itself. This was also indicated by the label `sphinx:usage/restructuredtext/domains` rendering as a link named *[MOVED: Domains](https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html)* (which was clearly not intended with the text flow), which pointed to a stub with redirections to the new location of moved content.

### Proposed changes
<!-- Describe this PR in more detail. -->

- update both labels to point to the content likely originally intended by the author of the docs


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

none


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes failing pipeline for #2904


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
