### PR TITLE
Add support for deepl glossaries

### DIFF
--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -924,6 +924,11 @@ DEEPL_API_URL: Final[str | None] = os.environ.get("INTEGREAT_CMS_DEEPL_API_URL")
 #: Authentication token for the DeepL API. If not set, automatic translations via DeepL are disabled
 DEEPL_AUTH_KEY: str | None = os.environ.get("INTEGREAT_CMS_DEEPL_AUTH_KEY")
 
+#: Whether to enable deepl glossaries
+DEEPL_GLOSSARIES_ENABLED: Final[bool] = strtobool(
+    os.environ.get("INTEGREAT_CMS_DEEPL_GLOSSARIES_ENABLED", "False")
+)
+
 #: Whether automatic translations via DeepL are enabled.
 #: This is ``True`` if :attr:`~integreat_cms.core.settings.DEEPL_AUTH_KEY` is set, ``False`` otherwise.
 DEEPL_ENABLED: bool = bool(DEEPL_AUTH_KEY)

--- a/integreat_cms/deepl_api/apps.py
+++ b/integreat_cms/deepl_api/apps.py
@@ -9,7 +9,7 @@ import os
 import sys
 from typing import TYPE_CHECKING
 
-from deepl import Translator
+from deepl import GlossaryInfo, Translator
 from deepl.exceptions import DeepLException
 from django.apps import AppConfig
 from django.conf import settings
@@ -36,6 +36,29 @@ class DeepLApiClientConfig(AppConfig):
     supported_source_languages: list[str] = []
     #: The supported target languages
     supported_target_languages: list[str] = []
+    #: The supported glossaries, a map from (source_language, target_language) to glossary info
+    supported_glossaries: dict[tuple[str, str], GlossaryInfo] = {}
+
+    def get_glossary(
+        self, source_language: str, target_language: str
+    ) -> GlossaryInfo | None:
+        """
+        Looks up a glossary for the specified source language and target language pair.
+        This method also returns the correct glossary for region variants (for example en-gb)
+
+        :param source_language: The source language
+        :param target_language: The target language
+        :return: A :class:`~deepl.glossaries.GlossaryInfo` object or None
+        """
+
+        def normalize(language: str) -> str:
+            """
+            Normalizes the language by converting it to lower-case and only keeping the non-regional part
+            """
+            return language.lower().split("-")[0]
+
+        key = normalize(source_language), normalize(target_language)
+        return self.supported_glossaries.get(key)
 
     def ready(self) -> None:
         """
@@ -52,6 +75,7 @@ class DeepLApiClientConfig(AppConfig):
 
                     self.init_supported_source_languages(deepl_translator)
                     self.init_supported_target_languages(deepl_translator)
+                    self.init_supported_glossaries(deepl_translator)
 
                     self.assert_usage_limit_not_reached(deepl_translator)
                 except (DeepLException, AssertionError) as e:
@@ -94,6 +118,26 @@ class DeepLApiClientConfig(AppConfig):
             self.supported_target_languages,
         )
         assert self.supported_target_languages
+
+    def init_supported_glossaries(self, translator: Translator) -> None:
+        """
+        Requests the supported glossaries from the translator and sets them
+
+        :param translator: The deepl translator
+        """
+        if not settings.DEEPL_GLOSSARIES_ENABLED:
+            logger.debug("No glossaries loaded because they are disabled in settings")
+            return
+
+        glossaries = translator.list_glossaries()
+        self.supported_glossaries = {
+            (glossary.source_lang.lower(), glossary.target_lang.lower()): glossary
+            for glossary in glossaries
+            if glossary.ready
+        }
+        logger.debug(
+            "Supported glossaries by DeepL: %s", list(self.supported_glossaries.keys())
+        )
 
     @staticmethod
     def assert_usage_limit_not_reached(translator: Translator) -> None:

--- a/integreat_cms/deepl_api/apps.py
+++ b/integreat_cms/deepl_api/apps.py
@@ -49,34 +49,11 @@ class DeepLApiClientConfig(AppConfig):
                         auth_key=settings.DEEPL_AUTH_KEY,
                         server_url=settings.DEEPL_API_URL,
                     )
-                    self.supported_source_languages = [
-                        source_language.code.lower()
-                        for source_language in deepl_translator.get_source_languages()
-                    ]
-                    logger.debug(
-                        "Supported source languages by DeepL: %r",
-                        self.supported_source_languages,
-                    )
-                    assert self.supported_source_languages
-                    self.supported_target_languages = [
-                        target_languages.code.lower()
-                        for target_languages in deepl_translator.get_target_languages()
-                    ]
-                    logger.debug(
-                        "Supported target languages by DeepL: %r",
-                        self.supported_target_languages,
-                    )
-                    assert self.supported_target_languages
-                    usage = deepl_translator.get_usage()
-                    if usage.any_limit_reached:
-                        logger.warning("DeepL API translation limit reached")
-                    # pylint: disable=protected-access
-                    logger.info(
-                        "DeepL API is available at: %r (character usage: %s of %s)",
-                        deepl_translator._server_url,
-                        usage.character.count,
-                        usage.character.limit,
-                    )
+
+                    self.init_supported_source_languages(deepl_translator)
+                    self.init_supported_target_languages(deepl_translator)
+
+                    self.assert_usage_limit_not_reached(deepl_translator)
                 except (DeepLException, AssertionError) as e:
                     logger.error(e)
                     logger.error(
@@ -85,3 +62,53 @@ class DeepLApiClientConfig(AppConfig):
                     )
             else:
                 logger.info("DeepL API is disabled.")
+
+    def init_supported_source_languages(self, translator: Translator) -> None:
+        """
+        Requests the supported sources languages from the translator and sets them
+
+        :param translator: The deepl translator
+        """
+        self.supported_source_languages = [
+            source_language.code.lower()
+            for source_language in translator.get_source_languages()
+        ]
+        logger.debug(
+            "Supported source languages by DeepL: %r",
+            self.supported_source_languages,
+        )
+        assert self.supported_source_languages
+
+    def init_supported_target_languages(self, translator: Translator) -> None:
+        """
+        Requests the supported target languages from the translator and sets them
+
+        :param translator: The deepl translator
+        """
+        self.supported_target_languages = [
+            target_languages.code.lower()
+            for target_languages in translator.get_target_languages()
+        ]
+        logger.debug(
+            "Supported target languages by DeepL: %r",
+            self.supported_target_languages,
+        )
+        assert self.supported_target_languages
+
+    @staticmethod
+    def assert_usage_limit_not_reached(translator: Translator) -> None:
+        """
+        Requests the usage from the translator and asserts that no limit was reached
+
+        :param translator: The deepl translator
+        """
+        usage = translator.get_usage()
+        if usage.any_limit_reached:
+            logger.warning("DeepL API translation limit reached")
+        # pylint: disable=protected-access
+        logger.info(
+            "DeepL API is available at: %r (character usage: %s of %s)",
+            translator._server_url,
+            usage.character.count,
+            usage.character.limit,
+        )


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pr adds basic support for deepl glossaries.
If enabled, every glossary defined at deepl will be used (undefined behavior if multiple glossaries for the same source to target language pair exist)

For now, the feature is disabled by default.
Note to self: Enable the setting on the test server when merged

### How to test

- Set `DEEPL_GLOSSARIES_ENABLED` to `True` in the settings
- Configure deepl by setting the integreat deepl password to the free deepl api password from passbolt.
- Translate a page that contains glossary words from german to english 
- Check that the english translation uses the corresponding glossary entry

You can print out all available glossary entries with `print(self.translator.get_glossary_entries(glossary))`

~~Note that at the time where I am writing this the de-en dictionary is accidentally reversed (so when translating from de to en, deepl replaces english words in the source translation with german words in the target translation)~~
This is fixed now

### Proposed changes
<!-- Describe this PR in more detail. -->

- Load available glossaries on startup
- Use matching glossary, if it exists


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

None, since the feature is disable by default


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3045


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
