### PR TITLE
Catch error when translating links into unsupprted languages

### DIFF
--- a/integreat_cms/cms/utils/internal_link_utils.py
+++ b/integreat_cms/cms/utils/internal_link_utils.py
@@ -52,9 +52,17 @@ def update_link(
     if not (source_translation := get_public_translation_for_link(current_url)):
         return None
 
-    if target_translation := source_translation.foreign_object.get_public_translation(
-        target_language_slug,
-    ):
+    try:
+        target_translation = source_translation.foreign_object.get_public_translation(
+            target_language_slug
+        )
+    except KeyError:
+        logger.exception(
+            "Could not resolve link translation due to missing language %s.",
+            target_language_slug,
+        )
+        return source_translation.full_url, source_translation.link_title
+    if target_translation:
         # Always use the full url, even if the url was previously a short url
         fixed_link = target_translation.full_url
 


### PR DESCRIPTION
### Short description
When translating links of other regions, not all languages are supported by the other region. This can result in an `KeyError: 'ar'`, see https://chat.tuerantuer.org/digitalfabrik/threads/c9iytpszs7dz3mdtdrhq47raro
This seems to happen for location objects only right now, pages do not seem to be a problem. Nonetheless it probably does not hurt to introduce some general error handling that keeps the original URL if it cannot be updated.

### Proposed changes
- Catch error and keep original URL


### Side effects
- URLs in translations will keep the original link target.


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
