### PR TITLE
only users with publishing rights can archive pages

### DIFF
--- a/integreat_cms/cms/templates/pages/page_form_sidebar/actions_box.html
+++ b/integreat_cms/cms/templates/pages/page_form_sidebar/actions_box.html
@@ -9,6 +9,7 @@
     {% translate "Actions" %}
 {% endblock collapsible_box_title %}
 {% block collapsible_box_content %}
+    {% has_perm 'cms.publish_page_object' request.user as can_publish_pages %}
     {% if page_form.instance.id and can_edit_page and not page.archived %}
         <label class="mt-0">
             {% translate "Refresh date" %}
@@ -53,7 +54,7 @@
                 <i icon-name="pen-square" class="mr-2"></i> {{ ancestor.best_translation.title }}
             </a>
         {% endfor %}
-    {% else %}
+    {% elif can_publish_pages %}
         <label>
             {% translate "Archive page" %}
         </label>

--- a/integreat_cms/cms/templates/pages/page_tree_node.html
+++ b/integreat_cms/cms/templates/pages/page_tree_node.html
@@ -178,7 +178,8 @@
            class="btn-icon">
             <i icon-name="pencil"></i>
         </a>
-        {% if can_edit_pages %}
+        {% has_perm 'cms.publish_page_object' request.user as can_publish_pages %}
+        {% if can_publish_pages %}
             {% if page.mirroring_pages.exists %}
                 <button title="{% translate "This page cannot be archived because it was embedded as live content from another page." %}"
                         class="btn-icon"

--- a/integreat_cms/cms/views/pages/page_actions.py
+++ b/integreat_cms/cms/views/pages/page_actions.py
@@ -68,7 +68,7 @@ def archive_page(
     region = request.region
     page = get_object_or_404(region.pages, id=page_id)
 
-    if not request.user.has_perm("cms.change_page_object", page):
+    if not request.user.has_perm("cms.publish_page_object", page):
         raise PermissionDenied(
             f"{request.user!r} does not have the permission to archive {page!r}",
         )

--- a/integreat_cms/release_notes/current/unreleased/3374.yml
+++ b/integreat_cms/release_notes/current/unreleased/3374.yml
@@ -1,0 +1,2 @@
+en: Only users with publishing rights can archive pages
+de: Nur Benutzer:innen mit Veröffentlichungsberechtigung können Seiten archivieren

--- a/tests/cms/views/view_config.py
+++ b/tests/cms/views/view_config.py
@@ -1267,7 +1267,7 @@ VIEWS: ViewConfig = [
             ("page_versions", [*STAFF_ROLES, MANAGEMENT, EDITOR, AUTHOR, OBSERVER]),
             (
                 "archive_page",
-                [*PRIV_STAFF_ROLES, MANAGEMENT, EDITOR, AUTHOR],
+                [*PRIV_STAFF_ROLES, MANAGEMENT, EDITOR],
                 {"post_data": True},
             ),
             (


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Only users with publishing rights should be able to archive pages

### Proposed changes
<!-- Describe this PR in more detail. -->

- change necessary permissions for archiving from "cms.change_page_object" to "cms.publish_page_object"
- don't show archive button to users without publishing rights


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- some users without publishing rights might be used to archiving pages and could be confused


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3374 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
