### PR TITLE
Chat: use self hosted translation model

### DIFF
--- a/integreat_cms/api/v3/chat/chat_bot.py
+++ b/integreat_cms/api/v3/chat/chat_bot.py
@@ -45,4 +45,13 @@ class ChatBot:
         """
         Use LLM to translate message
         """
-        raise NotImplementedError
+        url = f"https://{self.hostname}/chatanswers/translate_message/"
+        body = {
+            "message": message,
+            "source_language": source_lang_slug,
+            "target_language": target_lang_slug,
+        }
+        response = requests.post(url, json=body, timeout=30).json()
+        if "status" in response and response["status"] == "success":
+            return response["translation"]
+        return ""


### PR DESCRIPTION
### Short description
Use self hosted LLM translations to enable GDPR compliant chat message translations.


### Proposed changes
- Use chat bot translation endpoint for chat message translations.


### Side effects
- The quality of translations is probably not as good as Google translate but totally sufficient for simple messages. 


### Resolved issues
Fixes: https://github.com/digitalfabrik/integreat-chat/issues/37


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
