### PR TITLE
Fix data error when copying long contact

### DIFF
--- a/integreat_cms/cms/migrations/0109_custom_truncating_char_field.py
+++ b/integreat_cms/cms/migrations/0109_custom_truncating_char_field.py
@@ -1,0 +1,51 @@
+from django.db import migrations
+
+import integreat_cms.cms.models.fields.truncating_char_field
+
+
+class Migration(migrations.Migration):
+    """
+    Migration file to change the field point_of_contact_for from a CharField to a TruncatingCharField
+    """
+
+    dependencies = [
+        ("cms", "0108_rename_contact_title_to_point_of_contact_for"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="contact",
+            name="point_of_contact_for",
+            field=integreat_cms.cms.models.fields.truncating_char_field.TruncatingCharField(
+                blank=True, max_length=200, verbose_name="point of contact for"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="eventtranslation",
+            name="title",
+            field=integreat_cms.cms.models.fields.truncating_char_field.TruncatingCharField(
+                max_length=1024, verbose_name="title"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="imprintpagetranslation",
+            name="title",
+            field=integreat_cms.cms.models.fields.truncating_char_field.TruncatingCharField(
+                max_length=1024, verbose_name="title"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="pagetranslation",
+            name="title",
+            field=integreat_cms.cms.models.fields.truncating_char_field.TruncatingCharField(
+                max_length=1024, verbose_name="title"
+            ),
+        ),
+        migrations.AlterField(
+            model_name="poitranslation",
+            name="title",
+            field=integreat_cms.cms.models.fields.truncating_char_field.TruncatingCharField(
+                max_length=1024, verbose_name="title"
+            ),
+        ),
+    ]

--- a/integreat_cms/cms/models/abstract_content_translation.py
+++ b/integreat_cms/cms/models/abstract_content_translation.py
@@ -32,6 +32,7 @@ from ..utils.link_utils import fix_content_link_encoding
 from ..utils.round_hix_score import round_hix_score
 from ..utils.translation_utils import gettext_many_lazy as __
 from .abstract_base_model import AbstractBaseModel
+from .fields.truncating_char_field import TruncatingCharField
 from .languages.language import Language
 
 logger = logging.getLogger(__name__)
@@ -43,7 +44,7 @@ class AbstractContentTranslation(AbstractBaseModel):
     Data model representing a translation of some kind of content (e.g. pages or events)
     """
 
-    title = models.CharField(max_length=1024, verbose_name=_("title"))
+    title = TruncatingCharField(max_length=1024, verbose_name=_("title"))
     slug = models.SlugField(
         max_length=1024,
         allow_unicode=True,
@@ -632,7 +633,7 @@ class AbstractContentTranslation(AbstractBaseModel):
 
         :return: A readable string representation of the content translation
         """
-        return self.title
+        return str(self.title)
 
     def get_repr(self) -> str:
         """

--- a/integreat_cms/cms/models/contact/contact.py
+++ b/integreat_cms/cms/models/contact/contact.py
@@ -1,10 +1,12 @@
 from django.db import models
 from django.db.models import Q
+from django.db.utils import DataError
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 from ..abstract_base_model import AbstractBaseModel
+from ..fields.truncating_char_field import TruncatingCharField
 from ..pois.poi import POI
 from ..regions.region import Region
 
@@ -14,7 +16,7 @@ class Contact(AbstractBaseModel):
     Data model representing a contact
     """
 
-    point_of_contact_for = models.CharField(
+    point_of_contact_for = TruncatingCharField(
         max_length=200, blank=True, verbose_name=_("point of contact for")
     )
     name = models.CharField(max_length=200, blank=True, verbose_name=_("name"))
@@ -116,7 +118,6 @@ class Contact(AbstractBaseModel):
         """
         Copies the contact
         """
-        # In order to create a new object set pk to None
         self.pk = None
         self.point_of_contact_for = self.point_of_contact_for + " " + _("(Copy)")
         self.save()

--- a/integreat_cms/cms/models/fields/truncating_char_field.py
+++ b/integreat_cms/cms/models/fields/truncating_char_field.py
@@ -1,0 +1,16 @@
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+
+class TruncatingCharField(models.CharField):
+    """
+    Custom model field for CharFields that need to be truncated
+    This is necessary in cases where we append a suffix and need to ensure to not exceed the limit and get a `DataError`.
+    """
+
+    def get_prep_value(self, value: str) -> str | None:
+        value = super().get_prep_value(value)
+
+        if value and len(value) > self.max_length:
+            return value[: self.max_length - 3] + "..."
+        return value

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -2259,7 +2259,8 @@ msgstr "Sprachen und Übersetzungen kopieren"
 msgid ""
 "Disable to skip copying of the language tree and all content translations."
 msgstr ""
-"Abwählen, um das Kopieren des Sprachbaums und aller Inhaltsübersetzungen zu überspringen."
+"Abwählen, um das Kopieren des Sprachbaums und aller Inhaltsübersetzungen zu "
+"überspringen."
 
 #: cms/forms/regions/region_form.py
 msgid "Page based offers cloning behavior"
@@ -11037,6 +11038,9 @@ msgstr ""
 #~ msgstr ""
 #~ "Einzelne Sprachen können durch Anklicken der Beschriftungen ausgeblendet "
 #~ "werden."
+
+#~ msgid "Copy"
+#~ msgstr "(Kopie)"
 
 #~ msgid "Number of online accesses"
 #~ msgstr "Anzahl der Online-Zugriffe"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR attempts to fix the `DataError` which occurs when copying a long contact name. This is because appending the suffix exceeds the maximum length of the field.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Try & catch
- In case the `DataError` would occur truncate the pre-existing name and then append the suffix.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- ~~I don't have a finally block so there might be some?~~


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3145
Fixes: #3146

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
