### PR TITLE
Change Zammad ticket type

### DIFF
--- a/integreat_cms/api/v3/chat/zammad_api.py
+++ b/integreat_cms/api/v3/chat/zammad_api.py
@@ -111,16 +111,10 @@ class ZammadChatAPI:
         :param device_id: ID of the user requesting a new chat
         :param language_slug: user's language
         """
-        responsible_handlers = [
-            user["id"]
-            for user in self.client.user.all()
-            if user["email"] and user["email"] in self.responsible_handlers
-        ]
         params = {
             "title": f"[Integreat Chat] [{language_slug.upper()}] {device_id}",
             "group": self.ticket_group,
             "customer": self.client_identity,
-            "mentions": responsible_handlers,
         }
         return self._parse_response(  # type: ignore[return-value]
             self._attempt_call(self.client.ticket.create, params=params)

--- a/integreat_cms/api/v3/chat/zammad_api.py
+++ b/integreat_cms/api/v3/chat/zammad_api.py
@@ -172,7 +172,7 @@ class ZammadChatAPI:
         params = {
             "ticket_id": chat_id,
             "body": message,
-            "type": "chat",
+            "type": "web",
             "internal": False,
             "sender": "Customer",
         }


### PR DESCRIPTION
### Short description
Allow Zammad users to answer to chat messages / tickets and remove default mention.

### Proposed changes
- Set the Zammad ticket type to "web" instead of "chat".
- Remove default handler mention as this overrides the users personal notification settings.

### Side effects
None. This should only affect Zammad.

### Resolved issues

Fixes: https://github.com/digitalfabrik/integreat-chat/issues/20


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
