### PR TITLE
Error message when attempting to add inactive users to pages

### DIFF
--- a/integreat_cms/cms/views/pages/page_permission_actions.py
+++ b/integreat_cms/cms/views/pages/page_permission_actions.py
@@ -171,6 +171,11 @@ class AbstractPagePermission(ABC):
 
         :return: Response message
         """
+        if not user.is_active:
+            return PermissionMessage(
+                _("Inactive users cannot be assigned to pages."),
+                MessageLevel.WARNING,
+            )
         if not user.has_perm("cms.view_page"):
             return PermissionMessage(
                 _(

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -10259,6 +10259,10 @@ msgstr ""
 "Ein Fehler ist aufgetreten. Bitte kontaktieren Sie eine:n Administrator:in."
 
 #: cms/views/pages/page_permission_actions.py
+msgid "Inactive users cannot be assigned to pages."
+msgstr "Benutzer:innen können keiner Seite zugeordnet werden, solange ihr Konto nicht aktiviert wurde."
+
+#: cms/views/pages/page_permission_actions.py
 msgid ""
 "Page-specific permissions cannot be granted to users who do not have "
 "permission to view pages (e.g event managers)."


### PR DESCRIPTION
### Short description
Show a more sensible error message when attempting to add inactive users to pages

### Proposed changes
- grant_permission method checks if user is active before checking the permissions


### Side effects
None


### Resolved issues

Fixes: #3078 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
