### PR TITLE
only show MT-button if user has publish rights for a page

### DIFF
--- a/integreat_cms/cms/views/pages/page_context_mixin.py
+++ b/integreat_cms/cms/views/pages/page_context_mixin.py
@@ -31,6 +31,8 @@ class PageContextMixin(ContextMixin):
         context = super().get_context_data(**kwargs)
         context.update(
             {
+                "MT_PERMITTED": context.get("MT_PERMITTED", False)
+                and self.request.user.has_perm("cms.publish_page_object"),
                 "current_menu_item": "pages",
                 "translation_status": translation_status,
                 "archive_dialog_title": _(

--- a/integreat_cms/release_notes/current/unreleased/2961.yml
+++ b/integreat_cms/release_notes/current/unreleased/2961.yml
@@ -1,0 +1,2 @@
+en: Only users with publish rights for pages can use machine translations.
+de: Nur Benutzer mit Veröffentlichungsrechten für Seiten können maschinelle Übersetzungen verwenden.

--- a/tests/mt_api/test_mt_button_visibility.py
+++ b/tests/mt_api/test_mt_button_visibility.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from django.test.client import Client
+
+import re
+
+import pytest
+from django.apps import apps
+from django.urls import reverse
+
+from ..conftest import EDITOR, MANAGEMENT, PRIV_STAFF_ROLES
+
+
+@pytest.mark.django_db
+def test_mt_button_visibility(
+    load_test_data: None,
+    login_role_user: tuple[Client, str],
+) -> None:
+    """
+    Check that MT button is invisible for users without publishing rights
+    :param load_test_data: The fixture providing the test data (see :meth:`~tests.conftest.load_test_data`)
+    :param login_role_user: The fixture providing the http client and the current role (see :meth:`~tests.conftest.login_role_user`)
+    """
+    apps.get_app_config("deepl_api").supported_source_languages = "de"
+    apps.get_app_config("deepl_api").supported_target_languages = "en"
+
+    client, role = login_role_user
+    page = reverse(
+        "edit_page",
+        kwargs={"region_slug": "augsburg", "language_slug": "de", "page_id": 4},
+    )
+    data = {
+        "title": "Neuer Titel",
+        "content": "Neuer Inhalt",
+        "mirrored_page_region": "",
+    }
+
+    response = client.post(page, data=data)
+    pattern = r'<input[^>]*id="id_automatic_translation"[^>]*>'
+    match = re.search(pattern, response.content.decode())
+    if role in [*PRIV_STAFF_ROLES, EDITOR, MANAGEMENT]:
+        assert match is not None, f"MT button should be visible for role {role}"
+    else:
+        assert match is None, f"MT button should not be visible for role {role}"


### PR DESCRIPTION
### Short description
Show MT-button for pages only to users with publishing rights


### Proposed changes
- add additional check user_has_publish_rights in PageTranslationForm and return an empty queryset if they don't


### Side effects
- requires changes in some tests, because the AUTHOR role can now only use machine translations for specific pages


### Resolved issues

Fixes: #2961


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
