### PR TITLE
Update contact cards when the related POI is updated with a new address

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/3574.yml
+++ b/integreat_cms/release_notes/current/unreleased/3574.yml
@@ -1,0 +1,2 @@
+en: Update contact cards in contents when the referenced POI received a new address
+de: Aktualisiere Kontaktkarten in den Inhalten, wenn der verwendete Ort eine neue Adresse erhalten hat


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the bug that contact cards are not updated and still show the old address when the related POI is updated with a new address.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Send post save signal to trigger the contact card update function, if a POI is changed with a new address and there are cotnacts referring this POI.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- Should be none
- 


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3574 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
