### PR TITLE
Revert "Fix news_id to be number type"

### DIFF
--- a/integreat_cms/firebase_api/firebase_api_client.py
+++ b/integreat_cms/firebase_api/firebase_api_client.py
@@ -113,7 +113,7 @@ class FirebaseApiClient:
                 "topic": f"{region.slug}-{pnt.language.slug}-{self.push_notification.channel}",
                 "notification": {"title": pnt.title, "body": pnt.text},
                 "data": {
-                    "news_id": pnt.id,
+                    "news_id": str(pnt.id),
                     "city_code": region.slug,
                     "language_code": pnt.language.slug,
                     "group": self.push_notification.channel,


### PR DESCRIPTION
Revert #3382, which changed the type of a value in `data` from string to int

Google FCM Services [only allow specifying data as key-value pairs that are strictly strings](https://firebase.google.com/docs/reference/fcm/rest/v1/projects.messages#Message.FIELDS.data); the app has to parse data received by this third party on its own, where necessary.

Related conversation: https://chat.tuerantuer.org/digitalfabrik/pl/9aw91d3m5td3jm6c34pfpwoxzr