### PR TITLE
Prevent POIs in use from being archived

### DIFF
--- a/integreat_cms/cms/templates/pois/poi_form_sidebar/action_box.html
+++ b/integreat_cms/cms/templates/pois/poi_form_sidebar/action_box.html
@@ -28,14 +28,35 @@
             <label class="mt-0">
                 {% translate "Archive location" %}
             </label>
-            <button title="{% translate "Archive location" %}"
-                    class="btn confirmation-button w-full"
-                    data-confirmation-title="{{ archive_dialog_title }}"
-                    data-confirmation-text="{{ archive_dialog_text }}"
-                    data-confirmation-subject="{{ poi_form.instance|poi_translation_title:language }}"
-                    data-action="{% url 'archive_poi' poi_id=poi_form.instance.id region_slug=request.region.slug language_slug=language.slug %}">
-                <i icon-name="archive" class="mr-2"></i> {% translate "Archive this location" %}
-            </button>
+            {% if poi_form.instance.events.exists %}
+                <div class="bg-orange-100 border-l-4 border-orange-500 text-orange-700 px-4 py-3 mb-5"
+                     role="alert">
+                    <p>
+                        {% translate "You cannot archive a location which is referenced by an event." %}
+                        <br />
+                        {% blocktranslate count counter=poi_form.instance.events.count trimmed %}
+                            To archive this location, you have to delete this event first:
+                        {% plural %}
+                            To archive this location, you have to delete these events first:
+                        {% endblocktranslate %}
+                    </p>
+                </div>
+                {% for event in poi_form.instance.events.all %}
+                    <a href="{% url 'edit_event' event_id=event.id region_slug=request.region.slug language_slug=language.slug %}"
+                       class="block pt-2 hover:underline">
+                        <i icon-name="pen-square" class="mr-2"></i> {{ event.best_translation.title }}
+                    </a>
+                {% endfor %}
+            {% else %}
+                <button title="{% translate "Archive location" %}"
+                        class="btn confirmation-button w-full"
+                        data-confirmation-title="{{ archive_dialog_title }}"
+                        data-confirmation-text="{{ archive_dialog_text }}"
+                        data-confirmation-subject="{{ poi_form.instance|poi_translation_title:language }}"
+                        data-action="{% url 'archive_poi' poi_id=poi_form.instance.id region_slug=request.region.slug language_slug=language.slug %}">
+                    <i icon-name="archive" class="mr-2"></i> {% translate "Archive this location" %}
+                </button>
+            {% endif %}
         {% endif %}
     </div>
     {% if perms.cms.delete_poi %}

--- a/integreat_cms/cms/templates/pois/poi_list_row.html
+++ b/integreat_cms/cms/templates/pois/poi_list_row.html
@@ -135,14 +135,24 @@
             </button>
         {% endif %}
         {% if perms.cms.change_poi %}
-            <button title="{% translate "Archive location" %}"
-                    class="confirmation-button btn-icon"
-                    data-confirmation-title="{{ archive_dialog_title }}"
-                    data-confirmation-text="{{ archive_dialog_text }}"
-                    data-confirmation-subject="{{ poi_translation.title }}"
-                    data-action="{% url 'archive_poi' poi_id=poi.id region_slug=request.region.slug language_slug=language.slug %}">
-                <i icon-name="archive"></i>
-            </button>
+            {% if poi.events.exists %}
+                {# djlint:off H023 #}
+                <button title="{% translate "You cannot archive a location which is used by an event." %}&#013;{% translate "This also involves archived events." %}"
+                        class="btn-icon"
+                        disabled>
+                    <i icon-name="archive"></i>
+                </button>
+                {# djlint:on #}
+            {% else %}
+                <button title="{% translate "Archive location" %}"
+                        class="confirmation-button btn-icon"
+                        data-confirmation-title="{{ archive_dialog_title }}"
+                        data-confirmation-text="{{ archive_dialog_text }}"
+                        data-confirmation-subject="{{ poi_translation.title }}"
+                        data-action="{% url 'archive_poi' poi_id=poi.id region_slug=request.region.slug language_slug=language.slug %}">
+                    <i icon-name="archive"></i>
+                </button>
+            {% endif %}
         {% endif %}
         {% if perms.cms.delete_poi %}
             {% if poi.events.exists %}

--- a/integreat_cms/cms/views/pois/poi_actions.py
+++ b/integreat_cms/cms/views/pois/poi_actions.py
@@ -42,10 +42,15 @@ def archive_poi(
     """
     poi = POI.objects.get(id=poi_id)
 
-    poi.archive()
-
-    logger.debug("%r archived by %r", poi, request.user)
-    messages.success(request, _("Location was successfully archived"))
+    if poi.events.count() > 0:
+        messages.error(
+            request,
+            _("This location cannot be archived because it is referenced by an event."),
+        )
+    else:
+        poi.archive()
+        logger.debug("%r archived by %r", poi, request.user)
+        messages.success(request, _("Location was successfully archived"))
 
     return redirect(
         "pois",

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -7204,6 +7204,19 @@ msgid "Archive location"
 msgstr "Ort archivieren"
 
 #: cms/templates/pois/poi_form_sidebar/action_box.html
+msgid "You cannot archive a location which is referenced by an event."
+msgstr ""
+"Der Ort kann nicht archiviert werden, da er von einer Veranstaltung "
+"verwendet wird."
+
+#: cms/templates/pois/poi_form_sidebar/action_box.html
+msgid "To archive this location, you have to delete this event first:"
+msgid_plural "To archive this location, you have to delete these events first:"
+msgstr[0] "Löschen Sie zuerst diese Veranstaltung, um den Ort zu archivieren:"
+msgstr[1] ""
+"Löschen Sie zuerst diese Veranstaltungen, um den Ort zu archivieren:"
+
+#: cms/templates/pois/poi_form_sidebar/action_box.html
 msgid "Archive this location"
 msgstr "Diesen Ort archivieren"
 
@@ -7354,6 +7367,11 @@ msgid ""
 msgstr ""
 "Dieser Ort kann nicht in der Web-App geöffnet werden, weil er nicht "
 "veröffentlicht ist."
+
+#: cms/templates/pois/poi_list_row.html
+msgid "You cannot archive a location which is used by an event."
+msgstr ""
+"Der Ort kann nicht archiviert werden, da er von einer Veranstaltung verwendet wird."
 
 #: cms/templates/push_notifications/push_notification_form.html
 #, python-format
@@ -8539,6 +8557,21 @@ msgstr[1] ""
 
 #: cms/views/bulk_action_views.py
 #, python-brace-format
+msgid ""
+"Location {object_names} could not be archived because it is referenced by an "
+"event."
+msgid_plural ""
+"The following locations could not be archived because they were referenced "
+"by an event: {object_names}"
+msgstr[0] ""
+"Ort \"{object_names}\" kann nicht archiviert werden, da er von einer "
+"Veranstaltung verwendet wird."
+msgstr[1] ""
+"Die folgdenden Orten können nicht archiviert werden, da sie von einer "
+"Veranstaltung verwendet werden: \"{object_names}\""
+
+#: cms/views/bulk_action_views.py
+#, python-brace-format
 msgid "{model_name} {object_names} was successfully restored."
 msgid_plural ""
 "The following {model_name_plural} were successfully restored: {object_names}"
@@ -9401,6 +9434,12 @@ msgstr ""
 #: cms/views/pages/page_xliff_import_view.py
 msgid "This XLIFF import is no longer available."
 msgstr "Dieser XLIFF Import ist nicht länger verfügbar."
+
+#: cms/views/pois/poi_actions.py
+msgid "This location cannot be archived because it is referenced by an event."
+msgstr ""
+"Dieser Ort kann nicht archiviert werden, da er von einer "
+"Veranstaltung verwendet wurde."
 
 #: cms/views/pois/poi_actions.py
 msgid "Location was successfully archived"

--- a/integreat_cms/release_notes/current/unreleased/2906.yml
+++ b/integreat_cms/release_notes/current/unreleased/2906.yml
@@ -1,0 +1,2 @@
+en: Prevent POIs in use from being archived
+de: Verhindere, dass verwendete Orte archiviert werden können

--- a/tests/cms/views/poi/test_poi_form.py
+++ b/tests/cms/views/poi/test_poi_form.py
@@ -1,9 +1,35 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 import pytest
+
+if TYPE_CHECKING:
+    from _pytest.logging import LogCaptureFixture
+    from django.test.client import Client
+    from pytest_django.fixtures import SettingsWrapper
+
 from django.conf import settings
+from django.db.models import ProtectedError
 from django.test.client import Client
 from django.urls import reverse
 
-from tests.conftest import ANONYMOUS
+from integreat_cms.cms.constants import status
+from integreat_cms.cms.models import (
+    Event,
+    Language,
+    POI,
+    POICategory,
+    POITranslation,
+    Region,
+)
+from tests.conftest import (
+    ANONYMOUS,
+    HIGH_PRIV_STAFF_ROLES,
+    PRIV_STAFF_ROLES,
+    WRITE_ROLES,
+)
+from tests.utils import assert_message_in_log
 
 
 @pytest.mark.django_db
@@ -30,3 +56,162 @@ def test_barrier_free_and_organization_box_appear(
 
     assert organization_box in response.content.decode("utf-8")
     assert barrier_free_box in response.content.decode("utf-8")
+
+
+# Choose a region
+REGION_SLUG = "augsburg"
+
+
+def create_used_poi(region_slug: str) -> int:
+    """
+    A helper function to create a new POI used in an event
+    """
+    region = Region.objects.filter(slug=region_slug).first()
+    event = Event.objects.filter(region=region).first()
+    poi_category = POICategory.objects.first()
+
+    used_poi = POI.objects.create(
+        region_id=region.id,
+        address="Adress 42",
+        postcode="00000",
+        city="Augsburg",
+        country="Deutschland",
+        latitude="48.3780446",
+        longitude="10.8879783",
+        category=poi_category,
+    )
+
+    german_language = Language.objects.filter(slug="de").first()
+    POITranslation.objects.create(
+        title="Ort",
+        slug="ort",
+        status=status.PUBLIC,
+        content="",
+        language=german_language,
+        poi=used_poi,
+    )
+
+    event.location = used_poi
+    event.save()
+
+    assert used_poi.events.count() > 0
+
+    return used_poi.id
+
+
+@pytest.mark.django_db
+def test_poi_in_use_cannot_be_archived(
+    load_test_data: None,
+    login_role_user: tuple[Client, str],
+    caplog: LogCaptureFixture,
+    settings: SettingsWrapper,
+) -> None:
+    """
+    Checks whether a POI is protected from archiving if it is used in an event
+    """
+    settings.LANGUAGE_CODE = "en"
+    client, role = login_role_user
+
+    # Make sure the target POI is used in an event
+    poi_id = create_used_poi("augsburg")
+
+    # Try to archive the POI
+    archive_poi = reverse(
+        "archive_poi",
+        kwargs={"region_slug": "augsburg", "language_slug": "de", "poi_id": poi_id},
+    )
+    response = client.post(archive_poi)
+
+    if role == ANONYMOUS:
+        assert response.status_code == 302
+        assert (
+            response.headers.get("location")
+            == f"{settings.LOGIN_URL}?next={archive_poi}"
+        )
+    elif role in PRIV_STAFF_ROLES + WRITE_ROLES:
+        assert_message_in_log(
+            "ERROR    This location cannot be archived because it is referenced by an event.",
+            caplog,
+        )
+    else:
+        assert response.status_code == 403
+
+    # Check the POI is not archived
+    assert not POI.objects.filter(id=poi_id).first().archived
+
+
+@pytest.mark.django_db
+def test_poi_in_use_not_deleted(
+    load_test_data: None,
+    login_role_user: tuple[Client, str],
+) -> None:
+    """
+    Checks whether a POI is protected from deleting if it is used in an event
+    """
+    client, role = login_role_user
+
+    # Make sure the target POI is used in an event
+    poi_id = create_used_poi("augsburg")
+
+    # Try to delete the POI
+    delete_poi = reverse(
+        "delete_poi",
+        kwargs={"region_slug": "augsburg", "language_slug": "de", "poi_id": poi_id},
+    )
+
+    if role == ANONYMOUS:
+        response = client.post(delete_poi)
+        assert response.status_code == 302
+        assert (
+            response.headers.get("location")
+            == f"{settings.LOGIN_URL}?next={delete_poi}"
+        )
+    elif role in HIGH_PRIV_STAFF_ROLES:
+        with pytest.raises(ProtectedError):
+            response = client.post(delete_poi)
+    else:
+        response = client.post(delete_poi)
+        assert response.status_code == 403
+
+    # Check the POI still exists
+    assert POI.objects.filter(id=poi_id).first()
+
+
+@pytest.mark.django_db
+def test_poi_in_use_not_bulk_archived(
+    load_test_data: None,
+    login_role_user: tuple[Client, str],
+    caplog: LogCaptureFixture,
+    settings: SettingsWrapper,
+) -> None:
+    """
+    Checks whether a POI is protected from bulk archiving if it is used in an event
+    """
+    settings.LANGUAGE_CODE = "en"
+    client, role = login_role_user
+
+    # Make sure the target POI is used in an event
+    poi_id = create_used_poi("augsburg")
+
+    # Try to archive the POI by bulk action
+    bulk_archive_pois = reverse(
+        "bulk_archive_pois", kwargs={"region_slug": "augsburg", "language_slug": "de"}
+    )
+    response = client.post(bulk_archive_pois, data={"selected_ids[]": [poi_id]})
+
+    if role == ANONYMOUS:
+        assert response.status_code == 302
+        assert (
+            response.headers.get("location")
+            == f"{settings.LOGIN_URL}?next={bulk_archive_pois}"
+        )
+    elif role in PRIV_STAFF_ROLES + WRITE_ROLES:
+        assert_message_in_log(
+            'ERROR    Location "Ort" could not be archived because it is referenced by an event.',
+            caplog,
+        )
+    else:
+        assert response.status_code == 403
+
+    # Check the POI is not archived
+    assert not POI.objects.filter(id=poi_id).first().archived


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR deactivates archiving for POIs that are used in events.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Use the same logic with deactivating deletion for POIs in use


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- Almost same information is shown in the action box in the form both for archiving and deleting when those are deactivated with only slight wording difference "delete" vs "archive". Unifying both section came into consideration but the design has been kept and the warning is shown twice, because in my opinion users are used to seeing two different sections for each deleting and archiving.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2906 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
