### PR TITLE
Hide page based statistics

### DIFF
--- a/integreat_cms/cms/constants/roles.py
+++ b/integreat_cms/cms/constants/roles.py
@@ -206,7 +206,10 @@ SERVICE_TEAM_PERMISSIONS: Final[list[str]] = [
 ]
 
 #: The permissions of the cms team
-CMS_TEAM_PERMISSIONS: Final[list[str]] = SERVICE_TEAM_PERMISSIONS
+CMS_TEAM_PERMISSIONS: Final[list[str]] = [
+    *SERVICE_TEAM_PERMISSIONS,
+    "view_page_based_statistics",
+]
 
 #: The permissions of all roles
 PERMISSIONS: Final[dict[str, list[str]]] = {

--- a/integreat_cms/cms/fixtures/test_roles.json
+++ b/integreat_cms/cms/fixtures/test_roles.json
@@ -221,7 +221,8 @@
         ["view_statistics", "cms", "user"],
         ["view_translation_report", "cms", "user"],
         ["view_user", "cms", "user"],
-        ["test_beta_features", "cms", "user"]
+        ["test_beta_features", "cms", "user"],
+        ["view_page_based_statistics", "cms", "user"]
       ]
     }
   },

--- a/integreat_cms/cms/migrations/0127_hide_page_based_statistics.py
+++ b/integreat_cms/cms/migrations/0127_hide_page_based_statistics.py
@@ -1,0 +1,62 @@
+from django.apps.registry import Apps
+from django.core.management.sql import emit_post_migrate_signal
+from django.db import migrations
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+
+from integreat_cms.cms.constants import roles
+
+
+def update_roles(
+    apps: Apps,
+    _schema_editor: BaseDatabaseSchemaEditor,
+) -> None:
+    """
+    Add permissions for testing beta features
+    :param apps: The configuration of installed applications
+    """
+    Group = apps.get_model("auth", "Group")
+    Permission = apps.get_model("auth", "Permission")
+
+    # Emit post-migrate signal to make sure the Permission objects are created before they can be assigned
+    emit_post_migrate_signal(2, False, "default")
+
+    # Clear and update permissions according to new constants
+    for role_name in dict(roles.CHOICES):
+        group, _ = Group.objects.get_or_create(name=role_name)
+        # Clear permissions
+        group.permissions.clear()
+        # Set permissions
+        group.permissions.add(
+            *Permission.objects.filter(codename__in=roles.PERMISSIONS[role_name]),
+        )
+
+
+class Migration(migrations.Migration):
+    """
+    Migration file for adding permissions to test beta features
+    """
+
+    dependencies = [
+        ("cms", "0126_region_summ_ai_budget_used_and_more"),
+    ]
+
+    operations = [
+        migrations.AlterModelOptions(
+            name="user",
+            options={
+                "default_permissions": ("change", "delete", "view"),
+                "ordering": ["username"],
+                "permissions": (
+                    ("view_translation_report", "view_translation_report"),
+                    ("view_broken_links", "view_broken_links"),
+                    ("view_statistics", "view_statistics"),
+                    ("manage_translations", "manage_translations"),
+                    ("test_beta_features", "test_beta_features"),
+                    ("view_page_based_statistics", "view_page_based_statistics"),
+                ),
+                "verbose_name": "user",
+                "verbose_name_plural": "users",
+            },
+        ),
+        migrations.RunPython(update_roles, migrations.RunPython.noop),
+    ]

--- a/integreat_cms/cms/models/users/user.py
+++ b/integreat_cms/cms/models/users/user.py
@@ -298,4 +298,5 @@ class User(AbstractUser, AbstractBaseModel):
             ("view_statistics", "view_statistics"),
             ("manage_translations", "manage_translations"),
             ("test_beta_features", "test_beta_features"),
+            ("view_page_based_statistics", "view_page_based_statistics"),
         )

--- a/integreat_cms/cms/templates/statistics/statistics_overview.html
+++ b/integreat_cms/cms/templates/statistics/statistics_overview.html
@@ -12,7 +12,7 @@
             <div class="pt-4 lg:pt-0 3xl:grid grid-cols-2 3xl:grid-cols-[minmax(0px,_1fr)_400px] 4xl:grid-cols-[minmax(0px,_1fr)_816px] gap-4">
                 <div class="flex flex-col flex-wrap col-span-1 3xl:col-span-1">
                     {% include "statistics/statistics_chart.html" with box_id="statistics_chart" %}
-                    {% if perms.cms.test_beta_features %}
+                    {% if perms.cms.view_page_based_statistics %}
                         {% include "statistics/statistics_viewed_pages.html" with box_id="statistics_viewed_pages" %}
                     {% endif %}
                 </div>
@@ -21,7 +21,7 @@
                 </div>
             </div>
         </div>
-        {% if perms.cms.test_beta_features %}
+        {% if perms.cms.view_page_based_statistics %}
             {% include "../tutorials/page_access_statistics.html" with tutorial_id="page-access-statistics-info" hidden=tutorial_seen %}
         {% endif %}
     {% endblock content %}


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
After merging #3325 and introducing a first iteration of page based statistics, we discovered problems with loading data from matomo which can lead to crashing the server. To avoid this from accidentally happening this PR hides the page based statistics for the service team until the problems are fixed.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Introduce `view_page_based_statistics` permission and hide the page based statistics box behind it


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- We as CMS Team will still be able access the page based statistics on production after the upcoming release. It's probably a good idea for us as CMS Team to avoid the statistics section on production as much as possible.


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: n.a.


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
