### PR TITLE
Add `.python-version` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ docs/src/templates/footer.html*
 docs/src/templates/breadcrumbs.html*
 
 # Miscellaneous
+.python-version
 .idea
 .directory
 cms-django.iml


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
I am using pyenv to use a local python version for integreat-cms. However, this creates a `.python-version` file in the directory, which should not be tracked with git.


### Proposed changes
<!-- Describe this PR in more detail. -->

- Add the file to `.gitignore`


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

None


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: /


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
