### PR TITLE
Explicitely configure trusted source IP header

### DIFF
--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -206,6 +206,13 @@ BACKGROUND_TASKS_ENABLED = bool(
 #: The tag that events from external calendars need to get imported
 EXTERNAL_CALENDAR_CATEGORY: Final[str] = BRANDING
 
+#: HTTP Header that contains the client IP. This can be used behind reverse proxies
+#: Important: Use Django Header notiation, example: HTTP_X_FORWARDED_FOR. Ensure that
+#: this header cannot be sent by clients.
+TRUSTED_IP_HEADER: Final[str | None] = os.environ.get(
+    "INTEGREAT_CMS_TRUSTED_IP_HEADER", None
+)
+
 ##############################################################
 # Firebase Push Notifications (Firebase Cloud Messaging FCM) #
 ##############################################################


### PR DESCRIPTION
### Short description
@charludo was right all along. We should play it safe an assume that admins do not configure the CMS correctly.

### Proposed changes
- Do not trust the `X-Forwarded-For` header by default.
- Do not manually serialize list of timestamps into string as the cache can directly work with lists.

### Side effects
- Admins have to configure the trusted source IP header explicitly in the CMS and web server. 


### Resolved issues
Fixes: https://github.com/digitalfabrik/integreat-chat/issues/320


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
