### PR TITLE
[2024-11-07] Fix enter saves form

### DIFF
--- a/integreat_cms/cms/templates/events/external_calendar_form.html
+++ b/integreat_cms/cms/templates/events/external_calendar_form.html
@@ -21,7 +21,8 @@
                 <div class="flex flex-wrap justify-between gap-4">
                     {% if external_calendar_form.instance.id and perms.cms.delete_externalcalendar %}
                         <div class="flex flex-wrap gap-4">
-                            <button title="{% translate "Delete external calendar" %}"
+                            <button type="button"
+                                    title="{% translate "Delete external calendar" %}"
                                     class="btn confirmation-button btn-red"
                                     data-confirmation-title="{{ delete_dialog_title }}"
                                     data-confirmation-text="{{ delete_dialog_text }}"
@@ -32,7 +33,7 @@
                             </button>
                         </div>
                     {% endif %}
-                    <button class="btn">
+                    <button type="submit" class="btn">
                         {% if external_calendar_form.instance.id %}
                             {% translate "Update & Import" %}
                         {% else %}

--- a/integreat_cms/cms/templates/organizations/organization_form.html
+++ b/integreat_cms/cms/templates/organizations/organization_form.html
@@ -27,7 +27,8 @@
                                 {% translate "Delete" %}
                             </button>
                         {% else %}
-                            <button title="{% translate "Delete organization" %}"
+                            <button type="button"
+                                    title="{% translate "Delete organization" %}"
                                     class="btn confirmation-button btn-red"
                                     data-confirmation-title="{{ delete_dialog_title }}"
                                     data-confirmation-text="{{ delete_dialog_text }}"
@@ -41,7 +42,7 @@
                 {% endif %}
                 {% if perms.cms.change_organization %}
                     <div class="flex flex-wrap gap-4">
-                        <button class="btn">
+                        <button type="submit" class="btn">
                             {% translate "Save" %}
                         </button>
                     </div>


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Hitting `Enter` in our organization or external calendar form opens the "Do you really want to delete this?" popup. This is not the desired behavior. Instead the form should be saved when hitting `Enter`. This issue was because the delete button is the first one on our page and therefore by default the button that's going to be executed when hitting `Enter` (at least this was the result of my research).

### Proposed changes
<!-- Describe this PR in more detail. -->

- Adjust button type in organization and external calendar form. The "Submit"-Button will be executed when hitting `Enter`, which fixes the issue at hand


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- I went through the other content types (at least POI, event and pages). There we don't have this issue.
- I'm not aware of any possible side effects by this change


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3112


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
