### PR TITLE
Pytest: Enable using markers

### DIFF
--- a/tools/test.sh
+++ b/tools/test.sh
@@ -88,20 +88,21 @@ if [[ -z "${CHANGED}" ]] && (( ${#TESTS[@]} == 0 )); then
 fi
 
 if [[ -n "${KW_EXPR}" ]] || [[ -n "${MARKER}" ]] || (( ${#TESTS[@]} )); then
-    MESSAGES=()
+    TEST_MESSAGE=""
     if [[ -n "${KW_EXPR}" ]]; then
-        MESSAGES+=("\"${KW_EXPR}\"")
+        TEST_MESSAGE+=" \"${KW_EXPR}\""
         PYTEST_ARGS+=("-k" "${KW_EXPR}")
     fi
     if [[ -n "${MARKER}" ]]; then
-        MESSAGES+=("with ${MARKER}")
+        TEST_MESSAGE+=" with ${MARKER}"
         PYTEST_ARGS+=("-m" "${MARKER}")
     fi
+    FILES=()
     # Check whether test paths exist
     for t in "${TESTS[@]}"; do
         if [[ -e "${t%%::*}" ]]; then
             # Adapt message and append to pytest arguments
-            MESSAGES+=("${t}")
+            FILES+=("${t}")
             PYTEST_ARGS+=("${t}")
         elif [[ -n "${t}" ]]; then
             # If the test path does not exist but was non-zero, show an error
@@ -109,8 +110,8 @@ if [[ -n "${KW_EXPR}" ]] || [[ -n "${MARKER}" ]] || (( ${#TESTS[@]} )); then
             exit 1
         fi
     done
-    TEST_MESSAGE=$(join_by ", " "${MESSAGES[@]}")
-    TEST_MESSAGE=" in ${TEST_MESSAGE}"
+    FILES_MESSAGE=$(join_by ", " "${FILES[@]}")
+    TEST_MESSAGE+=" in $FILES_MESSAGE"
 fi
 
 "$(dirname "${BASH_SOURCE[0]}")/prune_pdf_cache.sh"

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -95,7 +95,7 @@ if [[ -n "${KW_EXPR}" ]] || [[ -n "${MARKER}" ]] || (( ${#TESTS[@]} )); then
     fi
     if [[ -n "${MARKER}" ]]; then
         MESSAGES+=("with ${MARKER}")
-        PYTEST_ARGS+=("-m" "${KW_EXPR}")
+        PYTEST_ARGS+=("-m" "${MARKER}")
     fi
     # Check whether test paths exist
     for t in "${TESTS[@]}"; do


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
While working on #2297 I made a mistake that left using markers dysfunctional.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Actually pass the specified marker to pytest, not the keyword arguments


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- ~~If you relied on the functionality to completely ignore a marker when no keyword was specified or to ignore the given marker string and replace it with whatever you specified as keyword, then this will be a breaking change for you~~

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
