### PR TITLE
Fix license name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ keywords = [
     "refugees",
     "multilingual",
 ]
-license = {text = "Apache2 2.0 License"}
+license = "Apache-2.0"
+license-files = ["LICENSE", "NOTICE.md"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Web Environment",
@@ -26,7 +27,6 @@ classifiers = [
     "Framework :: Django :: 3.2",
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
-    "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
     "Natural Language :: German",
     "Operating System :: POSIX :: Linux",
@@ -348,7 +348,6 @@ dev-pinned = [
 
 [tool.setuptools]
 script-files = ["integreat_cms/integreat-cms-cli"]
-license-files = ["LICENSE", "NOTICE.md"]
 
 [tool.setuptools.packages.find]
 include = ["integreat_cms*"]


### PR DESCRIPTION
### Short description
According to https://packaging.python.org/en/latest/guides/writing-pyproject-toml/ the license name should be an SPDX expression. The Apache2 SPDX expression according to https://spdx.org/licenses/ is `Apache-2.0`


### Resolved issues
Fixes: https://app.circleci.com/pipelines/github/digitalfabrik/integreat-cms/14816/workflows/0034cc25-8c8f-40dc-a8da-93d85ccb4915/jobs/197178?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
