### PR TITLE
Haunted CI

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/2801.yml
+++ b/integreat_cms/release_notes/current/unreleased/2801.yml
@@ -1,0 +1,2 @@
+en: Hide links to images with empty alt attributes
+de: Blende Links zu Bildern mit leeren Alt-Attributen aus


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Our CI is haunted.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Do nothing and see if it still fails. ~~If so, something already merged on develop is the culprit~~ ***all tests passed***
- Use a commit known to produce this error on the tip of develop. ~~If the error is reproduced, proceed with something like a bisect *(but using that commit on top various commits from `develop`s history)*~~ ***all tests passed***
- Use a commit known to produce this error on top of their original parent commit. ***all tests still passed***
- Use the exact commit known to produce this error *(same hash)* ***all tests passed, despite failing on a different branch, for a different PR***
  *Note that the pipeline d2103e7 now appears to have failed. Following the link reveals that the pipeline was run for the branch of #2901, not for this branch. CI Status and links are likely set by commit hash only.*
- Re-try existing CI once again for existing PR. ***the three tests failed again in the same way***
  \
  *→ the side effect must be in the combination of the commit with the branch or PR associated with it, or some initial conditions when the pipeline instance was created which is reproduced when retrying the run*
- Amend (nothing to) the commit d2103e7 of #2901 to start a new pipeline but without any actual changes but the commit hash (→ e51a053) ***the three tests failed in the same way***
- Rebase e51a053 onto develop (→ dc5cddd6) ***the three tests failed in the same way***

Separate approach: Something about CircleCI is off

- Hypothesis: The branch name or anything other than the commit hash only is used in the pipeline definition or settings for CircleCI. ***`config.yml` seems clean, but it explicitly calls pytest with `--circleci-parallelize` and `--ds=integreat_cms.core.circleci_settings`***
- `--circleci-parallelize` might be at fault. ***[At a quick glance](https://github.com/ryanwilsonperkin/pytest-circleci-parallelized/blob/main/pytest_circleci_parallelized.py), it seems unlikely that there are relevant side effects here***
- There might be a discrepancy between circleci_settings and the settings used for normal, local testing.
    - *Pytests `--ds` sets `DJANGO_SETTINGS_MODULE`. The file defining `integreat_cms.core.circleci_settings` starts with `from .settings import *` and proceeds to overwrite many settings, like `SECRET_KEY = "dummy"`, `SUMM_AI_API_KEY = "dummy"`, `SUMM_AI_ENABLED = True` etc.*
    - *"Normal" (local) tests are expected to be started by the developer via `tools/test.sh`. The script sets a couple of settings related environment variables like `export INTEGREAT_CMS_SUMM_AI_API_KEY="dummy"` and calls pytest without passing a python module to use as settings, but notably specifies less settings than `integreat_cms.core.circleci_settings`.*
    - *By default django should use `integreat_cms.core.settings` (or `integreat_cms.core.docker_settings` when using docker, which just imports `settings` and sets nothing else but the `DATABASES` dict).*
    - <details><summary>Potential differences <i>(influence not yet investigated)</i></summary>

      - `SECRET_KEY` is set to `"DUMMY"` in CircleCI, but only in local tests when it or `DEBUG` are additionally set as environment variables by the developer *(otherwise the default is `""`)*.
      - `FCM_CREDENTIALS` *(and implicitly `FCM_ENABLED`)* are not set for local tests, but for CircleCI
      - `MESSAGE_LOGGING_ENABLED` is not set for local tests, but for CircleCI
      - circleci_settings sets `LOG_LEVEL = "DEBUG"`, which is not mentioned for local tests

      </details>
    - Running the tests locally, on feature/hide-links-to-images-without-alt-tags (dc5cddd), but modifying test.sh to use the settings for CircleCI:
      <details><summary>diff</summary>

      ```diff
      diff --git a/integreat_cms/core/debug_settings.py b/integreat_cms/core/debug_settings.py
      new file mode 100644
      index 000000000..2c11e3bf3
      --- /dev/null
      +++ b/integreat_cms/core/debug_settings.py
      @@ -0,0 +1,2 @@
      +from .circleci_settings import *
      +from .docker_settings import *
      diff --git a/tools/test.sh b/tools/test.sh
      index 8f936a7d6..7e26ceeb4 100755
      --- a/tools/test.sh
      +++ b/tools/test.sh
      @@ -47,6 +47,8 @@ while [[ $# -gt 0 ]]; do
               -k) shift;KW_EXPR="$1";shift;;
               # Select tests by marker
               -m) shift;MARKER="$1";shift;;
      +        # Set django settings module
      +        --ds=*) DS="$(echo $1 | cut -d= -f2)";shift;;
               # If only particular tests should be run, test path can be passed as CLI argument
               *) TESTS+=("$1");shift;;
           esac
      @@ -113,9 +115,14 @@ if [[ -n "${KW_EXPR}" ]] || [[ -n "${MARKER}" ]] || (( ${#TESTS[@]} )); then
           TEST_MESSAGE=" in ${TEST_MESSAGE}"
       fi
       
      +if [[ -n "${DS}" ]]; then
      +    PYTEST_ARGS+=("--ds=${DS}")
      +fi
      +
       "$(dirname "${BASH_SOURCE[0]}")/prune_pdf_cache.sh"
       
       echo -e "Running all tests${TEST_MESSAGE}${CHANGED_MESSAGE}..." | print_info
      +set -x
       deescalate_privileges pytest "${PYTEST_ARGS[@]}"
       echo "✔ Tests successfully completed " | print_success
       
      ```

      </details>
      <details><summary><b><i>The problematic tests all passed</i></b></summary>

      ```bash
      $ tools/test.sh --ds=integreat_cms.core.debug_settings tests/cms/views/poi_categories/test_poi_category_form_view.py
      Checking if Integreat CMS is installed...
      ✔ Integreat CMS is installed
      ✔ Webpack bundle is in place
      Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
      Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
      Starting existing PostgreSQL database Docker container...
      Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
      Waiting for Docker container integreat_django_postgres to be ready...
      Container not ready yet, sleeping...
      Docker container integreat_django_postgres is ready!
      ✔ Started database container
      Removed PDF cache
      Running all tests in tests/cms/views/poi_categories/test_poi_category_form_view.py...
      + deescalate_privileges pytest --disable-warnings --color=yes --quiet --numprocesses=auto --testmon-noselect tests/cms/views/poi_categories/test_poi_category_form_view.py --ds=integreat_cms.core.debug_settings
      ++ id -u
      + [[ 1000 == 0 ]]
      + env pytest --disable-warnings --color=yes --quiet --numprocesses=auto --testmon-noselect tests/cms/views/poi_categories/test_poi_category_form_view.py --ds=integreat_cms.core.debug_settings
      bringing up nodes...
      ..............................................                                                                  [100%]
      46 passed, 37 warnings in 51.32s
      + echo '✔ Tests successfully completed '
      + print_success
      + IFS=
      + read -r line
      + echo -e '\x1b[1;32m✔ Tests successfully completed \x1b[0;39m'
      ✔ Tests successfully completed 
      + IFS=
      + read -r line
      + [[ -d /home/peter/NewStructure/Projects/Code/integreat-cms-clone/htmlcov ]]
      + stop_docker_container
      + docker stop integreat_django_postgres
      Emulate Docker CLI using podman. Create /etc/containers/nodocker to quiet msg.
      + echo -e '\nStopped database container'
      + print_info
      + IFS=
      + read -r line
      + echo -e '\x1b[1;34m\x1b[0;39m'
      
      + IFS=
      + read -r line
      + echo -e '\x1b[1;34mStopped database container\x1b[0;39m'
      Stopped database container
      + IFS=
      + read -r line
      $
      ```

      </details>

Our CI is haunted. I'll stop my investigation here for now.

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- The issue is the side effect from somewhere.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: the haunted Pipeline. In the best case.


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
