### PR TITLE
Add organization URLs to link check

### DIFF
--- a/integreat_cms/cms/fixtures/test_data.json
+++ b/integreat_cms/cms/fixtures/test_data.json
@@ -2616,6 +2616,18 @@
     }
   },
   {
+    "model": "linkcheck.link",
+    "pk": 34,
+    "fields": {
+      "content_type": ["cms", "organization"],
+      "object_id": 1,
+      "field": "content",
+      "url": 3,
+      "text": "",
+      "ignore": false
+    }
+  },
+  {
     "model": "cms.page",
     "pk": 1,
     "fields": {

--- a/integreat_cms/cms/linklists.py
+++ b/integreat_cms/cms/linklists.py
@@ -11,6 +11,7 @@ from .models import (
     EventTranslation,
     ImprintPageTranslation,
     LanguageTreeNode,
+    Organization,
     Page,
     PageTranslation,
     POITranslation,
@@ -141,9 +142,20 @@ class POITranslationLinklist(NonArchivedLinkList):
     model: ModelBase = POITranslation
 
 
+class OrganizationLinklist(Linklist):
+    """
+    Class for selecting the Organization model for link checks
+    """
+
+    model: ModelBase = Organization
+
+    url_fields = ["website"]
+
+
 linklists = {
     "PageTranslations": PageTranslationLinklist,
     "EventTranslations": EventTranslationLinklist,
     "POITranslations": POITranslationLinklist,
     "ImprintPageTranslations": ImprintTranslationLinklist,
+    "Organizations": OrganizationLinklist,
 }

--- a/integreat_cms/cms/templatetags/content_filters.py
+++ b/integreat_cms/cms/templatetags/content_filters.py
@@ -17,6 +17,7 @@ from ..models import (
     EventTranslation,
     ImprintPageTranslation,
     Language,
+    Organization,
     PageTranslation,
     POITranslation,
 )
@@ -248,4 +249,6 @@ def object_translation_has_view_perm(
         return user.has_perm("cms.view_poi")
     if isinstance(obj, ImprintPageTranslation):
         return user.has_perm("cms.view_imprint")
+    if isinstance(obj, Organization):
+        return user.has_perm("cms.view:organization")
     raise ValueError(f"Invalid model: {type(obj)}")

--- a/integreat_cms/cms/views/linkcheck/linkcheck_list_view.py
+++ b/integreat_cms/cms/views/linkcheck/linkcheck_list_view.py
@@ -154,13 +154,11 @@ class LinkcheckListView(ListView):
                 if TYPE_CHECKING:
                     assert self.instance
                 new_url = self.form.cleaned_data["url"]
-                # Get all current translations with the same url
-                translations = {
-                    link.content_object for link in self.instance.region_links
-                }
+                # Get all current contents with the same url
+                contents = {link.content_object for link in self.instance.region_links}
                 # Replace the old urls with the new urls in the content
-                for translation in translations:
-                    translation.replace_urls(
+                for content in contents:
+                    content.replace_urls(
                         {self.instance.url: new_url},
                         request.user,
                         True,

--- a/integreat_cms/release_notes/current/unreleased/2369.yml
+++ b/integreat_cms/release_notes/current/unreleased/2369.yml
@@ -1,0 +1,2 @@
+en: Add website URLs of organizations to the link checker
+de: Füge Website-URLs von Organisationen zum Link-Checker hinzu


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds URLs of organizations to our link check/replace feature.

The issue is planned not for Q3 but Q4, but in my opinion it's better to implement this before we start refactoring of link check/replace feature for performance and the centralised link management system.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add the model `Organization` to the link checker
- Add a new function `replace_urls` to the model `Organization` to be compatible with the refactoring from #3003 
- <s>Adjust functions for link replacement (because organization objects do not have any translations)</s>


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- <s>I hope it functions at least. We definately need some refactoring (but suggest to do it in another PR)</s> It's merged now :)


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2369 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
