### PR TITLE
Improve speed of page duplication in region cloning

### DIFF
--- a/integreat_cms/cms/forms/regions/region_form.py
+++ b/integreat_cms/cms/forms/regions/region_form.py
@@ -279,6 +279,9 @@ class RegionForm(CustomModelForm):
         region = super().save(commit=commit)
 
         if duplicate_region:
+            # Disable HIX during the duplication process,
+            # to skip recalculation for already known content
+            region.hix_enabled = False
             source_region = self.cleaned_data["duplicated_region"]
             keep_status = self.cleaned_data["duplication_keep_status"]
             keep_translations = self.cleaned_data["duplication_keep_translations"]
@@ -333,6 +336,7 @@ class RegionForm(CustomModelForm):
             # Create links for the most recent versions of all translations manually and replace internal links
             create_and_replace_links_async(source_region, region)
 
+        region.hix_enabled = self.cleaned_data["hix_enabled"]
         return region
 
     def clean(self) -> dict[str, Any]:

--- a/integreat_cms/release_notes/current/unreleased/3244.yml
+++ b/integreat_cms/release_notes/current/unreleased/3244.yml
@@ -1,0 +1,2 @@
+en: Improve speed of page duplication in region cloning
+de: Verbessere die Geschwindigkeit der Seitenduplikation beim Klonen von Regionen


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR improves the speed of page duplication, which is a part of region cloning.

### Proposed changes
<!-- Describe this PR in more detail. -->
- ~Disable the pre_save signal, to skip HIX score API call~
- Set `hix_enabled` of the newly created region to `False` while pages are duplicated to avoid hitting HIX API



### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- I hope None


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3244 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
