### PR TITLE
Correctly represent the last week in rrules

### DIFF
--- a/integreat_cms/cms/constants/weeks.py
+++ b/integreat_cms/cms/constants/weeks.py
@@ -33,3 +33,12 @@ CHOICES: Final[list[tuple[int, Promise]]] = [
     (FOURTH, _("Fourth week")),
     (LAST, _("Last week")),
 ]
+
+#: A mapping from our week constants to the expected rrule values
+WEEK_TO_RRULE_WEEK = {
+    FIRST: 1,
+    SECOND: 2,
+    THIRD: 3,
+    FOURTH: 4,
+    LAST: -1,
+}

--- a/integreat_cms/cms/models/events/recurrence_rule.py
+++ b/integreat_cms/cms/models/events/recurrence_rule.py
@@ -206,7 +206,8 @@ class RecurrenceRule(AbstractBaseModel):
             kwargs["byweekday"] = self.weekdays_for_weekly
         elif self.frequency == frequency.MONTHLY:
             kwargs["byweekday"] = rrule.weekday(
-                self.weekday_for_monthly, self.week_for_monthly
+                self.weekday_for_monthly,
+                weeks.WEEK_TO_RRULE_WEEK[self.week_for_monthly],
             )
         if self.recurrence_end_date:
             kwargs["until"] = make_aware(

--- a/integreat_cms/release_notes/current/unreleased/2989.yml
+++ b/integreat_cms/release_notes/current/unreleased/2989.yml
@@ -1,0 +1,2 @@
+en: Fix bug where adding an event on the last weekday of every month only adds it in months with 5 weeks
+de: Behebe einen Fehler wobei ein Event, das sich monatlich in der letzten Woche des Monats wiederholen soll, nur in Monaten mit 5 Wochen wiederholt hat

--- a/tests/cms/models/events/test_recurrence_rule.py
+++ b/tests/cms/models/events/test_recurrence_rule.py
@@ -8,6 +8,7 @@ import datetime
 from typing import TYPE_CHECKING
 from zoneinfo import ZoneInfo
 
+from integreat_cms.cms.constants import weekdays, weeks
 from integreat_cms.cms.models import Event, RecurrenceRule
 
 if TYPE_CHECKING:
@@ -63,7 +64,7 @@ class TestCreatingIcalRule:
         recurrence_rule = RecurrenceRule(
             frequency="WEEKLY",
             interval=1,
-            weekdays_for_weekly=[0, 1],
+            weekdays_for_weekly=[weekdays.MONDAY, weekdays.TUESDAY],
             weekday_for_monthly=None,
             week_for_monthly=None,
             recurrence_end_date=None,
@@ -77,12 +78,25 @@ class TestCreatingIcalRule:
             frequency="MONTHLY",
             interval=1,
             weekdays_for_weekly=None,
-            weekday_for_monthly=4,
-            week_for_monthly=1,
+            weekday_for_monthly=weekdays.FRIDAY,
+            week_for_monthly=weeks.FIRST,
             recurrence_end_date=None,
         )
         self.check_rrule(
             recurrence_rule, "DTSTART:20300101T113000\nRRULE:FREQ=MONTHLY;BYDAY=+1FR"
+        )
+
+    def test_api_rrule_last_week_in_month(self) -> None:
+        recurrence_rule = RecurrenceRule(
+            frequency="MONTHLY",
+            interval=1,
+            weekdays_for_weekly=None,
+            weekday_for_monthly=weekdays.WEDNESDAY,
+            week_for_monthly=weeks.LAST,
+            recurrence_end_date=None,
+        )
+        self.check_rrule(
+            recurrence_rule, "DTSTART:20300101T113000\nRRULE:FREQ=MONTHLY;BYDAY=-1WE"
         )
 
     def test_api_rrule_bimonthly_until(self) -> None:
@@ -90,8 +104,8 @@ class TestCreatingIcalRule:
             frequency="MONTHLY",
             interval=2,
             weekdays_for_weekly=None,
-            weekday_for_monthly=6,
-            week_for_monthly=1,
+            weekday_for_monthly=weekdays.SUNDAY,
+            week_for_monthly=weeks.FIRST,
             recurrence_end_date=datetime.date(2030, 10, 19),
         )
         self.check_rrule(


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr fixes a bug where an event that repeats monthly on the last week would produce an invalid rrule. Instead of saying `-1<Weekday>`, which represent <Weekday> on the last week of the month, our code produced `5<Weekday>`, specifying  <Weekday> in the 5th Week of the month.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add a mapping from week constant to rrule weekday
- Specify that `weeks.LAST` has value -1 in an rrule


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
/


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2989


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
