### PR TITLE
Fix text direction in form

### DIFF
--- a/integreat_cms/cms/forms/machine_translation_form.py
+++ b/integreat_cms/cms/forms/machine_translation_form.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 
 from ...core.utils.machine_translation_provider import MachineTranslationProvider
 from ...textlab_api.utils import check_hix_score
+from ..constants import text_directions
 from ..models import LanguageTreeNode
 from .custom_content_model_form import CustomContentModelForm
 
@@ -93,6 +94,14 @@ class MachineTranslationForm(CustomContentModelForm):
             self.request.region.language_tree_nodes.filter(id__in=to_update)
         )
         self.initial["mt_translations_to_update"] = to_update
+
+        localized_fields = ["title"]
+        for field in localized_fields:
+            self.fields[field].widget.attrs["dir"] = (
+                "rtl"
+                if self.language.text_direction == text_directions.RIGHT_TO_LEFT
+                else "ltr"
+            )
 
     def mt_form_is_enabled(self) -> NS_NodeQuerySet:
         """

--- a/integreat_cms/cms/templates/imprint/imprint_form.html
+++ b/integreat_cms/cms/templates/imprint/imprint_form.html
@@ -65,7 +65,7 @@
                                 </div>
                             {% endif %}
                         </div>
-                        {% render_field imprint_translation_form.title|add_error_class:"border-red-500" class+="mb-2" %}
+                        {% render_field imprint_translation_form.title|add_error_class:"border-red-500" class+="mb-2" dir=text_direction %}
                         {% if imprint_translation_form.instance.id %}
                             {% if request.region.short_urls_enabled and request.user.expert_mode %}
                                 <div class="flex items-center">

--- a/integreat_cms/cms/views/events/event_form_view.py
+++ b/integreat_cms/cms/views/events/event_form_view.py
@@ -12,7 +12,7 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import TemplateView
 
-from ...constants import status, translation_status
+from ...constants import status, text_directions, translation_status
 from ...decorators import permission_required
 from ...forms import EventForm, EventTranslationForm, RecurrenceRuleForm
 from ...models import Event, EventTranslation, Language, POI, RecurrenceRule
@@ -128,6 +128,9 @@ class EventFormView(
                     event_instance.translation_states if event_instance else []
                 ),
                 "disabled": disabled,
+                "right_to_left": (
+                    language.text_direction == text_directions.RIGHT_TO_LEFT
+                ),
             },
         )
 
@@ -315,6 +318,9 @@ class EventFormView(
                 "url_link": url_link,
                 "translation_states": (
                     event_instance.translation_states if event_instance else []
+                ),
+                "right_to_left": (
+                    language.text_direction == text_directions.RIGHT_TO_LEFT
                 ),
             },
         )

--- a/integreat_cms/cms/views/imprint/imprint_form_view.py
+++ b/integreat_cms/cms/views/imprint/imprint_form_view.py
@@ -10,7 +10,7 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import TemplateView
 
-from ...constants import status, translation_status
+from ...constants import status, text_directions, translation_status
 from ...decorators import permission_required
 from ...forms import ImprintTranslationForm
 from ...models import ImprintPage, ImprintPageTranslation
@@ -159,6 +159,14 @@ class ImprintFormView(TemplateView, ImprintContextMixin, MediaContextMixin):
                 ),
                 "translation_states": imprint.translation_states if imprint else [],
                 "lock_key": edit_lock_key,
+                "right_to_left": (
+                    language.text_direction == text_directions.RIGHT_TO_LEFT
+                ),
+                "text_direction": (
+                    "rtl"
+                    if language.text_direction == text_directions.RIGHT_TO_LEFT
+                    else "ltr"
+                ),
             },
         )
 
@@ -257,6 +265,14 @@ class ImprintFormView(TemplateView, ImprintContextMixin, MediaContextMixin):
                     imprint_instance.translation_states if imprint_instance else []
                 ),
                 "lock_key": lock_key,
+                "right_to_left": (
+                    language.text_direction == text_directions.RIGHT_TO_LEFT
+                ),
+                "text_direction": (
+                    "rtl"
+                    if language.text_direction == text_directions.RIGHT_TO_LEFT
+                    else "ltr"
+                ),
             },
         )
 

--- a/integreat_cms/cms/views/pois/poi_form_view.py
+++ b/integreat_cms/cms/views/pois/poi_form_view.py
@@ -14,7 +14,7 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import TemplateView
 
-from ...constants import status
+from ...constants import status, text_directions
 from ...decorators import permission_required
 from ...forms import POIForm, POITranslationForm
 from ...models import Language, POI, POITranslation
@@ -107,6 +107,9 @@ class POIFormView(
                 "languages": region.active_languages if poi else [language],
                 "url_link": url_link,
                 "translation_states": poi.translation_states if poi else [],
+                "right_to_left": (
+                    language.text_direction == text_directions.RIGHT_TO_LEFT
+                ),
             },
         )
 
@@ -270,6 +273,9 @@ class POIFormView(
                 "url_link": url_link,
                 "translation_states": (
                     poi_instance.translation_states if poi_instance else []
+                ),
+                "right_to_left": (
+                    language.text_direction == text_directions.RIGHT_TO_LEFT
                 ),
             },
         )

--- a/integreat_cms/release_notes/current/unreleased/3290.yml
+++ b/integreat_cms/release_notes/current/unreleased/3290.yml
@@ -1,0 +1,2 @@
+en: Fix text direction in event/location/imprint form
+de: Korrigiere Textrichtung im Veranstaltung-/Ort-/Impressum-Formular


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes text direction of the title and content field.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Pass `right_to_left` in the event, POI and imprint view too, which is already used in the page form to set the text direction of TinyMCE.
- Add `text_direction` in the event, POI, imprint and page view to set the text direction of title input field in the template.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- `right_to_left` and `text_direction` have almost the same function but I let both exist, because `right_to_left` is already being used in several places and it does not look cool (in my opinion) to write `text_direction == "rtl"` or something repeatedly 😅 (solved for page, POI and event)
- If I remember correctly, there was once a discusion about fixing the text direction of title field but it was rejected/postponed due to some technical problem or complexity or something. Though I couldn't find such thema in the repository, it may be a wrong memory. If you remember or know such (potential) problem, please comment 👀 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3290 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
