### PR TITLE
Add stdout message discouraging `AbstractTreeNode.objects.create()`

### DIFF
--- a/tests/core/management/commands/test_send_push_notifications.py
+++ b/tests/core/management/commands/test_send_push_notifications.py
@@ -106,9 +106,7 @@ class TestSendPushNotification:
 
         region = Region.objects.create(name="unit-test-region")
 
-        LanguageTreeNode.objects.create(
-            language=german_language, lft=1, rgt=2, tree_id=1, depth=1, region=region
-        )
+        LanguageTreeNode.add_root(language=german_language, region=region)
 
         push_notification = PushNotification.objects.create(
             channel="default",


### PR DESCRIPTION
suggest to use Node.add_root(), node.add_child() and node.add_sibling() instead

### Short description
<!-- Describe this PR in one or two sentences. -->
Tests not depending on test data fixtures but creating DB objects prior to assertions are self contained and thus very easy to understand. While values like the primary key are suitibly selected by the django ORM without problems of collision and values for foreign keys are determined by passing the desired model object to the ORM function, relationships like [the expectation that any combination of `lft` and `tree_id` values must be unique for models inheriting from `AbstractTreeNode`](https://github.com/digitalfabrik/integreat-cms/pull/2596/commits/38812657c30bf342b7b40ed2807c7867dc2cac51#diff-49c75de4c1fa67b8c725a15cd51b0b9467f659d07c1f2a552550cdf9b67dd26c) are not ensured by django. Treebeard supplies separate methods handling this, but one has to be aware that those exist.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add a stdout message to `AbstractTreeNode.objects.create()` discouraging its use in favour of `Node.add_root()`, `node.add_child()` and `node.add_sibling()`:

![image](https://github.com/user-attachments/assets/11aea2b4-8c63-4e8b-85a8-93758145501d)


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- This message should not show up in logs, except if stdout is captured in addition to the logging facilities. This is intended, as the message is mostly useful during active development, especially when dealing with tests, not on production servers.

### Alternatives

- #2919 

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)