### PR TITLE
Change hook in button link

### DIFF
--- a/integreat_cms/cms/views/dashboard/dashboard_view.py
+++ b/integreat_cms/cms/views/dashboard/dashboard_view.py
@@ -180,7 +180,7 @@ class DashboardView(TemplateView, ChatContextMixin):
             data={
                 "broken_links": len(invalid_urls),
                 "relevant_translation": str(relevant_translation),
-                "edit_url": f"{edit_url}#replace-url" if len(edit_url) > 0 else "",
+                "edit_url": f"{edit_url}" if len(edit_url) > 0 else "",
             }
         )
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR changes the hook from the "Go to link" button in that it removes `replace-url`. 
Before the link set us somewhere in the middle of the page and not nicely. This is again important for the release

Before:
![grafik](https://github.com/user-attachments/assets/ad57fe46-b833-4b50-aa5f-13b1dca38a98)

After:
![grafik](https://github.com/user-attachments/assets/8e298490-1529-41dd-ad05-db5eeecf079f)


### Proposed changes
<!-- Describe this PR in more detail. -->

- Change hook


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None I'm aware of


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: -


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
