### PR TITLE
Fix: Missing "Automatically saved on: ..." message in event form

### DIFF
--- a/integreat_cms/cms/templates/events/event_form.html
+++ b/integreat_cms/cms/templates/events/event_form.html
@@ -38,7 +38,7 @@
             </h1>
             <div class="flex flex-wrap gap-4 ml-auto mr-0 items-center">
                 {% if event_form.instance.id and not disabled %}
-                    {% include "generic_auto_save_note.html" with form_instance=event_form.instance %}
+                    {% include "generic_auto_save_note.html" with form_instance=event_translation_form.instance %}
                 {% endif %}
                 {% if event_form.instance.archived %}
                     <a href="{% url 'events_archived' region_slug=request.region.slug language_slug=language.slug %}"

--- a/integreat_cms/release_notes/current/unreleased/3519.yml
+++ b/integreat_cms/release_notes/current/unreleased/3519.yml
@@ -1,0 +1,2 @@
+en: Fix the bug that the message of automatic save is missing in the event form
+de: Behebe den Fehler, dass die Meldung des automatischen Speicherns im Veranstaltungsformular fehlt


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the bug that the message "Automatically saved on: ..." is not shown in the event form.

### Proposed changes
<!-- Describe this PR in more detail. -->
- `event_form` -> `event_translation_form`


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- I'd go without a release note if this is merged before the next release.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3517 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
