### PR TITLE
Improve the performance of `get_region_links`

### DIFF
--- a/integreat_cms/cms/views/dashboard/dashboard_view.py
+++ b/integreat_cms/cms/views/dashboard/dashboard_view.py
@@ -157,7 +157,9 @@ class DashboardView(TemplateView, ChatContextMixin):
 
         :return: Dictionary containing the context for broken links
         """
-        invalid_urls = filter_urls(request.region.slug, "invalid")[0]
+        invalid_urls = filter_urls(
+            request.region.slug, "invalid", prefetch_region_links=True
+        )[0]
         invalid_url = invalid_urls[0] if invalid_urls else None
 
         relevant_translation = (

--- a/integreat_cms/cms/views/linkcheck/linkcheck_list_view.py
+++ b/integreat_cms/cms/views/linkcheck/linkcheck_list_view.py
@@ -90,7 +90,9 @@ class LinkcheckListView(ListView):
         :return: The QuerySet of the filtered urls
         """
         urls, count_dict = filter_urls(
-            self.kwargs.get("region_slug"), self.kwargs.get("url_filter")
+            self.kwargs.get("region_slug"),
+            self.kwargs.get("url_filter"),
+            prefetch_region_links=True,
         )
         self.extra_context.update(count_dict)
         return urls
@@ -102,7 +104,9 @@ class LinkcheckListView(ListView):
         if edit_url_id := kwargs.pop("url_id", None):
             region = request.region.slug if request.region else None
             try:
-                self.instance = get_urls(region, url_ids=[edit_url_id])[0]
+                self.instance = get_urls(
+                    region, url_ids=[edit_url_id], prefetch_region_links=True
+                )[0]
             except IndexError as e:
                 raise Http404("This URL does not exist") from e
             if request.POST:


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
I noticed that postgres could not optimize our query which loads links for a specific region very well. A dramatic speedup is possible by making a multiple smaller queries and `union`ing them together, instead of making a big query with a more complex condition.


### Proposed changes
<!-- Describe this PR in more detail. -->

- use `union all` to speed up the `get_region_links` query by up to 90% (Augsburg)
- Add a new parameter to `get_urls` and `filter_urls` to prevent the prefetch. The prefetch typically takes more time than the query. Thus, it can save more than 50% when the prefetch is not needed.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- #3079 on the production data now takes one minute, instead of six minutes :tada: (Though there is still a lot of optimization potential)
- faster region linkcheck view loading 

### Future work
For testing, I added an index on the link model and got another 30-40% performance improvement. However, this will have to be a pr at django-linkcheck


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: /


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
