### PR TITLE
Exclude contact cards (and other non-editable blocks) from HIX

### DIFF
--- a/integreat_cms/cms/views/utils/hix.py
+++ b/integreat_cms/cms/views/utils/hix.py
@@ -54,6 +54,11 @@ def lookup_hix_score_helper(text: str) -> TextlabResult:
     """
     try:
         html = fromstring(text)
+
+        # remove divs which the authors have no control over (e.g. contact cards)
+        for div in html.xpath('//div[@contenteditable="false"]'):
+            div.getparent().remove(div)
+
         text_content = html.text_content()
         if not text_content.strip():
             return {
@@ -64,7 +69,7 @@ def lookup_hix_score_helper(text: str) -> TextlabResult:
         pass
 
     # Replace all line breaks with <br> because Textlab API returns different HIX value depending on the line break character
-    normalized_text = "<br>".join(text.splitlines())
+    normalized_text = "<br>".join(text_content.splitlines())
 
     try:
         return TextlabClient(


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
The contact cards introduced in #3169 have a severe negative impact on the HIX score. This PR excludes them from the HIX calculations.

### Proposed changes
<!-- Describe this PR in more detail. -->

- before sending text to Textlab, remove all divs with `contenteditable="false"`.
- this currently only affects contacts, but makes it simple to exclude other blocks in the future, should the need arise


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- `html.text_content()` was previously only used to check for empty pages. For convenience, I have changed the code to send the result of this operation to textlab instead of the raw HTML - but I am uncertain if there has been a decision against this in the past when you added the code in question @david-venhoff - are my changes OK?  


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3268


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
