### PR TITLE
Fix hix for pages without text

### DIFF
--- a/integreat_cms/cms/views/utils/hix.py
+++ b/integreat_cms/cms/views/utils/hix.py
@@ -20,7 +20,7 @@ from integreat_cms.cms.models.regions.region import Region
 from integreat_cms.cms.utils.round_hix_score import round_hix_score
 
 from ....api.decorators import json_response
-from ....textlab_api.textlab_api_client import TextlabClient
+from ....textlab_api.textlab_api_client import TextlabClient, TextlabResult
 
 if TYPE_CHECKING:
     from typing import Final
@@ -40,7 +40,7 @@ class CacheMeIfYouCan(Exception):
 
 
 @lru_cache(maxsize=512)
-def lookup_hix_score_helper(text: str) -> dict:
+def lookup_hix_score_helper(text: str) -> TextlabResult:
     """
     This function returns the hix score for the given text.
     It either performs an api request or returns the value from cache,
@@ -62,7 +62,7 @@ def lookup_hix_score_helper(text: str) -> dict:
         raise CacheMeIfYouCan from e
 
 
-def lookup_hix_score(text: str) -> dict | None:
+def lookup_hix_score(text: str) -> TextlabResult | None:
     """
     This function returns the hix score for the given text.
     It either performs an api request or returns the value from cache.

--- a/integreat_cms/cms/views/utils/hix.py
+++ b/integreat_cms/cms/views/utils/hix.py
@@ -52,8 +52,6 @@ def lookup_hix_score_helper(text: str) -> TextlabResult:
     :param text: The text to calculate the hix score for
     :return: The score for the given text
     """
-    # If the html has no text, don't send a request to textlab and immediately return the `None` score,
-    # which indicates an empty page
     try:
         html = fromstring(text)
         text_content = html.text_content()

--- a/integreat_cms/core/signals/hix_signals.py
+++ b/integreat_cms/core/signals/hix_signals.py
@@ -62,16 +62,10 @@ def page_translation_save_handler(instance: PageTranslation, **kwargs: Any) -> N
         return
 
     if data := lookup_hix_score(instance.content):
+        logger.debug("Storing hix score %s for %r", data["score"], instance)
+        instance.hix_score = data["score"]
 
-        if score := data.get("score"):
-            logger.debug("Storing hix score %s for %r", score, instance)
-            instance.hix_score = score
-
-            if feedback := data.get("feedback"):
-                instance.hix_feedback = json.dumps(feedback)
-
-        else:
-            logger.warning("Failed to retrieve the hix score for %r", instance)
-
+        if feedback := data.get("feedback"):
+            instance.hix_feedback = json.dumps(feedback)
     else:
         logger.warning("Failed to retrieve the hix data for %r", instance)

--- a/integreat_cms/release_notes/current/unreleased/2917.yml
+++ b/integreat_cms/release_notes/current/unreleased/2917.yml
@@ -1,0 +1,2 @@
+en: Fix hix for pages without text
+de: Behebe Fehler, die bei der Berechnung des HIX-Wertes von Seiten ohne Text auftraten

--- a/integreat_cms/static/src/js/analytics/hix-widget.ts
+++ b/integreat_cms/static/src/js/analytics/hix-widget.ts
@@ -37,7 +37,7 @@ const updateHixBar = (score: number, setOutdated: boolean) => {
  * Display a label depending on the current HIX state
  * States are "updated", "outdated", "no-content" and "error"
  */
-const updateHixStateLabel = (state: string) => {
+const updateHixStateLabel = (state: "updated" | "outdated" | "no-content" | "error") => {
     document.querySelectorAll("[data-hix-state]").forEach((element) => {
         if (element.getAttribute("data-hix-state") === state) {
             element.classList.remove("hidden");

--- a/integreat_cms/static/src/js/analytics/hix-widget.ts
+++ b/integreat_cms/static/src/js/analytics/hix-widget.ts
@@ -10,9 +10,11 @@ const calculateBackgroundColor = (score: number, setOutdated: boolean): string =
 
     if (setOutdated) {
         return "rgb(16, 111, 254, 0.3)";
-    } if (score >= hixThresholdGood) {
+    }
+    if (score >= hixThresholdGood) {
         return "rgb(74, 222, 128)";
-    } if (score > hixThresholdOk) {
+    }
+    if (score > hixThresholdOk) {
         return "rgb(250, 204, 21)";
     }
     return "rgb(239, 68, 68)";
@@ -35,7 +37,6 @@ const updateHixBar = (score: number, setOutdated: boolean) => {
 
 /**
  * Display a label depending on the current HIX state
- * States are "updated", "outdated", "no-content" and "error"
  */
 const updateHixStateLabel = (state: "updated" | "outdated" | "no-content" | "error") => {
     document.querySelectorAll("[data-hix-state]").forEach((element) => {

--- a/integreat_cms/textlab_api/textlab_api_client.py
+++ b/integreat_cms/textlab_api/textlab_api_client.py
@@ -18,6 +18,10 @@ logger = logging.getLogger(__name__)
 
 
 class TextlabResult(TypedDict):
+    """
+    The result that is returned from the textlab api via `benchmark`.
+    """
+
     score: float | None
     feedback: list[dict[str, Any]]
 
@@ -65,7 +69,7 @@ class TextlabClient:
             You can find the not so helpful API "documentation" here: https://comlab-ulm.github.io/swagger-V8/
             But since for now we are only interested in the HIX score anyway, we just use the benchmark
             "Letter Demo Integreat" with ID ``420`` by default.
-        :return: The score, or None if an error occurred
+        :return: The textlab result including score and feedback, or None if an error occurred
         """
         data = {"text": unescape(text), "locale_name": "de_DE"}
         path = f"/benchmark/{text_type}"

--- a/integreat_cms/textlab_api/textlab_api_client.py
+++ b/integreat_cms/textlab_api/textlab_api_client.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import logging
 from html import unescape
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, TypedDict
 from urllib.request import Request, urlopen
 
 from django.conf import settings
@@ -15,6 +15,11 @@ if TYPE_CHECKING:
     from typing import Any
 
 logger = logging.getLogger(__name__)
+
+
+class TextlabResult(TypedDict):
+    score: float | None
+    feedback: list[dict[str, Any]]
 
 
 class TextlabClient:
@@ -47,7 +52,7 @@ class TextlabClient:
 
     def benchmark(
         self, text: str, text_type: int = settings.TEXTLAB_API_DEFAULT_BENCHMARK_ID
-    ) -> dict:
+    ) -> TextlabResult:
         """
         Retrieves the hix score of the given text.
 

--- a/tests/cms/views/utils/test_hix.py
+++ b/tests/cms/views/utils/test_hix.py
@@ -16,12 +16,12 @@ from integreat_cms.cms.models import (
     PageTranslation,
     Region,
 )
-from integreat_cms.cms.views.utils.hix import lookup_hix_score
 from integreat_cms.cms.utils.round_hix_score import round_hix_score
 from integreat_cms.cms.views.utils.hix import (
     get_translation_over_hix_threshold,
     get_translation_under_hix_threshold,
     get_translations_relevant_to_hix,
+    lookup_hix_score,
 )
 from tests.utils import disable_hix_post_save_signal
 
@@ -330,6 +330,7 @@ def test_versions_of_hix_page(settings: SettingsWrapper, dummy_region: Region) -
     assert set(get_translation_under_hix_threshold(dummy_region)) == {
         translation_3,
     }
+
 
 def test_skip_textlab_call_if_html_is_empty() -> None:
     html = "<p>   </p>"

--- a/tests/cms/views/utils/test_hix.py
+++ b/tests/cms/views/utils/test_hix.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import math
 from copy import deepcopy
-from operator import itemgetter
 from typing import TYPE_CHECKING
 
 import pytest
@@ -17,6 +16,7 @@ from integreat_cms.cms.models import (
     PageTranslation,
     Region,
 )
+from integreat_cms.cms.views.utils.hix import lookup_hix_score
 from integreat_cms.cms.utils.round_hix_score import round_hix_score
 from integreat_cms.cms.views.utils.hix import (
     get_translation_over_hix_threshold,
@@ -330,3 +330,11 @@ def test_versions_of_hix_page(settings: SettingsWrapper, dummy_region: Region) -
     assert set(get_translation_under_hix_threshold(dummy_region)) == {
         translation_3,
     }
+
+def test_skip_textlab_call_if_html_is_empty() -> None:
+    html = "<p>   </p>"
+
+    result = lookup_hix_score(html)
+
+    assert result is not None
+    assert result["score"] is None


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr fixes hix calculation for pages without text.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Treat `None` as an indicator that the page has no relevant content
- If the page has no text content, don't even send a request to textlab, since we already know the result


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

Ideally none other


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2917
Fixes: #2916 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
