### PR TITLE
Fix language tab styling after browser resize

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/2956.yml
+++ b/integreat_cms/release_notes/current/unreleased/2956.yml
@@ -1,0 +1,2 @@
+en: Fix inconsistent language tab styling after resizing browser
+de: Behebe inkonsistente Darstellung der Sprachtabs nach Ändern der Browsergröße

--- a/integreat_cms/static/src/css/style.scss
+++ b/integreat_cms/static/src/css/style.scss
@@ -409,9 +409,20 @@ label:not([for]) {
     }
 }
 
+#language-switcher-current li a {
+    @apply px-3 py-[calc(0.75rem+2px)] bg-water-500 rounded-t hover:bg-white hover:text-blue-50;
+}
+
 #language-switcher-list {
     .language-name {
         @apply px-2;
+    }
+
+    li {
+        @apply mr-0;
+        a {
+            @apply px-3 py-2 flex bg-white whitespace-nowrap hover:bg-water-500 rounded-none;
+        }
     }
 }
 

--- a/integreat_cms/static/src/js/language-tabs.ts
+++ b/integreat_cms/static/src/js/language-tabs.ts
@@ -1,13 +1,3 @@
-const CLASS_ANCHOR_WHEN_SHOWN = [
-    "px-3",
-    "py-[calc(0.75rem+2px)]",
-    "bg-water-500",
-    "rounded-t",
-    "hover:bg-white",
-    "hover:text-blue-500",
-];
-
-const CLASS_ANCHOR_WHEN_HIDDEN = ["px-3", "py-2", "flex", "bg-white", "whitespace-nowrap", "hover:bg-water-500"];
 const BUFFER = 20;
 
 const hideElement = (element: HTMLElement | null) => {
@@ -33,22 +23,10 @@ const fitsInAvailableWidth = (tab: Element, usedSpace: number, availableWidth: n
 };
 
 const moveToLanguageSwitcherList = (tab: Element, languageSwitcherList: HTMLElement) => {
-    const anchor = tab.getElementsByTagName("a")[0];
-    tab.classList.remove("mr-2");
-    if (anchor) {
-        anchor.classList.remove(...CLASS_ANCHOR_WHEN_SHOWN);
-        anchor.classList.add(...CLASS_ANCHOR_WHEN_HIDDEN);
-    }
     languageSwitcherList.append(tab);
 };
 
 const moveToTabWrapper = (tab: Element, tabWrapper: HTMLElement, languageSwitcherListElement: HTMLElement) => {
-    const anchor = tab.getElementsByTagName("a")[0];
-    tab.classList.add("mr-2");
-    if (anchor && !anchor.closest("#language-switcher-list")) {
-        anchor.classList.remove(...CLASS_ANCHOR_WHEN_HIDDEN);
-        anchor.classList.add(...CLASS_ANCHOR_WHEN_SHOWN);
-    }
     if (!Array.from(tabWrapper.children).includes(tab)) {
         tabWrapper.insertBefore(tab, languageSwitcherListElement);
     }


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

When quickly resizing the browser window, language tab styling now stays consistent.

### Proposed changes
<!-- Describe this PR in more detail. -->

- basically the suggestion from the issue description:
- move tab styling into SCSS
- JS no longer adds/removes classes


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2956


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
