### PR TITLE
Remove `x Locations/Events selected` string for observer role

### DIFF
--- a/integreat_cms/cms/templates/events/event_list.html
+++ b/integreat_cms/cms/templates/events/event_list.html
@@ -153,7 +153,7 @@
             </tbody>
         </table>
     </div>
-    {% if events %}
+    {% if events and perms.cms.change_event %}
         <div class="pt-2 px-2">
             <div class="inline">
                 <span class="text-gray-800 font-bold" data-list-selection-count>0</span> <span class="text-gray-600">{% translate "Events selected" %}</span>

--- a/integreat_cms/cms/templates/pois/poi_list.html
+++ b/integreat_cms/cms/templates/pois/poi_list.html
@@ -115,7 +115,7 @@
             </tbody>
         </table>
     </div>
-    {% if pois %}
+    {% if pois and perms.cms.change_poi %}
         <div class="pt-2 px-2">
             <div class="inline">
                 <span class="text-gray-800 font-bold" data-list-selection-count>0</span> <span class="text-gray-600">{% translate "Locations selected" %}</span>

--- a/integreat_cms/cms/templates/pois/poi_list_archived.html
+++ b/integreat_cms/cms/templates/pois/poi_list_archived.html
@@ -81,6 +81,13 @@
             </tbody>
         </table>
     </div>
+    {% if pois and perms.cms.change_poi %}
+        <div class="pt-2 px-2">
+            <div class="inline">
+                <span class="text-gray-800 font-bold" data-list-selection-count>0</span> <span class="text-gray-600">{% translate "Locations selected" %}</span>
+            </div>
+        </div>
+    {% endif %}
     {% if perms.cms.change_poi %}
         <div class="flex flex-wrap gap-2 mt-4">
             <select id="bulk-action" class="w-auto max-w-full">

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -7813,7 +7813,7 @@ msgstr "Keine Orte mit diesen Filtern gefunden."
 msgid "No locations available yet."
 msgstr "Noch keine Orte vorhanden."
 
-#: cms/templates/pois/poi_list.html
+#: cms/templates/pois/poi_list.html cms/templates/pois/poi_list_archived.html
 msgid "Locations selected"
 msgstr "Orte ausgewählt"
 

--- a/integreat_cms/release_notes/current/unreleased/3263.yml
+++ b/integreat_cms/release_notes/current/unreleased/3263.yml
@@ -1,0 +1,2 @@
+en: Remove "x Locations/Events selected" text for the observer role
+de: Entferne den Text "x Orte/Veranstaltungen ausgewählt" für die Beobachterrolle


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Currently the strings `X Locations selected` and `X Events selected`are being displayed regardless of user role. The observer role can not see checkboxes and therefore can not manupulate anything thus the strings `X Locations/Events selected` should be hidden.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Hide the strings from non permitted roles
- Add `X Locations selected` in archived locations (currently it does not exist) and add check condition whether the user role allowed to see it or not


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3263 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
