### PR TITLE
Remove Chat body attribute

### DIFF
--- a/integreat_cms/cms/utils/zammad.py
+++ b/integreat_cms/cms/utils/zammad.py
@@ -108,7 +108,6 @@ class ZammadAPI:
             "status",
             "error",
             "id",
-            "body",
             "user_is_author",
             "automatic_answer",
             "role",


### PR DESCRIPTION
### Short description
To be more OpenAI like in our API, we replaced the body with a content attribute. The app will implement this with https://github.com/digitalfabrik/integreat-app/pull/3175


### Proposed changes
- Remove the legacy body attribute.


### Side effects
- API clients relying on the body attribute will break. As this never was production ready, it is acceptable.


### Resolved issues

Fixes: https://github.com/digitalfabrik/integreat-chat/issues/250


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
