### PR TITLE
Fix end date of all-day events in iCal imports

### DIFF
--- a/integreat_cms/cms/utils/external_calendar_utils.py
+++ b/integreat_cms/cms/utils/external_calendar_utils.py
@@ -51,6 +51,7 @@ class IcalEventData:
         :param logger: The logger to use
         :return: An instance of IcalEventData
         """
+        # pylint: disable=too-many-locals
         event_id = event.decoded("UID").decode("utf-8")
         title = event.decoded("SUMMARY").decode("utf-8")
         content = clean_content(
@@ -73,15 +74,25 @@ class IcalEventData:
             content[:32],
         )
 
+        is_all_day = not (
+            isinstance(start, datetime.datetime) and isinstance(end, datetime.datetime)
+        )
+        if is_all_day:
+            start_date, start_time = start, None
+            end_date, end_time = end - datetime.timedelta(days=1), None
+        else:
+            start_date, start_time = start.date(), start.time()
+            end_date, end_time = end.date(), end.time()
+
         return cls(
             event_id=event_id,
             title=title,
             content=content,
-            start_date=start.date() if isinstance(start, datetime.datetime) else start,
-            start_time=start.time() if isinstance(start, datetime.datetime) else None,
-            end_date=end.date() if isinstance(end, datetime.datetime) else end,
-            end_time=end.time() if isinstance(end, datetime.datetime) else None,
-            is_all_day=not isinstance(start, datetime.datetime),
+            start_date=start_date,
+            start_time=start_time,
+            end_date=end_date,
+            end_time=end_time,
+            is_all_day=is_all_day,
             external_calendar_id=external_calendar_id,
             categories=categories,
         )


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->


### Proposed changes
<!-- Describe this PR in more detail. -->

- simply subtract a day from the imported date if the event is all-day


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

Even though it is probably not likely to occur "in the wild", we previously had the possibility of *only* either the start or end date being a `datetime.date` instead of a `datetime.datetime`.

This could lead to either all-day events with and end time, or non-all-day events with no end time.
I opted to change the logic slightly, and now events are all-day as soon as either the start or end has no time.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3109


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
