### PR TITLE
Fix MT budget calculation for add-on package booked with mid-year start in January

### DIFF
--- a/integreat_cms/cms/models/regions/region.py
+++ b/integreat_cms/cms/models/regions/region.py
@@ -858,7 +858,7 @@ class Region(AbstractBaseModel):
         if not self.mt_addon_booked:
             return settings.MT_CREDITS_FREE
         # All regions which did book the add-on, but not mid-year, get the add-on credits
-        if not self.mt_midyear_start_month:
+        if self.mt_midyear_start_month is None:
             return settings.MT_CREDITS_ADDON + settings.MT_CREDITS_FREE
         # All regions which booked the add-on in mid-year get a fraction of the add-on credits
         # Calculate how many months lie between the renewal month and the start month of the add-on

--- a/integreat_cms/release_notes/current/unreleased/3309.yml
+++ b/integreat_cms/release_notes/current/unreleased/3309.yml
@@ -1,0 +1,2 @@
+en: Fix MT budget calculation for add-on package with mid-year start
+de: Korrigiere die MT-Budgetberechnung für Zusatzpakete mit unterjährigem Start des Abrechnungszeitraums

--- a/tests/cms/views/regions/test_region_mt_management.py
+++ b/tests/cms/views/regions/test_region_mt_management.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from integreat_cms.cms.constants import months
+from integreat_cms.cms.models import Region
+
+REGION_SLUG = "augsburg"
+
+parameters = [
+    (months.JANUARY, False, None, 50000),
+    (months.MAY, False, None, 50000),
+    (months.JANUARY, True, months.APRIL, 800000),
+    (months.FEBRUARY, True, months.MAY, 800000),
+    (months.OCTOBER, True, months.JANUARY, 800000),
+    (months.NOVEMBER, True, months.FEBRUARY, 800000),
+    (months.JANUARY, True, None, 1050000),
+    (months.MARCH, True, None, 1050000),
+]
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("parameter", parameters)
+def test_region_mt_budget_calc(
+    load_test_data: None,
+    parameter: tuple[int, bool, int, int],
+) -> None:
+    """
+    Test MT budget of a region is being calculated as expected, including mid year start and add-on package
+    """
+    mt_renewal_month, mt_addon_booked, mt_midyear_start_month, budget = parameter
+    region = Region.objects.filter(slug=REGION_SLUG).first()
+
+    region.mt_renewal_month = mt_renewal_month
+    region.mt_addon_booked = mt_addon_booked
+    region.mt_midyear_start_month = mt_midyear_start_month
+
+    assert region.mt_budget == budget


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes MT budget calculation of add-on package with mid-year start in January.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Check explicitly for `None` to avoid January (= 0) is avaluated as if `None`


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- None? 🙏 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3309 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
