### PR TITLE
Add automatic_answers attribute processing for Integreat chat

### DIFF
--- a/integreat_cms/api/v3/chat/user_chat.py
+++ b/integreat_cms/api/v3/chat/user_chat.py
@@ -225,7 +225,9 @@ def chat(
 
 
 def is_app_user_message(webhook_message: dict) -> bool:
-    """ """
+    """
+    Check if the message was sent by the Integreat App
+    """
     return (
         webhook_message["article"]["created_by"]["login"]
         == "tech+integreat-cms@tuerantuer.org"

--- a/integreat_cms/api/v3/chat/user_chat.py
+++ b/integreat_cms/api/v3/chat/user_chat.py
@@ -251,7 +251,7 @@ def zammad_webhook(request: HttpRequest) -> JsonResponse:
         )
     if is_app_user_message(webhook_message) and not webhook_message["ticket"]["automatic_answers"]:
         actions.append("question translation queued")
-        process_answer.apply_async(
+        process_translate_question.apply_async(
             args=[message_text, region.slug, webhook_message["ticket"]["id"]]
         )
     elif is_app_user_message(webhook_message):
@@ -261,7 +261,7 @@ def zammad_webhook(request: HttpRequest) -> JsonResponse:
         )
     else:
         actions.append("answer translation queued")
-        process_answer.apply_async(
+        process_translate_answer.apply_async(
             args=[message_text, region.slug, webhook_message["ticket"]["id"]]
         )
     return JsonResponse(

--- a/integreat_cms/api/v3/chat/utils/chat_bot.py
+++ b/integreat_cms/api/v3/chat/utils/chat_bot.py
@@ -97,15 +97,16 @@ def process_user_message(
         client.send_message(
             zammad_chat.zammad_id,
             translation["translation"],
-            True,
-            True,
+            internal = True,
+            automatic_message = True,
         )
     if answer:
         client.send_message(
             zammad_chat.zammad_id,
             answer["answer"],
-            False,
-            True,
+            internal = False,
+            automatic_message = True,
+            automatic_answers = answer["automatic_answers"],
         )
 
 
@@ -139,8 +140,8 @@ def process_translate_answer(message_text: str, region_slug: str, zammad_ticket_
         client.send_message(
             zammad_chat.zammad_id,
             translation["translation"],
-            False,
-            True,
+            internal = False,
+            automatic_message = True,
         )
 
 
@@ -160,6 +161,6 @@ def process_translate_question(message_text: str, region_slug: str, zammad_ticke
         client.send_message(
             zammad_chat.zammad_id,
             translation["translation"],
-            True,
-            True,
+            internal = True,
+            automatic_message = True,
         )

--- a/integreat_cms/api/v3/chat/utils/chat_bot.py
+++ b/integreat_cms/api/v3/chat/utils/chat_bot.py
@@ -97,16 +97,16 @@ def process_user_message(
         client.send_message(
             zammad_chat.zammad_id,
             translation["translation"],
-            internal = True,
-            automatic_message = True,
+            internal=True,
+            automatic_message=True,
         )
     if answer:
         client.send_message(
             zammad_chat.zammad_id,
             answer["answer"],
-            internal = False,
-            automatic_message = True,
-            automatic_answers = answer["automatic_answers"],
+            internal=False,
+            automatic_message=True,
+            automatic_answers=answer["automatic_answers"],
         )
 
 
@@ -124,7 +124,9 @@ async def async_process_translate(
 
 
 @shared_task
-def process_translate_answer(message_text: str, region_slug: str, zammad_ticket_id: int) -> None:
+def process_translate_answer(
+    message_text: str, region_slug: str, zammad_ticket_id: int
+) -> None:
     """
     Process translation of automatic or counselor answers
     """
@@ -140,13 +142,15 @@ def process_translate_answer(message_text: str, region_slug: str, zammad_ticket_
         client.send_message(
             zammad_chat.zammad_id,
             translation["translation"],
-            internal = False,
-            automatic_message = True,
+            internal=False,
+            automatic_message=True,
         )
 
 
 @shared_task
-def process_translate_question(message_text: str, region_slug: str, zammad_ticket_id: int) -> None:
+def process_translate_question(
+    message_text: str, region_slug: str, zammad_ticket_id: int
+) -> None:
     """
     Process translation of app user questions
     """
@@ -155,12 +159,13 @@ def process_translate_question(message_text: str, region_slug: str, zammad_ticke
     client = ZammadChatAPI(region)
     translation = asyncio.run(
         async_process_translate(
-            message_text, zammad_chat.language.slug, region.default_language.slug)
+            message_text, zammad_chat.language.slug, region.default_language.slug
+        )
     )
     if translation:
         client.send_message(
             zammad_chat.zammad_id,
             translation["translation"],
-            internal = True,
-            automatic_message = True,
+            internal=True,
+            automatic_message=True,
         )

--- a/integreat_cms/api/v3/chat/utils/chat_bot.py
+++ b/integreat_cms/api/v3/chat/utils/chat_bot.py
@@ -109,7 +109,7 @@ def process_user_message(
         )
 
 
-async def async_process_answer(
+async def async_process_translate(
     message_text: str, source_language: str, target_language: str
 ) -> dict:
     """
@@ -123,15 +123,15 @@ async def async_process_answer(
 
 
 @shared_task
-def process_answer(message_text: str, region_slug: str, zammad_ticket_id: int) -> None:
+def process_translate_answer(message_text: str, region_slug: str, zammad_ticket_id: int) -> None:
     """
-    Process automatic or counselor answers
+    Process translation of automatic or counselor answers
     """
     region = Region.objects.get(slug=region_slug)
     zammad_chat = UserChat.objects.get(zammad_id=zammad_ticket_id, region=region)
     client = ZammadChatAPI(region)
     translation = asyncio.run(
-        async_process_answer(
+        async_process_translate(
             message_text, region.default_language.slug, zammad_chat.language.slug
         )
     )
@@ -140,5 +140,26 @@ def process_answer(message_text: str, region_slug: str, zammad_ticket_id: int) -
             zammad_chat.zammad_id,
             translation["translation"],
             False,
+            True,
+        )
+
+
+@shared_task
+def process_translate_question(message_text: str, region_slug: str, zammad_ticket_id: int) -> None:
+    """
+    Process translation of app user questions
+    """
+    region = Region.objects.get(slug=region_slug)
+    zammad_chat = UserChat.objects.get(zammad_id=zammad_ticket_id, region=region)
+    client = ZammadChatAPI(region)
+    translation = asyncio.run(
+        async_process_translate(
+            message_text, zammad_chat.language.slug, region.default_language.slug)
+    )
+    if translation:
+        client.send_message(
+            zammad_chat.zammad_id,
+            translation["translation"],
+            True,
             True,
         )

--- a/integreat_cms/api/v3/chat/utils/chat_bot.py
+++ b/integreat_cms/api/v3/chat/utils/chat_bot.py
@@ -97,16 +97,16 @@ def process_user_message(
         client.send_message(
             zammad_chat.zammad_id,
             translation["translation"],
-            internal=True,
-            automatic_message=True,
+            True,
+            True,
         )
     if answer:
         client.send_message(
             zammad_chat.zammad_id,
             answer["answer"],
-            internal=False,
-            automatic_message=True,
-            automatic_answers=answer["automatic_answers"],
+            False,
+            True,
+            answer["automatic_answers"],
         )
 
 
@@ -142,8 +142,8 @@ def process_translate_answer(
         client.send_message(
             zammad_chat.zammad_id,
             translation["translation"],
-            internal=False,
-            automatic_message=True,
+            False,
+            True,
         )
 
 
@@ -166,6 +166,6 @@ def process_translate_question(
         client.send_message(
             zammad_chat.zammad_id,
             translation["translation"],
-            internal=True,
-            automatic_message=True,
+            True,
+            True,
         )

--- a/integreat_cms/api/v3/chat/utils/zammad_api.py
+++ b/integreat_cms/api/v3/chat/utils/zammad_api.py
@@ -174,6 +174,7 @@ class ZammadChatAPI:
         message: str,
         internal: bool = False,
         automatic_message: bool = False,
+        automatic_answers: bool = True,
     ) -> dict:
         # pylint: disable=method-hidden
         """
@@ -183,6 +184,7 @@ class ZammadChatAPI:
         param message: The message body
         param internal: keep the message internal in Zammad (do not show to user)
         param automatic_message: sets title to "automatically generated message"
+        param automatic_answers: sets the attribute
         return: dict with Zammad article data
         """
         params = {
@@ -197,6 +199,7 @@ class ZammadChatAPI:
                 else "app user message"
             ),
             "sender": "Customer" if not automatic_message else "Agent",
+            "automatic_answers": automatic_answers,
         }
         return self._parse_response(  # type: ignore[return-value]
             self._attempt_call(self.client.ticket_article.create, params=params)


### PR DESCRIPTION
### Short description
The automatic_answers attribute in zammad can be turned on/off when the user requests to talk to a human advisor. This PR  resolves the setting of the attribute between the chat backend and zammad

### Proposed changes
- Changes in zammad api to set the automatic_answers_attribute
- Disable answer generation in chat_bot.py if the attribute is set to False


### Side effects
Hopefully none


### Resolved issues

Fixes: [digitalfabrik/integreat-chat#25 ](https://github.com/digitalfabrik/integreat-chat/issues/25)


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
