### PR TITLE
Hide contact links and contact cards from the linkchecker

### DIFF
--- a/tests/cms/test_duplicate_regions.py
+++ b/tests/cms/test_duplicate_regions.py
@@ -125,15 +125,18 @@ def test_duplicate_regions(
             assert target_page_translation.status == status.DRAFT
 
     # Check if links exist
-    assert get_url_count(source_region.slug) == {
-        "number_all_urls": 18,
-        "number_email_urls": 0,
-        "number_ignored_urls": 1,
-        "number_invalid_urls": 4,
-        "number_phone_urls": 0,
-        "number_unchecked_urls": 0,
-        "number_valid_urls": 13,
-    }, "Links should exist in the source region"
+    assert (
+        get_url_count(source_region.slug)
+        == {
+            "number_all_urls": 16,  # temporary: https://github.com/digitalfabrik/integreat-cms/issues/3434
+            "number_email_urls": 0,
+            "number_ignored_urls": 1,
+            "number_invalid_urls": 4,
+            "number_phone_urls": 0,
+            "number_unchecked_urls": 0,
+            "number_valid_urls": 11,  # temporary: https://github.com/digitalfabrik/integreat-cms/issues/3434
+        }
+    ), "Links should exist in the source region"
     # Check if links have been cloned (except ignored ones)
     assert get_url_count(target_region.slug) == {
         "number_all_urls": 20,


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

As a temp solution, we will be hiding the contact cards as well as the links contained within them from the linkchecker (see the linked issue).

### Proposed changes
<!-- Describe this PR in more detail. -->

- remove all URLs from the set shown to the user which are used in a contact (of the same region)
- remove all contact-card URLs from the set


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- this is not exactly great for performance.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3434


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
