### PR TITLE
Move automatically saved note

### DIFF
--- a/integreat_cms/cms/templates/events/event_form.html
+++ b/integreat_cms/cms/templates/events/event_form.html
@@ -37,6 +37,9 @@
                 {% endif %}
             </h1>
             <div class="flex flex-wrap gap-4 ml-auto mr-0 items-center">
+                {% if event_form.instance.id and not disabled %}
+                    {% include "generic_auto_save_note.html" with form_instance=event_form.instance %}
+                {% endif %}
                 {% if event_form.instance.archived %}
                     <a href="{% url 'events_archived' region_slug=request.region.slug language_slug=language.slug %}"
                        class="btn btn-ghost">{% translate "Cancel" %}</a>
@@ -45,7 +48,6 @@
                        class="btn btn-ghost">{% translate "Cancel" %}</a>
                 {% endif %}
                 {% if not disabled %}
-                    {% include "generic_auto_save_note.html" with form_instance=event_form.instance %}
                     {% if perms.cms.publish_event %}
                         <button name="status"
                                 value="{{ DRAFT }}"

--- a/integreat_cms/cms/templates/pages/page_form.html
+++ b/integreat_cms/cms/templates/pages/page_form.html
@@ -45,6 +45,9 @@
                 {% endif %}
             </h1>
             <div class="flex flex-wrap grow justify-end gap-2 items-center">
+                {% if page_form.instance.id and not page_form.instance.archived and can_edit_page %}
+                    {% include "generic_auto_save_note.html" with form_instance=page_translation_form.instance %}
+                {% endif %}
                 {% if page_form.instance.id and page_form.instance.archived %}
                     <a href="{% url 'archived_pages' region_slug=request.region.slug language_slug=language.slug %}"
                        class="btn btn-ghost">{% translate "Cancel" %}</a>
@@ -53,7 +56,6 @@
                        class="btn btn-ghost">{% translate "Cancel" %}</a>
                 {% endif %}
                 {% if not page_form.instance.id or not page_form.instance.archived %}
-                    {% include "generic_auto_save_note.html" with form_instance=page_translation_form.instance %}
                     <button name="preview_page" type="button" data-preview-page data-edit-page-mode data-right-to-left={{ right_to_left }} class="btn btn-ghost">
                         {% translate "Preview" %}
                     </button>

--- a/integreat_cms/cms/templates/pois/poi_form.html
+++ b/integreat_cms/cms/templates/pois/poi_form.html
@@ -33,6 +33,9 @@
                 {% endif %}
             </h1>
             <div class="flex flex-wrap items-center gap-4 ml-auto mr-0">
+                {% if poi_form.instance.id and not poi_form.instance.archived and perms.cms.change_poi %}
+                    {% include "generic_auto_save_note.html" with form_instance=poi_translation_form.instance %}
+                {% endif %}
                 {% if poi_form.instance.archived %}
                     <a href="{% url 'archived_pois' region_slug=request.region.slug language_slug=language.slug %}"
                        class="btn btn-ghost">{% translate "Cancel" %}</a>
@@ -41,7 +44,6 @@
                        class="btn btn-ghost">{% translate "Cancel" %}</a>
                 {% endif %}
                 {% if not poi_form.instance.archived and perms.cms.change_poi %}
-                    {% include "generic_auto_save_note.html" with form_instance=poi_translation_form.instance %}
                     <button name="status"
                             value="{{ DRAFT }}"
                             class="btn btn-outline no-premature-submission">

--- a/integreat_cms/release_notes/current/unreleased/3327.yml
+++ b/integreat_cms/release_notes/current/unreleased/3327.yml
@@ -1,0 +1,2 @@
+en: Move note that page was automatically saved
+de: Verschiebe den Hinweis, dass die Seite automatisch gespeichert wurde


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Since adding the "Cancel" button on content forms, the info message that the page/event/poi has been automatically saved is in between two buttons, which doesn't look great. This PR moves the note so that it shows to the far left again.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Move automatically saved note


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- I'm not sure for which permission to check in the event form. If you have any suggestion, please let me know :)


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3327 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
