### PR TITLE
Fix cancel button color to have ghost button style

### DIFF
--- a/integreat_cms/cms/templates/_machine_translation_overlay.html
+++ b/integreat_cms/cms/templates/_machine_translation_overlay.html
@@ -124,7 +124,7 @@
                 <div class="flex justify-between mt-4">
                     <button type="button"
                             id="btn-close-machine-translation-overlay"
-                            class="btn !bg-red-500">
+                            class="btn btn-ghost">
                         {% translate "Cancel" %}
                     </button>
                     <button id="machine-translation-overlay-bulk-action-execute"

--- a/integreat_cms/cms/templates/generic_confirmation_dialog.html
+++ b/integreat_cms/cms/templates/generic_confirmation_dialog.html
@@ -21,7 +21,7 @@
             <form method="post" action="#">
                 {% csrf_token %}
                 <div class="flex justify-end gap-2">
-                    <button id="close-confirmation-popup" class="btn btn-outline">
+                    <button id="close-confirmation-popup" class="btn btn-ghost">
                         {% translate "Cancel" %}
                     </button>
                     <button class="btn">

--- a/integreat_cms/cms/templates/linkcheck/link_list_row.html
+++ b/integreat_cms/cms/templates/linkcheck/link_list_row.html
@@ -116,7 +116,7 @@
                 <div class="flex gap-2 p-2">
                     {% render_field edit_url_form.url|add_error_class:"border-red-500" type="url" form="edit-url-form" %}
                     <a href="{% url_for_current_region 'linkcheck' request url_filter=view.kwargs.url_filter %}{{ pagination_params }}"
-                       class="btn btn-red">{% translate "Cancel" %}</a>
+                       class="btn btn-ghost">{% translate "Cancel" %}</a>
                     <button type="submit" form="edit-url-form" class="btn">
                         {% translate "Save" %}
                     </button>

--- a/integreat_cms/cms/templates/pois/poi_form_sidebar/position_box.html
+++ b/integreat_cms/cms/templates/pois/poi_form_sidebar/position_box.html
@@ -157,7 +157,9 @@
                 <i icon-name="check" class="h-5"></i>
                 {% translate "Confirm" %}
             </button>
-            <button id="discard_map_input" type="button" class="btn btn-red w-full mt-2">
+            <button id="discard_map_input"
+                    type="button"
+                    class="btn btn-ghost w-full mt-2">
                 <i icon-name="x" class="h-5"></i>
                 {% translate "Cancel" %}
             </button>


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Right now cancel button in machine translation overlay has a red button instead of having ghost button. Additionally fix all other occurrences of cancel button not having the ghost button style.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Change the button style to ghost button


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2966 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
