### PR TITLE
Chatbot typing indicator

### DIFF
--- a/integreat_cms/api/v3/chat/utils/chat_bot.py
+++ b/integreat_cms/api/v3/chat/utils/chat_bot.py
@@ -108,6 +108,7 @@ def process_user_message(
     """
     region = Region.objects.get(slug=region_slug)
     zammad_chat = UserChat.objects.get(zammad_id=zammad_ticket_id, region=region)
+    zammad_chat.processing_answer = True
     # Prevent a race condition where new articles can be added to a ticket
     # while the webhook has not yet sent to and processed by the Integreat CMS
     messages = [
@@ -139,6 +140,7 @@ def process_user_message(
                 automatic_message=True,
             )
             zammad_chat.save_automatic_answers(answer["automatic_answers"])
+    zammad_chat.processing_answer = False
 
 
 async def async_process_translate(

--- a/integreat_cms/cms/models/chat/user_chat.py
+++ b/integreat_cms/cms/models/chat/user_chat.py
@@ -132,6 +132,7 @@ class UserChat(AbstractBaseModel, ZammadAPI):
         response = {
             "messages": list(self.messages),
             "evaluation_consent": bool(self.evaluation_consent),
+            "chatbot_typing": bool(self.processing_answer),
         }
         if self.region is not None:
             response["ticket_url"] = (

--- a/integreat_cms/cms/utils/zammad.py
+++ b/integreat_cms/cms/utils/zammad.py
@@ -252,3 +252,17 @@ class ZammadAPI:
                 "customer": self.get_zammad_user_mail(),
             },
         ).json()["id"]
+
+    @property
+    def processing_answer(self) -> None:
+        """
+        Indicate that an answer is currently being generated.
+        """
+        return cache.get(f"generating_answer_{self.device_id}", False)
+
+    @processing_answer.setter
+    def processing_answer(self, processing: bool) -> None:
+        """
+        Set the processing indicator in the cache
+        """
+        cache.set(f"generating_answer_{self.device_id}", processing, 120)


### PR DESCRIPTION
### Short description
This PR introduces a `chatbot_typing` attribute to the chat API endpoint. While the chat bot is generating an answer, a cache item is set and unset when the bot is finished. While the cache item is set to true, the API returns a `"chatbot_typing": true`, otherwise the value will be `false`

### Side effects
- None, I hope


### Resolved issues

Fixes: https://github.com/digitalfabrik/integreat-chat/issues/316


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
