### PR TITLE
Fix live content in page preview

### DIFF
--- a/integreat_cms/cms/forms/pages/mirrored_page_field_widget.py
+++ b/integreat_cms/cms/forms/pages/mirrored_page_field_widget.py
@@ -19,6 +19,8 @@ class MirroredPageFieldWidget(forms.widgets.Select):
     #: The current language slug
     language_slug: str | None = None
 
+    mirrored_page_region_slug: str | None = None
+
     def create_option(
         self,
         name: str,
@@ -59,7 +61,7 @@ class MirroredPageFieldWidget(forms.widgets.Select):
         preview_url = reverse(
             "get_page_content_ajax",
             kwargs={
-                "region_slug": self.form.instance.region.slug,
+                "region_slug": self.mirrored_page_region_slug,
                 "language_slug": self.language_slug,
                 "page_id": value,
             },

--- a/integreat_cms/cms/forms/pages/page_form.py
+++ b/integreat_cms/cms/forms/pages/page_form.py
@@ -109,6 +109,9 @@ class PageForm(CustomModelForm, CustomTreeNodeForm):
             self.fields[
                 "mirrored_page_region"
             ].initial = self.instance.mirrored_page.region_id
+            self.fields[
+                "mirrored_page"
+            ].widget.mirrored_page_region_slug = self.instance.mirrored_page.region.slug
 
         # Let mirrored page queryset be empty per default and only fill it if a region is selected
         mirrored_page_queryset = Page.objects.none()

--- a/integreat_cms/cms/views/pages/page_actions.py
+++ b/integreat_cms/cms/views/pages/page_actions.py
@@ -218,7 +218,7 @@ def get_page_content_ajax(
 
     :return: Page translation content as a JSON.
     """
-    region = request.region
+    region = Region.objects.filter(slug=region_slug).first()
     page = get_object_or_404(region.pages, id=page_id)
     if page_translation := page.get_translation(language_slug):
         return JsonResponse(data={"content": page_translation.content})
@@ -597,6 +597,7 @@ def render_mirrored_page_field(
     )
     # Pass language to mirrored page widget to render the preview urls
     page_form.fields["mirrored_page"].widget.language_slug = language_slug
+    page_form.fields["mirrored_page"].widget.mirrored_page_region_slug = region.slug
     return render(
         request,
         "pages/_mirrored_page_field.html",

--- a/integreat_cms/release_notes/current/unreleased/3426.yml
+++ b/integreat_cms/release_notes/current/unreleased/3426.yml
@@ -1,0 +1,2 @@
+en: Fix display of live content in page preview
+de: Korrigiere Anzeige von Live-Inhalten in der Seitenvorschau


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes rendering of live content in the page preview

### Proposed changes
<!-- Describe this PR in more detail. -->
- Fix the region slug of the mirrored pages



### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- I hope none 🙈 
- The page preview functionality is available both on the page tree (👁️ icon) and on the page form. Please check both are working fine and in the same way
- Please check also, that the styling is fine (see #3396 )
- Please check also (sorry for such many "please"s), that the rendering is working fine after changing the embedded content before and after saving the form.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3426 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
