### PR TITLE
Fix display of start and end of archived events

### DIFF
--- a/integreat_cms/cms/templates/events/event_list_archived_row.html
+++ b/integreat_cms/cms/templates/events/event_list_archived_row.html
@@ -82,15 +82,15 @@
         {% endif %}
     </td>
     <td class="py-3 pr-2">
-        <i icon-name="calendar"></i> {{ event.start_date|date:'d.m.Y' }}
+        <i icon-name="calendar"></i> {{ event.start_local|date:'d.m.Y' }}
         {% if not event.is_all_day %}
-            <i icon-name="clock" class="ml-2"></i> {{ event.start_time|time:'H:i' }}
+            <i icon-name="clock" class="ml-2"></i> {{ event.start_local|date:'H:i' }}
         {% endif %}
     </td>
     <td class="py-3 pr-2">
-        <i icon-name="calendar"></i> {{ event.end_date|date:'d.m.Y' }}
+        <i icon-name="calendar"></i> {{ event.end_local|date:'d.m.Y' }}
         {% if not event.is_all_day %}
-            <i icon-name="clock" class="ml-2"></i> {{ event.end_time|time:'H:i' }}
+            <i icon-name="clock" class="ml-2"></i> {{ event.end_local|date:'H:i' }}
         {% endif %}
     </td>
     <td class="py-3 pr-2">

--- a/integreat_cms/release_notes/current/unreleased/3190.yml
+++ b/integreat_cms/release_notes/current/unreleased/3190.yml
@@ -1,0 +1,2 @@
+en: Fix display of start and end of archived events
+de: Korrigiere die Anzeige der Start- und Endzeit für archivierte Veranstaltungen


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the bug that the start and end date/time of archived events are not displayed.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Use `start_local` and `end_local` as in the non-archived event list


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- None 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3190 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
