### PR TITLE
Chat: treat empty answer as no response

### DIFF
--- a/integreat_cms/api/v3/chat/chat_bot.py
+++ b/integreat_cms/api/v3/chat/chat_bot.py
@@ -29,6 +29,8 @@ class ChatBot:
         """
         Transform JSON into readable message
         """
+        if not response["answer"]:
+            return ""
         sources = "".join(
             [
                 f"<li><a href='{settings.WEBAPP_URL}{path}'>{path}</a></li>"

--- a/integreat_cms/api/v3/chat/user_chat.py
+++ b/integreat_cms/api/v3/chat/user_chat.py
@@ -263,8 +263,7 @@ def zammad_webhook(request: HttpRequest) -> JsonResponse:
         webhook_message["article"]["created_by"]["login"]
         == "tech+integreat-cms@tuerantuer.org"
     ):
-        logger.debug("Automatic answer & question translation")
-        actions.append("Automatic answer & question translation")
+        actions.append("question translation")
         client.send_message(
             zammad_chat.zammad_id,
             translate_message(message_text, region.default_language.slug),
@@ -272,18 +271,18 @@ def zammad_webhook(request: HttpRequest) -> JsonResponse:
             True,
         )
         chat_bot = ChatBot()
-        answer = chat_bot.automatic_answer(
+        if answer := chat_bot.automatic_answer(
             message_text, region, zammad_chat.language.slug
-        )
-        client.send_message(
-            zammad_chat.zammad_id,
-            answer,
-            False,
-            True,
-        )
+        ):
+            actions.append("automatic answer")
+            client.send_message(
+                zammad_chat.zammad_id,
+                answer,
+                False,
+                True,
+            )
     else:
-        logger.debug("Automatic answer translation")
-        actions.append("Automatic answer translation")
+        actions.append("answer translation")
         client.send_message(
             zammad_chat.zammad_id,
             translate_message(message_text, zammad_chat.language.slug),


### PR DESCRIPTION
### Short description
Ignore empty automatic answer messages. This enables the chat bot to decide which messages actually need an answer.


### Proposed changes
- Only send responses to Zammad that are not an empty string
- Update the actions list


### Side effects
- None


### Resolved issues
Fixes: https://github.com/digitalfabrik/integreat-chat/issues/45


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
