### PR TITLE
Move translation coverage and change text

### DIFF
--- a/integreat_cms/cms/templates/dashboard/_todo_dashboard_widget.html
+++ b/integreat_cms/cms/templates/dashboard/_todo_dashboard_widget.html
@@ -26,12 +26,12 @@
             {% include "dashboard/todo_dashboard_rows/_unread_feedback_row.html" %}
         {% endif %}
         {% if perms.cms.change_page %}
+            {% include "dashboard/todo_dashboard_rows/number_of_missing_or_outdated_translations_row.html" %}
+        {% endif %}
+        {% if perms.cms.change_page %}
             {% include "dashboard/todo_dashboard_rows/_unreviewed_pages_row.html" %}
             {% include "dashboard/todo_dashboard_rows/_automatically_saved_pages_row.html" %}
             {% include "dashboard/todo_dashboard_rows/_drafted_pages_row.html" %}
-        {% endif %}
-        {% if perms.cms.change_page %}
-            {% include "dashboard/todo_dashboard_rows/number_of_missing_or_outdated_translations_row.html" %}
         {% endif %}
     </div>
 {% endblock collapsible_box_content %}

--- a/integreat_cms/cms/templates/dashboard/todo_dashboard_rows/_missing_translations_row.html
+++ b/integreat_cms/cms/templates/dashboard/todo_dashboard_rows/_missing_translations_row.html
@@ -17,8 +17,8 @@
 {% block todo_dashboard_description %}
     {% if number_of_missing_translations > 0 %}
         {% blocktranslate trimmed %}
-            Your pages currently have <b>{{ number_of_missing_translations }} pages </b>that have an outdated or no translation.
-            In order for the users to benefit from your content you should translate them or have them translated.
+            Your pages currently have <b>{{ number_of_missing_translations }}</b> outdated or missing translations.
+            In order for the users to benefit from your content you should translate them.
         {% endblocktranslate %}
     {% else %}
         {% blocktranslate trimmed %}

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -5797,12 +5797,12 @@ msgstr "Veraltete und fehlende Übersetzungen"
 #: cms/templates/dashboard/todo_dashboard_rows/_missing_translations_row.html
 #, python-format
 msgid ""
-"Your pages currently have <b>%(number_of_missing_translations)s pages </"
-"b>that have an outdated or no translation. In order for the users to benefit "
-"from your content you should translate them or have them translated."
+"Your pages currently have <b>%(number_of_missing_translations)s</b> outdated "
+"or missing translations. In order for the users to benefit from your content "
+"you should translate them."
 msgstr ""
-"Ihre Inhalte haben momentan <b>%(number_of_missing_translations)s Seiten</b> "
-"mit fehlender oder veralteter Übersetzung. Damit die Nutzer:innen von Ihren "
+"Ihre Seiten haben momentan <b>%(number_of_missing_translations)s</b> "
+"veraltete oder fehlendende Übersetzungen. Damit die Nutzer:innen von Ihren "
 "Inhalten profitieren können, sollten Sie diese übersetzen (lassen)."
 
 #: cms/templates/dashboard/todo_dashboard_rows/_missing_translations_row.html


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR is a short follow-up to adding the translation coverage to the dashboard. It changes the provided description (correcting it) and moving the translation coverage up - just under the feedback row. This decisions were made during a conversation with @osmers 

### Proposed changes
<!-- Describe this PR in more detail. -->

- Change text to "Your pages currently have x outdated or missing translations. In order for the users to benefit from your content you should translate them." or in German "Ihre Seiten haben momentan x veraltete oder fehlendende Übersetzungen. Damit die Nutzer:innen von Ihren Inhalten profitieren können, sollten Sie diese übersetzen (lassen)."
- Move it up in the dashboard view


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
None? 
This PR blocks the next release, but should be a fairly quick fix :)


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: -


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
