### PR TITLE
Fix jumping language tabs

### DIFF
--- a/integreat_cms/cms/templates/_form_language_tabs.html
+++ b/integreat_cms/cms/templates/_form_language_tabs.html
@@ -58,10 +58,10 @@
                                         <i icon-name="x"></i>
                                     </span>
                                 {% endif %}
-                                <span class="language-name">{{ other_language.translated_name }}</span>
-                                <span class="fp fp-rounded fp-{{ other_language.primary_country_code }}"></span>
+                                <span class="flex-grow language-name">{{ other_language.translated_name }}</span>
+                                <span class="flex-end w-8 fp fp-rounded fp-{{ other_language.primary_country_code }}"></span>
                                 {% if other_language.secondary_country_code %}
-                                    <span class="fp fp-rounded fp-{{ other_language.secondary_country_code }}"></span>
+                                    <span class="fp ml-1 w-8 fp-rounded fp-{{ other_language.secondary_country_code }}"></span>
                                 {% endif %}
                                 {% if other_language != language %}
                                 </a>
@@ -74,14 +74,15 @@
         {% endfor %}
         {% if instance and sorted_translation_states|length > 4 %}
             <li class="z-10 ml-auto">
-                <div id="language-switcher" class="flex flex-col text-black">
+                <div id="language-switcher" class="relative flex flex-col text-black">
                     <div id="language-switcher-current"
-                         class="font-bold text-right bg-water-500 py-[calc(0.75rem+2px)] px-4 border-l border-t border-r border-blue-500 rounded-t cursor-default">
+                         class="flex font-bold text-right bg-water-500 py-[calc(0.75rem+2px)] px-4 border-l border-t border-r border-blue-500 rounded-t cursor-default">
                         <i id="language-switcher-globe" icon-name="globe" class="hidden"></i>
                         <span id="language-switcher-text">{% translate "Other Languages" %}</span>
                         <i icon-name="chevron-down"></i>
                     </div>
-                    <ul id="language-switcher-list" class="z-10 hidden h-0">
+                    <ul id="language-switcher-list"
+                        class="absolute bottom-0 right-0 z-10 hidden h-0">
                     </ul>
                 </div>
             </li>

--- a/integreat_cms/release_notes/current/unreleased/2918.yml
+++ b/integreat_cms/release_notes/current/unreleased/2918.yml
@@ -1,0 +1,2 @@
+en: Fix look of language tabs for long languages
+de: Korrigiere Darstellung der Sprachregisterkarten für lange Sprachen

--- a/integreat_cms/static/src/css/style.scss
+++ b/integreat_cms/static/src/css/style.scss
@@ -409,6 +409,12 @@ label:not([for]) {
     }
 }
 
+#language-switcher-list {
+    .language-name {
+        @apply px-2;
+    }
+}
+
 .password_toggle {
     .eye-icon {
         width: 42px;

--- a/integreat_cms/static/src/js/language-tabs.ts
+++ b/integreat_cms/static/src/js/language-tabs.ts
@@ -7,7 +7,7 @@ const CLASS_ANCHOR_WHEN_SHOWN = [
     "hover:text-blue-500",
 ];
 
-const CLASS_ANCHOR_WHEN_HIDDEN = ["px-3", "py-2", "bg-white", "whitespace-nowrap", "hover:bg-water-500"];
+const CLASS_ANCHOR_WHEN_HIDDEN = ["px-3", "py-2", "flex", "bg-white", "whitespace-nowrap", "hover:bg-water-500"];
 const BUFFER = 20;
 
 const hideElement = (element: HTMLElement | null) => {


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR attempts to fix the bug that the "Other languages" dropdown doesn't open up when too long languages are one of the dropdown options.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Decouple the list of "Other languages" from the button

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Graphical less pleasing 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2918


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
