### PR TITLE
Show only selected data in CSV export

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/3279.yml
+++ b/integreat_cms/release_notes/current/unreleased/3279.yml
@@ -1,0 +1,2 @@
+en: Export only statistics for selected languages
+de: Exportiere nur ausgewählte Seitenzugriffsstatistiken

--- a/integreat_cms/static/src/js/analytics/statistics-charts.ts
+++ b/integreat_cms/static/src/js/analytics/statistics-charts.ts
@@ -181,9 +181,10 @@ const exportStatisticsData = (): void => {
         downloadFile(`${filename}.png`, image);
     } else if (exportFormat.value === "csv") {
         // Convert datasets into the format [["language 1", "hits on day 1", "hits 2", ...], [["language 1", "hits on day 1", ...], ...]
-        const datasetsWithLabels: string[][] = chart.data.datasets.map((dataset) =>
-            [dataset.label].concat(dataset.data.map(String))
-        );
+        const datasets = chart.data.datasets;
+        const datasetsWithLabels: string[][] = datasets
+            .filter((dataset) => chart.isDatasetVisible(datasets.indexOf(dataset)))
+            .map((dataset) => [dataset.label].concat(dataset.data.map(String)));
         // Ensure export labels don't contain comma and corrupt CSV
         exportLabels = exportLabels.map((x) => x.replace(",", " - "));
         // Create matrix with date labels in the first row and the hits per language in the subsequent rows


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the CSV export of statistics so it does not contain de-selected data (language, access type) anymore.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Check whether the data is set to "visible" at the moment of export


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- None?


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3279 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
