### PR TITLE
Sort news/push notifications

### DIFF
--- a/docs/src/api-docs.rst
+++ b/docs/src/api-docs.rst
@@ -673,6 +673,7 @@ RESPONSE
       "message": String,       // The message of the push notification in the given language
       "timestamp": String,     // Deprecated field
       "last_updated": String,  // The date&time when the push notification was last updated
+      "display_date": String,  // The date&time when the push notification was sent / last updated (whichever is newer)
       "channel": String,       // The channel the push notification was sent to (e.g. "News")
       "available_languages": [           // The available languages of the push notification
             "<language_slug>": {


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
News items are sent out as push notifications to subscribed devices as well as served via our API. Push notifications are saved as separate objects in our database in order to retain the information for which news items we already sent notifications and to keep that separate from the concept of the content of the news item itself.

News items have a property `last_updated`, which describes when the content was last edited. Push Notification objects have a `sent_date`, which describes when the notification for this news item in that channel and this language was sent out. In the API, we only expose `last_updated`, which is the value also being displayed in the app. This can cause confusion whenever the date the news item was last edited is far before the date when it was actually sent.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add a value `display_date` to each news item returned by the API which equals either `last_updated` or `sent_date` of the corresponding push notification, whichever is greater *(effectively clamping the value of `last_updated` to be no earlier than `sent_date`)*
- Sort the news entries returned by the API by the `display_date` value instead of `last_updated`

> *Alternatively, we could decide to alter `last_updated` or `timestamp` to the new behaviour. It seems that we deprecated `timestamp` in 2022 in favour of the new `last_updated`, but it is still in use by the app. There are hints that converting the timestamp to be in the local time zone of the server is the reason, but we should ask directly if we wish to pursue such an alternative.*

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- After this PR is merged and released, the app will need to switch from ~~`last_updated`~~ `timestamp` over to `display_date`. No further change should be required.
  If it aligns with how the app team handles this, https://github.com/digitalfabrik/integreat-app/issues/2952 might be repurposed for that request.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2994


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
