### PR TITLE
Invalidate imprint cache after deleting or adding language tree node

### DIFF
--- a/integreat_cms/cms/forms/language_tree/language_tree_node_form.py
+++ b/integreat_cms/cms/forms/language_tree/language_tree_node_form.py
@@ -142,4 +142,6 @@ class LanguageTreeNodeForm(CustomModelForm, CustomTreeNodeForm):
             invalidate_obj(poi)
         for event in self.instance.region.events.all():
             invalidate_obj(event)
+        if self.instance.region.imprint:
+            invalidate_obj(self.instance.region.imprint)
         return result

--- a/integreat_cms/cms/views/language_tree/language_tree_actions.py
+++ b/integreat_cms/cms/views/language_tree/language_tree_actions.py
@@ -154,3 +154,5 @@ def manually_invalidate_models(region: Region) -> None:
         invalidate_obj(poi)
     for push_notification in region.push_notifications.all():
         invalidate_obj(push_notification)
+    if region.imprint:
+        invalidate_obj(region.imprint)

--- a/integreat_cms/release_notes/current/unreleased/2625.yml
+++ b/integreat_cms/release_notes/current/unreleased/2625.yml
@@ -1,0 +1,2 @@
+en: Invalidate imprint cache after deleting or adding language tree node
+de: Invalidiere das Impressum im Cache nach entfernen oder hinzufügen von Knoten im Sprach-Baum


### PR DESCRIPTION
### Short description
After deleting a language tree node, the language was still visible in the imprint form. A similar behavior showed when adding or moving nodes.


### Proposed changes

- Invalidate the imprint cache after deleting nodes
- Invalidate the imprint cache after adding nodes


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2625


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
