### PR TITLE
Fix machine translations being considered as not up-to-date

### DIFF
--- a/integreat_cms/cms/models/abstract_content_translation.py
+++ b/integreat_cms/cms/models/abstract_content_translation.py
@@ -441,11 +441,14 @@ class AbstractContentTranslation(AbstractBaseModel):
     def is_up_to_date(self) -> bool:
         """
         This property checks whether a translation is up to date.
-        A translation is considered up to date when it is not outdated and not being translated at the moment.
+        A translation is considered up to date when it is either explicitly set to up-to-date, or has been machine-translated.
 
         :return: Flag which indicates whether a translation is up to date
         """
-        return self.translation_state == translation_status.UP_TO_DATE
+        return self.translation_state in [
+            translation_status.UP_TO_DATE,
+            translation_status.MACHINE_TRANSLATED,
+        ]
 
     @cached_property
     def translation_state(self) -> str:

--- a/integreat_cms/release_notes/current/unreleased/2807.yml
+++ b/integreat_cms/release_notes/current/unreleased/2807.yml
@@ -1,0 +1,2 @@
+en: Fix a bug where machine-translated pages where considered out-of-date
+de: Behebe einen Fehler bei dem maschinell übersetzte Seiten als nicht aktuell markiert wurden


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

When marking pages as up-to-date, their machine-translated translations where changed to be out-of-date. This PR fixes this.

### Proposed changes
<!-- Describe this PR in more detail. -->

- in `AbstractContentTranslation`, change the definition of "up to date" to include machine translations
- surprisingly, this breaks 0 tests 🤔 


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none, but I think we might need a discussion about outdated/up-to-date definitions. Right now, there are multiple `translation_status` states which are neither up-to-date nor outdated, which is a bit weird.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2807


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
