### PR TITLE
Do not allow users to insert empty contact cards

### DIFF
--- a/integreat_cms/cms/templates/_tinymce_config.html
+++ b/integreat_cms/cms/templates/_tinymce_config.html
@@ -53,6 +53,7 @@
      data-contact-icon-src="{% get_base_url %}{% static 'svg/contact.svg' %}"
      data-contact-icon-alt="{% translate "Contact Person" %}"
      data-contact-ajax-url="{% url 'search_contact_ajax' region_slug=request.region.slug %}"
+     data-no-empty-contact-hint="{% translate "Please select at least one detail before inserting the contact." %}"
      data-contact-menu-text='{% translate "Contact..." %}'
      data-contact-no-results-text='{% translate "no results" %}'
      data-speech-icon-text='{% translate "Spoken Languages" %}'

--- a/integreat_cms/cms/utils/content_utils.py
+++ b/integreat_cms/cms/utils/content_utils.py
@@ -187,7 +187,11 @@ def update_contacts(content: HtmlElement) -> None:
         except IndexError:
             wanted_details = []
 
-        contact_card_new = render_contact_card(contact_id, wanted_details)
+        contact_card_new = (
+            render_contact_card(contact_id, wanted_details)
+            if any(detail for detail in wanted_details)
+            else Element("p")
+        )
         contact_card.getparent().replace(contact_card, contact_card_new)
 
 

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -4902,6 +4902,11 @@ msgid "Contact Person"
 msgstr "Kontaktperson"
 
 #: cms/templates/_tinymce_config.html
+msgid "Please select at least one detail before inserting the contact."
+msgstr ""
+"Bitte wählen Sie mindestens ein Detail aus, um den Kontakt ein zu fügen."
+
+#: cms/templates/_tinymce_config.html
 msgid "Contact..."
 msgstr "Kontakt..."
 

--- a/integreat_cms/static/src/js/tinymce-plugins/custom_contact_input/plugin.js
+++ b/integreat_cms/static/src/js/tinymce-plugins/custom_contact_input/plugin.js
@@ -4,6 +4,7 @@ import { getCsrfToken } from "../../utils/csrf-token";
 (() => {
     const tinymceConfig = document.getElementById("tinymce-config-options");
     const completionUrl = tinymceConfig.getAttribute("data-contact-ajax-url");
+    const noEmptyContactHint = tinymceConfig.getAttribute("data-no-empty-contact-hint");
     const HTTP_STATUS_OK = 200;
 
     const getCompletions = async (query) => {
@@ -136,14 +137,19 @@ import { getCsrfToken } from "../../utils/csrf-token";
                 const submitElement = document.querySelector(
                     ".tox-dialog:has(#completions) .tox-dialog__footer .tox-button:not(.tox-button--secondary)"
                 );
+                const anyChecked = () =>
+                    Array.from(document.querySelectorAll(".details-checkbox")).some((checkbox) => checkbox.checked);
                 const setSubmitDisableStatus = (value) => {
                     if (!submitElement) {
                         return;
                     }
 
-                    submitElement.disabled = !value;
+                    submitElement.disabled = !value || !anyChecked();
                     if (!submitElement.disabled) {
                         submitElement.focus();
+                        submitElement.title = "";
+                    } else {
+                        submitElement.title = noEmptyContactHint;
                     }
                 };
                 const updateDetailSelection = (value) => {
@@ -161,6 +167,7 @@ import { getCsrfToken } from "../../utils/csrf-token";
 
                         const checkbox = document.createElement("input");
                         checkbox.type = "checkbox";
+                        checkbox.classList = ["details-checkbox"];
                         checkbox.checked = selectedDetails?.includes(key) || !selectedDetails;
                         checkbox.value = key;
                         checkbox.id = key;
@@ -178,6 +185,10 @@ import { getCsrfToken } from "../../utils/csrf-token";
                         wrapper.append(checkbox);
                         wrapper.append(label);
                         detailsArea.append(wrapper);
+
+                        checkbox.addEventListener("click", () => {
+                            setSubmitDisableStatus(true);
+                        });
                     }
                 };
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

Currently, you can just de-select all details and insert a completely empty contact card.
This PR prevents that.

### Proposed changes
<!-- Describe this PR in more detail. -->

- If no detail is selected, disable the insert/submit button.
- if a user still manages to sneak an empty card in, filter it out server-side.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3400


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
