### PR TITLE
Fix contact insertion

### DIFF
--- a/integreat_cms/cms/models/contact/contact.py
+++ b/integreat_cms/cms/models/contact/contact.py
@@ -257,6 +257,18 @@ class Contact(AbstractBaseModel):
         self.point_of_contact_for = self.point_of_contact_for + " " + _("(Copy)")
         self.save()
 
+    def get_absolute_url(self) -> str:
+        """
+        Returns the absolute url to this contact:
+
+        For example::
+
+            /region_slug/contact/1
+
+        :return: The absolute url to this contact
+        """
+        return f"/{self.location.region.slug}/contact/{self.id}/"
+
     @cached_property
     def full_url(self) -> str:
         """
@@ -264,7 +276,8 @@ class Contact(AbstractBaseModel):
 
         :return: The full url
         """
-        return f"{settings.BASE_URL}/{self.location.region.slug}/contact/{self.id}/"
+        absolute_url = self.get_absolute_url()
+        return f"{settings.BASE_URL}{absolute_url}"
 
     class Meta:
         verbose_name = _("contact")

--- a/integreat_cms/cms/models/contact/contact.py
+++ b/integreat_cms/cms/models/contact/contact.py
@@ -182,7 +182,7 @@ class Contact(AbstractBaseModel):
         return PageTranslation.objects.filter(
             id__in=(
                 Link.objects.filter(
-                    url__url=self.full_url,
+                    url__url=self.absolute_url,
                     content_type=PageTranslationLinklist.content_type(),
                 ).values("object_id")
             ),
@@ -200,7 +200,7 @@ class Contact(AbstractBaseModel):
         return POITranslation.objects.filter(
             id__in=(
                 Link.objects.filter(
-                    url__url=self.full_url,
+                    url__url=self.absolute_url,
                     content_type=POITranslationLinklist.content_type(),
                 ).values("object_id")
             ),
@@ -218,7 +218,7 @@ class Contact(AbstractBaseModel):
         return EventTranslation.objects.filter(
             id__in=(
                 Link.objects.filter(
-                    url__url=self.full_url,
+                    url__url=self.absolute_url,
                     content_type=EventTranslationLinklist.content_type(),
                 ).values("object_id")
             ),
@@ -232,7 +232,8 @@ class Contact(AbstractBaseModel):
         :return: all objects referring to this contact
         """
         return (
-            link.content_object for link in Link.objects.filter(url__url=self.full_url)
+            link.content_object
+            for link in Link.objects.filter(url__url=self.absolute_url)
         )
 
     def archive(self) -> None:
@@ -258,13 +259,13 @@ class Contact(AbstractBaseModel):
         self.save()
 
     @cached_property
-    def full_url(self) -> str:
+    def absolute_url(self) -> str:
         """
-        This property returns the full url of this contact
+        This property returns the absolute url of this contact
 
         :return: The full url
         """
-        return f"{settings.BASE_URL}/{self.location.region.slug}/contact/{self.id}/"
+        return f"/{self.location.region.slug}/contact/{self.id}/"
 
     class Meta:
         verbose_name = _("contact")

--- a/integreat_cms/cms/models/contact/contact.py
+++ b/integreat_cms/cms/models/contact/contact.py
@@ -257,18 +257,6 @@ class Contact(AbstractBaseModel):
         self.point_of_contact_for = self.point_of_contact_for + " " + _("(Copy)")
         self.save()
 
-    def get_absolute_url(self) -> str:
-        """
-        Returns the absolute url to this contact:
-
-        For example::
-
-            /region_slug/contact/1
-
-        :return: The absolute url to this contact
-        """
-        return f"/{self.location.region.slug}/contact/{self.id}/"
-
     @cached_property
     def full_url(self) -> str:
         """
@@ -276,8 +264,7 @@ class Contact(AbstractBaseModel):
 
         :return: The full url
         """
-        absolute_url = self.get_absolute_url()
-        return f"{settings.BASE_URL}{absolute_url}"
+        return f"{settings.BASE_URL}/{self.location.region.slug}/contact/{self.id}/"
 
     class Meta:
         verbose_name = _("contact")

--- a/integreat_cms/cms/templates/contacts/contact_card.html
+++ b/integreat_cms/cms/templates/contacts/contact_card.html
@@ -3,12 +3,12 @@
 {% spaceless %}
     <div contenteditable="false"
          data-contact-id="{{ contact.pk }}"
-         data-contact-url="{{ contact.full_url }}"
+         data-contact-url="{{ contact.absolute_url }}"
          class="contact-card notranslate"
          dir="ltr"
          translate="no">
         {# djlint:off H021 #}
-        <a href="{{ contact.full_url }}" style="display: none">Contact</a>
+        <a href="{{ contact.absolute_url }}" style="display: none">Contact</a>
         {# djlint:on #}
         {% if contact %}
             {% if contact.name or contact.point_of_contact_for %}

--- a/integreat_cms/cms/views/utils/contact_utils.py
+++ b/integreat_cms/cms/views/utils/contact_utils.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, render
+from django.urls import reverse
 from django.views.decorators.http import require_POST
 
 from ...decorators import permission_required
@@ -37,8 +38,6 @@ def search_contact_ajax(
     :raises ~django.core.exceptions.PermissionDenied: If the user has no permission to the object type
     :return: Json object containing all matching elements, of shape {title: str, url: str, type: str}
     """
-    # pylint: disable=unused-argument
-
     body = json.loads(request.body.decode("utf-8"))
     if (query := body["query_string"]) is None:
         return JsonResponse({"data": []})
@@ -54,7 +53,10 @@ def search_contact_ajax(
         {
             "data": [
                 {
-                    "url": result.get_absolute_url(),
+                    "url": reverse(
+                        "get_contact",
+                        kwargs={"contact_id": result.id, "region_slug": region_slug},
+                    ),
                     "name": result.get_repr_short,
                 }
                 for result in results

--- a/integreat_cms/cms/views/utils/contact_utils.py
+++ b/integreat_cms/cms/views/utils/contact_utils.py
@@ -54,7 +54,7 @@ def search_contact_ajax(
         {
             "data": [
                 {
-                    "url": result.full_url,
+                    "url": result.get_absolute_url(),
                     "name": result.get_repr_short,
                 }
                 for result in results

--- a/integreat_cms/cms/views/utils/contact_utils.py
+++ b/integreat_cms/cms/views/utils/contact_utils.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, render
-from django.urls import reverse
 from django.views.decorators.http import require_POST
 
 from ...decorators import permission_required
@@ -38,6 +37,8 @@ def search_contact_ajax(
     :raises ~django.core.exceptions.PermissionDenied: If the user has no permission to the object type
     :return: Json object containing all matching elements, of shape {title: str, url: str, type: str}
     """
+    # pylint: disable=unused-argument
+
     body = json.loads(request.body.decode("utf-8"))
     if (query := body["query_string"]) is None:
         return JsonResponse({"data": []})
@@ -53,10 +54,7 @@ def search_contact_ajax(
         {
             "data": [
                 {
-                    "url": reverse(
-                        "get_contact",
-                        kwargs={"contact_id": result.id, "region_slug": region_slug},
-                    ),
+                    "url": result.absolute_url,
                     "name": result.get_repr_short,
                 }
                 for result in results

--- a/integreat_cms/static/src/js/forms/tinymce-init.ts
+++ b/integreat_cms/static/src/js/forms/tinymce-init.ts
@@ -106,7 +106,7 @@ window.addEventListener("load", () => {
             link_target_list: false,
             link_default_target: "",
             document_base_url: tinymceConfig.getAttribute("data-webapp-url"),
-            relative_urls: false,
+            convert_urls: false,
             remove_script_host: false,
             branding: false,
             paste_as_text: true,


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
On the testserver we have multiple possible backend urls, and the contacts were previously loaded using their complete server url. For example, if a user was on `https://cms-test.integreat-app.de` the contact was still loaded using `https://integreat-test.tuerantuer.org`. Then the login form would be returned, because the user had of course no valid session for the other url.

So instead of using full urls, we can just use relative urls, like we do for all other links.

It's a bit hard to test this pr, because everything worked anyways on localhost, but I hope the explanation helps :)

I also considered adding `redirect: "error",` to the fetch call. This would at least have prevented that the full login form gets pasted. But maybe that is something we should add to all our fetch calls?

### Proposed changes
<!-- Describe this PR in more detail. -->

-  Don't use the full url


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

Should be none


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3304


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
