### PR TITLE
Allow users to select shown contact details

### DIFF
--- a/integreat_cms/cms/models/contact/contact.py
+++ b/integreat_cms/cms/models/contact/contact.py
@@ -236,6 +236,34 @@ class Contact(AbstractBaseModel):
             for link in Link.objects.filter(url__url=self.absolute_url)
         ]
 
+    @cached_property
+    def available_details(self) -> dict:
+        """
+        Returns the available details and their human-readable representation
+
+        :return: key-value pairs of available detail and human-readable representation
+        """
+        details = {
+            "address": _("show address"),
+        }
+
+        if self.point_of_contact_for:
+            details["point_of_contact_for"] = _("show point of contact")
+
+        if self.name:
+            details["name"] = _("show name")
+
+        if self.email:
+            details["email"] = _("show email")
+
+        if self.phone_number:
+            details["phone_number"] = _("show phone number")
+
+        if self.website:
+            details["website"] = _("show website")
+
+        return details
+
     def archive(self) -> None:
         """
         Archives the contact

--- a/integreat_cms/cms/templates/contacts/contact_card.html
+++ b/integreat_cms/cms/templates/contacts/contact_card.html
@@ -3,52 +3,54 @@
 {% spaceless %}
     <div contenteditable="false"
          data-contact-id="{{ contact.pk }}"
-         data-contact-url="{{ contact.absolute_url }}"
+         data-contact-url="{{ contact.absolute_url }}?details={{ wanted|join:"," }}"
          class="contact-card notranslate"
          dir="ltr"
          translate="no">
         {# djlint:off H021 #}
-        <a href="{{ contact.absolute_url }}" style="display: none">Contact</a>
+        <a href="{{ contact.absolute_url }}?details={{ wanted|join:"," }}"
+           style="display: none">Contact</a>
         {# djlint:on #}
-        {% if contact %}
-            {% if contact.name or contact.point_of_contact_for %}
-                <h4>
-                    {% if contact.name %}
-                        {{ contact.name }}
-                    {% endif %}
-                    {% if contact.name and contact.point_of_contact_for %}
-                        |
-                    {% endif %}
-                    {% if contact.point_of_contact_for %}
-                        {{ contact.point_of_contact_for }}
-                    {% endif %}
-                </h4>
-            {% endif %}
+        {# "and" takes precedent: https://docs.djangoproject.com/en/4.2/ref/templates/builtins/#boolean-operators #}
+        {% if contact.name and "name" in wanted or contact.point_of_contact_for and "point_of_contact_for" in wanted %}
+            <h4>
+                {% if contact.name and "name" in wanted %}
+                    {{ contact.name }}
+                {% endif %}
+                {% if contact.name and "name" in wanted and contact.point_of_contact_for and "point_of_contact_for" in wanted %}
+                    |
+                {% endif %}
+                {% if contact.point_of_contact_for and "point_of_contact_for" in wanted %}
+                    {{ contact.point_of_contact_for }}
+                {% endif %}
+            </h4>
+        {% endif %}
+        {% if "address" in wanted %}
             <p>
                 <img src="{% get_svg_icon "pin" %}" alt="Address: " width="15" height="15" />
                 <a href="{{ contact.location.map_url }}">{{ contact.location.short_address }}</a>
             </p>
-            {% if contact.email %}
-                <p>
-                    <img src="{% get_svg_icon "email" %}" alt="Email: " width="15" height="15" />
-                    <a href="mailto:{{ contact.email }}">{{ contact.email }}</a>
-                </p>
-            {% endif %}
-            {% if contact.phone_number %}
-                <p>
-                    <img src="{% get_svg_icon "call" %}"
-                         alt="Phone Number: "
-                         width="15"
-                         height="15" />
-                    <a href="tel:{{ contact.phone_number }}">{{ contact.phone_number }}</a>
-                </p>
-            {% endif %}
-            {% if contact.website %}
-                <p>
-                    <img src="{% get_svg_icon "www" %}" alt="Website: " width="15" height="15" />
-                    <a href="{{ contact.website }}">{{ contact.website }}</a>
-                </p>
-            {% endif %}
+        {% endif %}
+        {% if contact.email and "email" in wanted %}
+            <p>
+                <img src="{% get_svg_icon "email" %}" alt="Email: " width="15" height="15" />
+                <a href="mailto:{{ contact.email }}">{{ contact.email }}</a>
+            </p>
+        {% endif %}
+        {% if contact.phone_number and "phone_number" in wanted %}
+            <p>
+                <img src="{% get_svg_icon "call" %}"
+                     alt="Phone Number: "
+                     width="15"
+                     height="15" />
+                <a href="tel:{{ contact.phone_number }}">{{ contact.phone_number }}</a>
+            </p>
+        {% endif %}
+        {% if contact.website and "website" in wanted %}
+            <p>
+                <img src="{% get_svg_icon "www" %}" alt="Website: " width="15" height="15" />
+                <a href="{{ contact.website }}">{{ contact.website }}</a>
+            </p>
         {% endif %}
     </div>
 {% endspaceless %}

--- a/integreat_cms/cms/views/utils/contact_utils.py
+++ b/integreat_cms/cms/views/utils/contact_utils.py
@@ -5,7 +5,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from django.core.exceptions import PermissionDenied
-from django.http import HttpResponse, JsonResponse
+from django.http import JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.views.decorators.http import require_POST
 
@@ -56,6 +56,7 @@ def search_contact_ajax(
                 {
                     "url": result.absolute_url,
                     "name": result.get_repr_short,
+                    "details": result.available_details,
                 }
                 for result in results
             ]
@@ -77,7 +78,11 @@ def get_contact(
     """
     # pylint: disable=unused-argument
     contact = get_object_or_404(Contact, pk=contact_id)
-    return render(request, "contacts/contact_card.html", {"contact": contact})
+
+    wanted = request.GET.get("details", "").split(",")
+    return render(
+        request, "contacts/contact_card.html", {"contact": contact, "wanted": wanted}
+    )
 
 
 @permission_required("cms.view_contact")
@@ -95,4 +100,12 @@ def get_contact_raw(
     """
     # pylint: disable=unused-argument
     contact = get_object_or_404(Contact, pk=contact_id)
-    return HttpResponse(contact.get_repr_short)
+    return JsonResponse(
+        {
+            "data": {
+                "url": contact.full_url,
+                "name": contact.get_repr_short,
+                "details": contact.available_details,
+            }
+        }
+    )

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -2818,6 +2818,30 @@ msgid "General contact information"
 msgstr "Allgemeine Kontaktinformationen"
 
 #: cms/models/contact/contact.py
+msgid "show address"
+msgstr "Adresse anzeigen"
+
+#: cms/models/contact/contact.py
+msgid "show point of contact"
+msgstr "Ansprechperson anzeigen"
+
+#: cms/models/contact/contact.py
+msgid "show name"
+msgstr "Name anzeigen"
+
+#: cms/models/contact/contact.py
+msgid "show email"
+msgstr "Email anzeigen"
+
+#: cms/models/contact/contact.py
+msgid "show phone number"
+msgstr "Telefonnummer anzeigen"
+
+#: cms/models/contact/contact.py
+msgid "show website"
+msgstr "Webseite anzeigen"
+
+#: cms/models/contact/contact.py
 msgid "(Copy)"
 msgstr "(Kopie)"
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

This PR allows users to choose which contact details are shown when they insert a contact into TinyMCE, as well as when updating the contact later on.

### Proposed changes
<!-- Describe this PR in more detail. -->

- use a GET parameter to encode which contact details should be shown on a per-contact-card basis
- show appropriate checkboxes after selecting a contact through Tomselect


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- styling the checkboxes was... a challenge, since I frustratingly was not able to target them through the `tinymce.css` file - if someone knows why/how to fix this, I am all ears!
- suboptimal from a UX perspective: if a user selects a contact, deselects some details, then chooses a different contact, the details selection is reset. Not sure if this is worth the effort to change, though, since the shown checkboxes are necessarily contact-specific


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3258 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
