### PR TITLE
[2024-12-18] Make the number of online accesses in statistics collapsible

### DIFF
--- a/integreat_cms/cms/templates/statistics/statistics_chart.html
+++ b/integreat_cms/cms/templates/statistics/statistics_chart.html
@@ -1,0 +1,30 @@
+{% extends "_collapsible_box.html" %}
+{% load i18n %}
+{% load static %}
+{% load widget_tweaks %}
+{% block collapsible_box_icon %}
+    trending-up
+{% endblock collapsible_box_icon %}
+{% block collapsible_box_title %}
+    {% translate "Total accesses" %}
+{% endblock collapsible_box_title %}
+{% block collapsible_box_content %}
+    <div class="lg:col-span-2 2xl:row-span-2 2xl:col-span-3 bg-white">
+        <div class="p-5 bg-white text-center">
+            <div id="chart-network-error" class="text-red-500 px-4 hidden">
+                <i icon-name="alert-triangle"></i> {% translate "A network error has occurred." %} {% translate "Please try again later." %}
+            </div>
+            <div id="chart-heavy-traffic-error" class="text-red-500 px-4 hidden">
+                <i icon-name="alert-triangle"></i> {% translate "The statistics network is currently experiencing heavy traffic." %} {% translate "Please try again later." %}
+            </div>
+            <div id="chart-server-error" class="text-red-500 px-4 hidden">
+                <i icon-name="alert-triangle"></i> {% translate "A server error has occurred." %} {% translate "Please contact the administrator." %}
+            </div>
+            <div id="chart-loading" class="px-4 hidden">
+                <i icon-name="loader" class="animate-spin"></i> {% translate "Loading..." %}
+            </div>
+            <canvas id="statistics"
+                    data-statistics-url="{% url 'statistics_visits_per_language' region_slug=request.region.slug %}"></canvas>
+        </div>
+    </div>
+{% endblock collapsible_box_content %}

--- a/integreat_cms/cms/templates/statistics/statistics_overview.html
+++ b/integreat_cms/cms/templates/statistics/statistics_overview.html
@@ -1,113 +1,16 @@
 {% extends "_base.html" %}
 {% load i18n %}
-{% load static %}
-{% load widget_tweaks %}
-{% block content %}
-    <div class="row">
-        <div class="col-sm-12">
-            <h1 class="heading">
-                {% translate "Statistics" %}
-            </h1>
-        </div>
-        <div class="grid grid-cols-1 lg:grid-cols-2 gap-3 2xl:grid-cols-4">
-            <div class="lg:col-span-2 2xl:row-span-3 2xl:col-span-3 rounded border border-solid border-blue-500 shadow-2xl bg-white">
-                <div class="rounded p-4 bg-water-500">
-                    <h3 class="heading font-bold text-black">
-                        <i icon-name="trending-up" class="pb-1"></i> {% translate "Total accesses" %}
-                    </h3>
+{% if request.region.statistics_enabled and perms.cms.view_statistics %}
+    {% block content %}
+        <div class="row">
+            <div class="xl:flex gap-3 pt-2">
+                <div class="xl:w-3/4">
+                    {% include "statistics/statistics_chart.html" with box_id="statistics_chart" %}
                 </div>
-                <div class="p-5 bg-white text-center">
-                    <div id="chart-network-error" class="text-red-500 px-4 hidden">
-                        <i icon-name="alert-triangle"></i> {% translate "A network error has occurred." %} {% translate "Please try again later." %}
-                    </div>
-                    <div id="chart-heavy-traffic-error" class="text-red-500 px-4 hidden">
-                        <i icon-name="alert-triangle"></i> {% translate "The statistics network is currently experiencing heavy traffic." %} {% translate "Please try again later." %}
-                    </div>
-                    <div id="chart-server-error" class="text-red-500 px-4 hidden">
-                        <i icon-name="alert-triangle"></i> {% translate "A server error has occurred." %} {% translate "Please contact the administrator." %}
-                    </div>
-                    <div id="chart-loading" class="px-4 hidden">
-                        <i icon-name="loader" class="animate-spin"></i> {% translate "Loading..." %}
-                    </div>
-                    <canvas id="statistics"
-                            data-statistics-url="{% url 'statistics_visits_per_language' region_slug=request.region.slug %}"></canvas>
-                </div>
-            </div>
-            <div class="rounded border border-solid border-blue-500 shadow-2xl bg-white hidden"
-                 id="chart-legend-container">
-                <div class="rounded p-4 bg-water-500">
-                    <h3 class="heading font-bold text-black">
-                        <i icon-name="settings" class="pb-1"></i> {% translate "Adjust shown data" %}
-                    </h3>
-                </div>
-                <div id="chart-legend">
-                </div>
-            </div>
-            <div class="rounded border border-solid border-blue-500 shadow-2xl bg-white">
-                <div class="rounded p-4 bg-water-500">
-                    <h3 class="heading font-bold text-black">
-                        <i icon-name="calendar" class="pb-1"></i> {% translate "Adjust time period" %}
-                    </h3>
-                </div>
-                <form id="statistics-form" class="flex flex-col p-4 pt-2">
-                    {% csrf_token %}
-                    <label for="{{ form.start_date.id_for_label }}">
-                        {{ form.start_date.label }}
-                    </label>
-                    {% render_field form.start_date|add_error_class:"border-red-500" %}
-                    <div id="start_date_error"
-                         class="chart-client-error text-red-500 pb-2 hidden">
-                        <i icon-name="alert-triangle"></i>
-                    </div>
-                    <label for="{{ form.end_date.id_for_label }}">
-                        {{ form.end_date.label }}
-                    </label>
-                    {% render_field form.end_date|add_error_class:"border-red-500" %}
-                    <div id="end_date_error"
-                         class="chart-client-error text-red-500 pb-2 hidden">
-                        <i icon-name="alert-triangle"></i>
-                    </div>
-                    <label for="{{ form.period.id_for_label }}">
-                        {{ form.period.label }}
-                    </label>
-                    {% render_field form.period|add_error_class:"border-red-500" %}
-                    <div id="period_error" class="chart-client-error text-red-500 pb-2 hidden">
-                        <i icon-name="alert-triangle"></i>
-                    </div>
-                    <button class="btn mt-4">
-                        {% translate "Customize view" %}
-                    </button>
-                </form>
-            </div>
-            <div class="rounded border border-solid border-blue-500 shadow-2xl bg-white">
-                <div class="rounded p-4 bg-water-500">
-                    <h3 class="heading font-bold text-black">
-                        <i icon-name="download" class="pb-1"></i> {% translate "Export" %}
-                    </h3>
-                </div>
-                <div class="flex flex-col gap-4 p-4 pt-2">
-                    <label for="export-format">
-                        {% translate "Choose format" %}
-                    </label>
-                    <select id="export-format"
-                            data-filename-prefix="{% translate "Statistics" %} {{ request.region.name }}"
-                            data-language-column-title="{% translate "Language" %}">
-                        <option value="" selected>
-                            --- {% translate "please select" %} ---
-                        </option>
-                        <option value="image">
-                            {% translate "Image/PNG" %}
-                        </option>
-                        <option value="csv">
-                            {% translate "Table Document/CSV" %}
-                        </option>
-                    </select>
-                    <button id="export-button" class="btn" disabled>
-                        {% translate "Export" %}
-                    </button>
-                    <a id="export-download-link" class="hidden"></a>
+                <div class="xl:w-1/4 grid grid-cols-1">
+                    {% include "statistics/statistics_sidebar.html" with box_id="statistics_sidebar" %}
                 </div>
             </div>
         </div>
-    </div>
-{% endblock content %}
+    {% endblock content %}
+{% endif %}

--- a/integreat_cms/cms/templates/statistics/statistics_sidebar.html
+++ b/integreat_cms/cms/templates/statistics/statistics_sidebar.html
@@ -1,0 +1,52 @@
+{% load i18n %}
+{% load static %}
+{% load widget_tweaks %}
+<div class="rounded border border-solid border-blue-500 shadow-2xl bg-white hidden mb-2"
+     id="chart-legend-container">
+    <div class="rounded p-4 bg-water-500">
+        <h3 class="heading font-bold text-black">
+            <i icon-name="settings" class="pb-1"></i> {% translate "Adjust shown data" %}
+        </h3>
+    </div>
+    <div id="chart-legend">
+        {% if request.region.statistics_enabled and perms.cms.view_statistics %}
+            {% include "statistics/_statistics_legend.html" with box_id="statistics_legend" %}
+        {% endif %}
+    </div>
+</div>
+<div class="rounded border border-solid border-blue-500 shadow-2xl bg-white">
+    <div class="rounded p-4 bg-water-500">
+        <h3 class="heading font-bold text-black">
+            <i icon-name="calendar" class="pb-1"></i> {% translate "Adjust time period" %}
+        </h3>
+    </div>
+    <form id="statistics-form" class="flex flex-col p-4 pt-2">
+        {% csrf_token %}
+        <label for="{{ form.start_date.id_for_label }}">
+            {{ form.start_date.label }}
+        </label>
+        {% render_field form.start_date|add_error_class:"border-red-500" %}
+        <div id="start_date_error"
+             class="chart-client-error text-red-500 pb-2 hidden">
+            <i icon-name="alert-triangle"></i>
+        </div>
+        <label for="{{ form.end_date.id_for_label }}">
+            {{ form.end_date.label }}
+        </label>
+        {% render_field form.end_date|add_error_class:"border-red-500" %}
+        <div id="end_date_error"
+             class="chart-client-error text-red-500 pb-2 hidden">
+            <i icon-name="alert-triangle"></i>
+        </div>
+        <label for="{{ form.period.id_for_label }}">
+            {{ form.period.label }}
+        </label>
+        {% render_field form.period|add_error_class:"border-red-500" %}
+        <div id="period_error" class="chart-client-error text-red-500 pb-2 hidden">
+            <i icon-name="alert-triangle"></i>
+        </div>
+        <button class="btn mt-4">
+            {% translate "Customize view" %}
+        </button>
+    </form>
+</div>

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -1961,7 +1961,6 @@ msgstr "Alle Regionen"
 #: cms/templates/feedback/region_feedback_list_archived.html
 #: cms/templates/languagetreenodes/languagetreenode_list.html
 #: cms/templates/pages/_page_xliff_import_diff.html
-#: cms/templates/statistics/statistics_overview.html
 #: cms/views/feedback/feedback_resource.py
 msgid "Language"
 msgstr "Sprache"
@@ -4461,7 +4460,6 @@ msgstr "Analyse"
 
 #: cms/templates/_base.html cms/templates/regions/region_form.html
 #: cms/templates/statistics/_statistics_widget.html
-#: cms/templates/statistics/statistics_overview.html
 msgid "Statistics"
 msgstr "Statistiken"
 
@@ -4916,7 +4914,7 @@ msgstr "Detailansicht"
 #: cms/templates/analytics/_broken_links_widget.html
 #: cms/templates/chat/_chat_widget.html
 #: cms/templates/statistics/_statistics_widget.html
-#: cms/templates/statistics/statistics_overview.html
+#: cms/templates/statistics/statistics_chart.html
 #: cms/views/media/media_context_mixin.py
 msgid "A network error has occurred."
 msgstr "Ein Netzwerkfehler ist aufgetreten."
@@ -4924,7 +4922,7 @@ msgstr "Ein Netzwerkfehler ist aufgetreten."
 #: cms/templates/analytics/_broken_links_widget.html
 #: cms/templates/chat/_chat_widget.html cms/templates/hix_widget.html
 #: cms/templates/statistics/_statistics_widget.html
-#: cms/templates/statistics/statistics_overview.html
+#: cms/templates/statistics/statistics_chart.html
 #: cms/views/media/media_context_mixin.py
 msgid "Please try again later."
 msgstr "Bitte versuchen Sie es später erneut."
@@ -4932,14 +4930,14 @@ msgstr "Bitte versuchen Sie es später erneut."
 #: cms/templates/analytics/_broken_links_widget.html
 #: cms/templates/chat/_chat_widget.html
 #: cms/templates/statistics/_statistics_widget.html
-#: cms/templates/statistics/statistics_overview.html
+#: cms/templates/statistics/statistics_chart.html
 msgid "A server error has occurred."
 msgstr "Ein Serverfehler ist aufgetreten."
 
 #: cms/templates/analytics/_broken_links_widget.html
 #: cms/templates/chat/_chat_widget.html
 #: cms/templates/statistics/_statistics_widget.html
-#: cms/templates/statistics/statistics_overview.html xliff/utils.py
+#: cms/templates/statistics/statistics_chart.html xliff/utils.py
 msgid "Please contact the administrator."
 msgstr "Bitte kontaktieren Sie eine:n Administrator:in."
 
@@ -4947,7 +4945,7 @@ msgstr "Bitte kontaktieren Sie eine:n Administrator:in."
 #: cms/templates/dashboard/_news_widget.html cms/templates/hix_widget.html
 #: cms/templates/pois/poi_form_sidebar/position_box.html
 #: cms/templates/statistics/_statistics_widget.html
-#: cms/templates/statistics/statistics_overview.html
+#: cms/templates/statistics/statistics_chart.html
 msgid "Loading..."
 msgstr "Laden..."
 
@@ -8385,45 +8383,25 @@ msgid "Number of total accesses over the last 14 days."
 msgstr "Anzahl der Gesamtzugriffe der letzten 14 Tage."
 
 #: cms/templates/statistics/_statistics_widget.html
-#: cms/templates/statistics/statistics_overview.html
+#: cms/templates/statistics/statistics_chart.html
 msgid "The statistics network is currently experiencing heavy traffic."
 msgstr "Der Statistik-Server hat aktuell eine hohe Auslastung."
 
-#: cms/templates/statistics/statistics_overview.html
+#: cms/templates/statistics/statistics_chart.html
 msgid "Total accesses"
 msgstr "Gesamtzugriffe"
 
-#: cms/templates/statistics/statistics_overview.html
+#: cms/templates/statistics/statistics_sidebar.html
 msgid "Adjust shown data"
 msgstr "Angezeigte Daten anpassen"
 
-#: cms/templates/statistics/statistics_overview.html
+#: cms/templates/statistics/statistics_sidebar.html
 msgid "Adjust time period"
 msgstr "Zeitraum anpassen"
 
-#: cms/templates/statistics/statistics_overview.html
+#: cms/templates/statistics/statistics_sidebar.html
 msgid "Customize view"
 msgstr "Ansicht anpassen"
-
-#: cms/templates/statistics/statistics_overview.html
-msgid "Export"
-msgstr "Exportieren"
-
-#: cms/templates/statistics/statistics_overview.html
-msgid "Choose format"
-msgstr "Format auswählen"
-
-#: cms/templates/statistics/statistics_overview.html
-msgid "please select"
-msgstr "bitte auswählen"
-
-#: cms/templates/statistics/statistics_overview.html
-msgid "Image/PNG"
-msgstr "Bild/PNG"
-
-#: cms/templates/statistics/statistics_overview.html
-msgid "Table Document/CSV"
-msgstr "Tabellendokument/CSV"
 
 #: cms/templates/translations/translations_management.html
 msgid "Manage machine translations"
@@ -11033,24 +11011,26 @@ msgstr ""
 "Diese Seite konnte nicht importiert werden, da sie zu einer anderen Region "
 "gehört ({})."
 
-#~ msgid "{}{}"
-#~ msgstr "{}{}"
-
-#~ msgid " "
-#~ msgstr " "
-
-#, python-format
-#~ msgid "%s %s"
-#~ msgstr "%s %s"
-
-#, python-format
-#~ msgid "%s with %s"
-#~ msgstr "%s mit %s"
 
 #~ msgid "Individual languages can be hidden by clicking on the labels."
 #~ msgstr ""
 #~ "Einzelne Sprachen können durch Anklicken der Beschriftungen ausgeblendet "
 #~ "werden."
+
+#~ msgid "Export"
+#~ msgstr "Exportieren"
+
+#~ msgid "Choose format"
+#~ msgstr "Format auswählen"
+
+#~ msgid "please select"
+#~ msgstr "bitte auswählen"
+
+#~ msgid "Image/PNG"
+#~ msgstr "Bild/PNG"
+
+#~ msgid "Table Document/CSV"
+#~ msgstr "Tabellendokument/CSV"
 
 #~ msgid "Copy"
 #~ msgstr "(Kopie)"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Make the number of online accesses collapsible as a part of the #1097 as shown in [design proposal v3](https://www.figma.com/design/6U7R7Xj4wL7sbjxKRmOG9D/CMS-Project?node-id=1179-830&node-type=frame&t=vaCXaXccgqveytL3-0)

### Proposed changes
<!-- Describe this PR in more detail. -->

- Make use of the template for collapsible box
- Create a new file called statistics to hold all the upcoming collapsible separate boxes in statistics and the sidebar
- Change the path to the template in statistics view

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- should be none?

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3131 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
