### PR TITLE
Disallow publishing imported events through version history

### DIFF
--- a/integreat_cms/cms/templates/content_versions.html
+++ b/integreat_cms/cms/templates/content_versions.html
@@ -131,104 +131,48 @@
         <div class="w-full p-4 flex justify-end gap-4 action-buttons">
             {% if not object.archived %}
                 {% if can_publish %}
-                    <!-- Reject buttons for latest version  -->
-                    <button name="status"
-                            class="btn btn-red hidden"
-                            data-status="{{ AUTO_SAVE }}"
-                            data-max>
-                        {% translate "Discard auto save" %}
+                    <button name="status" {% if translations.first.event.external_calendar %} disabled title="{% translate "The status of imported events can't be changed" %}" {% endif %} class="btn btn-red hidden" data-status="{{ AUTO_SAVE }}" data-max> {% translate "Discard auto save" %}
                     </button>
-                    <button name="status"
-                            class="btn btn-red hidden"
-                            data-status="{{ REVIEW }}"
-                            data-max>
+                    <button name="status" {% if translations.first.event.external_calendar %} disabled title="{% translate "The status of imported events can't be changed" %}" {% endif %} class="btn btn-red hidden" data-status="{{ REVIEW }}" data-max>
                         {% translate "Reject changes" %}
                     </button>
-                    <!-- Draft buttons -->
-                    <button name="status"
-                            value="{{ DRAFT }}"
-                            class="btn btn-outline hidden"
-                            data-status="{{ PUBLIC }}">
+                    <button name="status" {% if translations.first.event.external_calendar %} disabled title="{% translate "The status of imported events can't be changed" %}" {% endif %} value="{{ DRAFT }}" class="btn btn-outline hidden" data-status="{{ PUBLIC }}">
                         {% translate "Restore as draft" %}
                     </button>
-                    <button name="status"
-                            value="{{ DRAFT }}"
-                            class="btn btn-outline hidden"
-                            data-status="{{ DRAFT }}">
+                    <button name="status" {% if translations.first.event.external_calendar %} disabled title="{% translate "The status of imported events can't be changed" %}" {% endif %} value="{{ DRAFT }}" class="btn btn-outline hidden" data-status="{{ DRAFT }}">
                         {% translate "Restore as draft" %}
                     </button>
-                    <button name="status"
-                            value="{{ DRAFT }}"
-                            class="btn btn-outline hidden"
-                            data-status="{{ AUTO_SAVE }}">
+                    <button name="status" {% if translations.first.event.external_calendar %} disabled title="{% translate "The status of imported events can't be changed" %}" {% endif %} value="{{ DRAFT }}" class="btn btn-outline hidden" data-status="{{ AUTO_SAVE }}">
                         {% translate "Restore auto save as draft" %}
                     </button>
-                    <button name="status"
-                            value="{{ DRAFT }}"
-                            class="btn btn-outline hidden"
-                            data-status="{{ REVIEW }}">
+                    <button name="status" {% if translations.first.event.external_calendar %} disabled title="{% translate "The status of imported events can't be changed" %}" {% endif %} value="{{ DRAFT }}" class="btn btn-outline hidden" data-status="{{ REVIEW }}">
                         {% translate "Accept and restore changes as draft" %}
                     </button>
-                    <!-- Draft buttons for latest version -->
-                    <button name="status"
-                            value="{{ DRAFT }}"
-                            class="btn btn-outline hidden"
-                            data-status="{{ REVIEW }}"
-                            data-max>
+                    <button name="status" {% if translations.first.event.external_calendar %} disabled title="{% translate "The status of imported events can't be changed" %}" {% endif %} value="{{ DRAFT }}" class="btn btn-outline hidden" data-status="{{ REVIEW }}" data-max>
                         {% translate "Accept current changes as draft" %}
                     </button>
-                    <!-- Publish buttons -->
-                    <button name="status"
-                            value="{{ PUBLIC }}"
-                            class="btn hidden"
-                            data-status="{{ PUBLIC }}">
+                    <button name="status" {% if translations.first.event.external_calendar %} disabled title="{% translate "The status of imported events can't be changed" %}" {% endif %} value="{{ PUBLIC }}" class="btn hidden" data-status="{{ PUBLIC }}">
                         {% translate "Restore and publish" %}
                     </button>
-                    <button name="status"
-                            value="{{ PUBLIC }}"
-                            class="btn hidden"
-                            data-status="{{ DRAFT }}">
+                    <button name="status" {% if translations.first.event.external_calendar %} disabled title="{% translate "The status of imported events can't be changed" %}" {% endif %} value="{{ PUBLIC }}" class="btn hidden" data-status="{{ DRAFT }}">
                         {% translate "Restore and publish" %}
                     </button>
-                    <button name="status"
-                            value="{{ PUBLIC }}"
-                            class="btn hidden"
-                            data-status="{{ AUTO_SAVE }}">
+                    <button name="status" {% if translations.first.event.external_calendar %} disabled title="{% translate "The status of imported events can't be changed" %}" {% endif %} value="{{ PUBLIC }}" class="btn hidden" data-status="{{ AUTO_SAVE }}">
                         {% translate "Restore and publish auto save" %}
                     </button>
-                    <button name="status"
-                            value="{{ PUBLIC }}"
-                            class="btn hidden"
-                            data-status="{{ REVIEW }}">
+                    <button name="status" {% if translations.first.event.external_calendar %} disabled title="{% translate "The status of imported events can't be changed" %}" {% endif %} value="{{ PUBLIC }}" class="btn hidden" data-status="{{ REVIEW }}">
                         {% translate "Accept, restore and publish changes" %}
                     </button>
-                    <!-- Publish buttons for latest version  -->
-                    <button name="status"
-                            value="{{ PUBLIC }}"
-                            class="btn hidden"
-                            data-status="{{ PUBLIC }}"
-                            data-max>
+                    <button name="status" {% if translations.first.event.external_calendar %} disabled title="{% translate "The status of imported events can't be changed" %}" {% endif %} value="{{ PUBLIC }}" class="btn hidden" data-status="{{ PUBLIC }}" data-max>
                         {% translate "Refresh date" %}
                     </button>
-                    <button name="status"
-                            value="{{ PUBLIC }}"
-                            class="btn hidden"
-                            data-status="{{ DRAFT }}"
-                            data-max>
+                    <button name="status" {% if translations.first.event.external_calendar %} disabled title="{% translate "The status of imported events can't be changed" %}" {% endif %} value="{{ PUBLIC }}" class="btn hidden" data-status="{{ DRAFT }}" data-max>
                         {% translate "Publish the current draft" %}
                     </button>
-                    <button name="status"
-                            value="{{ PUBLIC }}"
-                            class="btn hidden"
-                            data-status="{{ AUTO_SAVE }}"
-                            data-max>
+                    <button name="status" {% if translations.first.event.external_calendar %} disabled title="{% translate "The status of imported events can't be changed" %}" {% endif %} value="{{ PUBLIC }}" class="btn hidden" data-status="{{ AUTO_SAVE }}" data-max>
                         {% translate "Publish auto save" %}
                     </button>
-                    <button name="status"
-                            value="{{ PUBLIC }}"
-                            class="btn hidden"
-                            data-status="{{ REVIEW }}"
-                            data-max>
+                    <button name="status" {% if translations.first.event.external_calendar %} disabled title="{% translate "The status of imported events can't be changed" %}" {% endif %} value="{{ PUBLIC }}" class="btn hidden" data-status="{{ REVIEW }}" data-max>
                         {% translate "Accept and publish the current changes" %}
                     </button>
                 {% elif can_edit %}

--- a/integreat_cms/cms/views/content_version_view.py
+++ b/integreat_cms/cms/views/content_version_view.py
@@ -13,6 +13,7 @@ from django.views.generic.base import TemplateView
 from django.views.generic.detail import SingleObjectMixin
 
 from ..constants import status
+from ..models import Event
 
 if TYPE_CHECKING:
     from typing import Any
@@ -274,6 +275,24 @@ class ContentVersionView(PermissionRequiredMixin, SingleObjectMixin, TemplateVie
 
         :return: The rendered template response
         """
+        if self.model is Event and self.get_object().external_calendar:
+            logger.info(
+                "%s %s can not change its status as it was imported from an external calendar",
+                self.model_name,
+                self.get_object(),
+            )
+
+            messages.info(
+                request,
+                _(
+                    "%s %s can not change its status as it was imported from an external calendar"
+                )
+                % (
+                    self.model_name,
+                    self.get_object(),
+                ),
+            )
+            return redirect(self.versions_url)
 
         if desired_status := request.POST.get("status"):
             try:

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -5533,6 +5533,10 @@ msgid "Minor edit"
 msgstr "Geringfügige Änderung"
 
 #: cms/templates/content_versions.html
+msgid "The status of imported events can't be changed"
+msgstr "Der Status von importierten Veranstaltungen kann nicht geändert werden"
+
+#: cms/templates/content_versions.html
 msgid "Discard auto save"
 msgstr "Automatische Speicherung verwerfen"
 
@@ -9227,6 +9231,14 @@ msgstr "Link zum {}"
 #: cms/views/content_version_view.py
 msgid "The version {} does not exist."
 msgstr "Die Version {} existiert nicht."
+
+#: cms/views/content_version_view.py
+#, python-format
+msgid ""
+"%s %s can not change its status as it was imported from an external calendar"
+msgstr ""
+"Der Status von %s %s kann nicht geändert "
+"werden, da diese Veranstaltung aus einem externen Kalender importiert wurde"
 
 #: cms/views/content_version_view.py
 msgid "You cannot reject changes if there is no version to return to."


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR removes the buttons from the version history for imported events from an external calendar.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Remove buttons


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- I'm not 100% sure if this is the best way to do it, or if maybe some explanatory text would be helpful. What do you think?


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3107 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
