### PR TITLE
Add utility `find_free_tree_id()` to future proof tests creating objects decended from AbstractTreeNode

### DIFF
--- a/tests/core/management/commands/test_send_push_notifications.py
+++ b/tests/core/management/commands/test_send_push_notifications.py
@@ -24,6 +24,7 @@ from integreat_cms.cms.models import (
 )
 from integreat_cms.firebase_api.firebase_api_client import FirebaseApiClient
 
+from ....utils import find_free_tree_id
 from ..utils import get_command_output
 
 
@@ -107,7 +108,12 @@ class TestSendPushNotification:
         region = Region.objects.create(name="unit-test-region")
 
         LanguageTreeNode.objects.create(
-            language=german_language, lft=1, rgt=2, tree_id=1, depth=1, region=region
+            language=german_language,
+            lft=1,
+            rgt=2,
+            tree_id=find_free_tree_id(LanguageTreeNode),
+            depth=1,
+            region=region,
         )
 
         push_notification = PushNotification.objects.create(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from _pytest.logging import LogCaptureFixture
 
+    from integreat_cms.cms.models.abstract_tree_node import AbstractTreeNode
+
 
 def get_messages(caplog: LogCaptureFixture) -> list[str]:
     """
@@ -64,3 +66,20 @@ def assert_message_in_log(message: str, caplog: LogCaptureFixture) -> None:
         f"The following message: \n\n{message}\n\nwas not found in the message log:\n\n"
         + ("\n".join(messages) if messages else "empty message log.")
     )
+
+
+def find_free_tree_id(model: type[AbstractTreeNode]) -> int:
+    """
+    Find a free tree id for the model to prevent collisions.
+
+    :param model: The model class to find a free tree_id for
+    """
+    highest_id = (
+        model.objects.values_list("tree_id", flat=True)
+        .distinct()
+        .order_by("-tree_id")
+        .first()
+    )
+    if highest_id is None:
+        return 1
+    return highest_id + 1


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Tests not depending on test data fixtures but creating DB objects prior to assertions are self contained and thus very easy to understand. While values like the primary key are suitibly selected by the django ORM without problems of collision and values for foreign keys are determined by passing the desired model object to the ORM function, relationships like [the expectation that any combination of `lft` and `tree_id` values must be unique for models inheriting from `AbstractTreeNode`](https://github.com/digitalfabrik/integreat-cms/pull/2596/commits/38812657c30bf342b7b40ed2807c7867dc2cac51#diff-49c75de4c1fa67b8c725a15cd51b0b9467f659d07c1f2a552550cdf9b67dd26c) are not ensured by django. The next best thing is to hard-code *some* value.

This is fine when running those tests isolated, but [may result in problems when running against a database that already had the test data loaded by a previous test](https://app.circleci.com/pipelines/github/digitalfabrik/integreat-cms/12171/workflows/dac8de10-10ed-4550-88d5-6bae754f835f/jobs/152082).

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add a utility function to find a free `tree_id` for the model.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- The function **does not** return the first free `tree_id`, but the highest existing one, incremented by 1
  E.g. given that these ids exist: `1`, `2`, `3`, `5`, `8`
  `find_free_tree_id()` would **not** return `4`, but `9`.
  This is because it is easier to implement and I don't see any reason to want exactly the *next free* one.


### Alternatives

- #2921 

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
