### PR TITLE
Fix location selection in the event filter

### DIFF
--- a/integreat_cms/cms/templates/_poi_query_result.html
+++ b/integreat_cms/cms/templates/_poi_query_result.html
@@ -14,7 +14,8 @@
                 <option class="option-existing-poi hover:bg-gray-200 cursor-pointer"
                         title="{{ poi.address }}, {{ poi.postcode }} {{ poi.city }}"
                         data-poi-address="{% render_poi_address poi %}"
-                        data-poi-title="{{ poi|poi_translation_title:current_language }}">
+                        data-poi-title="{{ poi|poi_translation_title:current_language }}"
+                        data-poi-id="{{ poi.id }}">
                     {{ poi|poi_translation_title:current_language }}
                 </option>
             {% endfor %}

--- a/integreat_cms/cms/views/pois/poi_form_ajax_view.py
+++ b/integreat_cms/cms/views/pois/poi_form_ajax_view.py
@@ -109,5 +109,6 @@ class POIFormAjaxView(TemplateView, POIContextMixin):
                     "ajax_poi_form/_poi_address_container.html",
                     {"poi": poi_translation_form.instance.poi},
                 ),
+                "poi_id": poi_translation_form.instance.poi.id,
             }
         )

--- a/integreat_cms/release_notes/current/unreleased/3212.yml
+++ b/integreat_cms/release_notes/current/unreleased/3212.yml
@@ -1,0 +1,2 @@
+en: Fix selection of event location for event filter
+de: Korrigiere Auswahl des Veranstaltungsortes für den Veranstaltungsfilter

--- a/integreat_cms/static/src/js/poi-box.ts
+++ b/integreat_cms/static/src/js/poi-box.ts
@@ -1,7 +1,7 @@
 import { createIconsAt } from "./utils/create-icons";
 import { getCsrfToken } from "./utils/csrf-token";
 
-type FormResponse = { success: boolean; poi_address_container: string };
+type FormResponse = { success: boolean; poi_address_container: string; poi_id: string };
 
 const showContactFieldBox = () => {
     const contactFieldsBox = document.getElementById("contact_fields");
@@ -15,9 +15,13 @@ const hideSearchResults = () => {
     (document.getElementById("poi-query-input") as HTMLInputElement).value = "";
 };
 
-const renderPoiData = (poiTitle: string, newPoiData: string) => {
-    document.getElementById("poi-address-container").outerHTML = newPoiData;
+const renderPoiData = (poiTitle: string, newPoiData: string, poiId: string) => {
+    const poiAddressContainer = document.getElementById("poi-address-container");
+    if (poiAddressContainer) {
+        poiAddressContainer.outerHTML = newPoiData;
+    }
     document.getElementById("poi-query-input").setAttribute("placeholder", poiTitle);
+    (document.getElementById("id_location") as HTMLInputElement).value = poiId;
     hideSearchResults();
     showContactFieldBox();
 };
@@ -31,7 +35,11 @@ const hidePoiFormWidget = () => {
 
 const setPoi = ({ target }: Event) => {
     const option = (target as HTMLElement).closest(".option-existing-poi");
-    renderPoiData(option.getAttribute("data-poi-title"), option.getAttribute("data-poi-address"));
+    renderPoiData(
+        option.getAttribute("data-poi-title"),
+        option.getAttribute("data-poi-address"),
+        option.getAttribute("data-poi-id")
+    );
     document.getElementById("poi-address-container")?.classList.remove("hidden");
     console.debug("Rendered POI data");
     document.getElementById("info-location-mandatory")?.classList.add("hidden");
@@ -87,7 +95,11 @@ const showPoiFormWidget = async ({ target }: Event) => {
             showMessage(responseData);
             // If POI was created successful, show it as selected option
             if (responseData.success) {
-                renderPoiData(formData.get("title").toString(), responseData.poi_address_container);
+                renderPoiData(
+                    formData.get("title").toString(),
+                    responseData.poi_address_container,
+                    responseData.poi_id
+                );
                 document.getElementById("poi-address-container")?.classList.remove("hidden");
             }
             hidePoiFormWidget();


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the bug that none of the suggested locations can be selected in the event form.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Putting the ID of selected POI to the input field to hand over to the filter
- Fix `TypeError: Cannot set properties of null` at `.outerHTML`


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
-  I hope none 🙈 Please check there is no side effect on ajax POI creation in the event and contact form too.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3212 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
