### PR TITLE
Fix issue template labels

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,7 +1,7 @@
 ---
 name: "Bug report \U0001F41B"
 about: Create a report to help us improve
-labels: ':bug: bug'
+labels: 'bug'
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,7 +1,7 @@
 ---
 name: "Feature request \U0001F4A1"
 about: Suggest an idea for this project
-labels: ':bulb: feature'
+labels: 'feature'
 
 ---
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
We renamed labels back from e.g. ***:bug: bug*** to *https://github.com/digitalfabrik/integreat-cms/labels/bug* and now issue templates don't automatically add labels anymore.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Fix the names of the labels in the issue temlates