### PR TITLE
Fix spacing of start and end date in event

### DIFF
--- a/integreat_cms/cms/templates/events/event_form_sidebar/date_and_time_box.html
+++ b/integreat_cms/cms/templates/events/event_form_sidebar/date_and_time_box.html
@@ -23,14 +23,14 @@
                 {% translate "These events take place over a longer period of time. E.g. Christmas markets or similar." %}
             </div>
             <div>
-                <div class="flex flex-wrap my-3">
-                    <div class="w-1/2 pr-2">
+                <div class="my-3">
+                    <div class="my-3 w-full">
                         <label class="mt-0" for="{{ event_form.start_date.id_for_label }}">
                             {{ event_form.start_date.label }}
                         </label>
                         {% render_field event_form.start_date|add_error_class:"border-red-500" %}
                     </div>
-                    <div class="w-1/2 {% if not event_form.is_long_term.value %} hidden {% endif %}"
+                    <div class="{% if not event_form.is_long_term.value %} hidden {% endif %}"
                          id="end-date">
                         <label class="mt-0" for="{{ event_form.end_date.id_for_label }}">
                             {{ event_form.end_date.label }}

--- a/integreat_cms/cms/templates/events/event_form_sidebar/date_and_time_box.html
+++ b/integreat_cms/cms/templates/events/event_form_sidebar/date_and_time_box.html
@@ -23,14 +23,14 @@
                 {% translate "These events take place over a longer period of time. E.g. Christmas markets or similar." %}
             </div>
             <div>
-                <div class="my-3">
-                    <div class="my-3 w-full">
+                <div class="xl:flex 3xl:block">
+                    <div class="3xl:mt-3 3xl:w-full xl:w-1/2 xl:pr-2 3xl:pr-0">
                         <label class="mt-0" for="{{ event_form.start_date.id_for_label }}">
                             {{ event_form.start_date.label }}
                         </label>
                         {% render_field event_form.start_date|add_error_class:"border-red-500" %}
                     </div>
-                    <div class="{% if not event_form.is_long_term.value %} hidden {% endif %}"
+                    <div class="3xl:mt-3 3xl:w-full xl:w-1/2 {% if not event_form.is_long_term.value %} hidden {% endif %}"
                          id="end-date">
                         <label class="mt-0" for="{{ event_form.end_date.id_for_label }}">
                             {{ event_form.end_date.label }}


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the spacing in the start and end date in events as they are currently being cut off. The first idea to change the width of the sidebars wasn't as easy as thought as it came with a bunch of side effects. Therefore I stuck to the second idea and put the two input fields below each other. If you have other ideas for this fix, please let me know :)

### Proposed changes
<!-- Describe this PR in more detail. -->

- Put start and end date beneath each other instead of next to each other


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- There might be, but I don't know about them at the moment


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3424


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
