### PR TITLE
[7.11.24] Extend ajax poi form

### DIFF
--- a/integreat_cms/cms/templates/_poi_query_result.html
+++ b/integreat_cms/cms/templates/_poi_query_result.html
@@ -18,7 +18,10 @@
                         data-poi-address="{{ poi.address }}"
                         data-poi-postcode="{{ poi.postcode }}"
                         data-poi-city="{{ poi.city }}"
-                        data-poi-country="{{ poi.country }}">
+                        data-poi-country="{{ poi.country }}"
+                        data-poi-email="{{ poi.email }}"
+                        data-poi-phone_number="{{ poi.phone_number }}"
+                        data-poi-website="{{ poi.website }}">
                     {{ poi|poi_translation_title:current_language }}
                 </option>
             {% endfor %}

--- a/integreat_cms/cms/templates/ajax_poi_form/_poi_form_widget.html
+++ b/integreat_cms/cms/templates/ajax_poi_form/_poi_form_widget.html
@@ -21,6 +21,18 @@
         {{ poi_form.country.label }}
     </label>
     {% render_field poi_form.country|append_attr:"form:ajax_poi_form" %}
+    <label for="{{ poi_form.email.id_for_label }}">
+        {{ poi_form.email.label }}
+    </label>
+    {% render_field poi_form.email|append_attr:"form:ajax_poi_form" %}
+    <label for="{{ poi_form.phone_number.id_for_label }}">
+        {{ poi_form.phone_number.label }}
+    </label>
+    {% render_field poi_form.phone_number|append_attr:"form:ajax_poi_form" %}
+    <label for="{{ poi_form.website.id_for_label }}">
+        {{ poi_form.website.label }}
+    </label>
+    {% render_field poi_form.website|append_attr:"form:ajax_poi_form" %}
     <label for="{{ poi_form.category.id_for_label }}">
         {{ poi_form.category.label }}
     </label>

--- a/integreat_cms/cms/templates/ajax_poi_form/poi_box.html
+++ b/integreat_cms/cms/templates/ajax_poi_form/poi_box.html
@@ -1,4 +1,4 @@
-{% extends "../../_collapsible_box.html" %}
+{% extends "_collapsible_box.html" %}
 {% load i18n %}
 {% load static %}
 {% load content_filters %}
@@ -8,18 +8,18 @@
     map-pin
 {% endblock collapsible_box_icon %}
 {% block collapsible_box_title %}
-    {% translate "Venue" %}
+    {{ title }}
 {% endblock collapsible_box_title %}
 {% block collapsible_box_content %}
-    {% render_field event_form.has_not_location class+='inline-block' %}
+    {% render_field form.has_not_location class+='inline-block' %}
     <label class="secondary !inline"
-           for="{{ event_form.has_not_location.id_for_label }}">
-        {{ event_form.has_not_location.label }}
+           for="{{ form.has_not_location.id_for_label }}">
+        {{ form.has_not_location.label }}
     </label>
     <div id="location-block"
-         class="{% if event_form.has_not_location.value %}hidden{% endif %}">
-        <label for="{{ event_form.location.id_for_label }}">
-            {{ event_form.location.label }}
+         class="{% if form.has_not_location.value %}hidden{% endif %}">
+        <label for="{{ form.location.id_for_label }}">
+            {{ form.location.label }}
         </label>
         {% translate "Name of event location" as poi_title_placeholder %}
         <div class="relative my-2">
@@ -27,7 +27,7 @@
                    type="search"
                    autocomplete="off"
                    class="pr-8 appearance-none block w-full bg-white text-gray-800 placeholder-gray-800 border border-gray-400 rounded py-3 px-4 leading-tight focus:outline-none focus:bg-white focus:placeholder-gray-600"
-                   {% if event_form.disabled %}disabled{% endif %}
+                   {% if form.disabled %}disabled{% endif %}
                    placeholder="{% if poi %}{{ poi|poi_translation_title:current_language }}{% else %}{{ poi_title_placeholder }}{% endif %}"
                    data-url="{% url 'search_poi_ajax' region_slug=request.region.slug %}"
                    data-region-slug="{{ request.region.slug }}"
@@ -35,7 +35,7 @@
             <div class="absolute inset-y-0 right-0 flex items-center px-2 text-gray-800">
                 <button id="poi-remove"
                         title="{% translate "Remove location from event" %}"
-                        {% if event_form.disabled %}disabled{% endif %}>
+                        {% if form.disabled %}disabled{% endif %}>
                     <i icon-name="trash-2" class="h-5 w-5"></i>
                 </button>
             </div>
@@ -44,7 +44,7 @@
             {% translate "Create an event location or start typing the name of an existing location. Only published locations can be set as event venues" %}.
         </p>
         <div class="relative" id="poi-query-result">
-            {% include "events/_poi_query_result.html" %}
+            {% include "_poi_query_result.html" %}
         </div>
         <div id="poi-address-container" class="{% if not poi %} hidden{% endif %}">
             <label class="secondary">
@@ -55,7 +55,7 @@
                    class="hidden"
                    value="{% if poi %}{{ poi.id }}{% else %}-1{% endif %}"
                    readonly
-                   {% if event_form.has_not_location.value %}disabled{% endif %} />
+                   {% if form.has_not_location.value %}disabled{% endif %} />
             <div id="poi-address" class="text-lg whitespace-pre-line">
                 {% if poi %}
                     {{ poi.address }}
@@ -70,6 +70,39 @@
                rel="noopener noreferrer">
                 {% translate "Open on Google Maps" %}
             </a>
+            <label class="secondary">
+                {% translate "Contact details" %}
+            </label>
+            <div id="poi-contact-information">
+                <p>
+                    {% translate "E-mail address: " %}
+                    <span id="email">
+                        {% if poi.email %}
+                            {{ poi.email }}
+                        {% endif %}
+                    </span>
+                    <span id="no-email" class="{% if poi.email %}hidden{% endif %}">{% translate "Not provided" %}</span>
+                </p>
+                <p>
+                    {% translate "Phone number: " %}
+                    <span id="phone_number">
+                        {% if poi.phone_number %}
+                            {{ poi.phone_number }}
+                        {% endif %}
+                    </span>
+                    <span id="no-phone_number"
+                          class="{% if poi.phone_number %}hidden{% endif %}">{% translate "Not provided" %}</span>
+                </p>
+                <p>
+                    {% translate "Website: " %}
+                    <span id="website">
+                        {% if poi.website %}
+                            {{ poi.website }}
+                        {% endif %}
+                    </span>
+                    <span id="no-website" class="{% if poi.website %}hidden{% endif %}">{% translate "Not provided" %}</span>
+                </p>
+            </div>
         </div>
         <div id="poi-ajax-success-message"
              class="bg-green-100 border-l-4 border-green-500 text-green-800 px-4 py-3 hidden">
@@ -77,7 +110,7 @@
         </div>
         <div id="poi-ajax-error-message"
              class="bg-red-100 border-l-4 border-red-500 text-red-700 px-4 py-3 hidden">
-            {% trans "An error occured." %}
+            {% trans "An error occurred." %}
         </div>
         <div id="poi-form-widget">
         </div>

--- a/integreat_cms/cms/templates/events/_event_filter_form.html
+++ b/integreat_cms/cms/templates/events/_event_filter_form.html
@@ -57,7 +57,7 @@
             </div>
             {% render_field filter_form.poi_id id="id_location" class+="hidden" %}
             <div class="relative" id="poi-query-result">
-                {% include "events/_poi_query_result.html" %}
+                {% include "_poi_query_result.html" %}
             </div>
         </div>
         <div class="w-1/3">

--- a/integreat_cms/cms/templates/events/event_form.html
+++ b/integreat_cms/cms/templates/events/event_form.html
@@ -153,7 +153,7 @@
                 </div>
                 <div id="right-sidebar-column"
                      class="md:w-full 3xl:col-end-3 4xl:col-end-auto flex flex-wrap flex-col">
-                    {% include "./event_form_sidebar/venue_box.html" with box_id="event-venue" %}
+                    {% include "../ajax_poi_form/poi_box.html" with form=event_form box_id="event-venue" title=_("Venue") %}
                     {% include "./event_form_sidebar/icon_box.html" with box_id="event-icon" %}
                     {% if event_form.instance.id and perms.cms.change_event %}
                         {% include "./event_form_sidebar/actions_box.html" with box_id="event-actions" %}

--- a/integreat_cms/cms/views/events/event_actions.py
+++ b/integreat_cms/cms/views/events/event_actions.py
@@ -186,7 +186,7 @@ def search_poi_ajax(request: HttpRequest, region_slug: str) -> HttpResponse:
 
     return render(
         request,
-        "events/_poi_query_result.html",
+        "_poi_query_result.html",
         {
             "poi_query": poi_query,
             "poi_query_result": poi_query_result,

--- a/integreat_cms/cms/views/pois/poi_form_ajax_view.py
+++ b/integreat_cms/cms/views/pois/poi_form_ajax_view.py
@@ -23,7 +23,7 @@ class POIFormAjaxView(TemplateView, POIContextMixin):
     """
 
     #: Template for ajax POI widget
-    template = "events/_poi_form_widget.html"
+    template = "ajax_poi_form/_poi_form_widget.html"
 
     def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         r"""Render a POI form widget template
@@ -39,7 +39,7 @@ class POIFormAjaxView(TemplateView, POIContextMixin):
 
         return render(
             request,
-            "events/_poi_form_widget.html",
+            "ajax_poi_form/_poi_form_widget.html",
             {
                 **self.get_context_data(**kwargs),
                 "poi_form": poi_form,

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -4577,6 +4577,15 @@ msgstr "Abbrechen"
 msgid "Confirm"
 msgstr "Bestätigen"
 
+#: cms/templates/_poi_query_result.html
+msgid "Select existing location"
+msgstr "Bestehenden Ort auswählen"
+
+#: cms/templates/_poi_query_result.html
+#, python-format
+msgid "Create location \"%(poi_query)s\""
+msgstr "Ort \"%(poi_query)s\" erstellen"
+
 #: cms/templates/_raw.html
 msgid "Editorial System"
 msgstr "Redaktionssystem"
@@ -4714,6 +4723,68 @@ msgstr "Automatisch den Titel des verlinkten Inhalts als Linktext verwenden"
 #: cms/templates/_tinymce_config.html
 msgid "Media Library..."
 msgstr "Medienbibliothek..."
+
+#: cms/templates/ajax_poi_form/_poi_form_widget.html
+#: cms/templates/events/event_form.html cms/templates/imprint/imprint_form.html
+#: cms/templates/imprint/imprint_sbs.html cms/templates/pages/page_form.html
+#: cms/templates/pages/page_sbs.html cms/templates/pois/poi_form.html
+msgid "Publish"
+msgstr "Veröffentlichen"
+
+#: cms/templates/ajax_poi_form/poi_box.html
+msgid "Name of event location"
+msgstr "Name des Veranstaltungsortes"
+
+#: cms/templates/ajax_poi_form/poi_box.html
+msgid "Remove location from event"
+msgstr "Veranstaltungsort von Veranstaltung entfernen"
+
+#: cms/templates/ajax_poi_form/poi_box.html
+msgid ""
+"Create an event location or start typing the name of an existing location. "
+"Only published locations can be set as event venues"
+msgstr ""
+"Erstellen Sie einen Veranstaltungsort oder beginnen Sie den Namen eines "
+"bestehenden Veranstaltungsortes einzutippen. Nur öffentliche Orte können als "
+"Veranstaltungsorte verwendet werden"
+
+#: cms/templates/ajax_poi_form/poi_box.html
+#: cms/templates/pois/poi_form_sidebar/position_box.html
+msgid "Address"
+msgstr "Adresse"
+
+#: cms/templates/ajax_poi_form/poi_box.html
+msgid "Open on Google Maps"
+msgstr "Auf Google Maps öffnen"
+
+#: cms/templates/ajax_poi_form/poi_box.html
+#: cms/templates/pois/poi_form_sidebar/contact_box.html
+msgid "Contact details"
+msgstr "Kontaktdaten"
+
+#: cms/templates/ajax_poi_form/poi_box.html
+msgid "E-mail address: "
+msgstr "E-Mail-Adresse: "
+
+#: cms/templates/ajax_poi_form/poi_box.html
+msgid "Not provided"
+msgstr "Keine Angabe"
+
+#: cms/templates/ajax_poi_form/poi_box.html
+msgid "Phone number: "
+msgstr "Telefonnummer: "
+
+#: cms/templates/ajax_poi_form/poi_box.html
+msgid "Website: "
+msgstr "Website: "
+
+#: cms/templates/ajax_poi_form/poi_box.html
+msgid "The new location was successfully created."
+msgstr "Ein neuer Ort wurde erfolgreich erstellt."
+
+#: cms/templates/ajax_poi_form/poi_box.html
+msgid "An error occurred."
+msgstr "Es ist ein Fehler aufgetreten."
 
 #: cms/templates/analytics/_broken_links_widget.html
 msgid "The list below shows all detected errors related to links."
@@ -5458,22 +5529,6 @@ msgstr "Filter zurücksetzen"
 msgid "Apply filter"
 msgstr "Filter anwenden"
 
-#: cms/templates/events/_poi_form_widget.html
-#: cms/templates/events/event_form.html cms/templates/imprint/imprint_form.html
-#: cms/templates/imprint/imprint_sbs.html cms/templates/pages/page_form.html
-#: cms/templates/pages/page_sbs.html cms/templates/pois/poi_form.html
-msgid "Publish"
-msgstr "Veröffentlichen"
-
-#: cms/templates/events/_poi_query_result.html
-msgid "Select existing location"
-msgstr "Bestehenden Ort auswählen"
-
-#: cms/templates/events/_poi_query_result.html
-#, python-format
-msgid "Create location \"%(poi_query)s\""
-msgstr "Ort \"%(poi_query)s\" erstellen"
-
 #: cms/templates/events/event_form.html
 #, python-format
 msgid "Edit event \"%(event_title)s\""
@@ -5520,6 +5575,10 @@ msgstr "Bearbeiten"
 msgid "Copy to clipboard"
 msgstr "In die Zwischenablage kopieren"
 
+#: cms/templates/events/event_form.html
+msgid "Venue"
+msgstr "Veranstaltungsort"
+
 #: cms/templates/events/event_form_sidebar/actions_box.html
 #: cms/templates/imprint/imprint_form.html
 #: cms/templates/imprint/imprint_sbs.html
@@ -5563,44 +5622,6 @@ msgstr "Diese Veranstaltung löschen"
 #: cms/templates/events/event_form_sidebar/date_and_time_box.html
 msgid "Date and time"
 msgstr "Datum und Uhrzeit"
-
-#: cms/templates/events/event_form_sidebar/venue_box.html
-msgid "Venue"
-msgstr "Veranstaltungsort"
-
-#: cms/templates/events/event_form_sidebar/venue_box.html
-msgid "Name of event location"
-msgstr "Name des Veranstaltungsortes"
-
-#: cms/templates/events/event_form_sidebar/venue_box.html
-msgid "Remove location from event"
-msgstr "Veranstaltungsort von Veranstaltung entfernen"
-
-#: cms/templates/events/event_form_sidebar/venue_box.html
-msgid ""
-"Create an event location or start typing the name of an existing location. "
-"Only published locations can be set as event venues"
-msgstr ""
-"Erstellen Sie einen Veranstaltungsort oder beginnen Sie den Namen eines "
-"bestehenden Veranstaltungsortes einzutippen. Nur öffentliche Orte können als "
-"Veranstaltungsorte verwendet werden"
-
-#: cms/templates/events/event_form_sidebar/venue_box.html
-#: cms/templates/pois/poi_form_sidebar/position_box.html
-msgid "Address"
-msgstr "Adresse"
-
-#: cms/templates/events/event_form_sidebar/venue_box.html
-msgid "Open on Google Maps"
-msgstr "Auf Google Maps öffnen"
-
-#: cms/templates/events/event_form_sidebar/venue_box.html
-msgid "The new location was successfully created."
-msgstr "Ein neuer Ort wurde erfolgreich erstellt"
-
-#: cms/templates/events/event_form_sidebar/venue_box.html
-msgid "An error occured."
-msgstr "Es ist ein Fehler aufgetreten."
 
 #: cms/templates/events/event_list.html
 #: cms/templates/events/event_list_archived.html
@@ -7315,10 +7336,6 @@ msgstr[1] "Löschen Sie zuerst diese Veranstaltungen, um den Ort zu löschen:"
 #: cms/templates/pois/poi_form_sidebar/action_box.html
 msgid "Delete this location"
 msgstr "Diesen Ort löschen"
-
-#: cms/templates/pois/poi_form_sidebar/contact_box.html
-msgid "Contact details"
-msgstr "Kontaktdaten"
 
 #: cms/templates/pois/poi_form_sidebar/position_box.html
 msgid "Position"
@@ -10474,6 +10491,15 @@ msgstr ""
 "Diese Seite konnte nicht importiert werden, da sie zu einer anderen Region "
 "gehört ({})."
 
+#~ msgid "Opening hours"
+#~ msgstr "Öffnungszeiten"
+
+#~ msgid "No E-mail address is provided."
+#~ msgstr "Keine E-Mail-Adresse ist angegeben."
+
+#~ msgid "No phone number is provided."
+#~ msgstr "Keine Telefonnummer ist angegeben."
+
 #~ msgid "\"{} {}\" was not in translation process."
 #~ msgid_plural "The following \"{}\" were not in translation process: \"{}\""
 #~ msgstr[0] "\"{} {}\" war nicht im Überestzungsprozess"
@@ -11986,9 +12012,6 @@ msgstr ""
 
 #~ msgid "What do you want to do?"
 #~ msgstr "Was möchten Sie tun?"
-
-#~ msgid "Your E-mail-address"
-#~ msgstr "Ihre E-Mail-Adresse"
 
 #~ msgid "Confirm your new password here"
 #~ msgstr "Ihr neues Passwort erneut eingeben"

--- a/integreat_cms/release_notes/current/unreleased/3015.yml
+++ b/integreat_cms/release_notes/current/unreleased/3015.yml
@@ -1,0 +1,2 @@
+en: Extend POI creation in event form
+de: Erweitere die POI-Erstellung im Veranstaltungsformular

--- a/integreat_cms/static/src/js/events/event-query-pois.ts
+++ b/integreat_cms/static/src/js/events/event-query-pois.ts
@@ -1,13 +1,26 @@
 import { createIconsAt } from "../utils/create-icons";
 import { getCsrfToken } from "../utils/csrf-token";
 
+const toggleContactInfo = (infoType: string, info: string) => {
+    document.getElementById(infoType).textContent = `${info}`;
+    const infoNotGivenMessage = document.getElementById(`no-${infoType}`);
+    if (info) {
+        infoNotGivenMessage.classList.add("hidden");
+    } else {
+        infoNotGivenMessage.classList.remove("hidden");
+    }
+};
+
 const renderPoiData = (
     queryPlaceholder: string,
     id: string,
     address: string,
     postcode: string,
     city: string,
-    country: string
+    country: string,
+    email: string,
+    phoneNumber: string,
+    website: string
 ) => {
     document.getElementById("poi-query-input").setAttribute("placeholder", queryPlaceholder);
     document.getElementById("id_location")?.setAttribute("value", id);
@@ -15,6 +28,12 @@ const renderPoiData = (
     if (poiAddress) {
         poiAddress.textContent = `${address}\n${postcode} ${city}\n${country}`;
     }
+    if (document.getElementById("poi-contact-information")) {
+        toggleContactInfo("email", email);
+        toggleContactInfo("phone_number", phoneNumber);
+        toggleContactInfo("website", website);
+    }
+
     document
         .getElementById("poi-google-maps-link")
         ?.setAttribute(
@@ -40,7 +59,10 @@ const setPoi = ({ target }: Event) => {
         option.getAttribute("data-poi-address"),
         option.getAttribute("data-poi-postcode"),
         option.getAttribute("data-poi-city"),
-        option.getAttribute("data-poi-country")
+        option.getAttribute("data-poi-country"),
+        option.getAttribute("data-poi-email"),
+        option.getAttribute("data-poi-phone_number"),
+        option.getAttribute("data-poi-website")
     );
     // Show the address container
     document.getElementById("poi-address-container")?.classList.remove("hidden");
@@ -104,7 +126,10 @@ const showPoiFormWidget = async ({ target }: Event) => {
                     formData.get("address").toString(),
                     formData.get("postcode").toString(),
                     formData.get("city").toString(),
-                    formData.get("country").toString()
+                    formData.get("country").toString(),
+                    formData.get("email").toString(),
+                    formData.get("phone_number").toString(),
+                    formData.get("website").toString()
                 );
                 document.getElementById("poi-address-container")?.classList.remove("hidden");
                 // Add the POI to the actual django form field
@@ -166,6 +191,9 @@ const removePoi = () => {
     renderPoiData(
         document.getElementById("poi-query-input").getAttribute("data-default-placeholder"),
         "-1",
+        "",
+        "",
+        "",
         "",
         "",
         "",


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR extends the ajax poi form in the event form with three new fields and renames some files and variables universal

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add fields E-mail, phone number and website to the ajax POI form.
- Show those informations together with the address if a POI is selected.
- Rename "venue_box.html" to "poi_box.html"
- Move "venue_box.html" and "_poi_form_widget.html" to a new folder "ajax_poi_form"
- Mov "_poi_query_result.html" to the folder "templates"
- Rename "event_form" to "form" in "venue_box.html" and make the box title configuarable.

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- None? 🙏 
- 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3015 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
