### PR TITLE
Fix poi table layout

### DIFF
--- a/integreat_cms/cms/templates/pois/poi_list.html
+++ b/integreat_cms/cms/templates/pois/poi_list.html
@@ -44,7 +44,7 @@
         <form id="bulk-action-form" method="post">
             {% csrf_token %}
         </form>
-        <table class="w-full mt-4 rounded border border-gray-200 shadow bg-white table-fixed">
+        <table class="w-full mt-4 rounded border border-gray-200 shadow bg-white">
             <thead>
                 <tr class="border-b border-gray-200">
                     <th class="py-3 pl-4 pr-2 min">

--- a/integreat_cms/cms/templates/pois/poi_list_archived.html
+++ b/integreat_cms/cms/templates/pois/poi_list_archived.html
@@ -30,7 +30,7 @@
         <form id="bulk-action-form" method="post">
             {% csrf_token %}
         </form>
-        <table class="w-full mt-4 rounded border border-gray-200 shadow bg-white table-fixed">
+        <table class="w-full mt-4 rounded border border-gray-200 shadow bg-white">
             <thead>
                 <tr class="border-b border-gray-200">
                     <th class="py-3 pl-4 pr-2 min">


### PR DESCRIPTION
### Short description
Before #2895, we had [a css rule](https://github.com/digitalfabrik/integreat-cms/pull/2895/files#diff-d0f24712a2bf2e307d18ff548e8aa7747ef3be932bb9456c0262b32c87285e65L337) that set every table listing table's width to `inherit`. This caused `table-fixed` to have no effect, because using `table-fixed` without a specific size is an error in css and causes css to fallback to `table-auto`, which is the default value.
Now, that every table has `w-full` though, this rule is valid and causes the table to get too large. Fortunately, simply removing this rule fixes the table layout.

Additional context: https://github.com/digitalfabrik/integreat-cms/pull/2895#discussion_r1744433126

<!-- Describe this PR in one or two sentences. -->


### Proposed changes
<!-- Describe this PR in more detail. -->

- Remove the `table-fixed` class


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3041


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
