### PR TITLE
Add option to not translate title of content

### DIFF
--- a/integreat_cms/cms/forms/events/event_form.py
+++ b/integreat_cms/cms/forms/events/event_form.py
@@ -82,6 +82,7 @@ class EventForm(CustomModelForm):
             "external_calendar",
             "external_event_id",
             "only_weekdays",
+            "do_not_translate_title",
         ]
         #: The widgets which are used in this form
         widgets = {

--- a/integreat_cms/cms/forms/pages/page_form.py
+++ b/integreat_cms/cms/forms/pages/page_form.py
@@ -73,6 +73,7 @@ class PageForm(CustomModelForm, CustomTreeNodeForm):
             "api_token",
             "hix_ignore",
             "embedded_offers",
+            "do_not_translate_title",
         ]
         #: The widgets for the fields if they differ from the standard widgets
         widgets = {

--- a/integreat_cms/cms/forms/pois/poi_form.py
+++ b/integreat_cms/cms/forms/pois/poi_form.py
@@ -57,6 +57,7 @@ class POIForm(CustomModelForm):
             "appointment_url",
             "organization",
             "barrier_free",
+            "do_not_translate_title",
         ]
         #: The widgets which are used in this form
         widgets = {

--- a/integreat_cms/cms/migrations/0122_add_do_not_translate_title_field.py
+++ b/integreat_cms/cms/migrations/0122_add_do_not_translate_title_field.py
@@ -1,0 +1,46 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("cms", "0121_remove_userchat_most_recent_hits_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="event",
+            name="do_not_translate_title",
+            field=models.BooleanField(
+                default=False,
+                help_text="Tick if you do not want to translate the title by automatic translation.",
+                verbose_name="do not translate the title",
+            ),
+        ),
+        migrations.AddField(
+            model_name="imprintpage",
+            name="do_not_translate_title",
+            field=models.BooleanField(
+                default=False,
+                help_text="Tick if you do not want to translate the title by automatic translation.",
+                verbose_name="do not translate the title",
+            ),
+        ),
+        migrations.AddField(
+            model_name="page",
+            name="do_not_translate_title",
+            field=models.BooleanField(
+                default=False,
+                help_text="Tick if you do not want to translate the title by automatic translation.",
+                verbose_name="do not translate the title",
+            ),
+        ),
+        migrations.AddField(
+            model_name="poi",
+            name="do_not_translate_title",
+            field=models.BooleanField(
+                default=False,
+                help_text="Tick if you do not want to translate the title by automatic translation.",
+                verbose_name="do not translate the title",
+            ),
+        ),
+    ]

--- a/integreat_cms/cms/models/abstract_content_model.py
+++ b/integreat_cms/cms/models/abstract_content_model.py
@@ -128,6 +128,13 @@ class AbstractContentModel(AbstractBaseModel):
         default=timezone.now,
         verbose_name=_("creation date"),
     )
+    do_not_translate_title = models.BooleanField(
+        default=False,
+        verbose_name=_("do not translate the title"),
+        help_text=_(
+            "Tick if you do not want to translate the title by automatic translation."
+        ),
+    )
 
     #: Custom model manager for content objects
     objects = ContentQuerySet.as_manager()

--- a/integreat_cms/cms/templates/events/event_form_sidebar/minor_edit_box.html
+++ b/integreat_cms/cms/templates/events/event_form_sidebar/minor_edit_box.html
@@ -53,5 +53,15 @@
                 {% endif %}
             </div>
         </div>
+        <div>
+            {% render_field event_form.do_not_translate_title %}
+            <label for="{{ event_form.do_not_translate_title.id_for_label }}"
+                   class="secondary">
+                {{ event_form.do_not_translate_title.label }}
+            </label>
+            <div class="help-text">
+                {{ event_form.do_not_translate_title.help_text }}
+            </div>
+        </div>
     {% endif %}
 {% endblock collapsible_box_content %}

--- a/integreat_cms/cms/templates/pages/page_form_sidebar/minor_edit_box.html
+++ b/integreat_cms/cms/templates/pages/page_form_sidebar/minor_edit_box.html
@@ -61,5 +61,15 @@
                 {% endif %}
             </div>
         </div>
+        <div>
+            {% render_field page_form.do_not_translate_title %}
+            <label for="{{ page_form.do_not_translate_title.id_for_label }}"
+                   class="secondary">
+                {{ page_form.do_not_translate_title.label }}
+            </label>
+            <div class="help-text">
+                {{ page_form.do_not_translate_title.help_text }}
+            </div>
+        </div>
     {% endif %}
 {% endblock collapsible_box_content %}

--- a/integreat_cms/cms/templates/pois/poi_form_sidebar/minor_edit_box.html
+++ b/integreat_cms/cms/templates/pois/poi_form_sidebar/minor_edit_box.html
@@ -53,5 +53,15 @@
                 {% endif %}
             </div>
         </div>
+        <div>
+            {% render_field poi_form.do_not_translate_title %}
+            <label for="{{ poi_form.do_not_translate_title.id_for_label }}"
+                   class="secondary">
+                {{ poi_form.do_not_translate_title.label }}
+            </label>
+            <div class="help-text">
+                {{ poi_form.do_not_translate_title.help_text }}
+            </div>
+        </div>
     {% endif %}
 {% endblock collapsible_box_content %}

--- a/integreat_cms/deepl_api/deepl_api_client.py
+++ b/integreat_cms/deepl_api/deepl_api_client.py
@@ -75,7 +75,7 @@ class DeepLApiClient(MachineTranslationApiClient):
                 return code
         return ""
 
-    def translate_queryset(
+    def translate_queryset(  # noqa: PLR0915
         self,
         queryset: list[Event] | (list[Page] | list[POI]),
         language_slug: str,
@@ -162,12 +162,20 @@ class DeepLApiClient(MachineTranslationApiClient):
                                 target_language_key,
                             )
                             logger.debug("Used glossary for translation: %s", glossary)
-                            data[attr] = self.translator.translate_text(
-                                unescape(getattr(source_translation, attr)),
-                                source_lang=source_language.slug,
-                                target_lang=target_language_key,
-                                tag_handling="html",
-                                glossary=glossary,
+
+                            source_text = getattr(source_translation, attr)
+
+                            data[attr] = (
+                                source_text
+                                if attr == "title"
+                                and content_object.do_not_translate_title
+                                else self.translator.translate_text(
+                                    unescape(source_text),
+                                    source_lang=source_language.slug,
+                                    target_lang=target_language_key,
+                                    tag_handling="html",
+                                    glossary=glossary,
+                                )
                             )
                         except DeepLException:
                             messages.error(

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -2608,6 +2608,16 @@ msgstr "Region"
 msgid "creation date"
 msgstr "Erstellungsdatum"
 
+#: cms/models/abstract_content_model.py
+msgid "do not translate the title"
+msgstr "Titel nicht übersetzen"
+
+#: cms/models/abstract_content_model.py
+msgid ""
+"Tick if you do not want to translate the title by automatic translation."
+msgstr ""
+"Kreuzen Sie an, wenn Sie den Titel nicht übersetzen wollen."
+
 #: cms/models/abstract_content_translation.py
 #: cms/models/push_notifications/push_notification_translation.py
 msgid "title"

--- a/integreat_cms/release_notes/current/unreleased/2311.yml
+++ b/integreat_cms/release_notes/current/unreleased/2311.yml
@@ -1,0 +1,2 @@
+en: Add the option to not translate the title of content
+de: Füge die Option hinzu, den Titel des Inhalts nicht zu übersetzen


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds an option to not translate the title of page/event/poi.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add a new field `do_not_translate_title` into `AbstractContentModel`
- Add a new check box to the side bar in the form.
- Skip Deepl/Googl API call if `do_not_translate_title = True`
- Add a test

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- Should be none 🙈 
- I decided for adding `do_not_translate_title` to the content model, not the translation model or the translation form, considering this is rather a characteistic set per content: I don't think it is usually the case that users want to translate a title into some languages but not into others. Another reason is to save the effort on user side: deciding for each language whether or not translate the title or clicking at least one more checkbox to check/uncheck all the languages would be too much work (many regions have a lot of languages). We could implement per-language flagging if wished later.
- No change for Textlab API, as it is not translating the title.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2311 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
