### PR TITLE
Add tests for organization actions

### DIFF
--- a/integreat_cms/cms/fixtures/test_data.json
+++ b/integreat_cms/cms/fixtures/test_data.json
@@ -830,6 +830,20 @@
     }
   },
   {
+    "model": "cms.organization",
+    "pk": 3,
+    "fields": {
+      "name": "Not Referenced Organisation",
+      "slug": "not-referenced-organisation",
+      "icon": 1,
+      "last_updated": "2024-08-08T07:57:42.456Z",
+      "region": 1,
+      "created_date": "2024-08-08T07:57:42.456Z",
+      "website": "https://integreat-app.de/",
+      "archived": false
+    }
+  },
+  {
     "model": "cms.poi",
     "pk": 4,
     "fields": {

--- a/integreat_cms/cms/views/organizations/organization_actions.py
+++ b/integreat_cms/cms/views/organizations/organization_actions.py
@@ -94,7 +94,7 @@ def delete(
         messages.success(request, _("Organization was successfully deleted"))
     else:
         logger.info("%r couldn't be deleted by %r", organization, request.user)
-        messages.success(
+        messages.error(
             request,
             _("Organization couldn't be deleted as it's used by a page, poi or user"),
         )

--- a/integreat_cms/cms/views/organizations/organization_bulk_actions.py
+++ b/integreat_cms/cms/views/organizations/organization_bulk_actions.py
@@ -57,8 +57,8 @@ class ArchiveBulkAction(OrganizationBulkAction):
             messages.success(
                 request,
                 ngettext_lazy(
-                    "{model_name} {object_names} was succesfully archived.",
-                    "The following {model_name_plural} were succesfully archived: {object_names}.",
+                    "{model_name} {object_names} was successfully archived.",
+                    "The following {model_name_plural} were successfully archived: {object_names}.",
                     len(archive_successful),
                 ).format(
                     model_name=self.model._meta.verbose_name.title(),
@@ -107,8 +107,8 @@ class RestoreBulkAction(OrganizationBulkAction):
             messages.success(
                 request,
                 ngettext_lazy(
-                    "{model_name} {object_names} was succesfully restored.",
-                    "The following {model_name_plural} were succesfully retsored: {object_names}.",
+                    "{model_name} {object_names} was successfully restored.",
+                    "The following {model_name_plural} were successfully restored: {object_names}.",
                     len(restore_successful),
                 ).format(
                     model_name=self.model._meta.verbose_name.title(),
@@ -154,8 +154,8 @@ class DeleteBulkAction(OrganizationBulkAction):
             messages.success(
                 request,
                 ngettext_lazy(
-                    "{model_name} {object_names} was succesfully deleted.",
-                    "The following {model_name_plural} were succesfully deleted: {object_names}.",
+                    "{model_name} {object_names} was successfully deleted.",
+                    "The following {model_name_plural} were successfully deleted: {object_names}.",
                     len(delete_successful),
                 ).format(
                     model_name=self.model._meta.verbose_name.title(),

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -9026,6 +9026,7 @@ msgid "The selected {} were successfully {}"
 msgstr "Die ausgewählten {} wurden erfolgreich {}"
 
 #: cms/views/bulk_action_views.py cms/views/contacts/contact_bulk_actions.py
+#: cms/views/organizations/organization_bulk_actions.py
 #, python-brace-format
 msgid "{model_name} {object_names} was successfully archived."
 msgid_plural ""
@@ -9075,6 +9076,7 @@ msgstr[1] ""
 "Veranstaltung oder einem Kontakt verwendet werden: \"{object_names}\""
 
 #: cms/views/bulk_action_views.py cms/views/contacts/contact_bulk_actions.py
+#: cms/views/organizations/organization_bulk_actions.py
 #, python-brace-format
 msgid "{model_name} {object_names} was successfully restored."
 msgid_plural ""
@@ -9127,6 +9129,7 @@ msgid "Contact {0} was successfully copied"
 msgstr "Kontakt {0} wurde erfolgreich kopiert"
 
 #: cms/views/contacts/contact_bulk_actions.py
+#: cms/views/organizations/organization_bulk_actions.py
 #, python-brace-format
 msgid "{model_name} {object_names} was successfully deleted."
 msgid_plural ""
@@ -9843,16 +9846,6 @@ msgstr ""
 
 #: cms/views/organizations/organization_bulk_actions.py
 #, python-brace-format
-msgid "{model_name} {object_names} was succesfully archived."
-msgid_plural ""
-"The following {model_name_plural} were succesfully archived: {object_names}."
-msgstr[0] "{model_name} {object_names} wurde erfolgreich archiviert."
-msgstr[1] ""
-"Die folgenden {model_name_plural} wurden erfolgreich archiviert: "
-"{object_names}"
-
-#: cms/views/organizations/organization_bulk_actions.py
-#, python-brace-format
 msgid ""
 "{model_name} {object_names} couldn't be archived as it's used by a page, poi "
 "or user."
@@ -9865,25 +9858,6 @@ msgstr[0] ""
 msgstr[1] ""
 "Die folgenden {model_name_plural} konnten nicht archiviert werden, da sie "
 "von einer Seite, einem Ort oder eines Users verwendet werden: {object_names}"
-
-#: cms/views/organizations/organization_bulk_actions.py
-#, python-brace-format
-msgid "{model_name} {object_names} was succesfully restored."
-msgid_plural ""
-"The following {model_name_plural} were succesfully retsored: {object_names}."
-msgstr[0] "{model_name} {object_names} wurde erfolgreich wiederhergestellt."
-msgstr[1] ""
-"Die folgenden {model_name_plural} wurden erfolgreich wiederhergestellt: "
-"{object_names}"
-
-#: cms/views/organizations/organization_bulk_actions.py
-#, python-brace-format
-msgid "{model_name} {object_names} was succesfully deleted."
-msgid_plural ""
-"The following {model_name_plural} were succesfully deleted: {object_names}."
-msgstr[0] "{model_name} {object_names} wurde erfolgreich gelöscht."
-msgstr[1] ""
-"Die folgenden {model_name_plural} wurden erfolgreich gelöscht: {object_names}"
 
 #: cms/views/organizations/organization_bulk_actions.py
 #, python-brace-format

--- a/tests/cms/views/organizations/test_organization_actions.py
+++ b/tests/cms/views/organizations/test_organization_actions.py
@@ -1,0 +1,408 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from _pytest.logging import LogCaptureFixture
+    from django.test.client import Client
+    from pytest_django.fixtures import SettingsWrapper
+
+import pytest
+from django.test.client import Client
+from django.urls import reverse
+
+from integreat_cms.cms.models import Organization
+from tests.conftest import ANONYMOUS, HIGH_PRIV_STAFF_ROLES, MANAGEMENT
+from tests.utils import assert_message_in_log
+
+REGION_SLUG = "augsburg"
+
+REFERENCED_ORGANIZATION_ID = 1
+NOT_REFERENCED_ORGANIZATION_ID = 3
+ARCHIVED_ORGANIZATION_ID = 2
+
+test_archive_parameters = [
+    (REFERENCED_ORGANIZATION_ID, False),
+    (NOT_REFERENCED_ORGANIZATION_ID, True),
+]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("parameter", test_archive_parameters)
+def test_archive_organization(
+    load_test_data: None,
+    login_role_user: tuple[Client, str],
+    settings: SettingsWrapper,
+    caplog: LogCaptureFixture,
+    parameter: tuple[int, bool],
+) -> None:
+    """
+    Test whether archiving an organization is working as expected
+    """
+    client, role = login_role_user
+    organization_id, should_be_archived = parameter
+
+    # Set the language setting to English so assertion does not fail because of corresponding German sentence appearing instead the english one.
+    settings.LANGUAGE_CODE = "en"
+
+    archive_organization = reverse(
+        "archive_organization",
+        kwargs={
+            "organization_id": organization_id,
+            "region_slug": REGION_SLUG,
+        },
+    )
+    response = client.post(archive_organization)
+
+    if role in HIGH_PRIV_STAFF_ROLES + [MANAGEMENT]:
+        assert response.status_code == 302
+
+        redirect_url = response.headers.get("location")
+
+        if should_be_archived:
+            assert_message_in_log(
+                "SUCCESS  Organization was successfully archived",
+                caplog,
+            )
+            assert "Organization was successfully archived" in client.get(
+                redirect_url
+            ).content.decode("utf-8")
+            assert Organization.objects.filter(id=organization_id).first().archived
+        else:
+            assert_message_in_log(
+                "ERROR    Organization couldn't be archived as it's used by a page, poi or user",
+                caplog,
+            )
+            assert "Organization couldn&#x27;t be archived as it&#x27;s used by a page, poi or user" in client.get(
+                redirect_url
+            ).content.decode(
+                "utf-8"
+            )
+            assert not Organization.objects.filter(id=organization_id).first().archived
+
+    elif role == ANONYMOUS:
+        assert response.status_code == 302
+        assert (
+            response.headers.get("location")
+            == f"{settings.LOGIN_URL}?next={archive_organization}"
+        )
+    else:
+        assert response.status_code == 403
+
+
+test_delete_parameters = [
+    (REFERENCED_ORGANIZATION_ID, False),
+    (NOT_REFERENCED_ORGANIZATION_ID, True),
+    (ARCHIVED_ORGANIZATION_ID, True),
+]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("parameter", test_delete_parameters)
+def test_delete_organization(
+    load_test_data: None,
+    login_role_user: tuple[Client, str],
+    settings: SettingsWrapper,
+    caplog: LogCaptureFixture,
+    parameter: tuple[int, bool],
+) -> None:
+    """
+    Test whether deleting an organization is working as expected
+    """
+    client, role = login_role_user
+    organization_id, should_be_deleted = parameter
+
+    # Set the language setting to English so assertion does not fail because of corresponding German sentence appearing instead the english one.
+    settings.LANGUAGE_CODE = "en"
+
+    delete_organization = reverse(
+        "delete_organization",
+        kwargs={
+            "organization_id": organization_id,
+            "region_slug": REGION_SLUG,
+        },
+    )
+    response = client.post(delete_organization)
+
+    if role in HIGH_PRIV_STAFF_ROLES + [MANAGEMENT]:
+        assert response.status_code == 302
+
+        redirect_url = response.headers.get("location")
+
+        if should_be_deleted:
+            assert_message_in_log(
+                "SUCCESS  Organization was successfully deleted",
+                caplog,
+            )
+            assert "Organization was successfully deleted" in client.get(
+                redirect_url
+            ).content.decode("utf-8")
+            assert not Organization.objects.filter(id=organization_id).first()
+        else:
+            assert_message_in_log(
+                "ERROR    Organization couldn't be deleted as it's used by a page, poi or user",
+                caplog,
+            )
+            assert "Organization couldn&#x27;t be deleted as it&#x27;s used by a page, poi or user" in client.get(
+                redirect_url
+            ).content.decode(
+                "utf-8"
+            )
+            assert Organization.objects.filter(id=organization_id).first()
+
+    elif role == ANONYMOUS:
+        assert response.status_code == 302
+        assert (
+            response.headers.get("location")
+            == f"{settings.LOGIN_URL}?next={delete_organization}"
+        )
+    else:
+        assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_restore_organization(
+    load_test_data: None,
+    login_role_user: tuple[Client, str],
+    settings: SettingsWrapper,
+    caplog: LogCaptureFixture,
+) -> None:
+    """
+    Test whether restoring an organization is working as expected
+    """
+    client, role = login_role_user
+
+    # Set the language setting to English so assertion does not fail because of corresponding German sentence appearing instead the english one.
+    settings.LANGUAGE_CODE = "en"
+
+    archived_organization = Organization.objects.filter(
+        region__slug=REGION_SLUG, archived=True
+    ).first()
+    assert archived_organization
+
+    archived_organization_id = archived_organization.id
+
+    restore_organization = reverse(
+        "restore_organization",
+        kwargs={
+            "organization_id": archived_organization_id,
+            "region_slug": REGION_SLUG,
+        },
+    )
+    response = client.post(restore_organization)
+
+    if role in HIGH_PRIV_STAFF_ROLES + [MANAGEMENT]:
+        response.status_code == 302
+        redirect_url = response.headers.get("location")
+        assert_message_in_log(
+            "SUCCESS  Organization was successfully restored",
+            caplog,
+        )
+        assert "Organization was successfully restored" in client.get(
+            redirect_url
+        ).content.decode("utf-8")
+        assert (
+            not Organization.objects.filter(id=archived_organization_id)
+            .first()
+            .archived
+        )
+
+    elif role == ANONYMOUS:
+        assert response.status_code == 302
+        assert (
+            response.headers.get("location")
+            == f"{settings.LOGIN_URL}?next={restore_organization}"
+        )
+    else:
+        assert response.status_code == 403
+
+
+BULK_ARCHIVE_SELECTED_IDS = [REFERENCED_ORGANIZATION_ID, NOT_REFERENCED_ORGANIZATION_ID]
+
+
+@pytest.mark.django_db
+def test_bulk_archive_organizations(
+    load_test_data: None,
+    login_role_user: tuple[Client, str],
+    settings: SettingsWrapper,
+    caplog: LogCaptureFixture,
+) -> None:
+    """
+    Test whether bulk archiving of organizations is working as expected
+    """
+    client, role = login_role_user
+
+    # Set the language setting to English so assertion does not fail because of corresponding German sentence appearing instead the english one.
+    settings.LANGUAGE_CODE = "en"
+
+    bulk_archive_organization = reverse(
+        "bulk_archive_organization",
+        kwargs={
+            "region_slug": REGION_SLUG,
+        },
+    )
+    response = client.post(
+        bulk_archive_organization,
+        data={"selected_ids[]": BULK_ARCHIVE_SELECTED_IDS},
+    )
+
+    if role in HIGH_PRIV_STAFF_ROLES + [MANAGEMENT]:
+        response.status_code == 302
+        redirect_url = response.headers.get("location")
+        redirect_page = client.get(redirect_url).content.decode("utf-8")
+
+        assert_message_in_log(
+            "ERROR    Organization \"Nicht archivierte Organisation\" couldn't be archived as it's used by a page, poi or user.",
+            caplog,
+        )
+        assert (
+            "Organization &quot;Nicht archivierte Organisation&quot; couldn&#x27;t be archived as it&#x27;s used by a page, poi or user."
+            in redirect_page
+        )
+        assert (
+            not Organization.objects.filter(id=REFERENCED_ORGANIZATION_ID)
+            .first()
+            .archived
+        )
+        assert_message_in_log(
+            'SUCCESS  Organization "Not Referenced Organisation" was successfully archived.',
+            caplog,
+        )
+        assert (
+            "Organization &quot;Not Referenced Organisation&quot; was successfully archived."
+            in redirect_page
+        )
+        assert (
+            Organization.objects.filter(id=NOT_REFERENCED_ORGANIZATION_ID)
+            .first()
+            .archived
+        )
+    elif role == ANONYMOUS:
+        assert response.status_code == 302
+        assert (
+            response.headers.get("location")
+            == f"{settings.LOGIN_URL}?next={bulk_archive_organization}"
+        )
+    else:
+        assert response.status_code == 403
+
+
+BULK_DELETE_SELECTED_IDS = [REFERENCED_ORGANIZATION_ID, NOT_REFERENCED_ORGANIZATION_ID]
+
+
+@pytest.mark.django_db
+def test_bulk_delete_organizations(
+    load_test_data: None,
+    login_role_user: tuple[Client, str],
+    settings: SettingsWrapper,
+    caplog: LogCaptureFixture,
+) -> None:
+    """
+    Test whether bulk deleting of organizations is working as expected
+    """
+    client, role = login_role_user
+
+    # Set the language setting to English so assertion does not fail because of corresponding German sentence appearing instead the english one.
+    settings.LANGUAGE_CODE = "en"
+
+    bulk_delete_organization = reverse(
+        "bulk_delete_organization",
+        kwargs={
+            "region_slug": REGION_SLUG,
+        },
+    )
+    response = client.post(
+        bulk_delete_organization,
+        data={"selected_ids[]": BULK_DELETE_SELECTED_IDS},
+    )
+
+    if role in HIGH_PRIV_STAFF_ROLES + [MANAGEMENT]:
+        response.status_code == 302
+        redirect_url = response.headers.get("location")
+        redirect_page = client.get(redirect_url).content.decode("utf-8")
+
+        assert_message_in_log(
+            "ERROR    Organization \"Nicht archivierte Organisation\" couldn't be deleted as it's used by a page, poi or user.",
+            caplog,
+        )
+        assert (
+            "Organization &quot;Nicht archivierte Organisation&quot; couldn&#x27;t be deleted as it&#x27;s used by a page, poi or user."
+            in redirect_page
+        )
+        assert Organization.objects.filter(id=REFERENCED_ORGANIZATION_ID).exists()
+        assert_message_in_log(
+            'SUCCESS  Organization "Not Referenced Organisation" was successfully deleted.',
+            caplog,
+        )
+        assert (
+            "Organization &quot;Not Referenced Organisation&quot; was successfully deleted."
+            in redirect_page
+        )
+        assert not Organization.objects.filter(
+            id=NOT_REFERENCED_ORGANIZATION_ID
+        ).exists()
+    elif role == ANONYMOUS:
+        assert response.status_code == 302
+        assert (
+            response.headers.get("location")
+            == f"{settings.LOGIN_URL}?next={bulk_delete_organization}"
+        )
+    else:
+        assert response.status_code == 403
+
+
+BULK_RESTORE_SELECTED_IDS = [ARCHIVED_ORGANIZATION_ID]
+
+
+@pytest.mark.django_db
+def test_bulk_restore_organizations(
+    load_test_data: None,
+    login_role_user: tuple[Client, str],
+    settings: SettingsWrapper,
+    caplog: LogCaptureFixture,
+) -> None:
+    """
+    Test whether bulk restoring of organizations is working as expected
+    """
+    client, role = login_role_user
+
+    # Set the language setting to English so assertion does not fail because of corresponding German sentence appearing instead the english one.
+    settings.LANGUAGE_CODE = "en"
+
+    bulk_restore_organization = reverse(
+        "bulk_restore_organization",
+        kwargs={
+            "region_slug": REGION_SLUG,
+        },
+    )
+    response = client.post(
+        bulk_restore_organization,
+        data={"selected_ids[]": BULK_RESTORE_SELECTED_IDS},
+    )
+
+    if role in HIGH_PRIV_STAFF_ROLES + [MANAGEMENT]:
+        response.status_code == 302
+        redirect_url = response.headers.get("location")
+        redirect_page = client.get(redirect_url).content.decode("utf-8")
+
+        assert_message_in_log(
+            'SUCCESS  Organization "Archivierte Organisation" was successfully restored.',
+            caplog,
+        )
+        assert (
+            "Organization &quot;Archivierte Organisation&quot; was successfully restored."
+            in redirect_page
+        )
+        assert (
+            not Organization.objects.filter(id=ARCHIVED_ORGANIZATION_ID)
+            .first()
+            .archived
+        )
+    elif role == ANONYMOUS:
+        assert response.status_code == 302
+        assert (
+            response.headers.get("location")
+            == f"{settings.LOGIN_URL}?next={bulk_restore_organization}"
+        )
+    else:
+        assert response.status_code == 403

--- a/tests/cms/views/organizations/test_organization_form.py
+++ b/tests/cms/views/organizations/test_organization_form.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from _pytest.logging import LogCaptureFixture
     from django.test.client import Client
     from pytest_django.fixtures import SettingsWrapper
 
@@ -11,36 +12,38 @@ from django.test.client import Client
 from django.urls import reverse
 
 from integreat_cms.cms.models import MediaFile, Organization, Page, POI, Region
-from tests.conftest import ANONYMOUS, MANAGEMENT, STAFF_ROLES
+from tests.conftest import ANONYMOUS, HIGH_PRIV_STAFF_ROLES, MANAGEMENT, STAFF_ROLES
+from tests.utils import assert_message_in_log
+
+# Choose a region
+REGION_SLUG = "augsburg"
+# An organization which has a page and a poi assigned and belongs to the above chosen region
+REFERENCED_ORGANIZATION_ID = 1
+# An organization which does not have a page and a poi assigned and belongs to the above chosen region
+NOT_REFERENCED_ORGANIZATION_ID = 3
+# Choose a name which is not used by any organization
+NEW_ORGANIZATION_NAME = "New Organization"
 
 
 @pytest.mark.django_db
-def test_poi_form_shows_no_contents(
+def test_organization_form_shows_no_contents(
     load_test_data: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
 ) -> None:
     """
-    Test that no contents are shown in the organization form if it does not have any content assinged
+    Test that no contents are shown in the organization form if it does not have any content assigned
     """
     client, role = login_role_user
 
     # Set the language setting to English so assertion does not fail because of corresponding German sentence appearing instead the english one.
     settings.LANGUAGE_CODE = "en"
 
-    new_organization = Organization.objects.create(
-        name="New Organization",
-        slug="new-organization",
-        icon=MediaFile.objects.filter(id=1).first(),
-        region=Region.objects.filter(id=1).first(),
-        website="https://integreat-app.de/",
-    )
-
     edit_organization = reverse(
         "edit_organization",
         kwargs={
-            "organization_id": new_organization.id,
-            "region_slug": new_organization.region.slug,
+            "organization_id": NOT_REFERENCED_ORGANIZATION_ID,
+            "region_slug": REGION_SLUG,
         },
     )
     response = client.get(edit_organization)
@@ -75,8 +78,6 @@ def test_organization_form_shows_associated_contents(
     Nicht archivierte Organisation in Augsburg has two pages and one location.
     They must be shown in the form.
     """
-    # Choose an organization which has a page and a poi assigned
-    ORGANIZATION_ID = 1
 
     # To check contents that do not belong to the organization do not appear in the form,
     # choose a page and a POI
@@ -94,7 +95,7 @@ def test_organization_form_shows_associated_contents(
     # Set the language setting to English so assertion does not fail because of corresponding German sentence appearing instead the english one.
     settings.LANGUAGE_CODE = "en"
 
-    organization = Organization.objects.filter(id=ORGANIZATION_ID).first()
+    organization = Organization.objects.filter(id=REFERENCED_ORGANIZATION_ID).first()
     organization_pages = list(organization.pages.all())
     organization_pois = list(organization.pois.all())
 
@@ -106,8 +107,8 @@ def test_organization_form_shows_associated_contents(
     edit_organization = reverse(
         "edit_organization",
         kwargs={
-            "organization_id": organization.id,
-            "region_slug": region.slug,
+            "organization_id": REFERENCED_ORGANIZATION_ID,
+            "region_slug": REGION_SLUG,
         },
     )
     response = client.get(edit_organization)
@@ -139,5 +140,173 @@ def test_organization_form_shows_associated_contents(
             == f"{settings.LOGIN_URL}?next={edit_organization}"
         )
 
+    else:
+        assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_create_new_organization(
+    load_test_data: None,
+    login_role_user: tuple[Client, str],
+    settings: SettingsWrapper,
+    caplog: LogCaptureFixture,
+) -> None:
+    """
+    Test an organization will be created as expected
+    """
+    client, role = login_role_user
+
+    settings.LANGUAGE_CODE = "en"
+
+    assert not Organization.objects.filter(name=NEW_ORGANIZATION_NAME).exists()
+
+    new_organization = reverse(
+        "new_organization",
+        kwargs={
+            "region_slug": REGION_SLUG,
+        },
+    )
+    response = client.post(
+        new_organization,
+        data={
+            "name": NEW_ORGANIZATION_NAME,
+            "slug": "new-organization",
+            "icon": 1,
+            "website": "https://integreat-app.de/",
+        },
+    )
+
+    if role in HIGH_PRIV_STAFF_ROLES + [MANAGEMENT]:
+        assert response.status_code == 302
+        assert_message_in_log(
+            f'SUCCESS  Organization "{NEW_ORGANIZATION_NAME}" was successfully created',
+            caplog,
+        )
+        edit_url = response.headers.get("location")
+        response = client.get(edit_url)
+        assert (
+            f"Organization &quot;{NEW_ORGANIZATION_NAME}&quot; was successfully created"
+            in response.content.decode("utf-8")
+        )
+        assert Organization.objects.filter(name=NEW_ORGANIZATION_NAME).exists()
+
+    elif role == ANONYMOUS:
+        assert response.status_code == 302
+        assert (
+            response.headers.get("location")
+            == f"{settings.LOGIN_URL}?next={new_organization}"
+        )
+    else:
+        assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_cannot_create_organization_with_duplicate_name(
+    load_test_data: None,
+    login_role_user: tuple[Client, str],
+    settings: SettingsWrapper,
+    caplog: LogCaptureFixture,
+) -> None:
+    """
+    No organization should be created with the same name with an existing organization.
+    """
+    client, role = login_role_user
+
+    settings.LANGUAGE_CODE = "en"
+
+    existing_organization = Organization.objects.filter(
+        region__slug=REGION_SLUG
+    ).first()
+    assert existing_organization
+
+    new_organization = reverse(
+        "new_organization",
+        kwargs={
+            "region_slug": REGION_SLUG,
+        },
+    )
+    response = client.post(
+        new_organization,
+        data={
+            "name": existing_organization.name,
+            "slug": existing_organization.slug,
+            "icon": 1,
+            "website": "https://integreat-app.de/",
+        },
+    )
+
+    if role in HIGH_PRIV_STAFF_ROLES + [MANAGEMENT]:
+        assert response.status_code == 200
+        assert_message_in_log(
+            "ERROR    Name: An organization with the same name already exists in this region. Please choose another name.",
+            caplog,
+        )
+        assert (
+            "An organization with the same name already exists in this region. Please choose another name."
+            in response.content.decode("utf-8")
+        )
+
+    elif role == ANONYMOUS:
+        assert response.status_code == 302
+        assert (
+            response.headers.get("location")
+            == f"{settings.LOGIN_URL}?next={new_organization}"
+        )
+    else:
+        assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_edit_organization(
+    load_test_data: None,
+    login_role_user: tuple[Client, str],
+    settings: SettingsWrapper,
+    caplog: LogCaptureFixture,
+) -> None:
+    """
+    Test an existing organization is updated as expected
+    """
+    client, role = login_role_user
+
+    settings.LANGUAGE_CODE = "en"
+
+    edit_organization = reverse(
+        "edit_organization",
+        kwargs={
+            "organization_id": NOT_REFERENCED_ORGANIZATION_ID,
+            "region_slug": REGION_SLUG,
+        },
+    )
+    response = client.post(
+        edit_organization,
+        data={
+            "name": "I got a new name",
+            "slug": "i-got-a-new-name",
+            "icon": 1,
+            "website": "https://integreat-app.de/",
+        },
+    )
+
+    if role in HIGH_PRIV_STAFF_ROLES + [MANAGEMENT]:
+        assert response.status_code == 200
+        assert_message_in_log(
+            'SUCCESS  Organization "I got a new name" was successfully saved',
+            caplog,
+        )
+        assert (
+            "Organization &quot;I got a new name&quot; was successfully saved"
+            in response.content.decode("utf-8")
+        )
+        assert (
+            Organization.objects.filter(id=NOT_REFERENCED_ORGANIZATION_ID).first().name
+            == "I got a new name"
+        )
+
+    elif role == ANONYMOUS:
+        assert response.status_code == 302
+        assert (
+            response.headers.get("location")
+            == f"{settings.LOGIN_URL}?next={edit_organization}"
+        )
     else:
         assert response.status_code == 403


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds tests for actions users can take with organization objects.

### Proposed changes
<!-- Describe this PR in more detail. -->
Following actions are tested:
- Archive, delete, restore an organization
- Archive, delete, restore organizations by bulk action
- Creating and editing an organization


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
<s>`test_create_new_organization` is disabled, as we are waiting for #3239 </s>


Some minor changes are done on the existing code:
- Change the type of message "Organization couldn't be deleted as..." to `error`
- Fix typo in the English messages (resulting in some translations removed)


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3216 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
