### PR TITLE
Fix: prevent early exit of tools/code_style.sh after exit code 1

### DIFF
--- a/tools/code_style.sh
+++ b/tools/code_style.sh
@@ -10,19 +10,19 @@ require_installed
 ensure_not_root
 
 # Run ruff
-bash "${DEV_TOOL_DIR}/ruff.sh"
+bash "${DEV_TOOL_DIR}/ruff.sh" || :
 
 # Run black
-bash "${DEV_TOOL_DIR}/black.sh"
+bash "${DEV_TOOL_DIR}/black.sh" || :
 
 # Run djlint
-bash "${DEV_TOOL_DIR}/djlint.sh"
+bash "${DEV_TOOL_DIR}/djlint.sh" || :
 
 # Run pylint
-bash "${DEV_TOOL_DIR}/pylint.sh"
+bash "${DEV_TOOL_DIR}/pylint.sh" || :
 
 # Run eslint
-bash "${DEV_TOOL_DIR}/eslint.sh"
+bash "${DEV_TOOL_DIR}/eslint.sh" || :
 
 # Run prettier
-bash "${DEV_TOOL_DIR}/prettier.sh"
+bash "${DEV_TOOL_DIR}/prettier.sh" || :


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

Some of the code style tools "fail" with exit code 1 when they performed an action (e.g.: djlint exits with code 1 after changing any file's formatting).

This exits the entire `tools/code_style.sh` script, and you need to invoke it again.

### Proposed changes
<!-- Describe this PR in more detail. -->

- continue with the next tool, even if the previous one "failed"


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none I think
- I will stop feeling annoyed by this 😂 😂 😂 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: n/a


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
