### PR TITLE
Do not count excluded content attributes towards translation budget

### DIFF
--- a/integreat_cms/cms/constants/machine_translatable_attributes.py
+++ b/integreat_cms/cms/constants/machine_translatable_attributes.py
@@ -1,0 +1,5 @@
+"""
+This module defines all attributes which can be machine-translated.
+"""
+
+TRANSLATABLE_ATTRIBUTES = ["title", "content", "meta_description"]

--- a/integreat_cms/cms/templates/_machine_translation_overlay.html
+++ b/integreat_cms/cms/templates/_machine_translation_overlay.html
@@ -44,7 +44,7 @@
                              class="hidden bg-red-100 border-l-4 border-red-500 text-red-700 px-4 py-3 mb-5">
                             {% if source_language.slug in textlab_languages %}
                                 {% blocktranslate trimmed with hix_threshold=hix_threshold|floatformat:0 %}
-                                    None of the selected {{ content_type }} fullfills the required HIX score of {{ hix_threshold }}.
+                                    None of the selected {{ content_type }} fulfills the required HIX score of {{ hix_threshold }}.
                                 {% endblocktranslate %}
                             {% else %}
                                 {% blocktranslate trimmed %}

--- a/integreat_cms/cms/views/utils/machine_translations.py
+++ b/integreat_cms/cms/views/utils/machine_translations.py
@@ -61,18 +61,18 @@ def build_json_for_machine_translation(
     source_language = request.region.get_source_language(language_slug)
 
     for content in selected_content:
+        source_translation = content.get_translation(source_language.slug)
+
         content.translatable_attributes = [
-            (attr, getattr(content.source_translation, attr))
+            (attr, getattr(source_translation, attr))
             for attr in TRANSLATABLE_ATTRIBUTES
-            if hasattr(content.source_translation, attr)
-            and getattr(content.source_translation, attr)
+            if hasattr(source_translation, attr)
+            and getattr(source_translation, attr)
             and not (content.do_not_translate_title and attr == "title")
         ]
         words = word_count(
             content.translatable_attributes,
         )
-
-        source_translation = content.get_translation(source_language.slug)
 
         if source_translation and check_hix_score(
             request,

--- a/integreat_cms/cms/views/utils/machine_translations.py
+++ b/integreat_cms/cms/views/utils/machine_translations.py
@@ -10,7 +10,9 @@ from typing import TYPE_CHECKING
 
 from django.http import JsonResponse
 
+from ....core.utils.word_count import word_count
 from ....textlab_api.utils import check_hix_score
+from ...constants.machine_translatable_attributes import TRANSLATABLE_ATTRIBUTES
 from ...models import Event, Page, POI
 
 if TYPE_CHECKING:
@@ -59,13 +61,18 @@ def build_json_for_machine_translation(
     source_language = request.region.get_source_language(language_slug)
 
     for content in selected_content:
-        source_translation = content.get_translation(source_language.slug)
-        words = (
-            len(source_translation.content.split())
-            + len(source_translation.title.split())
-            if source_translation
-            else 0
+        content.translatable_attributes = [
+            (attr, getattr(content.source_translation, attr))
+            for attr in TRANSLATABLE_ATTRIBUTES
+            if hasattr(content.source_translation, attr)
+            and getattr(content.source_translation, attr)
+            and not (content.do_not_translate_title and attr == "title")
+        ]
+        words = word_count(
+            content.translatable_attributes,
         )
+
+        source_translation = content.get_translation(source_language.slug)
 
         if source_translation and check_hix_score(
             request,

--- a/integreat_cms/core/utils/machine_translation_api_client.py
+++ b/integreat_cms/core/utils/machine_translation_api_client.py
@@ -259,7 +259,6 @@ class MachineTranslationApiClient(ABC):
             content_object.existing_target_translation = content_object.get_translation(
                 self.target_language.slug,
             )
-            content_object.word_count = word_count(content_object.source_translation)
             content_object.translatable_attributes = [
                 (attr, getattr(content_object.source_translation, attr))
                 for attr in self.translatable_attributes
@@ -267,6 +266,9 @@ class MachineTranslationApiClient(ABC):
                 and getattr(content_object.source_translation, attr)
                 and not (content_object.do_not_translate_title and attr == "title")
             ]
+            content_object.word_count = word_count(
+                content_object.translatable_attributes,
+            )
 
     def mark_successful(self, content_object: Event | Page | POI) -> None:
         """

--- a/integreat_cms/core/utils/machine_translation_api_client.py
+++ b/integreat_cms/core/utils/machine_translation_api_client.py
@@ -14,6 +14,7 @@ from django.contrib import messages
 from django.db import transaction
 from django.utils.translation import ngettext_lazy
 
+from ...cms.constants.machine_translatable_attributes import TRANSLATABLE_ATTRIBUTES
 from ...cms.utils.stringify_list import iter_to_string
 from ...textlab_api.utils import check_hix_score
 from .word_count import word_count
@@ -67,7 +68,7 @@ class MachineTranslationApiClient(ABC):
         self.request = request
         self.region = request.region
         self.form_class = form_class
-        self.translatable_attributes = ["title", "content", "meta_description"]
+        self.translatable_attributes = TRANSLATABLE_ATTRIBUTES
 
     def reset(self) -> None:
         """

--- a/integreat_cms/core/utils/word_count.py
+++ b/integreat_cms/core/utils/word_count.py
@@ -1,29 +1,22 @@
 from __future__ import annotations
 
 from html import unescape
-from typing import TYPE_CHECKING
 
 from django.utils.html import strip_tags
 
-if TYPE_CHECKING:
-    from ...cms.models import EventTranslation, PageTranslation, POITranslation
-
 
 def word_count(
-    translation: EventTranslation | (PageTranslation | POITranslation | None),
+    attributes_to_translate: list[tuple[str, str]],
 ) -> int:
     """
     This function counts the number of words in a content translation
     """
-    if not translation:
+    if not attributes_to_translate:
         return 0
 
-    attributes = [
-        getattr(translation, attr, None)
-        for attr in ["title", "content", "meta_description"]
+    content_to_translate = [
+        unescape(strip_tags(attr)) for (_, attr) in attributes_to_translate
     ]
-
-    content_to_translate = [unescape(strip_tags(attr)) for attr in attributes if attr]
     content_to_translate_str = " ".join(content_to_translate)
     for char in "-;:,;!?\n":
         content_to_translate_str = content_to_translate_str.replace(char, " ")

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -4715,7 +4715,7 @@ msgstr "Zu übersetzende %(content_type)s"
 #: cms/templates/_machine_translation_overlay.html
 #, python-format
 msgid ""
-"None of the selected %(content_type)s fullfills the required HIX score of "
+"None of the selected %(content_type)s fulfills the required HIX score of "
 "%(hix_threshold)s."
 msgstr ""
 "Keine der ausgewählten %(content_type)s erfüllt den benötigten HIX-Wert von "

--- a/tests/mt_api/utils.py
+++ b/tests/mt_api/utils.py
@@ -50,7 +50,7 @@ def get_word_count(
     """
     words = 0
     for translation in translations:
-        words += word_count(translation)
+        words += word_count([("", translation.title), ("", translation.content)])
     return words
 
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

Just noticed that content object attributes which get excluded from translation (currently, mostly titles, but maybe more in the future?) were still being counted towards the translation budget, because the `word_count` function used a hardcoded attribute list. 

### Proposed changes
<!-- Describe this PR in more detail. -->

- pass content object specific list of "wanted" attributes to that function
- 


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none, I think
- 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: n/a


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
