### PR TITLE
tools/ruff.sh: Allow restricting checking to specific subtrees

### DIFF
--- a/tools/ruff.sh
+++ b/tools/ruff.sh
@@ -6,11 +6,13 @@
 # shellcheck source=./tools/_functions.sh
 source "$(dirname "${BASH_SOURCE[0]}")/_functions.sh"
 
+as_precommit=()
 PATHS=()
 
 # Parse given command line arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
+        '--as-precommit') as_precommit+=("$1");shift;;
         *) PATHS+=("$1");shift;;
     esac
 done
@@ -31,7 +33,7 @@ else
 fi
 
 # shellcheck source=./tools/ruff_check.sh
-"$(dirname "${BASH_SOURCE[0]}")/ruff_check.sh" "${PATHS[@]}"
+"$(dirname "${BASH_SOURCE[0]}")/ruff_check.sh" "${as_precommit[@]}" "${PATHS[@]}"
 
 # shellcheck source=./tools/ruff_format.sh
-"$(dirname "${BASH_SOURCE[0]}")/ruff_format.sh" "${PATHS[@]}"
+"$(dirname "${BASH_SOURCE[0]}")/ruff_format.sh" "${as_precommit[@]}" "${PATHS[@]}"

--- a/tools/ruff.sh
+++ b/tools/ruff.sh
@@ -6,15 +6,32 @@
 # shellcheck source=./tools/_functions.sh
 source "$(dirname "${BASH_SOURCE[0]}")/_functions.sh"
 
-require_installed
+PATHS=()
 
-# Run ruff as a pre-commit hook
-run_as_precommit "ruff check" "$@"
-run_as_precommit "ruff format --check" "$@"
+# Parse given command line arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        *) PATHS+=("$1");shift;;
+    esac
+done
 
-# Run ruff
-echo "Starting code linting and formatting with ruff..." | print_info
-ruff check --fix "${BASE_DIR}" || true
-ruff format "${BASE_DIR}"
+if [ ${#PATHS[@]} -gt 0 ]; then
+    # Check whether paths exist
+    for p in "${PATHS[@]}"; do
+        if [[ -e "${p%%::*}" ]]; then
+            RUFF_ARGS+=("${p}")
+        elif [[ -n "${p}" ]]; then
+            # If the path does not exist but was non-zero, show an error
+            echo -e "${p%%::*}: No such file or directory" | print_error
+            exit 1
+        fi
+    done
+else
+    PATHS=("$BASE_DIR")
+fi
 
-echo "✔ Code formatting & linting finished" | print_success
+# shellcheck source=./tools/ruff_check.sh
+"$(dirname "${BASH_SOURCE[0]}")/ruff_check.sh" "${PATHS[@]}"
+
+# shellcheck source=./tools/ruff_format.sh
+"$(dirname "${BASH_SOURCE[0]}")/ruff_format.sh" "${PATHS[@]}"

--- a/tools/ruff_check.sh
+++ b/tools/ruff_check.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# This script can be used to lint the python code with ruff.
+
+# Import utility functions
+# shellcheck source=./tools/_functions.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_functions.sh"
+
+require_installed
+
+# Run ruff as a pre-commit hook
+run_as_precommit "ruff check" "$@"
+
+# Run ruff
+echo "Starting code linting with ruff..." | print_info
+ruff check --fix "$@" || true
+
+echo "✔ Code linting finished" | print_success

--- a/tools/ruff_format.sh
+++ b/tools/ruff_format.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# This script can be used to format the python code with ruff.
+
+# Import utility functions
+# shellcheck source=./tools/_functions.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_functions.sh"
+
+require_installed
+
+# Run ruff as a pre-commit hook
+run_as_precommit "ruff format --check" "$@"
+
+# Run ruff
+echo "Starting code formatting with ruff..." | print_info
+ruff format "$@"
+
+echo "✔ Code formatting finished" | print_success


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
With #3333 just merged, ruff became our main linting tool. However if you're like me and have a lot of messy files and experiments lying around your working directory, you might want to restrict ruff to only look at a few subtrees in your project. While the performance improvement barely matters because ruff is already so fast, you will appreciate having irrelevant files untouched and ruff only printing messages about files you care about.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Split `ruff.sh` into `ruff_check.sh` and `ruff_format.sh`, where arguments are handed over to ruff verbatim!
- `ruff.sh` now just calls those two scripts, and hands paths over to both if you specified them:
  - Parse arguments to `tools/ruff.sh` and save them to `PATHS`
  - Set `PATHS` to `BASE_DIR` if none are supplied
  - Run both `ruff_check.sh` and `ruff_format.sh` only for `PATHS`
  - Pass `--as-precommit` as is to both if given

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None, this change is fully backwards compatible to the previous intended usage. But if you relied on the tool ignoring any arguments at the end, it will now either complain that the file doesn't exist or lint those files.

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
