### PR TITLE
Fix news_id to be number type

### DIFF
--- a/integreat_cms/firebase_api/firebase_api_client.py
+++ b/integreat_cms/firebase_api/firebase_api_client.py
@@ -112,7 +112,7 @@ class FirebaseApiClient:
                 "topic": f"{region.slug}-{pnt.language.slug}-{self.push_notification.channel}",
                 "notification": {"title": pnt.title, "body": pnt.text},
                 "data": {
-                    "news_id": str(pnt.id),
+                    "news_id": pnt.id,
                     "city_code": region.slug,
                     "language_code": pnt.language.slug,
                     "group": self.push_notification.channel,


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This is a follow up PR which solves the Issue #2927 which was already merged by me. I oversaw last time that I also needed to include changes in `firebase_api_client` to fully fix this issue.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Remove `str()` function from news_id
### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- should be none? 

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
