### PR TITLE
Allow MT only when user can publish

### DIFF
--- a/integreat_cms/cms/views/bulk_action_views.py
+++ b/integreat_cms/cms/views/bulk_action_views.py
@@ -139,6 +139,10 @@ class BulkMachineTranslationView(BulkActionView):
                 ),
             )
             return super().post(request, *args, **kwargs)
+        if language_node.mt_provider.bulk_only_for_staff and not request.user.is_staff:
+            raise PermissionDenied(
+                f"Only staff users have the permission to bulk translate {self.form._meta.model._meta.model_name} via {language_node.mt_provider}"
+            )
         if not language_node.mt_provider.is_permitted(
             request.region, request.user, self.form._meta.model
         ):
@@ -146,13 +150,9 @@ class BulkMachineTranslationView(BulkActionView):
                 request,
                 _(
                     "Machine translations are not allowed for the current user or content type"
-                ).format(language_node),
+                ),
             )
             return super().post(request, *args, **kwargs)
-        if language_node.mt_provider.bulk_only_for_staff and not request.user.is_staff:
-            raise PermissionDenied(
-                f"Only staff users have the permission to bulk translate {self.form._meta.model._meta.model_name} via {language_node.mt_provider}"
-            )
 
         to_translate = language_node.mt_provider.is_needed(
             request.region, self.get_queryset(), language_node

--- a/integreat_cms/deepl_api/deepl_api_client.py
+++ b/integreat_cms/deepl_api/deepl_api_client.py
@@ -35,7 +35,12 @@ class DeepLApiClient(MachineTranslationApiClient):
     DeepL API client to automatically translate selected objects.
     """
 
-    def __init__(self, request: HttpRequest, form_class: ModelFormMetaclass) -> None:
+    def __init__(
+        self,
+        request: HttpRequest,
+        form_class: ModelFormMetaclass,
+        content: Page | None = None,
+    ) -> None:
         """
         Initialize the DeepL client
 
@@ -45,7 +50,7 @@ class DeepLApiClient(MachineTranslationApiClient):
         """
         super().__init__(request, form_class)
         if not MachineTranslationProvider.is_permitted(
-            request.region, request.user, form_class._meta.model
+            request.region, request.user, form_class._meta.model, content
         ):
             raise RuntimeError(
                 f'Machine translations are disabled for content type "{form_class._meta.model}" and {request.user!r}.'

--- a/integreat_cms/google_translate_api/google_translate_api_client.py
+++ b/integreat_cms/google_translate_api/google_translate_api_client.py
@@ -34,7 +34,12 @@ class GoogleTranslateApiClient(MachineTranslationApiClient):
     Google Translate API client to automatically translate selected objects.
     """
 
-    def __init__(self, request: HttpRequest, form_class: ModelFormMetaclass) -> None:
+    def __init__(
+        self,
+        request: HttpRequest,
+        form_class: ModelFormMetaclass,
+        content: Page | None = None,
+    ) -> None:
         """
         Initialize the Google Translate client
 
@@ -44,7 +49,7 @@ class GoogleTranslateApiClient(MachineTranslationApiClient):
         """
         super().__init__(request, form_class)
         if not MachineTranslationProvider.is_permitted(
-            request.region, request.user, form_class._meta.model
+            request.region, request.user, form_class._meta.model, content
         ):
             raise RuntimeError(
                 f'Machine translations are disabled for content type "{form_class._meta.model}" and {request.user!r}.'

--- a/integreat_cms/release_notes/current/unreleased/2961.yml
+++ b/integreat_cms/release_notes/current/unreleased/2961.yml
@@ -1,0 +1,2 @@
+en: Allow machine translation only for users with publish right
+de: Lasse maschinelle Übersetzung nur für Benutzer:innen mit Veröffentlichungsrechten zu

--- a/integreat_cms/summ_ai_api/summ_ai_api_client.py
+++ b/integreat_cms/summ_ai_api/summ_ai_api_client.py
@@ -49,7 +49,12 @@ class SummAiApiClient(MachineTranslationApiClient):
     SUMM.AI API client to get German pages in Easy German language.
     """
 
-    def __init__(self, request: HttpRequest, form_class: ModelFormMetaclass) -> None:
+    def __init__(
+        self,
+        request: HttpRequest,
+        form_class: ModelFormMetaclass,
+        content: Page | None = None,
+    ) -> None:
         """
         Constructor initializes the class variables
 
@@ -59,7 +64,7 @@ class SummAiApiClient(MachineTranslationApiClient):
         """
         super().__init__(request, form_class)
         if not MachineTranslationProvider.is_permitted(
-            request.region, request.user, form_class._meta.model
+            request.region, request.user, form_class._meta.model, content
         ):
             raise RuntimeError(
                 f'Machine translations are disabled for content type "{form_class._meta.model}" and {request.user!r}.'

--- a/tests/mt_api/deepl_api_test.py
+++ b/tests/mt_api/deepl_api_test.py
@@ -19,7 +19,7 @@ from django.urls import reverse
 from integreat_cms.cms.models import Page
 from tests.mock import MockServer
 
-from ..conftest import AUTHOR, EDITOR, MANAGEMENT, PRIV_STAFF_ROLES
+from ..conftest import EDITOR, MANAGEMENT, PRIV_STAFF_ROLES
 from ..utils import assert_message_in_log
 from .utils import get_content_translations
 
@@ -68,7 +68,7 @@ api_errors = [404, 413, 429, 456, 500]
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "login_role_user", PRIV_STAFF_ROLES + [AUTHOR, MANAGEMENT, EDITOR], indirect=True
+    "login_role_user", PRIV_STAFF_ROLES + [MANAGEMENT, EDITOR], indirect=True
 )
 @pytest.mark.parametrize("error", api_errors)
 def test_deepl_bulk_mt_api_error(

--- a/tests/mt_api/google_translate_api_test.py
+++ b/tests/mt_api/google_translate_api_test.py
@@ -13,7 +13,9 @@ import pytest
 from django.apps import apps
 from django.urls import reverse
 
-from ..conftest import AUTHOR, EDITOR, MANAGEMENT, PRIV_STAFF_ROLES
+from integreat_cms.cms.models import Page
+
+from ..conftest import EDITOR, MANAGEMENT, PRIV_STAFF_ROLES
 from ..utils import assert_message_in_log
 
 if TYPE_CHECKING:
@@ -60,7 +62,10 @@ class FakeClient:
 
 
 def setup_fake_google_translate_api(  # type: ignore[no-untyped-def]
-    self, request: HttpRequest, form_class: ModelFormMetaclass
+    self,
+    request: HttpRequest,
+    form_class: ModelFormMetaclass,
+    content: Page | None = None,
 ) -> None:
     """
     Setup a fake for Google Translate API
@@ -68,6 +73,7 @@ def setup_fake_google_translate_api(  # type: ignore[no-untyped-def]
     :param request: The current request
     :param form_class: The :class:`~integreat_cms.cms.forms.custom_content_model_form.CustomContentModelForm`
                        subclass of the current content type
+    :param content: The content which should be translated
     """
 
     self.request = request
@@ -80,7 +86,7 @@ def setup_fake_google_translate_api(  # type: ignore[no-untyped-def]
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "login_role_user", PRIV_STAFF_ROLES + [AUTHOR, MANAGEMENT, EDITOR], indirect=True
+    "login_role_user", PRIV_STAFF_ROLES + [MANAGEMENT, EDITOR], indirect=True
 )
 def test_google_translate_error(
     login_role_user: tuple[Client, str],


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR makes our MT feature available only for users who are allowed to publish the target contents.


### Proposed changes
<!-- Describe this PR in more detail. -->
- Change `is_permitted` to check whether the current user can "publish" the content(s) (required: `can_change` for Event and POI as before, `can_publish` for Page either per role >= Editor or per page based permission or as organization member)
- Deaktivate MT bulk action completely for observers and authors for pages


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- `is_permitted`, `DeeplApiClient` and `GoogleTranslateApiClient` are extended with a variable. I hope this won't affect other parts, for it is "optional" with default value
- 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2961 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
