### PR TITLE
restrict bulk archive for pages to users with publishing rights

### DIFF
--- a/integreat_cms/cms/templates/pages/page_tree.html
+++ b/integreat_cms/cms/templates/pages/page_tree.html
@@ -6,6 +6,7 @@
 {% load rules %}
 {% block content %}
     {% has_perm 'cms.change_page_object' request.user as can_edit_pages %}
+    {% has_perm 'cms.publish_page_object' request.user as can_publish_pages %}
     {% with filter_form.filters_visible as filters_visible %}
         <div class="table-header">
             <div class="flex flex-wrap justify-between gap-4">
@@ -170,7 +171,7 @@
                 <option>
                     {% translate "Select bulk action" %}
                 </option>
-                {% if can_edit_pages %}
+                {% if can_publish_pages %}
                     <option data-bulk-action="{% url 'bulk_archive_pages' region_slug=request.region.slug language_slug=language.slug %}">
                         {% translate "Archive pages" %}
                     </option>

--- a/integreat_cms/cms/urls/protected.py
+++ b/integreat_cms/cms/urls/protected.py
@@ -962,9 +962,7 @@ urlpatterns: list[URLPattern] = [
                                         ),
                                         path(
                                             "bulk-archive/",
-                                            bulk_action_views.BulkArchiveView.as_view(
-                                                model=Page,
-                                            ),
+                                            pages.PageBulkArchiveView.as_view(),
                                             name="bulk_archive_pages",
                                         ),
                                         path(

--- a/integreat_cms/cms/views/pages/__init__.py
+++ b/integreat_cms/cms/views/pages/__init__.py
@@ -23,6 +23,7 @@ from .page_bulk_actions import (
     ExportMultiLanguageXliffView,
     ExportXliffView,
     GeneratePdfView,
+    PageBulkArchiveView,
 )
 from .page_form_view import PageFormView
 from .page_permission_actions import (

--- a/integreat_cms/cms/views/pages/page_bulk_actions.py
+++ b/integreat_cms/cms/views/pages/page_bulk_actions.py
@@ -18,7 +18,7 @@ from ...utils.pdf_utils import generate_pdf
 from ...utils.stringify_list import iter_to_string
 from ...utils.translation_utils import gettext_many_lazy as __
 from ...utils.translation_utils import translate_link
-from ..bulk_action_views import BulkActionView
+from ..bulk_action_views import BulkActionView, BulkArchiveView
 from .page_actions import cancel_translation_process_ajax
 
 if TYPE_CHECKING:
@@ -70,6 +70,15 @@ class GeneratePdfView(PageBulkActionMixin, BulkActionView):
             str(kwargs.get("language_slug")),
             self.get_queryset(),
         )
+
+
+class PageBulkArchiveView(PageBulkActionMixin, BulkArchiveView):
+    """
+    Bulk action for archiving multiple pages at once
+    """
+
+    def get_permission_required(self) -> tuple[str]:
+        return ("cms.publish_page_object",)
 
 
 class ExportXliffView(PageBulkActionMixin, BulkActionView):

--- a/integreat_cms/release_notes/current/unreleased/3486.yml
+++ b/integreat_cms/release_notes/current/unreleased/3486.yml
@@ -1,0 +1,2 @@
+en: Users without publish rights for pages can no longer use bulk archive for pages.
+de: Benutzer ohne Veröffentlichungsrechte für Seiten können die Mehrfachaktion Seiten archivieren nicht mehr verwenden.

--- a/tests/cms/views/view_config.py
+++ b/tests/cms/views/view_config.py
@@ -446,7 +446,7 @@ VIEWS: ViewConfig = [
             ("pois", ROLES),
             (
                 "bulk_archive_pages",
-                [*PRIV_STAFF_ROLES, MANAGEMENT, EDITOR, AUTHOR],
+                [*PRIV_STAFF_ROLES, MANAGEMENT, EDITOR],
                 {"selected_ids[]": [1, 2, 3]},
             ),
             (


### PR DESCRIPTION
### Short description
Users without publishing rights should not be able to use the bulk archive method


### Proposed changes
<!-- Describe this PR in more detail. -->

- hide archive option in views for users without publishing rights
- check permissions when using the bulk action form for archiving pages


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Users without publishing rights can no longer archive pages, but can still see and restore archived pages


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3486 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
