### PR TITLE
Set poi instance to none

### DIFF
--- a/integreat_cms/cms/views/pois/poi_form_ajax_view.py
+++ b/integreat_cms/cms/views/pois/poi_form_ajax_view.py
@@ -8,8 +8,8 @@ from django.template.loader import render_to_string
 from django.views.generic import TemplateView
 
 from ...forms import POIForm, POITranslationForm
-from ...models import Language, POITranslation
-from ...models.pois.poi import get_default_opening_hours, POI
+from ...models import Language
+from ...models.pois.poi import get_default_opening_hours
 from .poi_context_mixin import POIContextMixin
 
 if TYPE_CHECKING:
@@ -63,19 +63,13 @@ class POIFormAjaxView(TemplateView, POIContextMixin):
         language_slug = kwargs.get("language_slug")
         language = get_object_or_404(Language, slug=language_slug)
 
-        poi_instance = POI.objects.filter(id=None).first()
-        poi_translation_instance = POITranslation.objects.filter(
-            poi=poi_instance,
-            language=language,
-        ).first()
-
         data = request.POST.dict()
         data["opening_hours"] = get_default_opening_hours()
 
         poi_form = POIForm(
             data=data,
             files=request.FILES,
-            instance=poi_instance,
+            instance=None,
             additional_instance_attributes={
                 "region": region,
             },
@@ -83,7 +77,7 @@ class POIFormAjaxView(TemplateView, POIContextMixin):
 
         poi_translation_form = POITranslationForm(
             data=request.POST,
-            instance=poi_translation_instance,
+            instance=None,
             additional_instance_attributes={
                 "creator": request.user,
                 "language": language,


### PR DESCRIPTION
### Short description

As a code enhancement, we do not filte for poi_instance anymore inside the ajax form, since it is always none.


### Proposed changes

- no more filtering for poi_instance (and poi_translation_instance respectively) since it is always None


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none



### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3359 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
