### PR TITLE
Fix sudden ruff complaint

### DIFF
--- a/integreat_cms/core/wsgi.py
+++ b/integreat_cms/core/wsgi.py
@@ -40,9 +40,9 @@ def application(environ: dict[str, str], start_response: Callable) -> WSGIHandle
             os.environ.setdefault(f"INTEGREAT_CMS_{KEY.upper()}", VALUE)
 
     # Read config from environment
-    for key in environ:
+    for key, value in environ.items():
         if key.startswith("INTEGREAT_CMS_"):
-            os.environ[key] = environ[key]
+            os.environ[key] = value
 
     _application = get_wsgi_application()
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Since yesterday, `ruff` has been complaining about the following:
```
integreat_cms/core/wsgi.py:43:5: PLC0206 Extracting value from dictionary without calling `.items()`
   |
42 |       # Read config from environment
43 |       for key in environ:
   |  _____^
44 | |         if key.startswith("INTEGREAT_CMS_"):
45 | |             os.environ[key] = environ[key]
   | |__________________________________________^ PLC0206
46 |   
47 |       _application = get_wsgi_application()
   |
```
That code was last touched 3 years ago, so not sure why the sudden complaint, but it *is* a valid complaint.

### Proposed changes
<!-- Describe this PR in more detail. -->

- use `items()` instead of implicitly iterating over / accessing by key


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- oof I hope none
- alternative would be to just ignore the ruff error


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: n/a


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
