### PR TITLE
Fix: phone numbers not being formatted any more

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/3285.yml
+++ b/integreat_cms/release_notes/current/unreleased/3285.yml
@@ -1,0 +1,2 @@
+en: Fix a bug which prevented phone numbers from being formatted in the editor
+de: Behebe einen Fehler, durch den Telefonnummern im Editor nicht mehr formatiert wurden

--- a/integreat_cms/static/src/js/tinymce-plugins/autolink_tel/plugin.js
+++ b/integreat_cms/static/src/js/tinymce-plugins/autolink_tel/plugin.js
@@ -23,7 +23,7 @@
             "autolink_pattern",
             /^(https?:\/\/|ssh:\/\/|ftp:\/\/|file:\/|www\.|(?:mailto:)?[A-Z0-9._%+-]+@(?!.*@))(.+)$/i
         );
-    const getDefaultLinkTarget = (editor) => editor.getParam("default_link_target", false);
+    const getDefaultLinkTarget = (editor) => editor.getParam("link_default_target", false);
     const getDefaultLinkProtocol = (editor) => editor.getParam("link_default_protocol", "http", "string");
 
     // constant values and magic numbers used below


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

Phone numbers are currently not being formatted upon pressing space/enter.

### Proposed changes
<!-- Describe this PR in more detail. -->

- change the TinyMCE parameter name `default_link_target` to `link_default_target` -> this variable no longer evaluates to false -> formatting happens
- I have no idea WHY this change is necessary. The line in question has not been touched in over two years. My best guess is that TinyMCE changed its name sometime in the past couple of months, but I cannot find any mention of this in their changelogs.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None, I think


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3285


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
