### PR TITLE
Hide the button for ajax contact creation when POI is archived

### DIFF
--- a/integreat_cms/cms/templates/pois/poi_form_sidebar/related_contacts_box.html
+++ b/integreat_cms/cms/templates/pois/poi_form_sidebar/related_contacts_box.html
@@ -34,7 +34,7 @@
             {% trans "The contact will be created once you save the location." %}
         </div>
     {% endif %}
-    {% if perms.cms.change_contact %}
+    {% if perms.cms.change_contact and not poi_form.instance.archived %}
         <div>
             <div class="help-text mt-4 font-bold">
                 <div>

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -1865,6 +1865,10 @@ msgstr "Letzte Woche"
 msgid "Location cannot be empty."
 msgstr "Ort darf nicht leer sein."
 
+#: cms/forms/contacts/contact_form.py
+msgid "An archived location cannot be used for contacts."
+msgstr "Ein archivierter Ort kann nicht für Kontakte verwendet werden."
+
 #: cms/forms/custom_content_model_form.py
 msgid ""
 "Could not update because this content because it is already being edited by "
@@ -11705,15 +11709,15 @@ msgstr ""
 #~ "Übersetzungen. Bitte haben Sie noch ein wenig Geduld."
 
 #~ msgid ""
-#~ "Your pages currently have "
-#~ "<b>%(number_of_missing_or_outdated_translations)s pages </b>that have an "
+#~ "Your pages currently have <b>"
+#~ "%(number_of_missing_or_outdated_translations)s pages </b>that have an "
 #~ "outdated or no translation. In order for the users to benefit from your "
 #~ "content you should translate them or have them translated."
 #~ msgstr ""
-#~ "Ihre Inhalten haben aktuell "
-#~ "<b>%(number_of_missing_or_outdated_translations)s Seiten </b> mit "
-#~ "fehlender oder veralteter Übersetzung. Damit die Nutzer:innen von Ihren "
-#~ "Inhalten profitieren können, sollten Sie diese übersetzen (lassen)."
+#~ "Ihre Inhalten haben aktuell <b>"
+#~ "%(number_of_missing_or_outdated_translations)s Seiten </b> mit fehlender "
+#~ "oder veralteter Übersetzung. Damit die Nutzer:innen von Ihren Inhalten "
+#~ "profitieren können, sollten Sie diese übersetzen (lassen)."
 
 #~ msgid "View location"
 #~ msgstr "Ort ansehen"

--- a/integreat_cms/release_notes/current/unreleased/3523.yml
+++ b/integreat_cms/release_notes/current/unreleased/3523.yml
@@ -1,0 +1,2 @@
+en: Hide the button for contact creation in thelocation form when the location is archived
+de: Blende die Taste zum Anlegen von Kontakten im Ortformular aus, wenn der Ort archiviert ist


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR hides the button for ajax contact creation if the POI is archived

### Proposed changes
<!-- Describe this PR in more detail. -->
- Check whether the POI is archived
- 


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None?
- 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3523 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
