### PR TITLE
Fix empty Zammad field in region form

### DIFF
--- a/integreat_cms/cms/forms/regions/region_form.py
+++ b/integreat_cms/cms/forms/regions/region_form.py
@@ -594,13 +594,14 @@ class RegionForm(CustomModelForm):
             )
         return cleaned_hix_enabled
 
-    def clean_zammad_url(self) -> str:
+    def clean_zammad_url(self) -> str | None:
         """
         Validate the zammad_url field (see :ref:`overriding-modelform-clean-method`).
 
         :return: The validated field
         """
-        cleaned_zammad_url = self.cleaned_data["zammad_url"]
+        if not (cleaned_zammad_url := self.cleaned_data["zammad_url"]):
+            return None
         # Remove superfluous path parts
         cleaned_zammad_url = cleaned_zammad_url.split("/api/v1")[0]
         cleaned_zammad_url = cleaned_zammad_url.rstrip("/")

--- a/integreat_cms/release_notes/current/unreleased/3098.yml
+++ b/integreat_cms/release_notes/current/unreleased/3098.yml
@@ -1,0 +1,2 @@
+en: Fix bug when saving a Region without a Zammad URL
+de: Fehlerkorrektur beim Speichern einer Region ohne Zammad URL


### PR DESCRIPTION
### Short description
Fix handling empty Zammad URL in region form. We allowed Null/None values for the zammad_url field in #3051 but forgot to consider this in the form sanitization.

### Proposed changes
- Check if the zammad_url field in the form is empty before doing string operations. If empty, return None (Null for database).

### Side effects
- I cannot think of any.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3098


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
