### PR TITLE
 Fix false positiv error message in statistics in dashboard

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/3213.yml
+++ b/integreat_cms/release_notes/current/unreleased/3213.yml
@@ -1,0 +1,2 @@
+en: Fix false positive error in statistics in dashboard
+de: Behebe den Netzwerkfehler in den Statistiken im Dashboard

--- a/integreat_cms/static/src/js/analytics/statistics-charts.ts
+++ b/integreat_cms/static/src/js/analytics/statistics-charts.ts
@@ -95,7 +95,7 @@ const updateChart = async (): Promise<void> => {
             }
             const items = chart.options.plugins.legend.labels.generateLabels(chart);
             items.forEach((item) => {
-                document.querySelector(`[data-chart-item="${item.text}"]`).addEventListener("change", () => {
+                document.querySelector(`[data-chart-item="${item.text}"]`)?.addEventListener("change", () => {
                     chart.setDatasetVisibility(item.datasetIndex, !chart.isDatasetVisible(item.datasetIndex));
                     chart.update();
                 });


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the error messsage in the dashboard statistics that is shown despite the statistics is working correctly.
The cause is `TypeError` (propaties of null) . It triggers `catch (error)`.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Avoid `TypeError`


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- The change is held minimal to avoid side effects.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3213 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
