### PR TITLE
Fix missing legend on png export in statistics

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/3266.yml
+++ b/integreat_cms/release_notes/current/unreleased/3266.yml
@@ -1,0 +1,2 @@
+en: Fix missing legends in exported png files in statistics
+de: Behebe fehlende Legenden in exportierten png-Dateien in Statistiken

--- a/integreat_cms/static/src/js/analytics/statistics-charts.ts
+++ b/integreat_cms/static/src/js/analytics/statistics-charts.ts
@@ -170,15 +170,29 @@ const exportStatisticsData = (): void => {
     }`;
 
     if (exportFormat.value === "image") {
-        // This is needed to get a white background for the image. The default background is transparent.
-        const ctx = chart.canvas.getContext("2d");
-        ctx.globalCompositeOperation = "destination-over";
-        ctx.fillStyle = "white";
-        ctx.fillRect(0, 0, chart.canvas.width, chart.canvas.height);
-        // Image Creation of the chart
-        const image = chart.toBase64Image();
-        // Initiate download
-        downloadFile(`${filename}.png`, image);
+        const timeoutDuration = 300;
+        chart.options.plugins.legend.display = true;
+        chart.update();
+
+        // Wait till the legend is fully rendered
+        setTimeout(() => {
+            const ctx = chart.canvas.getContext("2d");
+
+            if (ctx) {
+                // This is needed to get a white background for the image. The default background is transparent.
+                ctx.globalCompositeOperation = "destination-over";
+                ctx.fillStyle = "white";
+                ctx.fillRect(0, 0, chart.canvas.width, chart.canvas.height);
+
+                // Capture the chart as a PNG image
+                const image = chart.toBase64Image();
+                // Initiate download
+                downloadFile(`${filename}.png`, image);
+
+                chart.options.plugins.legend.display = false;
+                chart.update();
+            }
+        }, timeoutDuration);
     } else if (exportFormat.value === "csv") {
         // Convert datasets into the format [["language 1", "hits on day 1", "hits 2", ...], [["language 1", "hits on day 1", ...], ...]
         const datasetsWithLabels: string[][] = chart.data.datasets.map((dataset) =>
@@ -216,6 +230,10 @@ window.addEventListener("load", async () => {
             plugins: {
                 legend: {
                     display: false,
+                    labels: {
+                        usePointStyle: true,
+                        pointStyle: "circle",
+                    },
                 },
                 tooltip: {
                     usePointStyle: true,


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
After moving the language labels to the sidebar, the language legends disappeared on png export. Language legends should be there on exported png file.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Set legend display to true on image export and make necessary adjustments to render legends
- Make the legends border radius circle


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- should be none


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3266 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
