### PR TITLE
Disable Matomo tracking for test servers

### DIFF
--- a/integreat_cms/api/decorators.py
+++ b/integreat_cms/api/decorators.py
@@ -175,6 +175,7 @@ def matomo_tracking(func: Callable) -> Callable:
         """
         if (
             not settings.MATOMO_TRACKING
+            or settings.TEST
             or not request.region.matomo_id
             or not request.region.matomo_token
             or "HTTP_X_INTEGREAT_DEVELOPMENT" in request.META


### PR DESCRIPTION
### Short description
Test servers should never track any API hits in Matomo.


### Proposed changes
- Check if `settings.TEST` flag is set and quit the tracking decorator function.


### Side effects
- N/A

### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
