### PR TITLE
[2024-11-07] Show related contacts in the POI form

### DIFF
--- a/integreat_cms/cms/models/contact/contact.py
+++ b/integreat_cms/cms/models/contact/contact.py
@@ -3,6 +3,7 @@ from django.db.models import Q
 from django.db.utils import DataError
 from django.utils import timezone
 from django.utils.functional import cached_property
+from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
 
 from ..abstract_base_model import AbstractBaseModel
@@ -90,6 +91,21 @@ class Contact(AbstractBaseModel):
             return _("with website: {}").format(self.website)
 
         return ""
+
+    def label_in_reference_list(self) -> str:
+        """
+        This function returns a display name of this contact for the poi contacts list
+        """
+
+        label = (
+            _("General contact information")
+            if not self.point_of_contact_for
+            else f"{self.point_of_contact_for} {self.name}"
+        )
+        if self.archived:
+            label += " (⚠ " + gettext("Archived") + ")"
+
+        return label
 
     def get_repr(self) -> str:
         """

--- a/integreat_cms/cms/templates/pois/poi_form.html
+++ b/integreat_cms/cms/templates/pois/poi_form.html
@@ -167,6 +167,9 @@
                 <div id="right-sidebar-column"
                      class="flex flex-col flex-wrap 3xl:col-end-3 4xl:col-end-auto md:w-full">
                     {% include "./poi_form_sidebar/contact_box.html" with box_id="poi-contact" %}
+                    {% if poi_form.instance.id and perms.cms.view_contact %}
+                        {% include "./poi_form_sidebar/related_contacts_box.html" with box_id="poi-related-contacts" %}
+                    {% endif %}
                     {% include "./poi_form_sidebar/opening_hours_box.html" with box_id="poi-opening-hours" no_padding=True %}
                     {% include "./poi_form_sidebar/category_box.html" with box_id="poi-category" %}
                     {% include "./poi_form_sidebar/icon_box.html" with box_id="poi-icon" %}

--- a/integreat_cms/cms/templates/pois/poi_form_sidebar/action_box.html
+++ b/integreat_cms/cms/templates/pois/poi_form_sidebar/action_box.html
@@ -68,7 +68,7 @@
                         {% for contact in poi_form.instance.contacts.all %}
                             <a href="{% url 'edit_contact' contact_id=contact.id region_slug=request.region.slug %}"
                                class="block pt-2 hover:underline">
-                                <i icon-name="pen-square" class="mr-2"></i> {{ contact.point_of_contact_for }} {{ contact.name }}
+                                <i icon-name="pen-square" class="mr-2"></i> {{ contact.label_in_reference_list }}
                             </a>
                         {% endfor %}
                     </div>
@@ -130,7 +130,7 @@
                         {% for contact in poi_form.instance.contacts.all %}
                             <a href="{% url 'edit_contact' contact_id=contact.id region_slug=request.region.slug %}"
                                class="block pt-2 hover:underline">
-                                <i icon-name="pen-square" class="mr-2"></i> {{ contact.point_of_contact_for }} {{ contact.name }}
+                                <i icon-name="pen-square" class="mr-2"></i> {{ contact.label_in_reference_list }}
                             </a>
                         {% endfor %}
                     </div>

--- a/integreat_cms/cms/templates/pois/poi_form_sidebar/related_contacts_box.html
+++ b/integreat_cms/cms/templates/pois/poi_form_sidebar/related_contacts_box.html
@@ -1,0 +1,28 @@
+{% extends "../../_collapsible_box.html" %}
+{% load i18n %}
+{% load widget_tweaks %}
+{% block collapsible_box_icon %}
+    message-square
+{% endblock collapsible_box_icon %}
+{% block collapsible_box_title %}
+    {% trans "Related contacts" %}
+{% endblock collapsible_box_title %}
+{% block collapsible_box_content %}
+    {% with poi_form.instance.contacts.all as contacts %}
+        <div>
+            <div class="help-text">
+                {% if contacts %}
+                    {% trans "This location is currently referred to by the following contacts." %}
+                {% else %}
+                    {% trans "This location is not currently referred to in any contact." %}
+                {% endif %}
+            </div>
+            {% for contact in contacts %}
+                <a href="{% url 'edit_contact' contact_id=contact.id region_slug=request.region.slug %}"
+                   class="block pt-2 hover:underline">
+                    <i icon-name="pen-square" class="mr-2"></i> {{ contact.label_in_reference_list }}
+                </a>
+            {% endfor %}
+        </div>
+    {% endwith %}
+{% endblock collapsible_box_content %}

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -1680,9 +1680,9 @@ msgstr "Aktiv"
 msgid "Hidden"
 msgstr "Versteckt"
 
-#: cms/constants/region_status.py cms/models/pages/page_translation.py
-#: cms/models/regions/region.py cms/templates/events/event_form.html
-#: cms/templates/pages/page_form.html
+#: cms/constants/region_status.py cms/models/contact/contact.py
+#: cms/models/pages/page_translation.py cms/models/regions/region.py
+#: cms/templates/events/event_form.html cms/templates/pages/page_form.html
 #: cms/templates/pages/page_tree_archived_node.html
 #: cms/templates/pois/poi_form.html
 msgid "Archived"
@@ -2811,6 +2811,10 @@ msgstr "mit Telefonnummer: {}"
 #: cms/models/contact/contact.py
 msgid "with website: {}"
 msgstr "mit Website: {}"
+
+#: cms/models/contact/contact.py
+msgid "General contact information"
+msgstr "Allgemeine Kontaktinformationen"
 
 #: cms/models/contact/contact.py
 msgid "(Copy)"
@@ -7759,6 +7763,18 @@ msgstr "Nur Koordinaten übernehmen"
 #: cms/templates/pois/poi_form_sidebar/position_box.html
 msgid "Please choose one option or cancel"
 msgstr "Bitte eine Option auswählen oder abbrechen"
+
+#: cms/templates/pois/poi_form_sidebar/related_contacts_box.html
+msgid "Related contacts"
+msgstr "Zugehörige Kontakte"
+
+#: cms/templates/pois/poi_form_sidebar/related_contacts_box.html
+msgid "This location is currently referred to by the following contacts."
+msgstr "Dieser Ort wird in folgenden Kontakten verwendet."
+
+#: cms/templates/pois/poi_form_sidebar/related_contacts_box.html
+msgid "This location is not currently referred to in any contact."
+msgstr "Zur Zeit gibt es keine Kontakte zu diesem Ort."
 
 #: cms/templates/pois/poi_list.html cms/templates/pois/poi_list_archived.html
 msgid "Archived locations"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR implements a box into the POI form which shows contacts referring the POI.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add a new collapsible side box like "Organization", "Barrier free" or "Actions"
- List up related contacts with a link to contact form respectively
- Add tests for this box

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- This brings more duplicate than mentioned in #3147 but it is consistent with other models (Organization, for example) to show the list of related objects. I'll leave the duplicate problem to #3147.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3087 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
