### PR TITLE
Re-add warning for mobile phone

### DIFF
--- a/integreat_cms/cms/templates/ajax_contact_form/_contact_form_widget.html
+++ b/integreat_cms/cms/templates/ajax_contact_form/_contact_form_widget.html
@@ -36,7 +36,19 @@
     <label for="{{ contact_form.mobile_phone_number.id_for_label }}">
         {{ contact_form.mobile_phone_number.label }}
     </label>
-    {% render_field contact_form.mobile_phone_number|append_attr:"form:ajax_contact_form" %}
+    <div class="bg-yellow-100 border-l-4 border-yellow-500 text-orange-700 px-4 py-3 mb-5">
+        <p>
+            {% translate "Currently, the mobile phone number is not displayed in the Integreat App. You can find more information in the" %}
+            <a class="text-blue-500 underline"
+               href="https://wiki.integreat-app.de/kontakte-modul"
+               target="_blank">Wiki</a>.
+        </p>
+    </div>
+    {% if poi_id %}
+        {% render_field contact_form.mobile_phone_number|append_attr:"form:ajax_contact_form" %}
+    {% else %}
+        {% render_field contact_form.mobile_phone_number %}
+    {% endif %}
     <label for="{{ contact_form.website.id_for_label }}">
         {{ contact_form.website.label }}
     </label>

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -5004,6 +5004,15 @@ msgstr "Automatisch den Titel des verlinkten Inhalts als Linktext verwenden"
 msgid "Media Library..."
 msgstr "Medienbibliothek..."
 
+#: cms/templates/ajax_contact_form/_contact_form_widget.html
+#: cms/templates/contacts/contact_form.html
+msgid ""
+"Currently, the mobile phone number is not displayed in the Integreat App. "
+"You can find more information in the"
+msgstr ""
+"Aktuell wird die Mobiltelefonnummer nicht in der Integreat App angezeigt. "
+"Mehr Informationen finden Sie im"
+
 #: cms/templates/ajax_poi_form/_poi_address_container.html
 #: cms/templates/pois/poi_form_sidebar/position_box.html
 msgid "Address"
@@ -5407,14 +5416,6 @@ msgstr ""
 #: cms/templates/contacts/contact_form.html
 msgid "At least one field must be filled."
 msgstr "Es muss mindestens ein Feld ausgefüllt werden."
-
-#: cms/templates/contacts/contact_form.html
-msgid ""
-"Currently, the mobile phone number is not displayed in the Integreat App. "
-"You can find more information in the"
-msgstr ""
-"Aktuell wird die Mobiltelefonnummer nicht in der Integreat App angezeigt. "
-"Mehr Informationen finden Sie im"
 
 #: cms/templates/contacts/contact_form.html
 msgid "Contact information"
@@ -11847,7 +11848,6 @@ msgstr ""
 
 #~ msgid "Croatian"
 #~ msgstr "Kroatisch"
-
 
 #~ msgid "Italian"
 #~ msgstr "Italienisch"

--- a/integreat_cms/release_notes/current/unreleased/3591.yml
+++ b/integreat_cms/release_notes/current/unreleased/3591.yml
@@ -1,0 +1,2 @@
+en: Fix typo in contact form
+de: Korrigiere einen Tippfehler im Kontaktformular


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
First of all, sorry for this back and forth on my side. This PR re-adds the warning shown to users of the CMS that the mobile phone number is not yet shown in the app. Why? I removed the warning because I thought that with the changes in the API the mobile phone number would of course magically show up the second after in the apps. Well yes, no, actual people need to work on this. So therefore let's add this warning until this feature is done in the app-team. I will get notified by them in a channel and will remove the warning then. 

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add release note for correcting the typo in the mobile phone number warning
- Re-adding the warning to develop


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

None?


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: -


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
