### PR TITLE
Fix disappearing spaces next to Do Not Translate markers

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/2943.yml
+++ b/integreat_cms/release_notes/current/unreleased/2943.yml
@@ -1,0 +1,2 @@
+en: Fix disappearing spaces next to Do Not Translate markers
+de: Verschwindende Leerzeichen neben „Nicht übersetzen“-Markierungen behoben

--- a/integreat_cms/static/src/css/tinymce_custom.css
+++ b/integreat_cms/static/src/css/tinymce_custom.css
@@ -8,4 +8,5 @@
     background-color: rgb(239, 68, 68);
     direction: ltr;
     display: inline-block;
+    white-space: pre-wrap;
 }


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Specify whitespace handling for `translate="no"` elements

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add `white-space: pre-wrap;` to the `[translate="no"]` rule


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Spaces are *not* collapsed when at the beginning or end of a line if the element with `white-space: pre-wrap;` is starting/ending there
  - I don't see a better solution without implementing custom text layouting/rendering in the browser, which is likely a very bad idea
  - The impact of this is negligible, especially as it only concerns our editor in the backend


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2943 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
