### PR TITLE
Fix translation for back-to-pages-button

### DIFF
--- a/integreat_cms/cms/templates/pages/page_tree_archived.html
+++ b/integreat_cms/cms/templates/pages/page_tree_archived.html
@@ -14,7 +14,7 @@
                 </h1>
                 <a href="{% url 'pages' region_slug=request.region.slug language_slug=language.slug %}"
                    class="font-bold text-sm text-gray-800 flex items-center gap-1 mb-2 hover:underline">
-                    <span><i icon-name="layout" class="align-top h-5"></i> {% translate "Back to page tree" %}</span>
+                    <span><i icon-name="layout" class="align-top h-5"></i> {% translate "Back to pages" %}</span>
                 </a>
             </div>
             <div class="flex flex-wrap justify-between gap-4">

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -4708,8 +4708,7 @@ msgstr "Oder auf bestehende Inhalte verlinken"
 
 #: cms/templates/_tinymce_config.html
 msgid "Automatically use the title of the linked content for the link"
-msgstr ""
-"Automatisch den Titel des verlinkten Inhalts als Linktext verwenden"
+msgstr "Automatisch den Titel des verlinkten Inhalts als Linktext verwenden"
 
 #: cms/templates/_tinymce_config.html
 msgid "Media Library..."
@@ -7048,8 +7047,8 @@ msgid "Archived Pages"
 msgstr "Archivierte Seiten"
 
 #: cms/templates/pages/page_tree_archived.html
-msgid "Back to page tree"
-msgstr "Zurück zum Seiten-Baum"
+msgid "Back to pages"
+msgstr "Zurück zu Seiten"
 
 #: cms/templates/pages/page_tree_archived.html
 msgid "No archived pages found with these filters."


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
While reviewing #3018 I noticed, that I had messed up the translation for "Back to pages". It was "Back to page tree" before but should have been changed to "Back to pages" to fit the pattern of "Back to [model_name_plural]"

### Proposed changes
<!-- Describe this PR in more detail. -->

- Change translation of button


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Does this need a release note? To me this change is too small and unnoticeable, but I can add one if wished for


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: -


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
