### PR TITLE
Disable select for events from external calendars

### DIFF
--- a/integreat_cms/cms/templates/events/event_form_sidebar/date_and_time_box.html
+++ b/integreat_cms/cms/templates/events/event_form_sidebar/date_and_time_box.html
@@ -68,7 +68,8 @@
                 <select name="weekdays_for_weekly"
                         id="id_weekdays_for_weekly"
                         multiple="multiple"
-                        class="{% if recurrence_rule_form.weekdays_for_weekly.errors %} border-red-500{% endif %}">
+                        class="{% if recurrence_rule_form.weekdays_for_weekly.errors %} border-red-500{% endif %}"
+                        {% if recurrence_rule_form.weekdays_for_weekly.field.disabled %} disabled {% endif %}>
                     {% for choice_value, choice_label in recurrence_rule_form.fields.weekdays_for_weekly.widget.choices %}
                         <option value="{{ choice_value }}"
                                 {% if not recurrence_rule_form.data|is_empty %} {% if choice_value in recurrence_rule_form.data|get_int_list:'weekdays_for_weekly' %}selected{% endif %}


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This Pr disables the select button in the event form for events that have been imported from external calendars.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Disable dropdown when it's from an external calendar


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
This has been worked on in collaboration with @KateGithub12 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3204


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
