### PR TITLE
Chat: send full message history to back end

### DIFF
--- a/integreat_cms/api/v3/chat/user_chat.py
+++ b/integreat_cms/api/v3/chat/user_chat.py
@@ -98,7 +98,7 @@ def get_messages(
             {"error": "The requested chat does not exist. Did you delete it?"},
             status=404,
         )
-    return response_or_error(client.get_messages(user_chat))
+    return response_or_error(client.get_api_response(user_chat))
 
 
 def send_message(
@@ -249,7 +249,7 @@ def zammad_webhook(request: HttpRequest) -> JsonResponse:
     ):
         actions.append("question translation queued")
         process_user_message.apply_async(
-            args=[message_text, region.slug, webhook_message["ticket"]["id"]],
+            args=[region.slug, webhook_message["ticket"]["id"]],
         )
     else:
         actions.append("answer translation queued")


### PR DESCRIPTION
### Short description
Instead of sending the last user message, the chat bot should have the full history of the conversation available. This PR fetches the full history for a given message and transmits it as the `messages` attribute to the chat back end. The API is already compatible for that.


### Proposed changes
- Fetch full chat history for user generated messages
- Send the full message history to the chat back end


### Side effects
- Requests become larger and we add a bit of latency for generating answers.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: https://github.com/digitalfabrik/integreat-chat/issues/235

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
