### PR TITLE
Add @tree_mutex() decorator and trick treebeard into using transactions

### DIFF
--- a/integreat_cms/cms/utils/repair_tree.py
+++ b/integreat_cms/cms/utils/repair_tree.py
@@ -9,9 +9,9 @@ from collections import deque
 from typing import TYPE_CHECKING
 
 from django.apps import apps
-from django.db import transaction
 
 from .shadow_instance import ShadowInstance
+from .tree_mutex import tree_mutex
 
 if TYPE_CHECKING:
     from typing import Iterable
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     Page: Model = apps.get_model("cms", "Page")
 
 
-@transaction.atomic
+@tree_mutex("page")
 def repair_tree(
     page_id: Iterable[int] | None = None,
     commit: bool = False,

--- a/integreat_cms/cms/utils/tree_mutex.py
+++ b/integreat_cms/cms/utils/tree_mutex.py
@@ -1,0 +1,97 @@
+"""
+This module contains a custom decorator for db / redis mutexes
+"""
+
+import functools
+import threading
+from contextlib import contextmanager
+from typing import Callable, Generator, ParamSpec, Type, TypeVar
+
+from django.db import DEFAULT_DB_ALIAS, transaction
+from treebeard.models import Node
+
+#: For how many seconds the lock persists, and the timeout for retrying to acquire it.
+LOCK_SECONDS = 10
+#: How long to sleep between retries to acquire the lock.
+INTERVAL = 0.1
+
+
+#: A dictionary holding separate locks for each classname to be guarded
+_LOCKS = {}
+
+
+# pylint: disable=protected-access
+@contextmanager
+def monkeypatch_cursor_func(
+    using: str = DEFAULT_DB_ALIAS,
+) -> Generator[None, None, None]:
+    """
+    Get connection for upstream transaction and
+    set alternative :meth:`treebeard.models.Node._get_database_cursor` that returns its cursor instead.
+    Ensures that this is being called from within the same thread and context, otherwise still return original value.
+    """
+    connection = transaction.get_connection(using=using)
+    original_get_database_cursor = Node._get_database_cursor
+
+    def monkeypatched_get_cursor(cls: Type, action: str) -> None:
+        """
+        A fake classmethod to overwrite :meth:`treebeard.models.Node._get_database_cursor` with.
+        Gets the cursor for the currend django connection instead,
+        allowing treebeard to be forced to use database transactions.
+        """
+        print(
+            f"someone is getting our monkeypatched db cursor ({using})! {cls}, {action}"
+        )
+        return connection.cursor()
+
+    Node._get_database_cursor = classmethod(monkeypatched_get_cursor)
+    try:
+        yield None
+    finally:
+        Node._get_database_cursor = original_get_database_cursor
+
+
+R = TypeVar("R")
+P = ParamSpec("P")
+
+
+def tree_mutex(classname: str) -> Callable[[Callable[P, R]], Callable[P, R]]:
+    """
+    A decorator to prevent treebeard from screwing up the database.
+    Extending :func:`cache_based_lock`,
+    we use :func:`django.db.transaction.atomic`
+    and monkey patch :meth:`treebeard.models.Node._get_database_cursor`
+    to actually use djangos database cursor and force it into db transactions that way.
+
+    Allows page trees to be locked separately from POIs etc.,
+    but requires strict conformance to always specify the exact ``classname`` when using the decorator.
+    If there is a typo, there will be no indication at server startup, and collisions and data corruption may occur.
+    For more information, see :func:`cache_based_lock`.
+    """
+    if classname not in _LOCKS:
+        # Only one instance of lock per class is allowed to be functional
+        _LOCKS[classname] = threading.RLock()
+    lock = _LOCKS[classname]
+
+    def wrap(func: Callable[P, R]) -> Callable[P, R]:
+        """
+        This is the actual decorator that takes ``func`` and returns a function with the same signature.
+        The outer function :func:`tree_mutex` is necessary to get the ``classname`` variable.
+        """
+
+        @functools.wraps(func)
+        def innermost_function(*args: P.args, **kwargs: P.kwargs) -> R:
+            """
+            The function replacing the decorated function.
+            Invoke :func:`django.db.transaction.atomic`,
+            monkey patch :meth:`treebeard.models.Node._get_database_cursor` to get djangos db cursor
+            and finally call the decorated ``func``.
+            """
+            with lock:
+                with transaction.atomic(using=DEFAULT_DB_ALIAS, durable=False):
+                    with monkeypatch_cursor_func(using=DEFAULT_DB_ALIAS):
+                        return func(*args, **kwargs)
+
+        return innermost_function
+
+    return wrap

--- a/integreat_cms/cms/views/bulk_action_views.py
+++ b/integreat_cms/cms/views/bulk_action_views.py
@@ -1,5 +1,10 @@
 """
 This module contains the base view for bulk actions
+
+.. warning::
+    Any action modifying the database with treebeard should use ``@tree_mutex(MODEL_NAME)`` from ``integreat_cms.cms.utils.tree_mutex``
+    as a decorator instead of ``@transaction.atomic`` to force treebeard to actually use transactions.
+    Otherwise, the data WILL get corrupted during concurrent treebeard calls!
 """
 
 from __future__ import annotations
@@ -22,6 +27,7 @@ from django.views.generic.list import MultipleObjectMixin
 from ..constants import status
 from ..models import Page, POI
 from ..utils.stringify_list import iter_to_string
+from ..utils.tree_mutex import tree_mutex
 from .utils.publication_status import change_publication_status
 
 if TYPE_CHECKING:
@@ -269,6 +275,7 @@ class BulkArchiveView(BulkActionView):
     Bulk action for restoring multiple objects at once
     """
 
+    @tree_mutex("page")
     def post(
         self, request: HttpRequest, *args: Any, **kwargs: Any
     ) -> HttpResponseRedirect:
@@ -365,6 +372,7 @@ class BulkRestoreView(BulkActionView):
     Bulk action for restoring multiple objects at once
     """
 
+    @tree_mutex("page")
     def post(
         self, request: HttpRequest, *args: Any, **kwargs: Any
     ) -> HttpResponseRedirect:

--- a/integreat_cms/cms/views/language_tree/language_tree_bulk_actions.py
+++ b/integreat_cms/cms/views/language_tree/language_tree_bulk_actions.py
@@ -1,3 +1,10 @@
+"""
+.. warning::
+    Any action modifying the database with treebeard should use ``@tree_mutex(MODEL_NAME)`` from ``integreat_cms.cms.utils.tree_mutex``
+    as a decorator instead of ``@transaction.atomic`` to force treebeard to actually use transactions.
+    Otherwise, the data WILL get corrupted during concurrent treebeard calls!
+"""
+
 from __future__ import annotations
 
 import logging
@@ -12,6 +19,7 @@ from ...models import (
     PageTranslation,
     POITranslation,
 )
+from ...utils.tree_mutex import tree_mutex
 from ..bulk_action_views import BulkUpdateBooleanFieldView
 
 if TYPE_CHECKING:
@@ -53,6 +61,7 @@ class LanguageTreeBulkActionView(BulkUpdateBooleanFieldView):
             "Subclasses of LanguageTreeBulkActionView must provide an 'action' attribute"
         )
 
+    @tree_mutex("languagetreenode")
     def post(
         self, request: HttpRequest, *args: Any, **kwargs: Any
     ) -> HttpResponseRedirect:

--- a/integreat_cms/cms/views/language_tree/language_tree_node_form_view.py
+++ b/integreat_cms/cms/views/language_tree/language_tree_node_form_view.py
@@ -1,3 +1,10 @@
+"""
+.. warning::
+    Any action modifying the database with treebeard should use ``@tree_mutex(MODEL_NAME)`` from ``integreat_cms.cms.utils.tree_mutex``
+    as a decorator instead of ``@transaction.atomic`` to force treebeard to actually use transactions.
+    Otherwise, the data WILL get corrupted during concurrent treebeard calls!
+"""
+
 from __future__ import annotations
 
 import logging
@@ -7,6 +14,7 @@ from django.urls import reverse
 
 from ...forms import LanguageTreeNodeForm
 from ...models import EventTranslation, PageTranslation, POITranslation
+from ...utils.tree_mutex import tree_mutex
 from ..form_views import CustomCreateView, CustomUpdateView
 
 if TYPE_CHECKING:
@@ -50,6 +58,16 @@ class LanguageTreeNodeCreateView(CustomCreateView):
         kwargs["region"] = self.request.region
         return kwargs
 
+    @tree_mutex("languagetreenode")
+    # type: ignore[no-untyped-def]
+    def get(self, *args, **kwargs):
+        return super().post(*args, **kwargs)
+
+    @tree_mutex("languagetreenode")
+    # type: ignore[no-untyped-def]
+    def post(self, *args, **kwargs):
+        return super().post(*args, **kwargs)
+
 
 class LanguageTreeNodeUpdateView(CustomUpdateView):
     """
@@ -75,3 +93,13 @@ class LanguageTreeNodeUpdateView(CustomUpdateView):
                     else:
                         translation.links.all().delete()
         return response
+
+    @tree_mutex("languagetreenode")
+    # type: ignore[no-untyped-def]
+    def get(self, *args, **kwargs):
+        return super().post(*args, **kwargs)
+
+    @tree_mutex("languagetreenode")
+    # type: ignore[no-untyped-def]
+    def post(self, *args, **kwargs):
+        return super().post(*args, **kwargs)

--- a/integreat_cms/core/management/commands/repair_tree.py
+++ b/integreat_cms/core/management/commands/repair_tree.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import Iterable, TYPE_CHECKING
 
 from ....cms.utils.repair_tree import repair_tree
 from ..log_command import LogCommand
@@ -39,7 +39,9 @@ class Command(LogCommand):
             help="Whether changes should be written to the database",
         )
 
-    def handle(self, *args: Any, page_id: int, commit: bool, **options: Any) -> None:
+    def handle(
+        self, *args: Any, page_id: Iterable[int], commit: bool, **options: Any
+    ) -> None:
         # pylint: disable=arguments-differ
         """
         Try to run the command

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -2717,10 +2717,6 @@ msgid "The node \"{}\" in region \"{}\" cannot be moved to \"{}\"."
 msgstr ""
 "Der Knoten \"{}\" in Region \"{}\" kann nicht nach \"{}\" verschoben werden."
 
-#: cms/models/abstract_tree_node.py
-msgid "Could not change position in tree of \"{}\"."
-msgstr "Position von \"{}\" im Baum konnte nicht geändert werden."
-
 #: cms/models/chat/attachment_map.py
 msgid "attachment map"
 msgstr "Anhangs-Mapping"
@@ -11637,6 +11633,9 @@ msgstr ""
 #~ msgstr ""
 #~ "%(content_type)s maschinell via %(provider)s auf Deutsch (einfach) "
 #~ "übersetzen"
+
+#~ msgid "Could not change position in tree of \"{}\"."
+#~ msgstr "Position von \"{}\" im Baum konnte nicht geändert werden."
 
 #~ msgid "Language Selection"
 #~ msgstr "Sprachauswahl"

--- a/tests/cms/utils/test_tree_mutex.py
+++ b/tests/cms/utils/test_tree_mutex.py
@@ -1,0 +1,195 @@
+"""
+Test tree mutex for page tree
+
+Test execution order:
+Since there seem to be some weird side effects happening
+for unrelated tests when testing database consistency, we first run those,
+then the tests that make sure the :func:`~integreat_cms.cms.utils.repair_tree.repair_tree` is effective,
+and last the effectiveness of :func:`~integreat_cms.cms.utils.tree_mutex.tree_mutex` itself.
+This ordering is facilitated using pytest_order
+to specify the tests to run ``"last"`` (eqivalent to ``-1``, absolute ordering)
+and after certain other tests (relative ordering).
+
+See https://pytest-order.readthedocs.io/en/stable/usage.html#order-relative-to-other-tests
+"""
+
+from __future__ import annotations
+
+from threading import Thread
+from typing import Callable
+
+import pytest
+from django.db.utils import IntegrityError
+from treebeard.exceptions import InvalidMoveToDescendant
+
+from integreat_cms.cms.models import Page
+from integreat_cms.cms.utils.tree_mutex import tree_mutex
+
+after_tests = (
+    "tests/core/management/commands/test_replace_links.py::test_replace_links_commit",
+    "tests/core/management/commands/test_fix_internal_links.py::test_fix_internal_links_commit",
+    "tests/cms/utils/test_repair_tree.py::test_repair_tree",
+)
+
+
+@pytest.mark.order("last", after=after_tests)
+@pytest.mark.django_db(transaction=True, serialized_rollback=True)
+def test_tree_mutex(load_test_data_transactional: None) -> None:
+    """
+    Check whether :func:`~integreat_cms.cms.utils.tree_mutex.tree_mutex` is actually preventing collisions.
+    See :func:`run_mutex_test` for details.
+    """
+    run_mutex_test(use_mutex=True)
+
+
+@pytest.mark.order("last", after=after_tests + ("test_tree_mutex",))
+@pytest.mark.django_db(transaction=True, serialized_rollback=True)
+def test_rule_out_false_positive(load_test_data_transactional: None) -> None:
+    """
+    Rule out that :func:`~integreat_cms.cms.utils.tree_mutex.tree_mutex` is just doing nothing and :func:`test_tree_mutex`
+    only succeeded because the system magically worked without it.
+    Provoke and expect a variety of possible exceptions using :func:`run_mutex_test`.
+
+    If this test fails with an exception not expected and you can prove that it is indicative of
+    treebeard shooting itself in the foot, please add the exception as expected!
+    """
+    with pytest.raises(
+        (
+            IntegrityError,
+            AttributeError,
+            IndexError,
+            Page.DoesNotExist,
+            InvalidMoveToDescendant,
+        )
+    ) as exc_info:
+        run_mutex_test(use_mutex=False)
+
+    if isinstance(exc_info.value, AttributeError):
+        assert (
+            exc_info.value.args[0]
+            == "'NoneType' object has no attribute 'is_descendant_of'"
+        )
+
+
+def run_mutex_test(use_mutex: bool) -> None:
+    """
+    Start two :func:`five_ten_five` tests in parallel, in separate threads.
+    These each constantly move their "contestant" page back and forth.
+    TreeBeard seems to quickly run into inconsistencies,
+    as their code bypasses Djangos Object-Relationional Mapper (ORM),
+    directly running raw SQL commands, without database transactions.
+    """
+    exception = None
+
+    def handle_exception(e: Exception) -> None:
+        nonlocal exception
+        exception = e
+
+    one = Thread(
+        target=five_ten_five,
+        kwargs={
+            "contestant_id": 21,
+            "use_mutex": use_mutex,
+            "handle_exception": handle_exception,
+        },
+    )
+    two = Thread(
+        target=five_ten_five,
+        kwargs={
+            "contestant_id": 19,
+            "use_mutex": use_mutex,
+            "handle_exception": handle_exception,
+        },
+    )
+
+    print("starting threads…")
+    one.start()
+    two.start()
+
+    one.join()
+    two.join()
+    print("joined threads!")
+
+    if exception:
+        # Raise the exception from the child thread here in the main thread
+        raise exception  # pylint: disable-msg=E0702
+
+
+def five_ten_five(
+    contestant_id: int,
+    use_mutex: bool,
+    handle_exception: Callable | None = None,
+) -> None:
+    """
+    Move a "contestant" page back and forth repeatedly.
+    Exceptions are caught and handed to ``handle_exception``,
+    this is necessary to get them back out to the main thread.
+    ``use_mutex`` dictates whether to use :func:`mforth`/:func:`mback`
+    or :func:`forth`/:func:`back`.
+    """
+    print(
+        f"running 5-10-5 on contestant #{contestant_id} {'with' if use_mutex else 'without'} tree_mutex"
+    )
+    try:
+        for i in range(5):
+            print(f"    [#{contestant_id}] {i}")
+            if use_mutex:
+                mforth(contestant_id)
+                mback(contestant_id)
+            else:
+                forth(contestant_id)
+                back(contestant_id)
+    except Exception as e:  # pylint: disable=broad-exception-caught # noqa: BLE001
+        if handle_exception:
+            handle_exception(e)
+        print(
+            f"failed 5-10-5 of contestant #{contestant_id} {'with' if use_mutex else 'without'} tree_mutex:\n  {repr(e)}"
+        )
+    else:
+        print(
+            f"finished 5-10-5 of contestant #{contestant_id} {'with' if use_mutex else 'without'} tree_mutex"
+        )
+
+
+@tree_mutex("page")
+def mforth(contestant_id: int) -> None:
+    """
+    Only calls :func:`forth`, but decorated with :func:`~integreat_cms.cms.utils.tree_mutex.tree_mutex`.
+    """
+    forth(contestant_id)
+
+
+@tree_mutex("page")
+def mback(contestant_id: int) -> None:
+    """
+    Only calls :func:`back`, but decorated with :func:`~integreat_cms.cms.utils.tree_mutex.tree_mutex`.
+    """
+    back(contestant_id)
+
+
+def forth(contestant_id: int) -> None:
+    """
+    Gets the page with id ``contestant_id`` and the target page with id ``20``
+    and moves the contestant in as the last child of the target.
+    """
+    print(f"   moving contestant #{contestant_id}…")
+    contestant = Page.objects.get(id=contestant_id)
+    assert contestant is not None
+    other = Page.objects.get(id=20)
+    assert other is not None
+    contestant.move(other, "last-child")
+    print(f"OK moving contestant #{contestant_id}!")
+
+
+def back(contestant_id: int) -> None:
+    """
+    Gets the page with id ``contestant_id`` and the target page with id ``20``
+    and moves the contestant out as the right sibling of the target.
+    """
+    print(f"   moving back contestant #{contestant_id}…")
+    contestant = Page.objects.get(id=contestant_id)
+    assert contestant is not None
+    other = Page.objects.get(id=20)
+    assert other is not None
+    contestant.move(other, "right")
+    print(f"OK moving back contestant #{contestant_id}!")


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

Force treebeard to use transactions. This should remove any race conditions caused by the library. The tests seem promising.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add `@tree_mutex()` decorator to replace `@django.db.transactions.atomic` (still uses it inside in addition to the mutex implementation)
  - Monkeypatch treebeards Node class to use djangos database cursor for its raw SQL queries so that changes get rolled back on failure
- Add tests for `@tree_mutex()`


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- The system might respond slower when many page move operations are attempted simultaneously, because treebeard now waits with each operation until any previous operations are finished


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1518, possibly #1716


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
