### PR TITLE
Make `eslint` catch `console.log` statements

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -64,7 +64,6 @@ module.exports = {
         "implicit-arrow-linebreak": "off",
         "max-len": "off",
         "no-confusing-arrow": "off",
-        "no-console": "off",
         "no-multiple-empty-lines": "off",
         "object-curly-newline": "off",
         "operator-linebreak": "off",
@@ -137,6 +136,7 @@ module.exports = {
         "react/function-component-definition": ["error", { namedComponents: "arrow-function" }],
         "react-hooks/exhaustive-deps": "error",
         "vars-on-top": "error",
+        "no-console": ["error", { allow: ["debug", "warn", "error"] }],
     },
     overrides: [
         {

--- a/integreat_cms/static/src/js/media-management/component/edit-sidebar.tsx
+++ b/integreat_cms/static/src/js/media-management/component/edit-sidebar.tsx
@@ -128,7 +128,6 @@ const EditSidebar = ({
             ...changedFile,
             isHidden: !changedFile.isHidden,
         });
-        console.log(changedFile);
     };
 
     return (


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

In #3329 I noticed that neither eslint (nor prettier, which apprently was the original idea) complain about uses of `console.log`.

### Proposed changes
<!-- Describe this PR in more detail. -->

- let eslint throw errors on `console.log`
- `console.debug`, `console.warn`, `console.error` remain usable.

(TBH I am more than open to also forbidding `console.warn`, but did not want to deicde this unilaterally. Forbidding `console.log` is more important anyways, since those are our accidentally missed debug statements)

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: n/a


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
