### PR TITLE
Create contact links upon contact card insertion in TinyMCE

### DIFF
--- a/integreat_cms/core/signals/__init__.py
+++ b/integreat_cms/core/signals/__init__.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from . import (
     auth_signals,
     contact_signals,
+    content_signals,
     feedback_signals,
     hix_signals,
     organization_signals,

--- a/integreat_cms/core/signals/content_signals.py
+++ b/integreat_cms/core/signals/content_signals.py
@@ -1,0 +1,68 @@
+"""
+This module contains signal handlers related to contact objects.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from linkcheck.listeners import check_instance_links
+
+from ...cms.models import EventTranslation, PageTranslation, POITranslation
+from ..utils.decorators import disable_for_loaddata
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from typing import Any
+
+
+@receiver(post_save, sender=PageTranslation)
+@disable_for_loaddata
+def check_page_translation_links(
+    sender: PageTranslation, instance: PageTranslation, **kwargs: Any
+) -> None:
+    r"""
+    Update all links contained in the PageTranslation
+
+    :param sender: The model class the signal applies to
+    :param instance: The page translation that gets saved
+    :param \**kwargs: The supplied keyword arguments
+    """
+    logger.error('Updating all links contained in the PageTranslation "%r".', instance)
+    check_instance_links(sender, instance, **kwargs)
+
+
+@receiver(post_save, sender=EventTranslation)
+@disable_for_loaddata
+def check_event_translation_links(
+    sender: EventTranslation, instance: EventTranslation, **kwargs: Any
+) -> None:
+    r"""
+    Update all links contained in the EventTranslation
+
+    :param sender: The model class the signal applies to
+    :param instance: The event translation that gets saved
+    :param \**kwargs: The supplied keyword arguments
+    """
+    logger.error('Updating all links contained in the EventTranslation "%r".', instance)
+    check_instance_links(sender, instance, **kwargs)
+
+
+@receiver(post_save, sender=POITranslation)
+@disable_for_loaddata
+def check_poi_translation_links(
+    sender: POITranslation, instance: POITranslation, **kwargs: Any
+) -> None:
+    r"""
+    Update all links contained in the POITranslation
+
+    :param sender: The model class the signal applies to
+    :param instance: The POI translation that gets saved
+    :param \**kwargs: The supplied keyword arguments
+    """
+    logger.error('Updating all links contained in the POITranslation "%r".', instance)
+    check_instance_links(sender, instance, **kwargs)


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

This PR adds listeners which, upon saving of content objects, run linkcheck on those objects. As a result, contact card insertion are tracked immediately (as they are supposed to be!).

Unfortunately, it is not clear if/why this PR is even necessary. What we known is:

- in a local dev environment, with `LINKCHECK_DISABLE_LISTENERS=1`: this fix **is** necessary, otherwise contact insertions are not tracked automatically
- in a local dev environment, with `LINKCHECK_DISABLE_LISTENERS=0`: this fix is **not** necessary, contact insertions are tracked automatically, as they are supposed to be
- on the `integreat-test.tuerantuer.org` CMS: `LINKCHECK_DISABLE_LISTENERS` is [not set](https://chat.tuerantuer.org/digitalfabrik/pl/zod63urp3ifkfpqwxcnwqqgjqw), and thus [defaults to](https://github.com/digitalfabrik/integreat-cms/blob/664ac8ff2eb6258450126e1f031d1c7bf81138fe/integreat_cms/core/settings.py#L1174) `LINKCHECK_DISABLE_LISTENERS=0`. This *should* mean everyhting works and contacts are tracked, but [this is not the case](https://github.com/digitalfabrik/integreat-cms/issues/3280#issuecomment-2597718306)


### Proposed changes
<!-- Describe this PR in more detail. -->

- manually add the listeners, `LINKCHECK_DISABLE_LISTENERS=1` be damned


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- tests break
- in `LINKCHECK_DISABLE_LISTENERS=0` scenarios, the listeners are probably running twice now
- maybe other stuff as well?


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3280


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
