### PR TITLE
Hide create button in archived contacts list

### DIFF
--- a/integreat_cms/cms/templates/contacts/contact_list.html
+++ b/integreat_cms/cms/templates/contacts/contact_list.html
@@ -28,7 +28,7 @@
             {% endif %}
         </div>
         <div class="flex flex-wrap justify-end gap-4">
-            {% if perms.cms.change_contact %}
+            {% if perms.cms.change_contact and not is_archive %}
                 <a href="{% url 'new_contact' region_slug=request.region.slug %}"
                    class="btn">
                     {% translate "Create contact" %}


### PR DESCRIPTION
### Short description
Hide create button in archived contacts list


### Proposed changes

- add additional check in HTML form to hide 'Create contact' button in archived contacts


### Side effects

None 


### Resolved issues

Fixes: #3326


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
