### PR TITLE
Fix contact doesn't show up in search when searching for address

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/3464.yml
+++ b/integreat_cms/release_notes/current/unreleased/3464.yml
@@ -1,0 +1,2 @@
+en: Fix contact doesn't show up when searched for contact address
+de: Korrigiere, dass ein Kontakt nicht angezeigt wird, wenn nach der Kontaktadresse gesucht wird

--- a/tests/cms/views/contacts/test_contact_utils.py
+++ b/tests/cms/views/contacts/test_contact_utils.py
@@ -15,7 +15,7 @@ CONTACT1 = {
     "id": 3,
     "json": {
         "url": "/augsburg/contact/3/",
-        "name": "Integrationsberatung: Mariana Musterfrau (mariana-musterfrau@example.com, +49 (0) 123456789, https://integreat-app.de/)",
+        "name": "Integrationsberatung: Mariana Musterfrau (mariana-musterfrau@example.com, +49 (0) 123456789, https://integreat-app.de/)| Linked location: Draft location Viktoriastraße 1 86150 Augsburg",
         "details": {
             "address": "show address",
             "area_of_responsibility": "show area of responsibility",
@@ -33,7 +33,7 @@ CONTACT1 = {
 CONTACT2 = {
     "json": {
         "url": "/augsburg/contact/4/",
-        "name": "(generalcontactinformation@example.com, +49 (0) 123456789, https://integreat-app.de/)",
+        "name": "(generalcontactinformation@example.com, +49 (0) 123456789, https://integreat-app.de/)| Linked location: Draft location Viktoriastraße 1 86150 Augsburg",
         "details": {
             "address": "show address",
             "email": "show email",


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Currently a contact doesn't show up when searching for the address linked to the contact. As the address is part of the contact card it has been confusing to users why the contact card doesn't show when searching for the address. This PR attempts to fix this.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Include the full address to the string representation of a contact


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Unsure, there might be some


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3464


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
