### PR TITLE
Page revision timeline rework

### DIFF
--- a/integreat_cms/cms/templates/content_versions.html
+++ b/integreat_cms/cms/templates/content_versions.html
@@ -39,7 +39,9 @@
                 <b>{% translate "Date" %}:</b> <span id="date-text">Date Info</span>
             </p>
             {% if translations.first.hix_enabled and not translations.first.hix_ignore %}
-                <b>{% translate "HIX" %}:</b> <span id="hix-text">HIX Info</span>
+                <p>
+                    <b>{% translate "HIX" %}:</b> <span id="hix-text">HIX Info</span>
+                </p>
             {% endif %}
         </div>
         {% translate "deleted account" as deleted_user_text %}

--- a/integreat_cms/cms/templates/content_versions.html
+++ b/integreat_cms/cms/templates/content_versions.html
@@ -16,11 +16,11 @@
     </div>
     <form method="post" action="{{ versions_url }}">
         {% csrf_token %}
-        <div class="w-4/5 m-auto mb-28">
+        <div class="w-full m-auto mb-28">
             <div id="version-history"
-                 class="relative w-full flex justify-between items-center font-mono">
+                 class=" w-full flex items-center font-mono overflow-x-scroll gap-16">
                 {% for translation in translations reversed %}
-                    <div class="z-10 w-8 h-8 rounded-full flex items-center justify-center timeline-item"
+                    <div class="z-10 w-8 h-8 rounded-full flex items-center justify-center timeline-item flex-shrink-0"
                          data-number="{{ translation.version }}">
                         {{ translation.version }}
                     </div>

--- a/integreat_cms/cms/templates/content_versions.html
+++ b/integreat_cms/cms/templates/content_versions.html
@@ -16,12 +16,12 @@
     </div>
     <form method="post" action="{{ versions_url }}">
         {% csrf_token %}
-        <div class="w-full m-auto mb-28 flex items-center">
+        <div class="w-full m-auto mb-28 flex items-center relative">
             <div id="button-prev" class="flex-shrink-0 px-4 version-history-control">
                 <i icon-name="chevron-left" class="w-5"></i>
             </div>
             <div id="version-history"
-                 class="flex-grow flex items-center font-mono overflow-x-scroll gap-16">
+                 class="flex-grow flex items-center font-mono overflow-x-scroll gap-16 relative">
                 {% for translation in translations reversed %}
                     <div class="z-10 w-8 h-8 rounded-full flex items-center justify-center timeline-item flex-shrink-0"
                          data-number="{{ translation.version }}">

--- a/integreat_cms/cms/templates/content_versions.html
+++ b/integreat_cms/cms/templates/content_versions.html
@@ -16,15 +16,21 @@
     </div>
     <form method="post" action="{{ versions_url }}">
         {% csrf_token %}
-        <div class="w-full m-auto mb-28">
+        <div class="w-full m-auto mb-28 flex items-center">
+            <div id="button-prev" class="flex-shrink-0 px-4 version-history-control">
+                <i icon-name="chevron-left" class="w-5"></i>
+            </div>
             <div id="version-history"
-                 class=" w-full flex items-center font-mono overflow-x-scroll gap-16">
+                 class="flex-grow flex items-center font-mono overflow-x-scroll gap-16">
                 {% for translation in translations reversed %}
                     <div class="z-10 w-8 h-8 rounded-full flex items-center justify-center timeline-item flex-shrink-0"
                          data-number="{{ translation.version }}">
                         {{ translation.version }}
                     </div>
                 {% endfor %}
+            </div>
+            <div id="button-next" class="flex-shrink-0 px-4 version-history-control">
+                <i icon-name="chevron-right" class="w-5"></i>
             </div>
         </div>
         <div id="tooltip"

--- a/integreat_cms/cms/templates/content_versions.html
+++ b/integreat_cms/cms/templates/content_versions.html
@@ -16,38 +16,31 @@
     </div>
     <form method="post" action="{{ versions_url }}">
         {% csrf_token %}
-        <div class="w-3/5 m-auto mb-28 relative">
-            <input class="relative z-10 pt-1"
-                   type="range"
-                   name="revision"
-                   min="1"
-                   max="{{ translations|length }}"
-                   value="{{ selected_version.version }}"
-                   id="revision-slider"
-                   list="steplist" />
-            <output id="revision-info" class="whitespace-nowrap">
-                <b>{% translate "Version" %}:</b> <span id="revision-number"></span>
-                <br />
-                <b>{% translate "Author" %}:</b> <span id="revision-editor"></span>
-                <br />
-                <b>{% translate "Date" %}:</b> <span id="revision-date"></span>
-                {% if translations.first.hix_enabled and not translations.first.hix_ignore %}
-                    <br />
-                    <b>{% translate "HIX" %}:</b> <span id="revision-hix"></span>
-                {% endif %}
-            </output>
-            <datalist id="steplist" class="w-full flex font-mono">
+        <div class="w-4/5 m-auto mb-28">
+            <div id="version-history"
+                 class="relative w-full flex justify-between items-center font-mono">
                 {% for translation in translations reversed %}
-                    <option style="{% if translation.version > 1 %} margin-left: -webkit-calc(((100% - 25.6px) / ({{ translations|length }} - 1)) - 25.6px);
-                                   margin-left: -moz-calc(((100% - 25.6px) / ({{ translations|length }} - 1)) - 25.6px);
-                                   margin-left: calc(((100% - 25.6px) / ({{ translations|length }} - 1)) - 25.6px);
-                                   {% endif %} {% if translation.version > 9 %} padding-left: 3.2px;
-                                   padding-right: 3.2px;
-                                   {% endif %}">
+                    <div class="z-10 w-8 h-8 rounded-full flex items-center justify-center timeline-item"
+                         data-number="{{ translation.version }}">
                         {{ translation.version }}
-                    </option>
+                    </div>
                 {% endfor %}
-            </datalist>
+            </div>
+        </div>
+        <div id="tooltip"
+             class="hidden absolute text-white p-2 rounded revision-tooltip">
+            <p>
+                <b>{% translate "Version" %}:</b> <span id="version-text">Version Info</span>
+            </p>
+            <p>
+                <b>{% translate "Author" %}:</b> <span id="author-text">Author Info</span>
+            </p>
+            <p>
+                <b>{% translate "Date" %}:</b> <span id="date-text">Date Info</span>
+            </p>
+            {% if translations.first.hix_enabled and not translations.first.hix_ignore %}
+                <b>{% translate "HIX" %}:</b> <span id="hix-text">HIX Info</span>
+            {% endif %}
         </div>
         {% translate "deleted account" as deleted_user_text %}
         {% for translation in translations %}

--- a/integreat_cms/release_notes/current/unreleased/2912.yml
+++ b/integreat_cms/release_notes/current/unreleased/2912.yml
@@ -1,0 +1,2 @@
+en: Errors in the history of page revisions have been fixed and various options for browsing have been implemented
+de: Es wurden Fehler in der Historie von Seitenrevisionen behoben und verschiedene Möglichkeiten für das durchblättern implementiert

--- a/integreat_cms/static/src/css/style.scss
+++ b/integreat_cms/static/src/css/style.scss
@@ -523,16 +523,14 @@ datalist option {
     background: #4299e1;
 }
 
-#version-history::before {
-    content: "";
-    position: absolute;
-    top: 50%;
-    left: 0;
-    width: 100%;
-    height: 10px;
-    background-color: #e2e8f0;
-    transform: translateY(-50%);
-    z-index: 1;
+#version-history {
+    overflow-x: scroll; /* Allow scrolling */
+    -ms-overflow-style: none; /* Hide scrollbar for Internet Explorer and Edge */
+    scrollbar-width: none; /* Hide scrollbar for Firefox */
+}
+
+#version-history::-webkit-scrollbar {
+    display: none; /* Hide scrollbar for Chrome, Safari, and Opera */
 }
 
 /* Page revision slider info box */

--- a/integreat_cms/static/src/css/style.scss
+++ b/integreat_cms/static/src/css/style.scss
@@ -509,35 +509,30 @@ datalist option {
     font-weight: bolder;
 }
 
-/* Page Revision Slider */
-#revision-slider {
-    -webkit-appearance: none;
-    width: 100%;
-    height: 15px;
-    border-radius: 5px;
+.timeline-item {
+    cursor: pointer;
     background: #e2e8f0;
-    outline: none;
-    opacity: 0.7;
+}
 
-    &::-webkit-slider-thumb {
-        -webkit-appearance: none;
-        appearance: none;
-        width: 25px;
-        height: 25px;
-        border: 0;
-        border-radius: 50%;
-        background: #4299e1;
-        cursor: pointer;
-    }
+.timeline-item.active {
+    background: #4299e1 !important;
+    color: white !important;
+}
 
-    &::-moz-range-thumb {
-        width: 25px;
-        height: 25px;
-        border: 0;
-        border-radius: 50%;
-        background: #4299e1;
-        cursor: pointer;
-    }
+.revision-tooltip {
+    background: #4299e1;
+}
+
+#version-history::before {
+    content: "";
+    position: absolute;
+    top: 50%;
+    left: 0;
+    width: 100%;
+    height: 10px;
+    background-color: #e2e8f0;
+    transform: translateY(-50%);
+    z-index: 1;
 }
 
 /* Page revision slider info box */

--- a/integreat_cms/static/src/css/style.scss
+++ b/integreat_cms/static/src/css/style.scss
@@ -527,9 +527,37 @@ datalist option {
     cursor: pointer !important;
 }
 
-.version-history-control.disabled  {
+.version-history-control.disabled {
     color: #b8b6b6;
     cursor: default !important;
+}
+
+.timeline-item {
+    position: relative;
+    z-index: 10;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 16px;
+}
+
+.timeline-item::before {
+    content: "";
+    position: absolute;
+    left: 100%;
+    top: 50%;
+    height: 4px;
+    background: #e2e8f0;
+    transform: translateX(0%) translateY(-50%);
+    z-index: -1;
+}
+
+.timeline-item:last-child::before {
+    width: 0 !important;
+}
+
+.timeline-item::before {
+    width: calc(100% + 32px);
 }
 
 #version-history {

--- a/integreat_cms/static/src/css/style.scss
+++ b/integreat_cms/static/src/css/style.scss
@@ -523,6 +523,15 @@ datalist option {
     background: #4299e1;
 }
 
+.version-history-control.enabled {
+    cursor: pointer !important;
+}
+
+.version-history-control.disabled  {
+    color: #b8b6b6;
+    cursor: default !important;
+}
+
 #version-history {
     overflow-x: scroll; /* Allow scrolling */
     -ms-overflow-style: none; /* Hide scrollbar for Internet Explorer and Edge */

--- a/integreat_cms/static/src/js/revisions.ts
+++ b/integreat_cms/static/src/js/revisions.ts
@@ -4,94 +4,6 @@
 
 import HtmlDiff from "htmldiff-js";
 
-const calculateTooltipPositions = (target: Element, tooltip: Element) => {
-    const targetRect = target.getBoundingClientRect();
-    const tooltipRect = tooltip.getBoundingClientRect();
-
-    const viewportWidth = window.innerWidth;
-    const tooltipWidth = tooltipRect.width;
-    const scrollTop = window.scrollY || document.documentElement.scrollTop;
-
-    const verticalOffset = 10;
-    const horizontalOffset = 10;
-
-    // Berechne die Breite der rechten Icons
-    const rightIcon = document.querySelector(".flex-shrink-0.px-4:last-child") as HTMLElement;
-    const rightIconWidth = rightIcon ? rightIcon.getBoundingClientRect().width : 0;
-
-    // Berechne die verfügbare Breite für die Tooltip-Positionierung
-    const availableWidth = viewportWidth - rightIconWidth;
-
-    // Berechne die Tooltip-Positionen
-    let tooltipX = targetRect.left;
-    const tooltipY = targetRect.bottom + scrollTop + verticalOffset;
-
-    if (tooltipX + tooltipWidth > availableWidth) {
-        tooltipX = targetRect.right - tooltipWidth - horizontalOffset;
-    }
-
-    if (tooltipX < horizontalOffset) {
-        tooltipX = horizontalOffset;
-    }
-
-    return [`${tooltipY}px`, `${tooltipX}px`];
-};
-
-const toggleActionButtonVisibility = (revision: number, revisionCount: number) => {
-    const revisionElement = document.getElementById(`revision-${revision}`);
-
-    document.querySelectorAll(".action-buttons button").forEach((button) => {
-        const buttonHtml = button as HTMLElement;
-        const equivalentStatus = buttonHtml.dataset.status === revisionElement.dataset.status;
-        const dataMaxPresentIfLatestRevision = (revision === revisionCount) !== (buttonHtml.dataset.max === undefined);
-
-        if (equivalentStatus && dataMaxPresentIfLatestRevision) {
-            button.classList.remove("hidden");
-        } else {
-            button.classList.add("hidden");
-        }
-    });
-};
-
-const repositionTooltip = () => {
-    const tooltip = document.getElementById("tooltip");
-    const currentTimelineItem = document.querySelector(".timeline-item.active");
-
-    const [top, left] = calculateTooltipPositions(currentTimelineItem, tooltip);
-
-    tooltip.style.top = top;
-    tooltip.style.left = left;
-};
-
-const toggleVersionHistoryControls = () => {
-    const timelineItems = document.querySelectorAll(".timeline-item");
-
-    const firstItem = timelineItems[0];
-    const lastItem = timelineItems[timelineItems.length - 1];
-
-    const prevButton = document.getElementById("button-prev");
-    const nextButton = document.getElementById("button-next");
-
-    const firstItemActive = firstItem.classList.contains("active");
-    const lastItemActive = lastItem.classList.contains("active");
-
-    if (firstItemActive) {
-        prevButton.classList.add("disabled");
-        prevButton.classList.remove("enabled");
-    } else {
-        prevButton.classList.remove("disabled");
-        prevButton.classList.add("enabled");
-    }
-
-    if (lastItemActive) {
-        nextButton.classList.add("disabled");
-        nextButton.classList.remove("enabled");
-    } else {
-        nextButton.classList.remove("disabled");
-        nextButton.classList.add("enabled");
-    }
-};
-
 window.addEventListener("load", () => {
     // Iterate over revisions and calculate diff
     document.querySelectorAll(".revision-plain").forEach((revision) => {
@@ -126,6 +38,92 @@ window.addEventListener("load", () => {
     const authorLine = document.getElementById("author-text");
     const dateLine = document.getElementById("date-text");
     const hixLine = document.getElementById("hix-text");
+
+    const calculateTooltipPositions = (target: Element, tooltip: Element) => {
+        const targetRect = target.getBoundingClientRect();
+        const tooltipRect = tooltip.getBoundingClientRect();
+
+        const viewportWidth = window.innerWidth;
+        const tooltipWidth = tooltipRect.width;
+        const scrollTop = window.scrollY || document.documentElement.scrollTop;
+
+        const verticalOffset = 10;
+        const horizontalOffset = 10;
+
+        const rightIcon = document.getElementById("button-next") as HTMLElement;
+        const rightIconWidth = rightIcon ? rightIcon.getBoundingClientRect().width : 0;
+
+        const availableWidth = viewportWidth - rightIconWidth;
+
+        let tooltipX = targetRect.left;
+        const tooltipY = targetRect.bottom + scrollTop + verticalOffset;
+
+        if (tooltipX + tooltipWidth > availableWidth) {
+            tooltipX = targetRect.right - tooltipWidth - horizontalOffset;
+        }
+
+        if (tooltipX < horizontalOffset) {
+            tooltipX = horizontalOffset;
+        }
+
+        return [`${tooltipY}px`, `${tooltipX}px`];
+    };
+
+    const toggleActionButtonVisibility = (revision: number, revisionCount: number) => {
+        const revisionElement = document.getElementById(`revision-${revision}`);
+
+        document.querySelectorAll(".action-buttons button").forEach((button) => {
+            const buttonHtml = button as HTMLElement;
+            const equivalentStatus = buttonHtml.dataset.status === revisionElement.dataset.status;
+            const dataMaxPresentIfLatestRevision =
+                (revision === revisionCount) !== (buttonHtml.dataset.max === undefined);
+
+            if (equivalentStatus && dataMaxPresentIfLatestRevision) {
+                button.classList.remove("hidden");
+            } else {
+                button.classList.add("hidden");
+            }
+        });
+    };
+
+    const repositionTooltip = () => {
+        const tooltip = document.getElementById("tooltip");
+        const currentTimelineItem = document.querySelector(".timeline-item.active");
+
+        const [top, left] = calculateTooltipPositions(currentTimelineItem, tooltip);
+
+        tooltip.style.top = top;
+        tooltip.style.left = left;
+    };
+
+    const toggleVersionHistoryControls = () => {
+        const timelineItems = document.querySelectorAll(".timeline-item");
+
+        const firstItem = timelineItems[0];
+        const lastItem = timelineItems[timelineItems.length - 1];
+
+        const prevButton = document.getElementById("button-prev");
+        const nextButton = document.getElementById("button-next");
+
+        const firstItemActive = firstItem.classList.contains("active");
+        const lastItemActive = lastItem.classList.contains("active");
+
+        if (firstItemActive) {
+            prevButton.classList.add("disabled");
+            prevButton.classList.remove("enabled");
+        } else {
+            prevButton.classList.remove("disabled");
+            prevButton.classList.add("enabled");
+        }
+
+        if (lastItemActive) {
+            nextButton.classList.add("disabled");
+            nextButton.classList.remove("enabled");
+        } else {
+            nextButton.classList.remove("disabled");
+            nextButton.classList.add("enabled");
+        }
+    };
 
     const updateActiveTimelineItem = (item: Element) => {
         const revision = Number(item.getAttribute("data-number"));
@@ -223,35 +221,6 @@ window.addEventListener("load", () => {
         }
     };
 
-    // Event-Listener für Timeline-Items hinzufügen
-    document.querySelectorAll(".timeline-item").forEach((item) => {
-        item.addEventListener("click", () => {
-            updateActiveTimelineItem(item);
-        });
-    });
-
-    // Event-Listener für Vorherige/Nächste Schaltflächen hinzufügen
-    document.getElementById("button-next").addEventListener("click", () => {
-        selectNextTimelineItem();
-    });
-
-    document.getElementById("button-prev").addEventListener("click", () => {
-        selectPrevTimelineItem();
-    });
-
-    document.addEventListener("keydown", (event) => {
-        if (event.key === "ArrowRight") {
-            event.preventDefault();
-            selectNextTimelineItem();
-        } else if (event.key === "ArrowLeft") {
-            event.preventDefault();
-            selectPrevTimelineItem();
-        }
-    });
-
-    // Simulate initial input after page load
-    lastTimelineItem.dispatchEvent(new Event("click"));
-
     // Check if an element is within the visible range of its container
     const isElementInView = (element: HTMLElement, container: HTMLElement) => {
         const containerRect = container.getBoundingClientRect();
@@ -320,6 +289,32 @@ window.addEventListener("load", () => {
         repositionTooltip();
     };
 
-    // Listen to scroll event even when content is scrolled to an end
+    document.querySelectorAll(".timeline-item").forEach((item) => {
+        item.addEventListener("click", () => {
+            updateActiveTimelineItem(item);
+        });
+    });
+
+    document.getElementById("button-next").addEventListener("click", () => {
+        selectNextTimelineItem();
+    });
+
+    document.getElementById("button-prev").addEventListener("click", () => {
+        selectPrevTimelineItem();
+    });
+
+    document.addEventListener("keydown", (event) => {
+        if (event.key === "ArrowRight") {
+            event.preventDefault();
+            selectNextTimelineItem();
+        } else if (event.key === "ArrowLeft") {
+            event.preventDefault();
+            selectPrevTimelineItem();
+        }
+    });
+
     versionHistory.addEventListener("scroll", autoSelectTimelineItem);
+
+    // Move initial position to the very end of the timeline
+    lastTimelineItem.dispatchEvent(new Event("click"));
 });

--- a/integreat_cms/static/src/js/revisions.ts
+++ b/integreat_cms/static/src/js/revisions.ts
@@ -239,6 +239,16 @@ window.addEventListener("load", () => {
         selectPrevTimelineItem();
     });
 
+    document.addEventListener("keydown", (event) => {
+        if (event.key === "ArrowRight") {
+            event.preventDefault();
+            selectNextTimelineItem();
+        } else if (event.key === "ArrowLeft") {
+            event.preventDefault();
+            selectPrevTimelineItem();
+        }
+    });
+
     // Simulate initial input after page load
     lastTimelineItem.dispatchEvent(new Event("click"));
 


### PR DESCRIPTION
### Overview

This pull request re-implements the revision timeline feature. Originally targeting the issue described in #830, the project scope expanded to include a comprehensive refactor. The new implementation improves code readability and functionality by utilizing `flex-layout` and replacing `datalist` and `option` elements with click listeners for item selection.

In response to feedback from @osmers and @JoeyStk, the timeline has been made scrollable. Users can now navigate through the timeline using the previous and next buttons, the left and right arrow keys, or horizontal scrolling.

You can find a screencast that demonstrates the new behaviuor here: https://github.com/user-attachments/assets/418389df-3168-431f-a2c9-894acbdbb0b8.



### Key Changes

- Enhanced accessibility by increasing contrast for revision numbers.
- Improved layout by centering the timeline behind items for a more balanced and visually appealing design.
- Enhanced user interaction with an updated cursor to a pointer to indicate clickable items.
- Refined tooltips by adjusting positioning to ensure they consistently appear directly below the selected item.
- Fixed alignment issues to address any previous misplacement of items.
- Implemented fixed tooltip overflow management to ensure tooltips render on the left if they would exceed the container boundary.
- Enabled horizontal scrolling to accommodate numerous revisions without crowding.
- Added multiple navigation options for a comprehensive overview of the changes.

### Side Effects

- Scrolling Behavior: Scrolling events are only triggered when the content exceeds the container size. This means users cannot scroll through items if the timeline is not scrollable or is scrolled to the end.
- Feature Behavior Change: Users may notice changes in feature behavior. A tooltip introducing the new controls could be considered to assist those familiarizing themselves with the updated feature.

### Visual Comparison

**Before:**
![Before Screenshot](https://github.com/user-attachments/assets/9b60b08e-c0c1-49f6-9b7c-113cfa1906ea)

**After:**
![After Screenshot](https://github.com/user-attachments/assets/f007d447-131f-4b12-8006-2f1ff40484ce)

### Related Issue

- Fixes: #830

---

<!-- For potential reviewers -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
