### PR TITLE
Unifiy calculation of pages (not) ready for mt

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/2903.yml
+++ b/integreat_cms/release_notes/current/unreleased/2903.yml
@@ -1,0 +1,2 @@
+en: Make calculation of pages (not) ready for machine translation consistent
+de: Konsistente Berechnung der für die maschinelle Übersetzung (nicht) geeigneten Seiten

--- a/tests/cms/utils/test_disable_hix_post_save_signal.py
+++ b/tests/cms/utils/test_disable_hix_post_save_signal.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from integreat_cms.cms.constants.administrative_division import MUNICIPALITY
+from integreat_cms.cms.constants.region_status import ACTIVE
+from integreat_cms.cms.models import (
+    Language,
+    LanguageTreeNode,
+    Page,
+    PageTranslation,
+    Region,
+)
+
+from ...utils import disable_hix_post_save_signal
+
+if TYPE_CHECKING:
+    from pytest_django.plugin import _DatabaseBlocker  # type: ignore[attr-defined]
+
+
+@pytest.fixture(scope="session")
+def dummy_region(django_db_setup: None, django_db_blocker: _DatabaseBlocker) -> Region:
+    """
+    Fixture to create a dummy region, along with a dummy language.
+    """
+    with django_db_blocker.unblock():
+        dummy_language = Language.objects.create(
+            slug="du",
+            bcp47_tag="du_DU",
+            primary_country_code="de",
+        )
+        dummy_language.save()
+        dummy_region = Region.objects.create(
+            name="HIX Test",
+            slug="hix-test",
+            status=ACTIVE,
+            administrative_division=MUNICIPALITY,
+            postal_code="12345",
+            admin_mail="admin@example.com",
+            hix_enabled=False,
+        )
+        dummy_region.save()
+        dummy_tree_node = LanguageTreeNode.add_root(
+            language=dummy_language,
+            region=dummy_region,
+        )
+        dummy_tree_node.save()
+
+    return dummy_region
+
+
+# pylint: disable=redefined-outer-name
+@pytest.mark.django_db
+def test_disable_hix_post_save_signal(dummy_region: Region) -> None:
+    with disable_hix_post_save_signal():
+        demo_page_translation = create_dummy_page_translation(dummy_region)
+
+    assert demo_page_translation.hix_score == 16
+
+
+@pytest.mark.django_db
+def test_rule_out_false_positive(dummy_region: Region) -> None:
+    demo_page_translation = create_dummy_page_translation(dummy_region)
+
+    assert demo_page_translation.hix_score is None
+
+
+def create_dummy_page_translation(dummy_region: Region) -> PageTranslation:
+    dummy_page = Page.add_root(region=dummy_region)
+    dummy_page.save()
+
+    dummy_page_translation = PageTranslation.objects.create(
+        page=dummy_page,
+        slug="dummy_page",
+        title="Dummy Page",
+        content="",
+        hix_score=16.0,
+        language=dummy_region.default_language,
+    )
+    dummy_page_translation.save()
+
+    return dummy_page_translation

--- a/tests/cms/views/utils/test_hix.py
+++ b/tests/cms/views/utils/test_hix.py
@@ -1,0 +1,332 @@
+from __future__ import annotations
+
+import math
+from copy import deepcopy
+from operator import itemgetter
+from typing import TYPE_CHECKING
+
+import pytest
+from pytest_django.fixtures import SettingsWrapper
+
+from integreat_cms.cms.constants.administrative_division import MUNICIPALITY
+from integreat_cms.cms.constants.region_status import ACTIVE
+from integreat_cms.cms.models import (
+    Language,
+    LanguageTreeNode,
+    Page,
+    PageTranslation,
+    Region,
+)
+from integreat_cms.cms.utils.round_hix_score import round_hix_score
+from integreat_cms.cms.views.utils.hix import (
+    get_translation_over_hix_threshold,
+    get_translation_under_hix_threshold,
+    get_translations_relevant_to_hix,
+)
+from tests.utils import disable_hix_post_save_signal
+
+if TYPE_CHECKING:
+    from pytest_django.plugin import _DatabaseBlocker  # type: ignore[attr-defined]
+
+
+@pytest.fixture(scope="session")
+def dummy_region(django_db_setup: None, django_db_blocker: _DatabaseBlocker) -> Region:
+    """
+    Fixture to create a hix enabled dummy region, along with a dummy language.
+    """
+    with django_db_blocker.unblock():
+        dummy_language = Language.objects.create(
+            slug="du",
+            bcp47_tag="du_DU",
+            primary_country_code="de",
+        )
+        dummy_language.save()
+        dummy_region = Region.objects.create(
+            name="HIX Test",
+            slug="hix-test",
+            status=ACTIVE,
+            administrative_division=MUNICIPALITY,
+            postal_code="12345",
+            admin_mail="admin@example.com",
+            hix_enabled=True,
+        )
+        dummy_region.save()
+        dummy_tree_node = LanguageTreeNode.add_root(
+            language=dummy_language,
+            region=dummy_region,
+        )
+        dummy_tree_node.save()
+
+    return dummy_region
+
+
+def test_hix_rounding(settings: SettingsWrapper) -> None:
+    HIX_ROUNDING_PRECISION = 0.01
+    actual_raw_hix_score_threshold = (
+        settings.HIX_REQUIRED_FOR_MT - HIX_ROUNDING_PRECISION / 2
+    )
+    # Since this will likely differ from the mathematical threshold due to floating point errors,
+    # get the nearest value representable in memory as examples for the raw hix score
+    hix_score_just_on_threshold = math.nextafter(
+        actual_raw_hix_score_threshold, math.inf
+    )
+    hix_score_just_under_threshold = math.nextafter(
+        actual_raw_hix_score_threshold, -math.inf
+    )
+
+    assert (
+        round_hix_score(hix_score_just_on_threshold) == settings.HIX_REQUIRED_FOR_MT
+    ), f"Raw HIX score expected to be accepted: {hix_score_just_on_threshold}"
+    assert (
+        round_hix_score(hix_score_just_under_threshold) < settings.HIX_REQUIRED_FOR_MT
+    ), f"Raw HIX score expected to be rejected: {hix_score_just_under_threshold}"
+
+
+@pytest.mark.django_db
+def test_disregard_archived_pages(
+    settings: SettingsWrapper, dummy_region: Region
+) -> None:
+    dummy_language = dummy_region.default_language
+    settings.TEXTLAB_API_LANGUAGES = [dummy_language.slug]
+
+    with disable_hix_post_save_signal():
+        page_1 = Page.add_root(
+            region=dummy_region,
+            explicitly_archived=True,
+        )
+        page_1.save()
+
+        translation_1 = PageTranslation.objects.create(
+            page=page_1,
+            hix_score=16.0,
+            title="Page 1",
+            slug="page-1",
+            language=dummy_language,
+            content="",
+        )
+        translation_1.save()
+
+        page_2 = page_1.add_child(
+            region=dummy_region,
+            # we want a page that is implicitly archived
+            explicitly_archived=False,
+        )
+        page_2.save()
+
+        translation_2 = PageTranslation.objects.create(
+            page=page_2,
+            hix_score=16.0,
+            title="Page 2",
+            slug="page-2",
+            language=dummy_language,
+            content="",
+        )
+        translation_2.save()
+
+        page_3 = page_1.add_sibling(
+            region=dummy_region,
+            explicitly_archived=False,
+        )
+        page_3.save()
+
+        translation_3 = PageTranslation.objects.create(
+            page=page_3,
+            hix_score=16.0,
+            title="Page 3",
+            slug="page-3",
+            language=dummy_language,
+            content="",
+        )
+        translation_3.save()
+
+    assert set(get_translations_relevant_to_hix(dummy_region)) == {translation_3}
+    assert set(get_translation_over_hix_threshold(dummy_region)) == {translation_3}
+    assert set(get_translation_under_hix_threshold(dummy_region)) == set()
+
+
+@pytest.mark.django_db
+def test_disregard_pages_with_hix_ignore(
+    settings: SettingsWrapper, dummy_region: Region
+) -> None:
+    dummy_language = dummy_region.default_language
+    settings.TEXTLAB_API_LANGUAGES = [dummy_language.slug]
+
+    with disable_hix_post_save_signal():
+        page_1 = Page.add_root(
+            region=dummy_region,
+            hix_ignore=True,
+        )
+        page_1.save()
+
+        translation_1 = PageTranslation.objects.create(
+            page=page_1,
+            hix_score=16.0,
+            title="Page 1",
+            slug="page-1",
+            language=dummy_language,
+            content="",
+        )
+        translation_1.save()
+
+        page_2 = page_1.add_child(
+            region=dummy_region,
+            hix_ignore=False,
+        )
+        page_2.save()
+
+        translation_2 = PageTranslation.objects.create(
+            page=page_2,
+            hix_score=16.0,
+            title="Page 2",
+            slug="page-2",
+            language=dummy_language,
+            content="",
+        )
+        translation_2.save()
+
+        page_3 = page_1.add_sibling(
+            region=dummy_region,
+            hix_ignore=False,
+        )
+        page_3.save()
+
+        translation_3 = PageTranslation.objects.create(
+            page=page_3,
+            hix_score=16.0,
+            title="Page 3",
+            slug="page-3",
+            language=dummy_language,
+            content="",
+        )
+        translation_3.save()
+
+    assert set(get_translations_relevant_to_hix(dummy_region)) == {
+        translation_2,
+        translation_3,
+    }
+    assert set(get_translation_over_hix_threshold(dummy_region)) == {
+        translation_2,
+        translation_3,
+    }
+    assert set(get_translation_under_hix_threshold(dummy_region)) == set()
+
+
+@pytest.mark.django_db
+def test_hix_values(settings: SettingsWrapper, dummy_region: Region) -> None:
+    dummy_language = dummy_region.default_language
+    settings.TEXTLAB_API_LANGUAGES = [dummy_language.slug]
+
+    HIX_ROUNDING_PRECISION = 0.01
+    actual_raw_hix_score_threshold = (
+        settings.HIX_REQUIRED_FOR_MT - HIX_ROUNDING_PRECISION / 2
+    )
+    # Since this will likely differ from the mathematical threshold due to floating point errors,
+    # get the nearest value representable in memory as examples for the raw hix score
+    hix_score_just_on_threshold = math.nextafter(
+        actual_raw_hix_score_threshold, math.inf
+    )
+    hix_score_just_under_threshold = math.nextafter(
+        actual_raw_hix_score_threshold, -math.inf
+    )
+
+    with disable_hix_post_save_signal():
+        page_1 = Page.add_root(
+            region=dummy_region,
+        )
+        page_1.save()
+
+        translation_1 = PageTranslation.objects.create(
+            page=page_1,
+            hix_score=0.0,
+            title="Page 1",
+            slug="page-1",
+            language=dummy_language,
+            content="",
+        )
+        translation_1.save()
+
+        page_2 = page_1.add_sibling(
+            region=dummy_region,
+        )
+        page_2.save()
+
+        translation_2 = PageTranslation.objects.create(
+            page=page_2,
+            hix_score=hix_score_just_under_threshold,
+            title="Page 2",
+            slug="page-2",
+            language=dummy_language,
+            content="",
+        )
+        translation_2.save()
+
+        page_3 = page_2.add_sibling(
+            region=dummy_region,
+        )
+        page_3.save()
+
+        translation_3 = PageTranslation.objects.create(
+            page=page_3,
+            hix_score=hix_score_just_on_threshold,
+            title="Page 2",
+            slug="page-2",
+            language=dummy_language,
+            content="",
+        )
+        translation_3.save()
+
+    assert set(get_translations_relevant_to_hix(dummy_region)) == {
+        translation_1,
+        translation_2,
+        translation_3,
+    }
+    assert set(get_translation_over_hix_threshold(dummy_region)) == {translation_3}
+    assert set(get_translation_under_hix_threshold(dummy_region)) == {
+        translation_1,
+        translation_2,
+    }
+
+
+@pytest.mark.django_db
+def test_versions_of_hix_page(settings: SettingsWrapper, dummy_region: Region) -> None:
+    dummy_language = dummy_region.default_language
+    settings.TEXTLAB_API_LANGUAGES = [dummy_language.slug]
+
+    with disable_hix_post_save_signal():
+        page = Page.add_root(
+            region=dummy_region,
+        )
+        page.save()
+
+        translation_1 = PageTranslation.objects.create(
+            page=page,
+            hix_score=5.0,
+            title="Version 1",
+            slug="page",
+            language=dummy_language,
+            content="",
+            version=1,
+        )
+        translation_1.save()
+
+        translation_2 = deepcopy(translation_1)
+        translation_2.pk = None
+        translation_2.title = "Version 2"
+        translation_2.version = 2
+        translation_2.hix_score = 18.0
+        translation_2.save()
+
+        translation_3 = deepcopy(translation_2)
+        translation_3.pk = None
+        translation_3.title = "Version 3"
+        translation_3.version = 3
+        translation_3.hix_score = 2.0
+        translation_3.save()
+
+    assert set(get_translations_relevant_to_hix(dummy_region)) == {
+        translation_3,
+    }
+    assert set(get_translation_over_hix_threshold(dummy_region)) == set()
+    assert set(get_translation_under_hix_threshold(dummy_region)) == {
+        translation_3,
+    }

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,9 +5,17 @@ This file contains helper functions for tests.
 from __future__ import annotations
 
 import re
+from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
+from django.db.models.signals import pre_save
+
+from integreat_cms.cms.models import PageTranslation
+from integreat_cms.core.signals.hix_signals import page_translation_save_handler
+
 if TYPE_CHECKING:
+    from typing import Generator
+
     from _pytest.logging import LogCaptureFixture
 
 
@@ -64,3 +72,12 @@ def assert_message_in_log(message: str, caplog: LogCaptureFixture) -> None:
         f"The following message: \n\n{message}\n\nwas not found in the message log:\n\n"
         + ("\n".join(messages) if messages else "empty message log.")
     )
+
+
+@contextmanager
+def disable_hix_post_save_signal() -> Generator[None, None, None]:
+    pre_save.disconnect(receiver=page_translation_save_handler, sender=PageTranslation)
+    try:
+        yield None
+    finally:
+        pre_save.connect(receiver=page_translation_save_handler, sender=PageTranslation)


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Move calculation of pages ready / not ready for mt from multiple places to singular location

### Proposed changes
<!-- Describe this PR in more detail. -->

- Move implementation from region dashboard and translation coverage analytics to view utils
  - `get_translations_relevant_to_hix()`
  - `get_translation_under_hix_threshold()`
  - `get_translation_over_hix_threshold()`
- Calculate effects of rounding / threshold on raw hix value to more efficiently determine set of PageTranslations directly on the database
- Add test validating implementation of `round_hix_value()` based on this new method of calculation
- Add tests validating util functions
- Add decorator to disable the hix calculation post save hook
- Add tests validating functionality of said decorator


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- There are still two ways with distinct implementations of the same functionality: Our new utility functions and iterating over python PageTranslation objects, filtering them by the `hix_sufficient_for_mt` property. While `hix_sufficient.for_mt` relies on the `round_hix_score()` function, our utility functions predict the effect of the rounding, calculating where the threshold must be on the raw `hix_score`, and using it directly on a database filter. While these are intended to yield the same results *(and we try to validate it in `test_round_hix_score()`)*, they are still different implementations of the same thing which is not ideal.
- One might argue that the `disable_hix_post_save_signal()` decorator might be useful even outside of tests *(e.g. for management commands)* and should be placed among the utils in the `integreat_cms` package. As nothing in the package uses it yet, we still opted to leave it in the test utils.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2903 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
