### PR TITLE
Startup redis server in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,6 +8,8 @@ RUN apt-get update && \
     ln -sf /usr/local/bin/node /usr/bin/node
 
 RUN apt-get install -y netcat-traditional pcregrep
+RUN apt-get install -y redis-server && \
+    usermod -aG redis www-data
 
 WORKDIR /workspace
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,7 +31,7 @@
     }
   },
   "postCreateCommand": "./tools/install.sh --python python3.11 && ./tools/migrate.sh && ./tools/loadtestdata.sh",
-  "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder}",
+  "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder} && redis-server --daemonize yes --unixsocket /workspace/redis-server.sock --unixsocketperm 770",
   "remoteEnv": {
     "DJANGO_SETTINGS_MODULE": "integreat_cms.core.settings",
     "INTEGREAT_CMS_DEBUG": "1",


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Add Redis Server to Development Container similar to #3256 did for nix


### Proposed changes
<!-- Describe this PR in more detail. -->

- Since the introduction of Cellery, Redis Server is now required to run the cms
- Adds installation of Redis Server while building the container
- Adds startup of Redis Server after building the container

Since as far as I know I'm the only one using the dev container, it should be enough to check if there is no unwanted side effect on your own setup


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: n.a.


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
