### PR TITLE
fix link auto update checkbox always checked

### DIFF
--- a/integreat_cms/cms/templates/_tinymce_config.html
+++ b/integreat_cms/cms/templates/_tinymce_config.html
@@ -63,7 +63,7 @@
      data-link-dialog-url-text='{% translate "URL" %}'
      data-link-dialog-text-text='{% translate "Text to display" %}'
      data-link-dialog-internal_link-text='{% translate "Or link to existing content" %}'
-     data-link-dialog-autoupdate-text='{% translate "Automatically update the link text when the linked content changes" %}'
+     data-link-dialog-autoupdate-text='{% translate "Automatically use the title of the linked content for the link" %}'
      data-custom-plugins="{% get_base_url %}{{ editor_content_js_files.0.url }}"
      data-content-css="{% get_base_url %}{{ editor_content_css_files.0.url }}"
      data-content-style="{{ content_style }}"

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -4707,9 +4707,9 @@ msgid "Or link to existing content"
 msgstr "Oder auf bestehende Inhalte verlinken"
 
 #: cms/templates/_tinymce_config.html
-msgid "Automatically update the link text when the linked content changes"
+msgid "Automatically use the title of the linked content for the link"
 msgstr ""
-"Den Linktext automatisch aktualisieren, wenn sich der verlinkte Inhalt ändert"
+"Automatisch den Titel des verlinkten Inhalts als Linktext verwenden"
 
 #: cms/templates/_tinymce_config.html
 msgid "Media Library..."

--- a/integreat_cms/release_notes/current/unreleased/3001.yml
+++ b/integreat_cms/release_notes/current/unreleased/3001.yml
@@ -1,0 +1,2 @@
+en: Fix link auto update checkbox always checked
+de: Behebe, dass die Link Auto-Update Checkbox ständig aktiviert ist


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fix link auto update checkbox always checked

### Proposed changes
<!-- Describe this PR in more detail. -->

- When the dialog is opened without an existing anchor being selected, determine whether the checkbox should be checked by checking if the selection is empty
- Disable the text field when the checkbox is checked
- Always set the text field to the targets title, and set text and URL to nothing whenever there is no auto completion when the checkbox is checked
- Reword the checkbox description
- Omit the `data-integreat-auto-update` attribute on links if `autoupdate` is `false` in order to not unnecessarily clutter the source code for normal links


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- When the checkbox should be checked when the dialog is first opened, the text field is not yet disabled *(only once the update function is run)* – tell me if you know how to initially disable a field
- `data-integreat-auto-update` is not changing our "normal form" of content in the database. But maybe it should be? *(as in, stripping out `data-integreat-auto-update="false"` that do nothing but take up space)*


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3001


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
