### PR TITLE
Fix #3063: Make save button consistent in organization form

### DIFF
--- a/integreat_cms/cms/templates/organizations/organization_form.html
+++ b/integreat_cms/cms/templates/organizations/organization_form.html
@@ -41,9 +41,15 @@
                 {% endif %}
                 {% if perms.cms.change_organization %}
                     <div class="flex flex-wrap gap-4">
+                        {% if form.instance.id %}
                         <button class="btn">
-                            {% translate "Save" %}
+                            {% translate "Update" %}
                         </button>
+                        {% else %}
+                        <button class="btn">
+                            {% translate "Create" %}
+                        </button>
+                        {% endif %}
                     </div>
                 {% endif %}
             </div>


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Updated the save button text in the organization form to be consistent. Now it shows "Create" for new organizations and "Update" for existing ones.


### Proposed changes
<!-- Describe this PR in more detail. -->
- Modified the `organization_form.html` template to display "Create" when creating a new organization and "Update" when editing an existing organization.
- This ensures consistency across the CMS forms.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- No side effects expected. Only the button text in the organization form is modified.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->
Fixes: #3063


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
