### PR TITLE
Fix: error thrown when an empty contact card is rendered

### DIFF
--- a/integreat_cms/cms/utils/content_utils.py
+++ b/integreat_cms/cms/utils/content_utils.py
@@ -159,7 +159,7 @@ def render_contact_card(contact_id: int, wanted_details: list[str]) -> HtmlEleme
         return fromstring(raw_element)
     except Contact.DoesNotExist:
         logger.warning("Contact with id=%i does not exist!", contact_id)
-        return Element("p")
+        return fromstring("<div><p></p></div>")
     except LxmlError as e:
         logger.debug(
             "Failed to parse rendered HTML for contact card: %r\n→ %s\nEOF",
@@ -190,7 +190,7 @@ def update_contacts(content: HtmlElement) -> None:
         contact_card_new = (
             render_contact_card(contact_id, wanted_details)
             if any(detail for detail in wanted_details)
-            else Element("p")
+            else fromstring("<div><p></p></div>")
         )
         contact_card.getparent().replace(contact_card, *contact_card_new)
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

Circumventing the client-side protection for not inserting empty or non-existent contacts, then saving the content object with the empty card, leads to an error because the HTML element representing the contact card is being "unpacked" to prevent deep nesting of contact cards (see: #3440). This PR fixes this.

### Proposed changes
<!-- Describe this PR in more detail. -->

- instead of returning an empty `p` in these error cases, return a `p` wrapped in a `div`; this can then be unwrapped, just like normal contact cards.
- I have not added a release note, because this should only affect naughty, naughty users who tried to circumvent client-side protections, and those do not deserve release notes! 😆


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3461


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
