### PR TITLE
send_push_notifications: 1–based counting, improve messages

### DIFF
--- a/integreat_cms/cms/models/push_notifications/push_notification.py
+++ b/integreat_cms/cms/models/push_notifications/push_notification.py
@@ -182,7 +182,7 @@ class PushNotification(AbstractBaseModel):
 
         :return: The canonical string representation of the push notification
         """
-        return f"<PushNotification (id: {self.id}, channel: {self.channel}, regions: {self.regions.values_list('slug', flat=True)})>"
+        return f"<PushNotification (id: {self.id}, channel: {self.channel!r}, regions: {self.regions.values_list('slug', flat=True)})>"
 
     class Meta:
         #: The verbose name of the model

--- a/integreat_cms/cms/models/push_notifications/push_notification_translation.py
+++ b/integreat_cms/cms/models/push_notifications/push_notification_translation.py
@@ -121,7 +121,7 @@ class PushNotificationTranslation(AbstractBaseModel):
 
         :return: The canonical string representation of the event
         """
-        return f"<PushNotificationTranslation (id: {self.id}, push_notification_id: {self.push_notification.id}, title: {self.title})>"
+        return f"<PushNotificationTranslation (id: {self.id}, push_notification_id: {self.push_notification.id}, title: {self.title!r})>"
 
     class Meta:
         #: The verbose name of the model

--- a/integreat_cms/core/management/commands/send_push_notifications.py
+++ b/integreat_cms/core/management/commands/send_push_notifications.py
@@ -74,7 +74,7 @@ class Command(LogCommand):
         )
 
         if total := len(pending_push_notifications):
-            for counter, push_notification in enumerate(pending_push_notifications):
+            for counter, push_notification in enumerate(pending_push_notifications, 1):
                 self.send_push_notification(counter, total, push_notification)
             logger.success(  # type: ignore[attr-defined]
                 "✔ All %d scheduled push notifications have been processed.",
@@ -102,14 +102,14 @@ class Command(LogCommand):
             push_sender = FirebaseApiClient(push_notification)
             if not push_sender.is_valid():
                 logger.error(
-                    "Push notification %d/%d %r cannot be sent because required texts are missing",
+                    "Push notification %d/%d cannot be sent because required texts are missing: %r",
                     counter,
                     total,
                     push_notification,
                 )
             elif push_sender.send_all():
                 logger.success(  # type: ignore[attr-defined]
-                    "Successfully sent %d/%d %r",
+                    "Successfully sent %d/%d: %r",
                     counter,
                     total,
                     push_notification,
@@ -118,14 +118,14 @@ class Command(LogCommand):
                 push_notification.save()
             else:
                 logger.error(
-                    "Push notification %d/%d %r could not be sent",
+                    "Push notification %d/%d could not be sent: %r",
                     counter,
                     total,
                     push_notification,
                 )
         except ImproperlyConfigured:
             logger.exception(
-                "Push notification %d/%d %r could not be sent due to a configuration error",
+                "Push notification %d/%d could not be sent due to a configuration error: %r",
                 counter,
                 total,
                 push_notification,

--- a/integreat_cms/firebase_api/firebase_api_client.py
+++ b/integreat_cms/firebase_api/firebase_api_client.py
@@ -113,10 +113,10 @@ class FirebaseApiClient:
                 "topic": f"{region.slug}-{pnt.language.slug}-{self.push_notification.channel}",
                 "notification": {"title": pnt.title, "body": pnt.text},
                 "data": {
-                    "news_id": pnt.id,
-                    "city_code": region.slug,
-                    "language_code": pnt.language.slug,
-                    "group": self.push_notification.channel,
+                    "news_id": str(pnt.id),
+                    "city_code": str(region.slug),
+                    "language_code": str(pnt.language.slug),
+                    "group": str(self.push_notification.channel),
                 },
                 "apns": {
                     "headers": {"apns-priority": "5"},


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
<details><summary>Our `send_push_notifications` management command is giving confusing output.</summary>

```
INFO    integreat_cms.firebase_api.firebase_api_client - <PushNotificationTranslation (id: …, push_notification_id: …, title: …)> sent, FCM id: …
SUCCESS integreat_cms.core.management.commands.send_push_notifications - Successfully sent 0/3 <PushNotification (id: …, channel: …, regions: <QuerySet […]>)>
INFO    integreat_cms.firebase_api.firebase_api_client - <PushNotificationTranslation (id: …, push_notification_id: …, title: …)> sent, FCM id: …
INFO    integreat_cms.firebase_api.firebase_api_client - <PushNotificationTranslation (id: …, push_notification_id: …, title: …)> sent, FCM id: …
SUCCESS integreat_cms.core.management.commands.send_push_notifications - Successfully sent 1/3 <PushNotification (id: …, channel: …, regions: <QuerySet […]>)>
INFO    integreat_cms.firebase_api.firebase_api_client - <PushNotificationTranslation (id: …, push_notification_id: …, title: …)> sent, FCM id: …
INFO    integreat_cms.firebase_api.firebase_api_client - <PushNotificationTranslation (id: …, push_notification_id: …, title: …)> sent, FCM id: …
SUCCESS integreat_cms.core.management.commands.send_push_notifications - Successfully sent 2/3 <PushNotification (id: …, channel: …, regions: <QuerySet […]>)>
SUCCESS integreat_cms.core.management.commands.send_push_notifications - ✔ All 3 scheduled push notifications have been processed.
```

</details>

`Successfully sent COUNT/TOTAL`–messages are off by one, as we just use `for count, pn in enumerate(pns):` *(0–based)*.

Additionally, I have ideas how to further improve the messages.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Management command:
  - Change enumeration to start at 1
    *This removes uncertainty while interpreting logs.*
  - Change messages to print object representations at the very end
    *This improves readability of logs, as object representations can be very long and wrap multiple lines. With this change first the event/action is clear (length fixed and easily readable even with many similar log lines), then specifics about the object in question can be read (highly variable character count)*
- Representations of `PushNotification` and `PushNotificationTranslation`
  - Change representations to interpolate strings *(like `title`)* quoted, not verbatim
    *This improves readability as the start and end of the field in the representation is clearly recognizable.*
    ```diff
    - <PushNotificationTranslation (id: 12673, push_notification_id: 1877, title: COURSE START ON 27.01.2025, GENERAL INTEGRATION COURSE FROM MODULE 1 (A1-B1), MO-FR, 9:00-12:30, IN AICHACH)>
    + <PushNotificationTranslation (id: 12673, push_notification_id: 1877, title: "COURSE START ON 27.01.2025, GENERAL INTEGRATION COURSE FROM MODULE 1 (A1-B1), MO-FR, 9:00-12:30, IN AICHACH")>
    ```


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Any tool depending on the old log output might show unexpected behaviour


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
