### PR TITLE
Add tests for contact actions

### DIFF
--- a/tests/cms/models/contacts/test_contacts.py
+++ b/tests/cms/models/contacts/test_contacts.py
@@ -34,3 +34,55 @@ def test_contact_string(
         str(contact_4)
         == "Draft location with email: generalcontactinformation@example.com"
     )
+
+
+@pytest.mark.django_db
+def test_copying_contact_works(
+    load_test_data: None,
+) -> None:
+    assert Contact.objects.all().count() == 4
+
+    contact = Contact.objects.get(id=1)
+    contact.copy()
+
+    assert Contact.objects.all().count() == 5
+
+
+@pytest.mark.django_db
+def test_deleting_contact_works(
+    load_test_data: None,
+) -> None:
+    assert Contact.objects.all().count() == 4
+
+    contact = Contact.objects.get(id=1)
+    contact.delete()
+
+    assert Contact.objects.all().count() == 3
+
+
+@pytest.mark.django_db
+def test_archiving_contact_works(
+    load_test_data: None,
+) -> None:
+    assert Contact.objects.all().count() == 4
+
+    contact = Contact.objects.get(id=1)
+    assert contact.archived is False
+    contact.archive()
+
+    assert Contact.objects.all().count() == 4
+    assert contact.archived is True
+
+
+@pytest.mark.django_db
+def test_restoring_contact_works(
+    load_test_data: None,
+) -> None:
+    assert Contact.objects.all().count() == 4
+
+    contact = Contact.objects.get(id=2)
+    assert contact.archived is True
+    contact.restore()
+
+    assert Contact.objects.all().count() == 4
+    assert contact.archived is False

--- a/tests/cms/views/contacts/test_contact_actions.py
+++ b/tests/cms/views/contacts/test_contact_actions.py
@@ -1,60 +1,404 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from _pytest.logging import LogCaptureFixture
+    from django.test.client import Client
+    from pytest_django.fixtures import SettingsWrapper
+
 import pytest
 from django.test.client import Client
+from django.urls import reverse
 
-from integreat_cms.cms.models.contact.contact import Contact
+from integreat_cms.cms.models import Contact
+from tests.conftest import ANONYMOUS, HIGH_PRIV_STAFF_ROLES
+from tests.utils import assert_message_in_log
 
+# Use the region Augsburg, as it has some contacts in the test data
+REGION_SLUG = "augsburg"
 
-@pytest.mark.django_db
-def test_copying_contact_works(
-    load_test_data: None,
-    login_role_user: tuple[Client, str],
-) -> None:
-    assert Contact.objects.all().count() == 4
-
-    contact = Contact.objects.get(id=1)
-    contact.copy()
-
-    assert Contact.objects.all().count() == 5
+NOT_USED_CONTACT_ID = 3
+ARCHIVED_CONTACT_ID = 2
 
 
-@pytest.mark.django_db
-def test_deleting_contact_works(
-    load_test_data: None,
-    login_role_user: tuple[Client, str],
-) -> None:
-    assert Contact.objects.all().count() == 4
-
-    contact = Contact.objects.get(id=1)
-    contact.delete()
-
-    assert Contact.objects.all().count() == 3
+test_archive_parameters = [(NOT_USED_CONTACT_ID, True)]
 
 
 @pytest.mark.django_db
-def test_archiving_contact_works(
+@pytest.mark.parametrize("parameter", test_archive_parameters)
+@pytest.mark.django_db
+def test_archive_contact(
     load_test_data: None,
     login_role_user: tuple[Client, str],
+    settings: SettingsWrapper,
+    caplog: LogCaptureFixture,
+    parameter: tuple[int, bool],
 ) -> None:
-    assert Contact.objects.all().count() == 4
+    """
+    Test that archiving a contact works as expected
+    """
+    client, role = login_role_user
+    contact_id, should_be_archived = parameter
 
-    contact = Contact.objects.get(id=1)
-    assert contact.archived is False
-    contact.archive()
+    # Set the language setting to English so assertion does not fail because of corresponding German sentence appearing instead the english one.
+    settings.LANGUAGE_CODE = "en"
 
-    assert Contact.objects.all().count() == 4
-    assert contact.archived is True
+    contact_string = str(Contact.objects.filter(id=contact_id).first())
+
+    archive_contact = reverse(
+        "archive_contact",
+        kwargs={
+            "contact_id": contact_id,
+            "region_slug": REGION_SLUG,
+        },
+    )
+    response = client.post(archive_contact)
+
+    if role in HIGH_PRIV_STAFF_ROLES:
+        assert response.status_code == 302
+        redirect_url = response.headers.get("location")
+        if should_be_archived:
+            assert_message_in_log(
+                f"SUCCESS  Contact {contact_string} was successfully archived",
+                caplog,
+            )
+            assert f"Contact {contact_string} was successfully archived" in client.get(
+                redirect_url
+            ).content.decode("utf-8")
+            assert Contact.objects.filter(id=contact_id).first().archived
+        else:
+            # To be adjusted after #3282
+            assert_message_in_log(
+                "ERROR    Contact couldn't be archived as it's used in a content",
+                caplog,
+            )
+            assert (
+                "Contact couldn&#x27;t be archived as it&#x27;s used in a content"
+                in client.get(redirect_url).content.decode("utf-8")
+            )
+            assert not Contact.objects.filter(id=contact_id).first().archived
+    elif role == ANONYMOUS:
+        assert response.status_code == 302
+        assert (
+            response.headers.get("location")
+            == f"{settings.LOGIN_URL}?next={archive_contact}"
+        )
+    else:
+        assert response.status_code == 403
+
+
+test_delete_parameters = [(NOT_USED_CONTACT_ID, True)]
 
 
 @pytest.mark.django_db
-def test_restoring_contact_works(
+@pytest.mark.parametrize("parameter", test_delete_parameters)
+@pytest.mark.django_db
+def test_delete_contact(
     load_test_data: None,
     login_role_user: tuple[Client, str],
+    settings: SettingsWrapper,
+    caplog: LogCaptureFixture,
+    parameter: tuple[int, bool],
 ) -> None:
-    assert Contact.objects.all().count() == 4
+    """
+    Test that deleting a contact works as expected
+    """
+    client, role = login_role_user
+    contact_id, should_be_deleted = parameter
 
-    contact = Contact.objects.get(id=2)
-    assert contact.archived is True
-    contact.restore()
+    # Set the language setting to English so assertion does not fail because of corresponding German sentence appearing instead the english one.
+    settings.LANGUAGE_CODE = "en"
 
-    assert Contact.objects.all().count() == 4
-    assert contact.archived is False
+    contact_string = str(Contact.objects.filter(id=contact_id).first())
+
+    delete_contact = reverse(
+        "delete_contact",
+        kwargs={
+            "contact_id": contact_id,
+            "region_slug": REGION_SLUG,
+        },
+    )
+    response = client.post(delete_contact)
+
+    if role in HIGH_PRIV_STAFF_ROLES:
+        assert response.status_code == 302
+        redirect_url = response.headers.get("location")
+        if should_be_deleted:
+            assert_message_in_log(
+                f"SUCCESS  Contact {contact_string} was successfully deleted",
+                caplog,
+            )
+            assert f"Contact {contact_string} was successfully deleted" in client.get(
+                redirect_url
+            ).content.decode("utf-8")
+            assert not Contact.objects.filter(id=contact_id).first()
+        else:
+            # To be adjusted after #3282
+            assert_message_in_log(
+                "ERROR    Contact couldn't be archived as it's used in a content",
+                caplog,
+            )
+            assert (
+                "Contact couldn&#x27;t be archived as it&#x27;s used in a content"
+                in client.get(redirect_url).content.decode("utf-8")
+            )
+            assert Contact.objects.filter(id=contact_id).first()
+    elif role == ANONYMOUS:
+        assert response.status_code == 302
+        assert (
+            response.headers.get("location")
+            == f"{settings.LOGIN_URL}?next={delete_contact}"
+        )
+    else:
+        assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_restore_contact(
+    load_test_data: None,
+    login_role_user: tuple[Client, str],
+    settings: SettingsWrapper,
+    caplog: LogCaptureFixture,
+) -> None:
+    """
+    Test whether restoring a contact works as expected
+    """
+    client, role = login_role_user
+
+    # Set the language setting to English so assertion does not fail because of corresponding German sentence appearing instead the english one.
+    settings.LANGUAGE_CODE = "en"
+
+    archived_contact = Contact.objects.filter(id=ARCHIVED_CONTACT_ID).first()
+    assert archived_contact.archived
+
+    contact_string = str(archived_contact)
+
+    restore_contact = reverse(
+        "restore_contact",
+        kwargs={
+            "contact_id": ARCHIVED_CONTACT_ID,
+            "region_slug": REGION_SLUG,
+        },
+    )
+    response = client.post(restore_contact)
+
+    if role in HIGH_PRIV_STAFF_ROLES:
+        response.status_code == 302
+        redirect_url = response.headers.get("location")
+        assert_message_in_log(
+            f"SUCCESS  Contact {contact_string} was successfully restored",
+            caplog,
+        )
+        assert f"Contact {contact_string} was successfully restored" in client.get(
+            redirect_url
+        ).content.decode("utf-8")
+        assert not Contact.objects.filter(id=ARCHIVED_CONTACT_ID).first().archived
+
+    elif role == ANONYMOUS:
+        assert response.status_code == 302
+        assert (
+            response.headers.get("location")
+            == f"{settings.LOGIN_URL}?next={restore_contact}"
+        )
+    else:
+        assert response.status_code == 403
+
+
+BULK_ARCHIVE_SELECTED_IDS = [NOT_USED_CONTACT_ID]
+
+
+@pytest.mark.django_db
+def test_bulk_archive_contacts(
+    load_test_data: None,
+    login_role_user: tuple[Client, str],
+    settings: SettingsWrapper,
+    caplog: LogCaptureFixture,
+) -> None:
+    """
+    Test whether bulk archiving of contacts works as expected
+    """
+    client, role = login_role_user
+
+    # Set the language setting to English so assertion does not fail because of corresponding German sentence appearing instead the english one.
+    settings.LANGUAGE_CODE = "en"
+
+    not_used_contact_string = str(
+        Contact.objects.filter(id=NOT_USED_CONTACT_ID).first()
+    )
+
+    bulk_archive_contacts = reverse(
+        "bulk_archive_contacts",
+        kwargs={
+            "region_slug": REGION_SLUG,
+        },
+    )
+    response = client.post(
+        bulk_archive_contacts,
+        data={"selected_ids[]": BULK_ARCHIVE_SELECTED_IDS},
+    )
+
+    if role in HIGH_PRIV_STAFF_ROLES:
+        response.status_code == 302
+        redirect_url = response.headers.get("location")
+        redirect_page = client.get(redirect_url).content.decode("utf-8")
+        # To be adjusted after #3282
+        """
+        assert_message_in_log(
+            "ERROR    could not be archived",
+            caplog,
+        )
+        assert (
+            " could not be archived"
+            in redirect_page
+        )
+        assert (
+            not Contact.objects.filter(id=USED_CONTACT_ID)
+            .first()
+            .archived
+        )
+        """
+        assert_message_in_log(
+            f'SUCCESS  Contact "{not_used_contact_string}" was successfully archived.',
+            caplog,
+        )
+        assert (
+            f"Contact &quot;{not_used_contact_string}&quot; was successfully archived."
+            in redirect_page
+        )
+        assert Contact.objects.filter(id=NOT_USED_CONTACT_ID).first().archived
+    elif role == ANONYMOUS:
+        assert response.status_code == 302
+        assert (
+            response.headers.get("location")
+            == f"{settings.LOGIN_URL}?next={bulk_archive_contacts}"
+        )
+    else:
+        assert response.status_code == 403
+
+
+BULK_DELETE_SELECTED_IDS = [NOT_USED_CONTACT_ID]
+
+
+@pytest.mark.django_db
+def test_bulk_delete_contacts(
+    load_test_data: None,
+    login_role_user: tuple[Client, str],
+    settings: SettingsWrapper,
+    caplog: LogCaptureFixture,
+) -> None:
+    """
+    Test whether bulk deleting of contacts works as expected
+    """
+    client, role = login_role_user
+
+    # Set the language setting to English so assertion does not fail because of corresponding German sentence appearing instead the english one.
+    settings.LANGUAGE_CODE = "en"
+
+    not_used_contact_string = str(
+        Contact.objects.filter(id=NOT_USED_CONTACT_ID).first()
+    )
+
+    bulk_delete_contacts = reverse(
+        "bulk_delete_contacts",
+        kwargs={
+            "region_slug": REGION_SLUG,
+        },
+    )
+    response = client.post(
+        bulk_delete_contacts,
+        data={"selected_ids[]": BULK_DELETE_SELECTED_IDS},
+    )
+
+    if role in HIGH_PRIV_STAFF_ROLES:
+        response.status_code == 302
+        redirect_url = response.headers.get("location")
+        redirect_page = client.get(redirect_url).content.decode("utf-8")
+        # To be adjusted after #3282
+        """
+        assert_message_in_log(
+            "ERROR    could not be archived",
+            caplog,
+        )
+        assert (
+            " could not be archived"
+            in redirect_page
+        )
+        assert (
+            not Contact.objects.filter(id=USED_CONTACT_ID)
+            .first()
+            .archived
+        )
+        """
+        assert_message_in_log(
+            f'SUCCESS  Contact "{not_used_contact_string}" was successfully deleted.',
+            caplog,
+        )
+        assert (
+            f"Contact &quot;{not_used_contact_string}&quot; was successfully deleted."
+            in redirect_page
+        )
+        assert not Contact.objects.filter(id=NOT_USED_CONTACT_ID).first()
+    elif role == ANONYMOUS:
+        assert response.status_code == 302
+        assert (
+            response.headers.get("location")
+            == f"{settings.LOGIN_URL}?next={bulk_delete_contacts}"
+        )
+    else:
+        assert response.status_code == 403
+
+
+BULK_RESTORE_SELECTED_IDS = [ARCHIVED_CONTACT_ID]
+
+
+@pytest.mark.django_db
+def test_bulk_restore_contacts(
+    load_test_data: None,
+    login_role_user: tuple[Client, str],
+    settings: SettingsWrapper,
+    caplog: LogCaptureFixture,
+) -> None:
+    """
+    Test whether bulk restoring of contacts works as expected
+    """
+    client, role = login_role_user
+
+    # Set the language setting to English so assertion does not fail because of corresponding German sentence appearing instead the english one.
+    settings.LANGUAGE_CODE = "en"
+
+    contact_string = str(Contact.objects.filter(id=ARCHIVED_CONTACT_ID).first())
+
+    bulk_restore_contacts = reverse(
+        "bulk_restore_contacts",
+        kwargs={
+            "region_slug": REGION_SLUG,
+        },
+    )
+    response = client.post(
+        bulk_restore_contacts,
+        data={"selected_ids[]": BULK_RESTORE_SELECTED_IDS},
+    )
+
+    if role in HIGH_PRIV_STAFF_ROLES:
+        response.status_code == 302
+        redirect_url = response.headers.get("location")
+        redirect_page = client.get(redirect_url).content.decode("utf-8")
+
+        assert_message_in_log(
+            f'SUCCESS  Contact "{contact_string}" was successfully restored.',
+            caplog,
+        )
+        assert (
+            f"Contact &quot;{contact_string}&quot; was successfully restored."
+            in redirect_page
+        )
+        assert not Contact.objects.filter(id=ARCHIVED_CONTACT_ID).first().archived
+    elif role == ANONYMOUS:
+        assert response.status_code == 302
+        assert (
+            response.headers.get("location")
+            == f"{settings.LOGIN_URL}?next={bulk_restore_contacts}"
+        )
+    else:
+        assert response.status_code == 403


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds test for archiving, deleting and restoring of contact objects.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Test archiving, deleting and restoring one contact object
- Test bulk archiving, deleting and restoring


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- The existing tests of the model functions are moved to another file, as they are rather test for "the model" than the user view/action
- Protection of used contacts is not (yet) tested in this PR. We can either merge this PR first and adjust the relevant parts in #3282 or we wait for #3282 and do adjustment here.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3245 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
