### PR TITLE
Fix copying of language tree nodes in the region form

### DIFF
--- a/integreat_cms/cms/forms/regions/region_form.py
+++ b/integreat_cms/cms/forms/regions/region_form.py
@@ -704,7 +704,7 @@ def duplicate_language_tree(
             "  " if i == num_source_nodes - 1 else "│  "
         )
         if target_parent:
-            # If the target parent already exist, we inherit its tree id for all its sub nodes
+            # If the target parent already exists, we inherit its tree id for all its sub nodes
             target_tree_id = target_parent.tree_id
         else:
             # If the language tree node is a root node, we need to assign a new tree id
@@ -724,6 +724,11 @@ def duplicate_language_tree(
         target_node.tree_id = target_tree_id
         # Delete the primary key to force an insert
         target_node.pk = None
+        # Fix lft and rgt of the tree if the children of this node should not be cloned
+        # Otherwise, the tree structure will be inconsistent
+        if only_root:
+            target_node.lft = 1
+            target_node.rgt = 2
         # Check if the resulting node is valid
         target_node.full_clean()
         # Save the duplicated node


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
When creating a new region which copies contents from another region and only the root languages should be included, the `lft` and `rgt` values of the new language node must be set to `1` and `2`, respectively. Otherwise, it would behave as if it still contained child nodes.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Set the correct `lft` and `rgt` values


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3200


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
