### PR TITLE
Change text and display of in total in broken link row on dashboard

### DIFF
--- a/integreat_cms/cms/templates/dashboard/_todo_dashboard_row.html
+++ b/integreat_cms/cms/templates/dashboard/_todo_dashboard_row.html
@@ -18,7 +18,7 @@
             {# djlint:off #}<a href="{% spaceless %}{% block todo_dashboard_title_link %}{% endblock todo_dashboard_title_link %}{% endspaceless %}"
             class="font-bold text-blue-500 underline">{% spaceless %}{% block todo_dashboard_title %}{% endblock todo_dashboard_title %}{% endspaceless %}</a>{# djlint:on #}
             {% block todo_dashboard_number %}
-                <span class="total-results">({% translate "in total" %} <span>{{ total }}</span>)</span>
+                <span class="hidden total-results">({% translate "in total" %} <span>{{ total }}</span>)</span>
             {% endblock todo_dashboard_number %}
             <p>
                 {% block todo_dashboard_description %}

--- a/integreat_cms/cms/templates/dashboard/todo_dashboard_rows/_broken_links_row.html
+++ b/integreat_cms/cms/templates/dashboard/todo_dashboard_rows/_broken_links_row.html
@@ -35,7 +35,7 @@
     </div>
     <div class="waiting-message">
         {% blocktranslate trimmed %}
-            Loading...
+            We are loading your broken links in the background. Please be patient.
         {% endblocktranslate %}
     </div>
 {% endblock todo_dashboard_description %}

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -4714,9 +4714,7 @@ msgid "Please contact the administrator."
 msgstr "Bitte kontaktieren Sie eine:n Administrator:in."
 
 #: cms/templates/analytics/_broken_links_widget.html
-#: cms/templates/dashboard/_news_widget.html
-#: cms/templates/dashboard/todo_dashboard_rows/_broken_links_row.html
-#: cms/templates/hix_widget.html
+#: cms/templates/dashboard/_news_widget.html cms/templates/hix_widget.html
 #: cms/templates/pois/poi_form_sidebar/position_box.html
 #: cms/templates/statistics/_statistics_widget.html
 #: cms/templates/statistics/statistics_overview.html
@@ -5181,6 +5179,10 @@ msgstr ""
 #: cms/templates/dashboard/todo_dashboard_rows/_broken_links_row.html
 msgid "At the moment there are no broken links. Good job!"
 msgstr "Aktuell gibt es keine fehlerhaften Links. Gute Arbeit!"
+
+#: cms/templates/dashboard/todo_dashboard_rows/_broken_links_row.html
+msgid "We are loading your broken links in the background. Please be patient."
+msgstr "Wir laden im Hintergrund gerade Ihre kaputten Links. Bitte haben Sie noch ein wenig Geduld."
 
 #: cms/templates/dashboard/todo_dashboard_rows/_broken_links_row.html
 msgid "Go to link"
@@ -7371,7 +7373,8 @@ msgstr ""
 #: cms/templates/pois/poi_list_row.html
 msgid "You cannot archive a location which is used by an event."
 msgstr ""
-"Der Ort kann nicht archiviert werden, da er von einer Veranstaltung verwendet wird."
+"Der Ort kann nicht archiviert werden, da er von einer Veranstaltung "
+"verwendet wird."
 
 #: cms/templates/push_notifications/push_notification_form.html
 #, python-format
@@ -9438,8 +9441,8 @@ msgstr "Dieser XLIFF Import ist nicht länger verfügbar."
 #: cms/views/pois/poi_actions.py
 msgid "This location cannot be archived because it is referenced by an event."
 msgstr ""
-"Dieser Ort kann nicht archiviert werden, da er von einer "
-"Veranstaltung verwendet wurde."
+"Dieser Ort kann nicht archiviert werden, da er von einer Veranstaltung "
+"verwendet wurde."
 
 #: cms/views/pois/poi_actions.py
 msgid "Location was successfully archived"

--- a/integreat_cms/static/src/js/dashboard/broken-links.ts
+++ b/integreat_cms/static/src/js/dashboard/broken-links.ts
@@ -16,7 +16,20 @@ const getContent = async (url: string): Promise<Content> => {
     return response.json();
 };
 
+const showAllTotalNumbers = () => {
+    const elements = document.querySelectorAll<HTMLElement>(".total-results");
+
+    elements.forEach((element) => {
+        if (!element.closest("#broken-links")) {
+            const el = element;
+            el.classList.remove("hidden");
+        }
+    });
+};
+
 window.addEventListener("load", async () => {
+    showAllTotalNumbers();
+
     const brokenLinksElement = document.getElementById("broken-links");
 
     if (!brokenLinksElement) {


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR changes the text and hide the "in total" string in the broken link row on our dashboard while waiting for the broken link row to load.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Hide all "in total" strings
- Show those of the other rows again
- Show "in total" of broken link row once it has been loaded


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- I'm a bit insecure about doing the toggling of the "in total" strings. We have to do it this way (I think) due to the Django template that we use. I'm unsure, because there might be municipalities that have JS disabled and then this would look quite messy (I think). Plus the code doesn't look great


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: -


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
