### PR TITLE
Remove dependabot for pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,15 +21,6 @@ updates:
     schedule:
       interval: monthly
 
-  - package-ecosystem: pip
-    directory: "/"
-    groups:
-      python:
-        patterns:
-          - "*"
-    schedule:
-      interval: monthly
-
   - package-ecosystem: devcontainers
     directory: "/"
     groups:


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Dependabot does not work with our `pyproject.toml` format: #3047

### Proposed changes
<!-- Describe this PR in more detail. -->

- Disable dependabot for pip


### Linked issues
<!-- List all issues which should be closed when this PR is merged. -->

Links to: #2812


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
