### PR TITLE
Refactor translation api clients

### DIFF
--- a/integreat_cms/core/utils/machine_translation_api_client.py
+++ b/integreat_cms/core/utils/machine_translation_api_client.py
@@ -8,24 +8,28 @@ import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING
 
+from django.apps import apps
 from django.conf import settings
+from django.contrib import messages
+from django.db import transaction
+from django.utils.translation import ngettext_lazy
+
+from ...cms.utils.stringify_list import iter_to_string
+from ...textlab_api.utils import check_hix_score
+from .word_count import word_count
 
 if TYPE_CHECKING:
-    from django.db.models.query import QuerySet
     from django.forms.models import ModelFormMetaclass
     from django.http import HttpRequest
 
     from ...cms.models import (
         Event,
-        EventTranslation,
+        Language,
         Page,
-        PageTranslation,
         POI,
-        POITranslation,
         Region,
     )
 
-from .word_count import word_count
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +45,16 @@ class MachineTranslationApiClient(ABC):
     region: Region
     #: The :class:`~integreat_cms.cms.forms.custom_content_model_form.CustomContentModelForm`
     form_class: ModelFormMetaclass
+    #: Successful translations
+    successful_translations: list[Event] | list[Page] | list[POI] = []
+    #: Translations with an attached API failure
+    failed_translations: list[str] = []
+    #: Content objects untranslatable due to missing source translations
+    failed_because_no_source_translation: list[str] = []
+    #: Content objects untranslatable due to too-low hix score
+    failed_because_insufficient_hix_score: list[str] = []
+    #: Content objects untranslatable due to insufficient translation budget
+    failed_because_exceeds_limit: list[str] = []
 
     def __init__(self, request: HttpRequest, form_class: ModelFormMetaclass) -> None:
         """
@@ -55,18 +69,38 @@ class MachineTranslationApiClient(ABC):
         self.form_class = form_class
         self.translatable_attributes = ["title", "content", "meta_description"]
 
-    @abstractmethod
-    def translate_queryset(
-        self,
-        queryset: QuerySet[Event | Page | POI],
-        language_slug: str,
-    ) -> None:
+    def reset(self) -> None:
         """
-        Translate a given queryset into one specific language.
+        A single instance of a MachineTranslationApiClient may
+        be used multiple times in succession, requiring a reset
+        of the stored results and failures.
+
+        Forgetting to call this function will not result in additional
+        machine translation budget use, but will produce nonsense messages
+        shown to the user.
+        """
+        self.successful_translations = []
+        self.failed_translations = []
+        self.failed_because_no_source_translation = []
+        self.failed_because_insufficient_hix_score = []
+        self.failed_because_exceeds_limit = []
+
+    @abstractmethod
+    def invoke_translation_api(self) -> None:
+        """
+        Translate all content objects stored in self.queryset.
+        Needs to be implemented by subclasses of MachineTranslationApiClient.
+        """
+
+    @staticmethod
+    @abstractmethod
+    def get_target_language_key(target_language: Language) -> str:
+        """
+        This function decides the correct target language key
         Needs to be implemented by subclasses of MachineTranslationApiClient.
 
-        :param queryset: The QuerySet of content objects to translate
-        :param language_slug: The target language slug to translate into
+        :param target_language: the target language
+        :return: target_language_key which is 2 characters long for all languages except English and Portuguese where the BCP tag is transmitted
         """
 
     def translate_object(self, obj: Event | Page | POI, language_slug: str) -> None:
@@ -78,28 +112,334 @@ class MachineTranslationApiClient(ABC):
         """
         return self.translate_queryset([obj], language_slug)
 
-    def check_usage(
+    @transaction.atomic
+    def translate_queryset(
         self,
-        region: Region,
-        source_translation: EventTranslation | (PageTranslation | POITranslation),
-    ) -> tuple[bool, int]:
+        queryset: list[Event] | (list[Page] | list[POI]),
+        language_slug: str,
+    ) -> None:
         """
-        This function checks if the attempted translation would exceed the region's word limit
+        This function translates a content queryset via DeepL
 
-        :param region: region for which to check usage
-        :param source_translation: single content object
-        :return: translation would exceed limit, region budget, attempted translation word count
+        :param queryset: The content QuerySet
+        :param language_slug: The target language slug
         """
+        if not queryset:
+            return
 
-        words = word_count(source_translation)
+        self.reset()
 
-        # Check if translation would exceed MT usage limit
-        region.refresh_from_db()
-        # Allow up to MT_SOFT_MARGIN more words than the actual limit
-        word_count_leeway = max(1, words - settings.MT_SOFT_MARGIN)
-        translation_exceeds_limit = region.mt_budget_remaining < word_count_leeway
+        # Re-select the region from db to prevent simultaneous
+        # requests exceeding the DeepL usage limit
+        region = (
+            apps.get_model("cms", "Region")
+            .objects.select_for_update()
+            .get(id=self.request.region.id)
+        )
 
-        return (translation_exceeds_limit, words)
+        # Store parameters used by all content objects
+        self.source_language = region.get_source_language(language_slug)
+        self.target_language = region.get_language_or_404(language_slug)
+        self.target_language_key = self.get_target_language_key(self.target_language)
+        self.queryset = queryset
+        self.region = region
+
+        # Store content object info for later use in messages shown to user
+        meta = type(self.queryset[0])._meta
+        self.model_name = meta.verbose_name.title()
+        self.model_name_plural = meta.verbose_name_plural
+
+        # Filter out content objects which can not be translated
+        self.prepare_content_objects()
+        self.filter_no_source_translation()
+        self.filter_insufficient_hix_score()
+        self.filter_exceeds_limit()
+
+        # Provider-API-spcific implementation
+        self.invoke_translation_api()
+
+        # Update remaining budget of the region
+        region.mt_budget_used += sum(
+            content_object.word_count for content_object in self.successful_translations
+        )
+        region.save()
+
+        # Show success/error messages to the user
+        self.alert_successful_translations()
+        self.alert_failed_translations()
+        self.alert_no_source_translation()
+        self.alert_insufficient_hix_score()
+        self.alert_exceeds_limit()
+
+    def filter_no_source_translation(self) -> None:
+        """
+        This method removes content objects from the main queryset
+        if they do not have the required source translation.
+
+        The removed elements are stored in order to show users
+        batched error messages after all objects have been handled.
+
+        :param source_language: The source language slug
+        """
+        filtered_queryset = []
+
+        for content_object in self.queryset:
+            if content_object.source_translation:
+                filtered_queryset.append(content_object)
+            else:
+                self.failed_because_no_source_translation.append(
+                    content_object.best_translation.title
+                )
+
+        self.queryset[:] = filtered_queryset
+
+    def filter_insufficient_hix_score(self) -> None:
+        """
+        This method removes content objects from the main queryset
+        if they do not have the required HIX score.
+
+        The removed elements are stored in order to show users
+        batched error messages after all objects have been handled.
+
+        :param source_language: The source language slug
+        """
+        filtered_queryset = []
+
+        for content_object in self.queryset:
+            if check_hix_score(
+                self.request,
+                content_object.source_translation,
+                show_message=False,
+            ):
+                filtered_queryset.append(content_object)
+            else:
+                self.failed_because_insufficient_hix_score.append(
+                    content_object.source_translation.title
+                )
+
+        self.queryset[:] = filtered_queryset
+
+    def filter_exceeds_limit(self) -> None:
+        """
+        This method removes content objects from the main queryset
+        if translating them would exceed the translation budget.
+
+        The removed elements are stored in order to show users
+        batched error messages after all objects have been handled.
+
+        :param source_language: The source language slug
+        """
+        remaining_budget = self.region.mt_budget_remaining
+        filtered_queryset = []
+
+        for content_object in self.queryset:
+            if (
+                max(1, content_object.word_count - settings.MT_SOFT_MARGIN)
+                < remaining_budget
+            ):
+                filtered_queryset.append(content_object)
+                remaining_budget -= content_object.word_count
+            else:
+                self.failed_because_exceeds_limit.append(
+                    content_object.source_translation.title
+                )
+
+        self.queryset[:] = filtered_queryset
+
+    def prepare_content_objects(self) -> None:
+        """
+        Prepare the content objects to be translated by annotating
+        them with information which otherwise would need to be
+        recalculated multiple times.
+        """
+        for content_object in self.queryset:
+            content_object.source_translation = content_object.get_translation(
+                self.source_language.slug,
+            )
+            content_object.existing_target_translation = content_object.get_translation(
+                self.target_language.slug,
+            )
+            content_object.word_count = word_count(content_object.source_translation)
+            content_object.translatable_attributes = [
+                (attr, getattr(content_object.source_translation, attr))
+                for attr in self.translatable_attributes
+                if hasattr(content_object.source_translation, attr)
+                and getattr(content_object.source_translation, attr)
+                and not (content_object.do_not_translate_title and attr == "title")
+            ]
+
+    def mark_successful(self, content_object: Event | Page | POI) -> None:
+        """
+        Mark a content object as having been translated successfully
+        """
+        logger.debug(
+            "Successfully translated for: %r",
+            content_object.existing_target_translation,
+        )
+        self.successful_translations.append(content_object)
+
+    def mark_unsuccessful(
+        self, content_object: Event | Page | POI, errors: bool
+    ) -> None:
+        """
+        Mark a translation as unuccessfull (usually due to API errors)
+        """
+        logger.error(
+            "Automatic translation for %r could not be created because of %r",
+            content_object,
+            errors,
+        )
+        self.failed_translations.append(content_object.source_translation.title)
+
+    def save_translation(
+        self, content_object: Event | Page | POI, translation_data: dict
+    ) -> None:
+        """
+        Create a translation form based on the extracted content object data,
+        save it, and validate the translation.
+        """
+        content_translation_form = self.form_class(
+            data=translation_data,
+            instance=content_object.existing_target_translation,
+            additional_instance_attributes={
+                "creator": self.request.user,
+                "language": self.target_language,
+                content_object.source_translation.foreign_field(): content_object,
+            },
+        )
+
+        # Validate content translation
+        if content_translation_form.is_valid():
+            content_translation_form.save()
+            # Revert "currently in translation" value of all versions
+            if content_object.existing_target_translation:
+                if settings.REDIS_CACHE:
+                    content_object.existing_target_translation.all_versions.invalidated_update(
+                        currently_in_translation=False,
+                    )
+                else:
+                    content_object.existing_target_translation.all_versions.update(
+                        currently_in_translation=False,
+                    )
+
+            self.mark_successful(content_object)
+        else:
+            self.mark_unsuccessful(content_object, content_translation_form.errors)
+
+    def alert_successful_translations(self) -> None:
+        """
+        Add messages informing the user about successful translations
+        """
+        if not self.successful_translations:
+            return
+
+        messages.success(
+            self.request,
+            ngettext_lazy(
+                "{model_name} {object_names} has successfully been translated ({source_language} ➜ {target_language}).",
+                "The following {model_name_plural} have successfully been translated ({source_language} ➜ {target_language}): {object_names}",
+                len(self.successful_translations),
+            ).format(
+                model_name=self.model_name,
+                model_name_plural=self.model_name_plural,
+                source_language=self.source_language,
+                target_language=self.target_language,
+                object_names=iter_to_string(
+                    content_object.source_translation.title
+                    for content_object in self.successful_translations
+                ),
+            ),
+        )
+
+    def alert_failed_translations(self) -> None:
+        """
+        Add messages informing the user about failed translations
+        """
+        if not self.failed_translations:
+            return
+
+        messages.success(
+            self.request,
+            ngettext_lazy(
+                "{model_name} {object_names} could not be translated automatically.",
+                "The following {model_name_plural} could not translated automatically: {object_names}",
+                len(self.failed_translations),
+            ).format(
+                model_name=self.model_name,
+                model_name_plural=self.model_name_plural,
+                object_names=iter_to_string(self.failed_translations),
+            ),
+        )
+
+    def alert_no_source_translation(self) -> None:
+        """
+        Add messages alerting the user that machine translation failed
+        due to missing source translations
+        """
+        if not self.failed_because_no_source_translation:
+            return
+
+        messages.error(
+            self.request,
+            ngettext_lazy(
+                "{model_name} {object_names} could not be translated because its source translation is missing.",
+                "The following {model_name_plural} could not be translated because their source translations are missing: {object_names}",
+                len(self.failed_because_no_source_translation),
+            ).format(
+                model_name=self.model_name,
+                model_name_plural=self.model_name_plural,
+                object_names=iter_to_string(
+                    self.failed_because_no_source_translation,
+                ),
+            ),
+        )
+
+    def alert_insufficient_hix_score(self) -> None:
+        """
+        Add messages alerting the user that machine translation failed
+        due to insufficient HIX scores
+        """
+        if not self.failed_because_insufficient_hix_score:
+            return
+
+        messages.error(
+            self.request,
+            ngettext_lazy(
+                "{model_name} {object_names} could not be translated because its HIX score is too low for machine translation (minimum required: {min_required}).",
+                "The following {model_name_plural} could not be translated because their HIX score is too low for machine translation (minimum required: {min_required}): {object_names}",
+                len(self.failed_because_insufficient_hix_score),
+            ).format(
+                model_name=self.model_name,
+                model_name_plural=self.model_name_plural,
+                object_names=iter_to_string(
+                    self.failed_because_insufficient_hix_score,
+                ),
+            ),
+        )
+
+    def alert_exceeds_limit(self) -> None:
+        """
+        Add messages alerting the user that machine translation failed
+        due to insufficient translation budget
+        """
+        if not self.failed_because_exceeds_limit:
+            return
+
+        messages.error(
+            self.request,
+            ngettext_lazy(
+                "{model_name} {object_names} could not be translated because it would exceed the remaining budget of {remaining_budget} words.",
+                "The following {model_name_plural} could not be translated because they would exceed the remaining budget of {remaining_budget} words: {object_names}",
+                len(self.failed_because_exceeds_limit),
+            ).format(
+                model_name=self.model_name,
+                model_name_plural=self.model_name_plural,
+                remaining_budget=self.region.mt_budget_remaining,
+                object_names=iter_to_string(
+                    self.failed_because_exceeds_limit,
+                ),
+            ),
+        )
 
     def __str__(self) -> str:
         """

--- a/integreat_cms/core/utils/word_count.py
+++ b/integreat_cms/core/utils/word_count.py
@@ -10,11 +10,14 @@ if TYPE_CHECKING:
 
 
 def word_count(
-    translation: EventTranslation | (PageTranslation | POITranslation),
+    translation: EventTranslation | (PageTranslation | POITranslation | None),
 ) -> int:
     """
     This function counts the number of words in a content translation
     """
+    if not translation:
+        return 0
+
     attributes = [
         getattr(translation, attr, None)
         for attr in ["title", "content", "meta_description"]

--- a/integreat_cms/deepl_api/deepl_api_client.py
+++ b/integreat_cms/deepl_api/deepl_api_client.py
@@ -9,23 +9,16 @@ from deepl.exceptions import DeepLException
 from django.apps import apps
 from django.conf import settings
 from django.contrib import messages
-from django.db import transaction
 from django.utils.translation import gettext_lazy as _
-from django.utils.translation import ngettext_lazy
 
-from ..cms.utils.stringify_list import iter_to_string
 from ..core.utils.machine_translation_api_client import MachineTranslationApiClient
 from ..core.utils.machine_translation_provider import MachineTranslationProvider
-from ..textlab_api.utils import check_hix_score
 
 if TYPE_CHECKING:
     from django.forms.models import ModelFormMetaclass
     from django.http import HttpRequest
 
-    from integreat_cms.cms.models.events.event import Event
     from integreat_cms.cms.models.languages.language import Language
-    from integreat_cms.cms.models.pages.page import Page
-    from integreat_cms.cms.models.pois.poi import POI
 
     from .apps import DeepLApiClientConfig
 
@@ -67,7 +60,7 @@ class DeepLApiClient(MachineTranslationApiClient):
         This function decides the correct target language key
 
         :param target_language: the target language
-        :return: target_language_key which is 2 characters long for all languages except English and Portugese where the BCP tag is transmitted
+        :return: target_language_key which is 2 characters long for all languages except English and Portuguese where the BCP tag is transmitted
         """
         deepl_config = apps.get_app_config("deepl_api")
         for code in [target_language.slug, target_language.bcp47_tag]:
@@ -75,241 +68,43 @@ class DeepLApiClient(MachineTranslationApiClient):
                 return code
         return ""
 
-    def translate_queryset(  # noqa: PLR0915
-        self,
-        queryset: list[Event] | (list[Page] | list[POI]),
-        language_slug: str,
-    ) -> None:
+    def invoke_translation_api(self) -> None:
         """
-        This function translates a content queryset via DeepL
-
-        :param queryset: The content QuerySet
-        :param language_slug: The target language slug
+        Translate all content objects stored in self.queryset using DeepL.
         """
         deepl_config: DeepLApiClientConfig = apps.get_app_config("deepl_api")
 
-        with transaction.atomic():
-            # Re-select the region from db to prevent simultaneous
-            # requests exceeding the DeepL usage limit
-            region = (
-                apps.get_model("cms", "Region")
-                .objects.select_for_update()
-                .get(id=self.request.region.id)
-            )
-            # Get target language
-            target_language = region.get_language_or_404(language_slug)
-            source_language = region.get_source_language(language_slug)
+        for content_object in self.queryset:
+            data = {
+                "status": content_object.source_translation.status,
+                "machine_translated": True,
+                "currently_in_translation": False,
+                "title": unescape(content_object.source_translation.title),
+            }
 
-            target_language_key = self.get_target_language_key(target_language)
-
-            failed_changes_because_no_source_translation = []
-            failed_changes_because_exceeds_limit = []
-            failed_changes_because_insufficient_hix_score = []
-            failed_changes_generic_error = []
-            successful_changes = []
-
-            for content_object in queryset:
-                source_translation = content_object.get_translation(
-                    source_language.slug,
-                )
-                if not source_translation:
-                    failed_changes_because_no_source_translation.append(
-                        content_object.best_translation.title,
+            for attr, attr_val in content_object.translatable_attributes:
+                try:
+                    # data has to be unescaped for DeepL to recognize Umlaute
+                    glossary = deepl_config.get_glossary(
+                        self.source_language.slug,
+                        self.target_language_key,
                     )
-                    continue
-
-                if not check_hix_score(
-                    self.request,
-                    source_translation,
-                    show_message=False,
-                ):
-                    failed_changes_because_insufficient_hix_score.append(
-                        source_translation.title,
+                    logger.debug("Used glossary for translation: %s", glossary)
+                    data[attr] = self.translator.translate_text(
+                        unescape(attr_val),
+                        source_lang=self.source_language.slug,
+                        target_lang=self.target_language_key,
+                        tag_handling="html",
+                        glossary=glossary,
                     )
-                    continue
-
-                existing_target_translation = content_object.get_translation(
-                    target_language.slug,
-                )
-
-                # Before translating, check if translation would exceed usage limit
-                (
-                    translation_exceeds_limit,
-                    word_count,
-                ) = self.check_usage(region, source_translation)
-                if translation_exceeds_limit:
-                    failed_changes_because_exceeds_limit.append(
-                        source_translation.title,
-                    )
-                    continue
-
-                data = {
-                    "status": source_translation.status,
-                    "machine_translated": True,
-                    "currently_in_translation": False,
-                }
-
-                for attr in self.translatable_attributes:
-                    # Only translate existing, non-empty attributes
-                    if hasattr(source_translation, attr) and getattr(
-                        source_translation,
-                        attr,
-                    ):
-                        try:
-                            # data has to be unescaped for DeepL to recognize Umlaute
-                            glossary = deepl_config.get_glossary(
-                                source_language.slug,
-                                target_language_key,
-                            )
-                            logger.debug("Used glossary for translation: %s", glossary)
-
-                            source_text = getattr(source_translation, attr)
-
-                            data[attr] = (
-                                source_text
-                                if attr == "title"
-                                and content_object.do_not_translate_title
-                                else self.translator.translate_text(
-                                    unescape(source_text),
-                                    source_lang=source_language.slug,
-                                    target_lang=target_language_key,
-                                    tag_handling="html",
-                                    glossary=glossary,
-                                )
-                            )
-                        except DeepLException:
-                            messages.error(
-                                self.request,
-                                _(
-                                    "A problem with DeepL API has occurred. Please contact an administrator.",
-                                ),
-                            )
-                            logger.exception("")
-                            return
-
-                content_translation_form = self.form_class(
-                    data=data,
-                    instance=existing_target_translation,
-                    additional_instance_attributes={
-                        "creator": self.request.user,
-                        "language": target_language,
-                        source_translation.foreign_field(): content_object,
-                    },
-                )
-                # Validate content translation
-                if content_translation_form.is_valid():
-                    content_translation_form.save()
-                    # Revert "currently in translation" value of all versions
-                    if existing_target_translation:
-                        if settings.REDIS_CACHE:
-                            existing_target_translation.all_versions.invalidated_update(
-                                currently_in_translation=False,
-                            )
-                        else:
-                            existing_target_translation.all_versions.update(
-                                currently_in_translation=False,
-                            )
-
-                    logger.debug(
-                        "Successfully translated for: %r",
-                        content_translation_form.instance,
-                    )
-                    successful_changes.append(source_translation.title)
-                else:
-                    logger.error(
-                        "Automatic translation for %r could not be created because of %r",
-                        content_object,
-                        content_translation_form.errors,
-                    )
-                    failed_changes_generic_error.append(source_translation.title)
-
-                # Update remaining DeepL usage for the region
-                region.mt_budget_used += word_count
-                region.save()
-
-            if queryset:
-                meta = type(queryset[0])._meta
-                model_name = meta.verbose_name.title()
-                model_name_plural = meta.verbose_name_plural
-            else:
-                model_name = model_name_plural = ""
-
-            if successful_changes:
-                messages.success(
-                    self.request,
-                    ngettext_lazy(
-                        "{model_name} {object_names} has successfully been translated ({source_language} ➜ {target_language}).",
-                        "The following {model_name_plural} have successfully been translated ({source_language} ➜ {target_language}): {object_names}",
-                        len(successful_changes),
-                    ).format(
-                        model_name=model_name,
-                        model_name_plural=model_name_plural,
-                        source_language=source_language,
-                        target_language=target_language,
-                        object_names=iter_to_string(successful_changes),
-                    ),
-                )
-
-            if failed_changes_because_no_source_translation:
-                messages.error(
-                    self.request,
-                    ngettext_lazy(
-                        "{model_name} {object_names} could not be translated because its source translation is missing.",
-                        "The following {model_name_plural} could not be translated because their source translations are missing: {object_names}",
-                        len(failed_changes_because_exceeds_limit),
-                    ).format(
-                        model_name=model_name,
-                        model_name_plural=model_name_plural,
-                        object_names=iter_to_string(
-                            failed_changes_because_no_source_translation,
+                except DeepLException:
+                    messages.error(
+                        self.request,
+                        _(
+                            "A problem with DeepL API has occurred. Please contact an administrator.",
                         ),
-                    ),
-                )
+                    )
+                    logger.exception("")
+                    return
 
-            if failed_changes_because_exceeds_limit:
-                messages.error(
-                    self.request,
-                    ngettext_lazy(
-                        "{model_name} {object_names} could not be translated because it would exceed the remaining budget of {remaining_budget} words.",
-                        "The following {model_name_plural} could not be translated because they would exceed the remaining budget of {remaining_budget} words: {object_names}",
-                        len(failed_changes_because_exceeds_limit),
-                    ).format(
-                        model_name=model_name,
-                        model_name_plural=model_name_plural,
-                        remaining_budget=region.mt_budget_remaining,
-                        object_names=iter_to_string(
-                            failed_changes_because_exceeds_limit,
-                        ),
-                    ),
-                )
-
-            if failed_changes_because_insufficient_hix_score:
-                messages.error(
-                    self.request,
-                    ngettext_lazy(
-                        "{model_name} {object_names} could not be translated because its HIX score is too low for machine translation (minimum required: {min_required}).",
-                        "The following {model_name_plural} could not be translated because their HIX score is too low for machine translation (minimum required: {min_required}): {object_names}",
-                        len(failed_changes_because_insufficient_hix_score),
-                    ).format(
-                        model_name=model_name,
-                        model_name_plural=model_name_plural,
-                        min_required=settings.HIX_REQUIRED_FOR_MT,
-                        object_names=iter_to_string(
-                            failed_changes_because_insufficient_hix_score,
-                        ),
-                    ),
-                )
-
-            if failed_changes_generic_error:
-                messages.error(
-                    self.request,
-                    ngettext_lazy(
-                        "{model_name} {object_names} could not be translated automatically.",
-                        "The following {model_name_plural} could not translated automatically: {object_names}",
-                        len(failed_changes_generic_error),
-                    ).format(
-                        model_name=model_name,
-                        model_name_plural=model_name_plural,
-                        object_names=iter_to_string(failed_changes_generic_error),
-                    ),
-                )
+            self.save_translation(content_object, data)

--- a/integreat_cms/google_translate_api/google_translate_api_client.py
+++ b/integreat_cms/google_translate_api/google_translate_api_client.py
@@ -6,28 +6,21 @@ from typing import TYPE_CHECKING
 from django.apps import apps
 from django.conf import settings
 from django.contrib import messages
-from django.db import transaction
 from django.utils.translation import gettext_lazy as _
-from django.utils.translation import ngettext_lazy
 from google.cloud import (  # type: ignore[attr-defined]
     translate_v2,
     translate_v3,
 )
 from google.oauth2 import service_account
 
-from ..cms.utils.stringify_list import iter_to_string
 from ..core.utils.machine_translation_api_client import MachineTranslationApiClient
 from ..core.utils.machine_translation_provider import MachineTranslationProvider
-from ..textlab_api.utils import check_hix_score
 
 if TYPE_CHECKING:
     from django.forms.models import ModelFormMetaclass
     from django.http import HttpRequest
 
-    from integreat_cms.cms.models.events.event import Event
     from integreat_cms.cms.models.languages.language import Language
-    from integreat_cms.cms.models.pages.page import Page
-    from integreat_cms.cms.models.pois.poi import POI
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +71,7 @@ class GoogleTranslateApiClient(MachineTranslationApiClient):
         This function decides the correct target language key
 
         :param target_language: the target language
-        :return: target_language_key which is 2 characters long for all languages except English and Portugese where the BCP tag is transmitted
+        :return: target_language_key which is 2 characters long for all languages except English and Portuguese where the BCP tag is transmitted
         """
         google_translate_config = apps.get_app_config("google_translate_api")
         for code in [target_language.slug, target_language.bcp47_tag]:
@@ -86,257 +79,52 @@ class GoogleTranslateApiClient(MachineTranslationApiClient):
                 return code
         return ""
 
-    def translate_queryset(  # noqa: PLR0915, PLR0912
-        self,
-        queryset: list[Event] | (list[Page] | list[POI]),
-        language_slug: str,
-    ) -> None:
+    def invoke_translation_api(self) -> None:
         """
-        This function translates a content queryset via Google Translate
-
-        :param queryset: The content QuerySet
-        :param language_slug: The target language slug
+        Translate all content objects stored in self.queryset using DeepL.
         """
-        with transaction.atomic():
-            # Re-select the region from db to prevent simultaneous
-            # requests exceeding the MT usage limit
-            region = (
-                apps.get_model("cms", "Region")
-                .objects.select_for_update()
-                .get(id=self.request.region.id)
-            )
-            # Get target language
-            target_language = region.get_language_or_404(language_slug)
-            source_language = region.get_source_language(language_slug)
+        for content_object in self.queryset:
+            data = {
+                "status": content_object.source_translation.status,
+                "machine_translated": True,
+                "currently_in_translation": False,
+                "title": content_object.source_translation.title,
+            }
 
-            target_language_key = self.get_target_language_key(target_language)
-
-            failed_changes_because_no_source_translation = []
-            failed_changes_because_exceeds_limit = []
-            failed_changes_because_insufficient_hix_score = []
-            failed_changes_generic_error = []
-            successful_changes = []
-
-            google_translate_api_error = False
-
-            for content_object in queryset:
-                source_translation = content_object.get_translation(
-                    source_language.slug,
-                )
-                if not source_translation:
-                    failed_changes_because_no_source_translation.append(
-                        content_object.best_translation.title,
-                    )
-                    continue
-
-                if not check_hix_score(
-                    self.request,
-                    source_translation,
-                    show_message=False,
-                ):
-                    failed_changes_because_insufficient_hix_score.append(
-                        source_translation.title,
-                    )
-                    continue
-
-                existing_target_translation = content_object.get_translation(
-                    target_language.slug,
-                )
-
-                # Before translating, check if translation would exceed usage limit
-                (
-                    translation_exceeds_limit,
-                    word_count,
-                ) = self.check_usage(region, source_translation)
-                if translation_exceeds_limit:
-                    failed_changes_because_exceeds_limit.append(
-                        source_translation.title,
-                    )
-                    continue
-
-                data = {
-                    "status": source_translation.status,
-                    "machine_translated": True,
-                    "currently_in_translation": False,
-                }
-
-                for attr in self.translatable_attributes:
-                    # Only translate existing, non-empty attributes
-                    if hasattr(source_translation, attr) and getattr(
-                        source_translation,
-                        attr,
-                    ):
-                        try:
-                            # data has to be unescaped to recognize Umlaute
-                            source_text = getattr(source_translation, attr)
-
-                            if (
-                                attr == "title"
-                                and content_object.do_not_translate_title
-                            ):
-                                data[attr] = source_text
-
-                            elif settings.GOOGLE_TRANSLATE_VERSION == "Advanced":
-                                mime_type = (
-                                    "text/html" if attr == "content" else "text/plain"
-                                )
-                                parent = settings.GOOGLE_PARENT_PARAM
-                                request = translate_v3.TranslateTextRequest(
-                                    contents=[source_text],
-                                    parent=parent,
-                                    target_language_code=target_language_key,
-                                    source_language_code=source_language.slug,
-                                    mime_type=mime_type,
-                                )
-                                data[attr] = (
-                                    self.translator_v3.translate_text(request=request)
-                                    .translations[0]
-                                    .translated_text
-                                )
-                            else:
-                                format_ = "html" if attr == "content" else "text"
-                                data[attr] = self.translator_v2.translate(
-                                    values=[source_text],
-                                    target_language=target_language_key,
-                                    source_language=source_language.slug,
-                                    format_=format_,
-                                )[0]["translatedText"]
-                        except Exception:
-                            google_translate_api_error = True
-                            logger.exception("")
-                            break
-
-                content_translation_form = self.form_class(
-                    data=data,
-                    instance=existing_target_translation,
-                    additional_instance_attributes={
-                        "creator": self.request.user,
-                        "language": target_language,
-                        source_translation.foreign_field(): content_object,
-                    },
-                )
-                # Validate content translation
-                if content_translation_form.is_valid():
-                    content_translation_form.save()
-                    # Revert "currently in translation" value of all versions
-                    if existing_target_translation:
-                        if settings.REDIS_CACHE:
-                            existing_target_translation.all_versions.invalidated_update(
-                                currently_in_translation=False,
-                            )
-                        else:
-                            existing_target_translation.all_versions.update(
-                                currently_in_translation=False,
-                            )
-
-                    logger.debug(
-                        "Successfully translated for: %r",
-                        content_translation_form.instance,
-                    )
-                    successful_changes.append(source_translation.title)
-                else:
-                    logger.error(
-                        "Automatic translation for %r could not be created because of %r",
-                        content_object,
-                        content_translation_form.errors,
-                    )
-                    failed_changes_generic_error.append(source_translation.title)
-
-                # Update remaining MT usage for the region
-                region.mt_budget_used += word_count
-                region.save()
-
-            if queryset:
-                meta = type(queryset[0])._meta
-                model_name = meta.verbose_name.title()
-                model_name_plural = meta.verbose_name_plural
-            else:
-                model_name = model_name_plural = ""
-
-            if successful_changes:
-                messages.success(
-                    self.request,
-                    ngettext_lazy(
-                        "{model_name} {object_names} has successfully been translated ({source_language} ➜ {target_language}).",
-                        "The following {model_name_plural} have successfully been translated ({source_language} ➜ {target_language}): {object_names}",
-                        len(successful_changes),
-                    ).format(
-                        model_name=model_name,
-                        model_name_plural=model_name_plural,
-                        source_language=source_language,
-                        target_language=target_language,
-                        object_names=iter_to_string(successful_changes),
-                    ),
-                )
-
-            if failed_changes_because_no_source_translation:
-                messages.error(
-                    self.request,
-                    ngettext_lazy(
-                        "{model_name} {object_names} could not be translated because its source translation is missing.",
-                        "The following {model_name_plural} could not be translated because their source translations are missing: {object_names}",
-                        len(failed_changes_because_exceeds_limit),
-                    ).format(
-                        model_name=model_name,
-                        model_name_plural=model_name_plural,
-                        object_names=iter_to_string(
-                            failed_changes_because_no_source_translation,
+            for attr, attr_val in content_object.translatable_attributes:
+                try:
+                    # data has to be unescaped to recognize Umlaute
+                    if settings.GOOGLE_TRANSLATE_VERSION == "Advanced":
+                        mime_type = "text/html" if attr == "content" else "text/plain"
+                        parent = settings.GOOGLE_PARENT_PARAM
+                        request = translate_v3.TranslateTextRequest(
+                            contents=[attr_val],
+                            parent=parent,
+                            target_language_code=self.target_language_key,
+                            source_language_code=self.source_language.slug,
+                            mime_type=mime_type,
+                        )
+                        data[attr] = (
+                            self.translator_v3.translate_text(request=request)
+                            .translations[0]
+                            .translated_text
+                        )
+                    else:
+                        format_ = "html" if attr == "content" else "text"
+                        data[attr] = self.translator_v2.translate(
+                            values=[attr_val],
+                            target_language=self.target_language_key,
+                            source_language=self.source_language.slug,
+                            format_=format_,
+                        )[0]["translatedText"]
+                except Exception:
+                    messages.error(
+                        self.request,
+                        _(
+                            "A problem with Google Translate API has occurred. Please contact an administrator.",
                         ),
-                    ),
-                )
+                    )
+                    logger.exception("")
+                    return
 
-            if failed_changes_because_exceeds_limit:
-                messages.error(
-                    self.request,
-                    ngettext_lazy(
-                        "{model_name} {object_names} could not be translated because it would exceed the remaining budget of {remaining_budget} words.",
-                        "The following {model_name_plural} could not be translated because they would exceed the remaining budget of {remaining_budget} words: {object_names}",
-                        len(failed_changes_because_exceeds_limit),
-                    ).format(
-                        model_name=model_name,
-                        model_name_plural=model_name_plural,
-                        remaining_budget=region.mt_budget_remaining,
-                        object_names=iter_to_string(
-                            failed_changes_because_exceeds_limit,
-                        ),
-                    ),
-                )
-
-            if failed_changes_because_insufficient_hix_score:
-                messages.error(
-                    self.request,
-                    ngettext_lazy(
-                        "{model_name} {object_names} could not be translated because its HIX score is too low for machine translation (minimum required: {min_required}).",
-                        "The following {model_name_plural} could not be translated because their HIX score is too low for machine translation (minimum required: {min_required}): {object_names}",
-                        len(failed_changes_because_insufficient_hix_score),
-                    ).format(
-                        model_name=model_name,
-                        model_name_plural=model_name_plural,
-                        min_required=settings.HIX_REQUIRED_FOR_MT,
-                        object_names=iter_to_string(
-                            failed_changes_because_insufficient_hix_score,
-                        ),
-                    ),
-                )
-
-            if failed_changes_generic_error:
-                messages.error(
-                    self.request,
-                    ngettext_lazy(
-                        "{model_name} {object_names} could not be translated automatically.",
-                        "The following {model_name_plural} could not translated automatically: {object_names}",
-                        len(failed_changes_generic_error),
-                    ).format(
-                        model_name=model_name,
-                        model_name_plural=model_name_plural,
-                        object_names=iter_to_string(failed_changes_generic_error),
-                    ),
-                )
-
-            if google_translate_api_error:
-                messages.error(
-                    self.request,
-                    _(
-                        "A problem with Google Translate API has occurred. Please contact an administrator.",
-                    ),
-                )
+            self.save_translation(content_object, data)

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -11198,18 +11198,7 @@ msgstr "Englisch"
 msgid "Dutch"
 msgstr "Niederländisch"
 
-#: deepl_api/apps.py
-msgid "DeepL API"
-msgstr "DeepL API"
-
-#: deepl_api/deepl_api_client.py
-msgid "A problem with DeepL API has occurred. Please contact an administrator."
-msgstr ""
-"Ein Fehler mit DeepL API ist aufgetreten. Bitte kontaktieren Sie eine:n "
-"Administrator:in."
-
-#: deepl_api/deepl_api_client.py
-#: google_translate_api/google_translate_api_client.py
+#: core/utils/machine_translation_api_client.py
 #, python-brace-format
 msgid ""
 "{model_name} {object_names} has successfully been translated "
@@ -11224,8 +11213,19 @@ msgstr[1] ""
 "Die folgenden {model_name_plural} wurden erfolgreich übersetzt "
 "({source_language} ➜ {target_language}): {object_names}"
 
-#: deepl_api/deepl_api_client.py
-#: google_translate_api/google_translate_api_client.py
+#: core/utils/machine_translation_api_client.py
+#, python-brace-format
+msgid "{model_name} {object_names} could not be translated automatically."
+msgid_plural ""
+"The following {model_name_plural} could not translated automatically: "
+"{object_names}"
+msgstr[0] ""
+"{model_name} {object_names} konnte nicht automatisch übersetzt werden."
+msgstr[1] ""
+"Die folgenden {model_name_plural} konnten nicht automatisch übersetzt "
+"werden: {object_names}"
+
+#: core/utils/machine_translation_api_client.py
 #, python-brace-format
 msgid ""
 "{model_name} {object_names} could not be translated because its source "
@@ -11240,26 +11240,7 @@ msgstr[1] ""
 "Die folgenden {model_name_plural} konnten nicht übersetzt werden, da ihre "
 "Quell-Übersetzung fehlen: {object_names}"
 
-#: deepl_api/deepl_api_client.py
-#: google_translate_api/google_translate_api_client.py
-#, python-brace-format
-msgid ""
-"{model_name} {object_names} could not be translated because it would exceed "
-"the remaining budget of {remaining_budget} words."
-msgid_plural ""
-"The following {model_name_plural} could not be translated because they would "
-"exceed the remaining budget of {remaining_budget} words: {object_names}"
-msgstr[0] ""
-"{model_name} {object_names} konnte nicht übersetzt werden, da die "
-"Übersetzung das verbleibende Übersetzungsbudget von {remaining_budget} "
-"Wörtern übersteigen würde."
-msgstr[1] ""
-"Die folgenden {model_name_plural} konnten nicht übersetzt werden, da die "
-"Übersetzung das verbleibende Übersetzungsbudget von {remaining_budget} "
-"Wörtern übersteigen würde: {object_names}"
-
-#: deepl_api/deepl_api_client.py
-#: google_translate_api/google_translate_api_client.py
+#: core/utils/machine_translation_api_client.py
 #, python-brace-format
 msgid ""
 "{model_name} {object_names} could not be translated because its HIX score is "
@@ -11277,18 +11258,32 @@ msgstr[1] ""
 "HIX Werte für die maschinelle Übersetzung zu gering sind (erforderlicher "
 "Mindestwert: {min_required}): {object_names}"
 
-#: deepl_api/deepl_api_client.py
-#: google_translate_api/google_translate_api_client.py
+#: core/utils/machine_translation_api_client.py
 #, python-brace-format
-msgid "{model_name} {object_names} could not be translated automatically."
+msgid ""
+"{model_name} {object_names} could not be translated because it would exceed "
+"the remaining budget of {remaining_budget} words."
 msgid_plural ""
-"The following {model_name_plural} could not translated automatically: "
-"{object_names}"
+"The following {model_name_plural} could not be translated because they would "
+"exceed the remaining budget of {remaining_budget} words: {object_names}"
 msgstr[0] ""
-"{model_name} {object_names} konnte nicht automatisch übersetzt werden."
+"{model_name} {object_names} konnte nicht übersetzt werden, da die "
+"Übersetzung das verbleibende Übersetzungsbudget von {remaining_budget} "
+"Wörtern übersteigen würde."
 msgstr[1] ""
-"Die folgenden {model_name_plural} konnten nicht automatisch übersetzt "
-"werden: {object_names}"
+"Die folgenden {model_name_plural} konnten nicht übersetzt werden, da die "
+"Übersetzung das verbleibende Übersetzungsbudget von {remaining_budget} "
+"Wörtern übersteigen würde: {object_names}"
+
+#: deepl_api/apps.py
+msgid "DeepL API"
+msgstr "DeepL API"
+
+#: deepl_api/deepl_api_client.py
+msgid "A problem with DeepL API has occurred. Please contact an administrator."
+msgstr ""
+"Ein Fehler mit DeepL API ist aufgetreten. Bitte kontaktieren Sie eine:n "
+"Administrator:in."
 
 #: firebase_api/apps.py
 msgid "Firebase API"
@@ -11721,15 +11716,15 @@ msgstr ""
 #~ "Übersetzungen. Bitte haben Sie noch ein wenig Geduld."
 
 #~ msgid ""
-#~ "Your pages currently have <b>"
-#~ "%(number_of_missing_or_outdated_translations)s pages </b>that have an "
+#~ "Your pages currently have "
+#~ "<b>%(number_of_missing_or_outdated_translations)s pages </b>that have an "
 #~ "outdated or no translation. In order for the users to benefit from your "
 #~ "content you should translate them or have them translated."
 #~ msgstr ""
-#~ "Ihre Inhalten haben aktuell <b>"
-#~ "%(number_of_missing_or_outdated_translations)s Seiten </b> mit fehlender "
-#~ "oder veralteter Übersetzung. Damit die Nutzer:innen von Ihren Inhalten "
-#~ "profitieren können, sollten Sie diese übersetzen (lassen)."
+#~ "Ihre Inhalten haben aktuell "
+#~ "<b>%(number_of_missing_or_outdated_translations)s Seiten </b> mit "
+#~ "fehlender oder veralteter Übersetzung. Damit die Nutzer:innen von Ihren "
+#~ "Inhalten profitieren können, sollten Sie diese übersetzen (lassen)."
 
 #~ msgid "View location"
 #~ msgstr "Ort ansehen"

--- a/integreat_cms/summ_ai_api/summ_ai_api_client.py
+++ b/integreat_cms/summ_ai_api/summ_ai_api_client.py
@@ -38,6 +38,7 @@ if TYPE_CHECKING:
     from django.forms.models import ModelFormMetaclass
     from django.http import HttpRequest
 
+    from ..cms.models import Language
     from ..cms.models.pages.page import Page
 
 logger = logging.getLogger(__name__)
@@ -341,3 +342,15 @@ class SummAiApiClient(MachineTranslationApiClient):
             )
             raise SummAiRateLimitingExceeded
         return False
+
+    @staticmethod
+    def get_target_language_key(_target_language: Language) -> str:
+        """
+        Dummy placeholder for the (unused) abstract method from MachineTranslationApiClient
+        """
+        return ""
+
+    def invoke_translation_api(self) -> None:
+        """
+        Dummy placeholder for the (unused) abstract method from MachineTranslationApiClient
+        """


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

Refactors the DeepL and Google Translate API client `translate_queryset` functions. Since they were largely identical, a lot of things have not only been broken off into smaller methods, but also moved to the parent class.

@juliankehne testing only really involves checking that all machine translation invocations work like they did beforehand

### Proposed changes
<!-- Describe this PR in more detail. -->

- refactor `translate_queryset`

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- a couple more iterations over the `content_objects`-to-be-translated. No nested loops though, still O(n) iterations for length n of the content_objects; but now it's about 7n instead of 1n. Should not really matter though, just a heads up that I did take it into consideration, I just could not come up with a fewer-iterations way to split everything up into nice, small methods. 
- *failed* translations (as in, an actual API error occurred) are now no longer being counted towards the region's `mt_translation_budget`. That is a different behavior than previously, however, I am pretty sure this should be the intended way...?


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2666 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
