### PR TITLE
Drop root privileges for celery worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,5 +71,8 @@ integreat_cms/xliff/download
 .postgres
 
 # Celery
-celerybeat-schedule.db
 celerybeat-schedule
+celerybeat-schedule.db
+celerybeat-schedule.bak
+celerybeat-schedule.dir
+celerybeat-schedule.dat

--- a/tools/run.sh
+++ b/tools/run.sh
@@ -47,7 +47,9 @@ done
 listen_for_devserver &
 
 # Run Celery worker process
-celery -A integreat_cms.integreat_celery worker -l INFO -B --concurrency=1 &
+if [ "$INTEGREAT_CMS_REDIS_CACHE" == "1" ]; then
+  deescalate_privileges celery -A integreat_cms.integreat_celery worker -l INFO -B --concurrency=1 &
+fi
 
 # Start Integreat CMS development webserver
 deescalate_privileges integreat-cms-cli runserver "localhost:${INTEGREAT_CMS_PORT}"


### PR DESCRIPTION
### Short description
The run.sh is running with root privileges. However, celery does not need those.


### Proposed changes
- Drop root privileges before executing the celery worker
- add additional celery temp files to gitignore


### Side effects
- none


### Resolved issues
Fixes: https://chat.tuerantuer.org/digitalfabrik/pl/qcemkcp5aid8dnhes6obwtiooo


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
