### PR TITLE
Attempt to fix issue with none existant other translation

### DIFF
--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8332,8 +8332,7 @@ msgstr "Push-Benachrichtigung archivieren"
 #: cms/templates/push_notifications/push_notification_list_row.html
 msgid "Please confirm that you really want to archive this push notification"
 msgstr ""
-"Bitte bestätigen Sie, dass diese Push-Benachrichtigung archiviert werden "
-"soll"
+"Bitte bestätigen Sie, dass diese Push-Benachrichtigung archiviert werden soll"
 
 #: cms/templates/push_notifications/push_notification_template_list.html
 msgid "News Templates"
@@ -10653,6 +10652,11 @@ msgid ""
 msgstr ""
 "Der URL-Parameter wurde von '{user_slug}' zu '{slug}' geändert, da "
 "'{user_slug}' bereits von <a>{translation}</a> verwendet wird."
+
+#: cms/views/pages/page_form_view.py
+#, python-brace-format
+msgid "The slug was changed from '{user_slug}' to '{slug}."
+msgstr "Der URL-Parameter wurde von '{user_slug}' zu '{slug}' geändert."
 
 #: cms/views/pages/page_form_view.py
 msgid ""


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR is an attempt to fix the `NoneType` error that occurs sometimes when renaming a page. Some more testing on our side show that this issue is indeed flaky and seems to be caused because `other_translation` is `None`.  

### Proposed changes
<!-- Describe this PR in more detail. -->

- Catch case when `other_translation` is still `None` and show an error message instead. 


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- This is not ideal for user experience. An alternative could be to wait for a while to make sure there is enough time for `other_translation` to be set.
- Please note that this really is only a draft and I'm shooting out ideas hoping that it sparks some more ideas from your side :sparkles: 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: Parts of #3319


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
