### PR TITLE
Fix translation for empty archived contact list

### DIFF
--- a/integreat_cms/cms/templates/contacts/contact_list.html
+++ b/integreat_cms/cms/templates/contacts/contact_list.html
@@ -74,7 +74,11 @@
                     {% empty %}
                         <tr>
                             <td colspan="8" class="px-4 py-3">
-                                {% translate "No contacts available yet." %}
+                                {% if is_archive %}
+                                    {% translate "No contacts archived yet." %}
+                                {% else %}
+                                    {% translate "No contacts available yet." %}
+                                {% endif %}
                             </td>
                         </tr>
                     {% endfor %}

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -5329,8 +5329,12 @@ msgid "Options"
 msgstr "Optionen"
 
 #: cms/templates/contacts/contact_list.html
+msgid "No contacts archived yet."
+msgstr "Es gibt noch keine archivierten Kontakte."
+
+#: cms/templates/contacts/contact_list.html
 msgid "No contacts available yet."
-msgstr "Noch keine Kontakte vorhanden."
+msgstr "Es gibt noch keine Kontakte."
 
 #: cms/templates/contacts/contact_list.html
 msgid "Contacts selected"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
When opening the list of archived contacts and the list is still empty the wrong text is shown. This PR fixes the translation.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Fix translation


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

None


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3152


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
