### PR TITLE
Add option to archive push notifications

### DIFF
--- a/integreat_cms/cms/constants/roles.py
+++ b/integreat_cms/cms/constants/roles.py
@@ -105,6 +105,7 @@ EDITOR_PERMISSIONS: Final[list[str]] = [
 #: The permissions of the management role
 MANAGEMENT_PERMISSIONS: Final[list[str]] = [
     *EDITOR_PERMISSIONS,
+    "archive_pushnotification",
     "change_feedback",
     "change_imprintpage",
     "change_organization",
@@ -175,6 +176,7 @@ APP_TEAM_PERMISSIONS: Final[list[str]] = [
 #: The permissions of the service team
 SERVICE_TEAM_PERMISSIONS: Final[list[str]] = [
     *APP_TEAM_PERMISSIONS,
+    "archive_pushnotification",
     "change_externalcalendar",
     "change_language",
     "change_languagetreenode",

--- a/integreat_cms/cms/forms/push_notifications/push_notification_form.py
+++ b/integreat_cms/cms/forms/push_notifications/push_notification_form.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
     from django.db.models.query import QuerySet
 
-    from ..models import Region
+    from ...models import Region
 
 
 class PushNotificationForm(CustomModelForm):

--- a/integreat_cms/cms/migrations/0132_archive_pushnotification.py
+++ b/integreat_cms/cms/migrations/0132_archive_pushnotification.py
@@ -1,0 +1,63 @@
+from django.apps.registry import Apps
+from django.core.management.sql import emit_post_migrate_signal
+from django.db import migrations, models
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+
+from integreat_cms.cms.constants import roles
+
+
+def update_roles(
+    apps: Apps,
+    _schema_editor: BaseDatabaseSchemaEditor,
+) -> None:
+    """
+    Update translation settings permissions
+
+    :param apps: The configuration of installed applications
+    """
+    Group = apps.get_model("auth", "Group")
+    Permission = apps.get_model("auth", "Permission")
+
+    # Emit post-migrate signal to make sure the Permission objects are created before they can be assigned
+    emit_post_migrate_signal(2, False, "default")
+
+    # Assign the correct permissions
+    for role_name in dict(roles.CHOICES):
+        group, _ = Group.objects.get_or_create(name=role_name)
+        # Clear permissions
+        group.permissions.clear()
+        # Set permissions
+        group.permissions.add(
+            *Permission.objects.filter(codename__in=roles.PERMISSIONS[role_name]),
+        )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("cms", "0131_add_automatical_feedback_to_searchresultfeedback"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="pushnotification",
+            name="archived",
+            field=models.BooleanField(
+                default=False,
+                help_text="Whether or not the push notification is read-only and hidden in the API.",
+                verbose_name="archived",
+            ),
+        ),
+        migrations.AlterModelOptions(
+            name="pushnotification",
+            options={
+                "default_permissions": ("change", "delete", "view", "archive"),
+                "ordering": ["-created_date"],
+                "permissions": (
+                    ("send_push_notification", "Can send push notification"),
+                ),
+                "verbose_name": "push notification",
+                "verbose_name_plural": "push notifications",
+            },
+        ),
+        migrations.RunPython(update_roles, migrations.RunPython.noop),
+    ]

--- a/integreat_cms/cms/models/push_notifications/push_notification.py
+++ b/integreat_cms/cms/models/push_notifications/push_notification.py
@@ -82,6 +82,13 @@ class PushNotification(AbstractBaseModel):
         verbose_name=_("News template name"),
         help_text=_("Provide a distinct name for the template"),
     )
+    archived = models.BooleanField(
+        default=False,
+        verbose_name=_("archived"),
+        help_text=_(
+            "Whether or not the push notification is read-only and hidden in the API."
+        ),
+    )
 
     @cached_property
     def languages(self) -> QuerySet[Language]:
@@ -184,13 +191,27 @@ class PushNotification(AbstractBaseModel):
         """
         return f"<PushNotification (id: {self.id}, channel: {self.channel!r}, regions: {self.regions.values_list('slug', flat=True)})>"
 
+    def archive(self) -> None:
+        """
+        Archives the contact
+        """
+        self.archived = True
+        self.save()
+
+    def restore(self) -> None:
+        """
+        Restores the contact
+        """
+        self.archived = False
+        self.save()
+
     class Meta:
         #: The verbose name of the model
         verbose_name = _("push notification")
         #: The plural verbose name of the model
         verbose_name_plural = _("push notifications")
         #: The default permissions for this model
-        default_permissions = ("change", "delete", "view")
+        default_permissions = ("change", "delete", "view", "archive")
         #: The custom permissions for this model
         permissions = (("send_push_notification", "Can send push notification"),)
         #: The fields which are used to sort the returned objects of a QuerySet

--- a/integreat_cms/cms/templates/push_notifications/push_notification_form.html
+++ b/integreat_cms/cms/templates/push_notifications/push_notification_form.html
@@ -46,24 +46,26 @@
                             {# BUTTONS FOR NEWS #}
                             <a href="{% url 'push_notifications' region_slug=request.region.slug %}"
                                class="btn btn-ghost">{% translate "Cancel" %}</a>
-                            <button name="submit_draft" class="btn btn-outline">
-                                {% translate "Save as draft" %}
-                            </button>
-                            {% if push_notification_form.instance.sent_date %}
-                                <button name="submit_update" class="btn">
-                                    {% translate "Update" %}
+                            {% if not push_notification_form.instance.archived %}
+                                <button name="submit_draft" class="btn btn-outline">
+                                    {% translate "Save as draft" %}
                                 </button>
-                            {% elif perms.cms.send_push_notification %}
-                                <div id="button_submit_send">
-                                    <button name="submit_send"
-                                            class="btn {% if push_notification_form.instance.scheduled_send_date %}hidden{% endif %}">
-                                        {% translate "Save & Send" %}
+                                {% if push_notification_form.instance.sent_date %}
+                                    <button name="submit_update" class="btn">
+                                        {% translate "Update" %}
                                     </button>
-                                    <button name="submit_schedule"
-                                            class="btn {% if not push_notification_form.instance.scheduled_send_date %}hidden{% endif %}">
-                                        {% translate "Save & Schedule" %}
-                                    </button>
-                                </div>
+                                {% elif perms.cms.send_push_notification %}
+                                    <div id="button_submit_send">
+                                        <button name="submit_send"
+                                                class="btn {% if push_notification_form.instance.scheduled_send_date %}hidden{% endif %}">
+                                            {% translate "Save & Send" %}
+                                        </button>
+                                        <button name="submit_schedule"
+                                                class="btn {% if not push_notification_form.instance.scheduled_send_date %}hidden{% endif %}">
+                                            {% translate "Save & Schedule" %}
+                                        </button>
+                                    </div>
+                                {% endif %}
                             {% endif %}
                         {% endif %}
                     {% endif %}

--- a/integreat_cms/cms/templates/push_notifications/push_notification_list.html
+++ b/integreat_cms/cms/templates/push_notifications/push_notification_list.html
@@ -4,15 +4,38 @@
 {% load push_notification_filters %}
 {% block content %}
     <div class="table-header">
-        <h1 class="heading">
-            {% translate "News" %}
-        </h1>
+        <div class="flex flex-wrap justify-between">
+            <h1 class="heading">
+                {% if is_archived %}
+                    {% translate "Archived news" %}
+                {% else %}
+                    {% translate "News" %}
+                {% endif %}
+            </h1>
+            <div class="flex gap-4">
+                {% if is_archived %}
+                    <a href="{% url 'push_notifications' region_slug=request.region.slug %}"
+                       class="font-bold text-sm text-gray-800 flex items-center gap-1 pb-3 hover:underline">
+                        <span><i icon-name="book-open" class="align-top h-5"></i> {% translate "Back to news" %}</span>
+                    </a>
+                {% else %}
+                    <a href="{% url 'archived_push_notifications' region_slug=request.region.slug language_slug=language.slug %}"
+                       class="font-bold text-sm text-gray-800 flex items-center pb-3 hover:underline">
+                        <span>
+                            <i icon-name="archive" class="align-top h-5"></i>
+                            {% translate "Archived news" %}
+                            ({{ archived_count }})
+                        </span>
+                    </a>
+                {% endif %}
+            </div>
+        </div>
         <div class="flex flex-wrap justify-between gap-4">
             <div class="flex flex-wrap gap-4">
                 {% include "generic_language_switcher.html" with target="push_notifications" %}
                 {% include "search_input_form.html" with object_type="push_notification" language_slug=language.slug %}
             </div>
-            {% if perms.cms.change_pushnotification %}
+            {% if perms.cms.change_pushnotification and not is_archived %}
                 <div class="flex flex-wrap gap-4">
                     <a href="{% url 'push_notifications_templates' region_slug=request.region.slug language_slug=language.slug %}"
                        class="btn btn-outline">
@@ -27,9 +50,15 @@
         </div>
     </div>
     <div class="table-listing">
+        <form id="bulk-action-form" method="post">
+            {% csrf_token %}
+        </form>
         <table class="w-full mt-4 rounded border border-solid border-gray-200 shadow bg-white">
             <thead>
                 <tr class="border-b border-solid border-gray-200">
+                    <th class="py-3 pl-4 min">
+                        <input form="bulk-action-form" type="checkbox" id="bulk-select-all" />
+                    </th>
                     <th class="text-sm text-left uppercase py-3 pl-4 pr-2">
                         {% translate "Title" %}
                     </th>
@@ -59,6 +88,9 @@
                     <th class="text-sm text-left uppercase py-3 px-2 min">
                         {% translate "Sent" %}
                     </th>
+                    <th class="text-sm text-left uppercase py-3 px-2 min">
+                        {% translate "Options" %}
+                    </th>
                 </tr>
             </thead>
             <tbody>
@@ -68,10 +100,18 @@
                 {% empty %}
                     <tr>
                         <td colspan="4" class="px-4 py-3">
-                            {% if search_query %}
-                                {% translate "No push notifications found with these filters." %}
+                            {% if is_archived %}
+                                {% if search_query %}
+                                    {% translate "No archived push notifications found with these filters." %}
+                                {% else %}
+                                    {% translate "No push notifications archived yet." %}
+                                {% endif %}
                             {% else %}
-                                {% translate "No push notifications available yet." %}
+                                {% if search_query %}
+                                    {% translate "No push notifications found with these filters." %}
+                                {% else %}
+                                    {% translate "No push notifications available yet." %}
+                                {% endif %}
                             {% endif %}
                         </td>
                     </tr>
@@ -79,6 +119,35 @@
             </tbody>
         </table>
     </div>
+    {% if push_notifications %}
+        <div class="pt-2 px-2">
+            <div class="inline">
+                <span class="text-gray-800 font-bold" data-list-selection-count>0</span> <span class="text-gray-600">{% translate "Push notifications selected" %}</span>
+            </div>
+        </div>
+    {% endif %}
+    {% if perms.cms.archive_pushnotification %}
+        <div class="flex flex-wrap gap-2 mt-4">
+            <select id="bulk-action" class="w-auto max-w-full">
+                <option>
+                    {% translate "Select bulk action" %}
+                </option>
+                {% if is_archived %}
+                    <option data-bulk-action="{% url "bulk_restore_push_notifications" region_slug=request.region.slug language_slug=language.slug %}">
+                        {% translate "Restore push notifications" %}
+                    </option>
+                {% else %}
+                    <option data-bulk-action="{% url "bulk_archive_push_notifications" region_slug=request.region.slug language_slug=language.slug %}">
+                        {% translate "Archive push notifications" %}
+                    </option>
+                {% endif %}
+            </select>
+            <button form="bulk-action-form" id="bulk-action-execute" class="btn" disabled>
+                {% translate "Execute" %}
+            </button>
+        </div>
+    {% endif %}
+    {% include "../generic_confirmation_dialog.html" %}
     {% url "push_notifications" as url %}
     {% include "pagination.html" with chunk=push_notifications %}
 {% endblock content %}

--- a/integreat_cms/cms/templates/push_notifications/push_notification_list_row.html
+++ b/integreat_cms/cms/templates/push_notifications/push_notification_list_row.html
@@ -1,5 +1,12 @@
 {% load i18n %}
 <tr class="border-t border-solid border-gray-200 hover:bg-gray-100">
+    <td class="py-3 pl-4">
+        <input type="checkbox"
+               name="selected_ids[]"
+               value="{{ push_notification.id }}"
+               form="bulk-action-form"
+               class="bulk-select-item" />
+    </td>
     <td class="pl-2">
         <a title="{% if push_notification_translation.title %} {{ push_notification_translation.title }}{% endif %}"
            href="{% url 'edit_push_notification' push_notification_id=push_notification.id region_slug=request.region.slug language_slug=language.slug %}"
@@ -58,6 +65,29 @@
             <i icon-name="x" class="text-red-500 align-text-top"></i> {% translate "Message is overdue and will not be sent" %}
         {% else %}
             <i icon-name="x" class="text-red-500 align-text-top"></i> {% translate "Message not sent yet" %}
+        {% endif %}
+    </td>
+    <td>
+        {% if is_archived %}
+            {% if perms.cms.archive_pushnotification %}
+                <button title="{% translate "Restore push notification" %}"
+                        class="confirmation-button btn-icon"
+                        data-confirmation-title="{% trans "Please confirm that you really want to restore this push notification" %}"
+                        data-confirmation-subject="{{ push_notification.title }}"
+                        data-action="{% url 'restore_push_notification' push_notification_id=push_notification.id region_slug=request.region.slug language_slug=language.slug %}">
+                    <i icon-name="refresh-ccw"></i>
+                </button>
+            {% endif %}
+        {% else %}
+            {% if perms.cms.archive_pushnotification %}
+                <button title="{% translate "Archive push notification" %}"
+                        class="confirmation-button btn-icon"
+                        data-confirmation-title="{% trans "Please confirm that you really want to archive this push notification" %}"
+                        data-confirmation-subject="{{ push_notification.title }}"
+                        data-action="{% url 'archive_push_notification' push_notification_id=push_notification.id region_slug=request.region.slug language_slug=language.slug %}">
+                    <i icon-name="archive"></i>
+                </button>
+            {% endif %}
         {% endif %}
     </td>
 </tr>

--- a/integreat_cms/cms/urls/protected.py
+++ b/integreat_cms/cms/urls/protected.py
@@ -26,6 +26,7 @@ from ..models import (
     Page,
     POI,
     POICategory,
+    PushNotification,
     Role,
 )
 from ..views import (
@@ -1614,6 +1615,27 @@ urlpatterns: list[URLPattern] = [
                                             name="push_notifications",
                                         ),
                                         path(
+                                            "archived/",
+                                            push_notifications.PushNotificationListView.as_view(
+                                                archived=True
+                                            ),
+                                            name="archived_push_notifications",
+                                        ),
+                                        path(
+                                            "bulk-archive/",
+                                            push_notifications.ArchivePushNotificationsBulkAction.as_view(
+                                                model=PushNotification,
+                                            ),
+                                            name="bulk_archive_push_notifications",
+                                        ),
+                                        path(
+                                            "bulk-restore/",
+                                            push_notifications.RestorePushNotificationsBulkAction.as_view(
+                                                model=PushNotification,
+                                            ),
+                                            name="bulk_restore_push_notifications",
+                                        ),
+                                        path(
                                             "templates/",
                                             push_notifications.PushNotificationListView.as_view(
                                                 templates=True,
@@ -1633,6 +1655,16 @@ urlpatterns: list[URLPattern] = [
                                                         "edit/",
                                                         push_notifications.PushNotificationFormView.as_view(),
                                                         name="edit_push_notification",
+                                                    ),
+                                                    path(
+                                                        "archive/",
+                                                        push_notifications.archive_push_notification,
+                                                        name="archive_push_notification",
+                                                    ),
+                                                    path(
+                                                        "restore/",
+                                                        push_notifications.restore_push_notification,
+                                                        name="restore_push_notification",
                                                     ),
                                                 ],
                                             ),

--- a/integreat_cms/cms/views/contacts/contact_context_mixin.py
+++ b/integreat_cms/cms/views/contacts/contact_context_mixin.py
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
 
 class ContactContextMixin(ContextMixin):
     """
-    This mixin provides extra context for language tree views
+    This mixin provides extra context for contacts.
     """
 
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:

--- a/integreat_cms/cms/views/push_notifications/__init__.py
+++ b/integreat_cms/cms/views/push_notifications/__init__.py
@@ -4,5 +4,13 @@ This package contains all views related to push notifications
 
 from __future__ import annotations
 
+from .push_notification_actions import (
+    archive_push_notification,
+    restore_push_notification,
+)
+from .push_notification_bulk_actions import (
+    ArchivePushNotificationsBulkAction,
+    RestorePushNotificationsBulkAction,
+)
 from .push_notification_form_view import PushNotificationFormView
 from .push_notification_list_view import PushNotificationListView

--- a/integreat_cms/cms/views/push_notifications/push_notification_actions.py
+++ b/integreat_cms/cms/views/push_notifications/push_notification_actions.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.contrib import messages
+from django.shortcuts import get_object_or_404, redirect
+from django.utils.translation import gettext_lazy as _
+
+from integreat_cms.cms.models.push_notifications.push_notification import (
+    PushNotification,
+)
+
+from ...decorators import permission_required
+
+if TYPE_CHECKING:
+    from django.http import HttpRequest, HttpResponseRedirect
+
+
+@permission_required("cms.archive_pushnotification")
+def archive_push_notification(
+    request: HttpRequest,
+    push_notification_id: int,
+    region_slug: str,
+    language_slug: str,
+) -> HttpResponseRedirect:
+    """
+    Method that archives a given push notification
+
+    :param request: The current request
+    :param push_notification_id: Id of the existing push notification that is supposed to be archived
+    :param region_slug: The slug of the current region
+    :return: A redirection to the :class:`~integreat_cms.cms.views.push_notifications.push_notification_list_view.PushNotificationListView`
+    """
+    to_be_archived_pn = get_object_or_404(
+        PushNotification,
+        id=push_notification_id,
+        regions=request.region,
+    )
+    to_be_archived_pn.archive()
+    messages.success(
+        request,
+        _("Push notification {0} was successfully archived").format(to_be_archived_pn),
+    )
+    return redirect(
+        "push_notifications",
+        **{
+            "region_slug": region_slug,
+            "language_slug": language_slug,
+        },
+    )
+
+
+@permission_required("cms.archive_pushnotification")
+def restore_push_notification(
+    request: HttpRequest,
+    push_notification_id: int,
+    region_slug: str,
+    language_slug: str,
+) -> HttpResponseRedirect:
+    """
+    Restore given push notification
+
+    :param request: The current request
+    :param push_notification_id: The id of the push notification which should be restored
+    :param region_slug: The slug of the current region
+    :return: A redirection to the :class:`~integreat_cms.cms.views.push_notifications.push_notification_list_view.PushNotificationListView`
+    """
+    to_be_restored_pn = get_object_or_404(
+        PushNotification,
+        id=push_notification_id,
+        regions=request.region,
+    )
+    to_be_restored_pn.restore()
+
+    messages.success(
+        request,
+        _("Push notification {0} was successfully restored").format(to_be_restored_pn),
+    )
+
+    return redirect(
+        "archived_push_notifications",
+        **{
+            "region_slug": region_slug,
+            "language_slug": language_slug,
+        },
+    )

--- a/integreat_cms/cms/views/push_notifications/push_notification_bulk_actions.py
+++ b/integreat_cms/cms/views/push_notifications/push_notification_bulk_actions.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from integreat_cms.cms.models.push_notifications.push_notification import (
+    PushNotification,
+)
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from django.http import HttpRequest, HttpResponse
+from django.contrib import messages
+from django.db.models import Q
+from django.urls import reverse
+from django.utils.translation import ngettext, ngettext_lazy
+
+from ...utils.stringify_list import iter_to_string
+from ..bulk_action_views import BulkActionView
+
+
+class PushNotificationBulkAction(BulkActionView):
+    """
+    View for executing contact bulk actions
+    """
+
+    #: The model of this :class:`~integreat_cms.cms.views.bulk_action_views.BulkActionView`
+    model = PushNotification
+
+    def get_extra_filters(self) -> Q:
+        """
+        Overwrite to filter queryset for regions since push notification can have multiple regions
+        """
+        return Q(regions=self.request.region)
+
+    def get_redirect_url(self, *args: Any, **kwargs: Any) -> str:
+        r"""
+        Normally this function redirects to the URL namespace by getting the model name. This only works if namespace and model name are the same.
+        It doesn't work in this instance, because the model is called `pushnotification`, but the URL namespace is called `push_notification`.
+        Therefore we need to overwrite this function and redirect from `pushnotification` to `push_notification`.
+
+        :param \*args: The supplied arguments
+        :param \**kwargs: The supplied keyword arguments
+        :return: url to redirect to
+        """
+        redirect_kwargs = {
+            "region_slug": self.request.region.slug,
+        }
+        if "language_slug" in kwargs:
+            redirect_kwargs["language_slug"] = kwargs["language_slug"]
+        return reverse("push_notifications", kwargs=redirect_kwargs)
+
+
+class ArchivePushNotificationsBulkAction(PushNotificationBulkAction):
+    """
+    Bulk action to archive multiple contacts at once
+    """
+
+    def get_permission_required(self) -> tuple[str]:
+        return ("cms.archive_pushnotification",)
+
+    def post(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
+        r"""
+        Archive multiple contacts at once
+
+        :param request: The current request
+        :param \*args: The supplied arguments
+        :param \**kwargs: The supplied keyword arguments
+        :return: The redirect
+        """
+
+        archive_successful = []
+
+        for content_object in self.get_queryset():
+            content_object.archive()
+            archive_successful.append(content_object)
+
+        if archive_successful:
+            messages.success(
+                request,
+                ngettext_lazy(
+                    "{model_name} {object_names} was successfully archived.",
+                    "The following {model_name} were successfully archived: {object_names}",
+                    len(archive_successful),
+                ).format(
+                    model_name=ngettext(
+                        self.model._meta.verbose_name.title(),
+                        self.model._meta.verbose_name_plural,
+                        len(archive_successful),
+                    ),
+                    object_names=iter_to_string(archive_successful),
+                ),
+            )
+
+        return super().post(request, *args, **kwargs)
+
+
+class RestorePushNotificationsBulkAction(PushNotificationBulkAction):
+    """
+    Bulk action to restore multiple contacts at once
+    """
+
+    def get_permission_required(self) -> tuple[str]:
+        return ("cms.archive_pushnotification",)
+
+    def post(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
+        r"""
+        Function to restore multiple contacts at once
+
+        :param request: The current request
+        :param \*args: The supplied arguments
+        :param \**kwargs: The supplied keyword arguments
+        :return: The redirect
+        """
+        restore_sucessful = []
+        for content_object in self.get_queryset():
+            content_object.restore()
+            restore_sucessful.append(content_object)
+
+        if restore_sucessful:
+            messages.success(
+                request,
+                ngettext_lazy(
+                    "{model_name} {object_names} was successfully restored.",
+                    "The following {model_name} were successfully restored: {object_names}",
+                    len(restore_sucessful),
+                ).format(
+                    model_name=ngettext(
+                        self.model._meta.verbose_name.title(),
+                        self.model._meta.verbose_name_plural,
+                        len(restore_sucessful),
+                    ),
+                    object_names=iter_to_string(restore_sucessful),
+                ),
+            )
+
+        return super().post(request, *args, **kwargs)

--- a/integreat_cms/core/management/commands/send_push_notifications.py
+++ b/integreat_cms/core/management/commands/send_push_notifications.py
@@ -57,12 +57,14 @@ class Command(LogCommand):
             scheduled_send_date__isnull=False,
             sent_date__isnull=True,
             draft=False,
+            archived=False,
             scheduled_send_date__lte=timezone.now(),
             scheduled_send_date__gte=timezone.now() - timedelta(hours=retain_time),
         )
 
         failed_push_notifications = PushNotification.objects.filter(
             draft=False,
+            archived=False,
             is_template=False,
             sent_date__isnull=True,
             scheduled_send_date__isnull=True,

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -2801,6 +2801,7 @@ msgstr "Webseite"
 
 #: cms/models/contact/contact.py cms/models/events/event.py
 #: cms/models/feedback/feedback.py cms/models/pois/poi.py
+#: cms/models/push_notifications/push_notification.py
 #: cms/models/users/organization.py
 msgid "archived"
 msgstr "archiviert"
@@ -3931,6 +3932,12 @@ msgid "Provide a distinct name for the template"
 msgstr "Bitte vergeben Sie einen eindeutigen Namen für die Vorlage"
 
 #: cms/models/push_notifications/push_notification.py
+msgid ""
+"Whether or not the push notification is read-only and hidden in the API."
+msgstr ""
+"Ob die Nachricht schreibgeschützt und in der API verborgen ist oder nicht."
+
+#: cms/models/push_notifications/push_notification.py
 #: cms/models/push_notifications/push_notification_translation.py
 msgid "push notification"
 msgstr "Push-Benachrichtigung"
@@ -4354,7 +4361,9 @@ msgstr "Angepasste Integreat Chat Datenschutzerklärung"
 
 #: cms/models/regions/region.py
 msgid "Link to custom privacy policy for self-hosted Zammad server."
-msgstr "Link zur angepassten Datenschutzerklärung für einen selbstverwalteten Zammad-Server"
+msgstr ""
+"Link zur angepassten Datenschutzerklärung für einen selbstverwalteten Zammad-"
+"Server."
 
 #: cms/models/regions/region.py
 msgid "Chat beta tester percentage"
@@ -5599,7 +5608,9 @@ msgstr "Webseite"
 #: cms/templates/offertemplates/offertemplate_list.html
 #: cms/templates/organizations/organization_list.html
 #: cms/templates/pages/pages_page_tree.html cms/templates/pois/poi_list.html
-#: cms/templates/pois/poi_list_archived.html cms/templates/roles/role_list.html
+#: cms/templates/pois/poi_list_archived.html
+#: cms/templates/push_notifications/push_notification_list.html
+#: cms/templates/roles/role_list.html
 msgid "Options"
 msgstr "Optionen"
 
@@ -5632,6 +5643,7 @@ msgstr "Kontakte ausgewählt"
 #: cms/templates/organizations/organization_list.html
 #: cms/templates/pages/pages_page_tree.html cms/templates/pois/poi_list.html
 #: cms/templates/pois/poi_list_archived.html
+#: cms/templates/push_notifications/push_notification_list.html
 msgid "Select bulk action"
 msgstr "Mehrfachaktion auswählen"
 
@@ -5657,6 +5669,7 @@ msgstr "Kontakte löschen"
 #: cms/templates/pages/_page_xliff_export_overlay.html
 #: cms/templates/pages/pages_page_tree.html cms/templates/pois/poi_list.html
 #: cms/templates/pois/poi_list_archived.html
+#: cms/templates/push_notifications/push_notification_list.html
 msgid "Execute"
 msgstr "Ausführen"
 
@@ -8241,6 +8254,14 @@ msgid "News not sent yet"
 msgstr "Nachricht noch nicht gesendet"
 
 #: cms/templates/push_notifications/push_notification_list.html
+msgid "Archived news"
+msgstr "Archivierte Nachrichten"
+
+#: cms/templates/push_notifications/push_notification_list.html
+msgid "Back to news"
+msgstr "Zurück zu Nachrichten"
+
+#: cms/templates/push_notifications/push_notification_list.html
 msgid "Open Templates"
 msgstr "Vorlagen öffnen"
 
@@ -8253,6 +8274,14 @@ msgid "Planned send date"
 msgstr "Terminiert am"
 
 #: cms/templates/push_notifications/push_notification_list.html
+msgid "No archived push notifications found with these filters."
+msgstr "Keine archivierten Push-Benachrichtigungen mit diesen Filter gefunden."
+
+#: cms/templates/push_notifications/push_notification_list.html
+msgid "No push notifications archived yet."
+msgstr "Noch keine Push-Benachrichtigungen vorhanden."
+
+#: cms/templates/push_notifications/push_notification_list.html
 #: cms/templates/push_notifications/push_notification_template_list.html
 msgid "No push notifications found with these filters."
 msgstr "Keine Push-Benachrichtigungen mit diesen Filter gefunden."
@@ -8261,6 +8290,18 @@ msgstr "Keine Push-Benachrichtigungen mit diesen Filter gefunden."
 #: cms/templates/push_notifications/push_notification_template_list.html
 msgid "No push notifications available yet."
 msgstr "Noch keine Push-Benachrichtigungen vorhanden."
+
+#: cms/templates/push_notifications/push_notification_list.html
+msgid "Push notifications selected"
+msgstr "Push-Benachrichtigungen ausgewählt"
+
+#: cms/templates/push_notifications/push_notification_list.html
+msgid "Restore push notifications"
+msgstr "Push-Benachrichtigungen wiederherstellen"
+
+#: cms/templates/push_notifications/push_notification_list.html
+msgid "Archive push notifications"
+msgstr "Push-Benachrichtigungen archivieren"
 
 #: cms/templates/push_notifications/push_notification_list_row.html
 msgid "Title not available"
@@ -8273,6 +8314,26 @@ msgstr "Nachricht ist überfällig und wird nicht mehr gesendet"
 #: cms/templates/push_notifications/push_notification_list_row.html
 msgid "Message not sent yet"
 msgstr "Nachricht noch nicht gesendet"
+
+#: cms/templates/push_notifications/push_notification_list_row.html
+msgid "Restore push notification"
+msgstr "Push-Benachrichtigung wiederherstellen"
+
+#: cms/templates/push_notifications/push_notification_list_row.html
+msgid "Please confirm that you really want to restore this push notification"
+msgstr ""
+"Bitte bestätigen Sie, dass diese Push-Benachrichtigung wiederhergestellt "
+"werden soll"
+
+#: cms/templates/push_notifications/push_notification_list_row.html
+msgid "Archive push notification"
+msgstr "Push-Benachrichtigung archivieren"
+
+#: cms/templates/push_notifications/push_notification_list_row.html
+msgid "Please confirm that you really want to archive this push notification"
+msgstr ""
+"Bitte bestätigen Sie, dass diese Push-Benachrichtigung archiviert werden "
+"soll"
 
 #: cms/templates/push_notifications/push_notification_template_list.html
 msgid "News Templates"
@@ -8914,8 +8975,8 @@ msgstr "Kontext zählt: Auch Seiten mit wenigen Zugriffen können wichtig sein."
 
 #: cms/templates/tutorials/page_access_statistics.html
 msgid ""
-"Pages relevant to target groups: fewer views, but high relevance for specific "
-"target groups."
+"Pages relevant to target groups: fewer views, but high relevance for "
+"specific target groups."
 msgstr ""
 "Zielgruppen-relevante Seiten: Weniger Aufrufe, aber hohe Relevanz für "
 "spezifische Zielgruppen."
@@ -9405,6 +9466,7 @@ msgstr "Die ausgewählten {} wurden erfolgreich {}"
 
 #: cms/views/bulk_action_views.py cms/views/contacts/contact_bulk_actions.py
 #: cms/views/organizations/organization_bulk_actions.py
+#: cms/views/push_notifications/push_notification_bulk_actions.py
 #, python-brace-format
 msgid "{model_name} {object_names} was successfully archived."
 msgid_plural ""
@@ -9452,6 +9514,7 @@ msgstr[1] ""
 
 #: cms/views/bulk_action_views.py cms/views/contacts/contact_bulk_actions.py
 #: cms/views/organizations/organization_bulk_actions.py
+#: cms/views/push_notifications/push_notification_bulk_actions.py
 #, python-brace-format
 msgid "{model_name} {object_names} was successfully restored."
 msgid_plural ""
@@ -10879,6 +10942,16 @@ msgstr ""
 msgid "Back to the poi form"
 msgstr "Zurück zum Formular"
 
+#: cms/views/push_notifications/push_notification_actions.py
+#, python-brace-format
+msgid "Push notification {0} was successfully archived"
+msgstr "Push-Benachrichtigung {0} wurde erfolgreich archiviert"
+
+#: cms/views/push_notifications/push_notification_actions.py
+#, python-brace-format
+msgid "Push notification {0} was successfully restored"
+msgstr "Push-Benachrichtigung {0} wurde erfolgreich wiederhergestellt"
+
 #: cms/views/push_notifications/push_notification_form_view.py
 #: cms/views/push_notifications/push_notification_list_view.py
 msgid "Push notifications are disabled."
@@ -10965,6 +11038,10 @@ msgstr "Nachricht \"{}\" wurde erfolgreich aus der Vorlage \"{}\" erstellt."
 #: cms/views/push_notifications/push_notification_form_view.py
 msgid "In the next step, the news can now be sent."
 msgstr "Im nächsten Schritt kann diese Nachricht nun versendet werden."
+
+#: cms/views/push_notifications/push_notification_form_view.py
+msgid "News \"{}\" cannot be sent, because it is archived"
+msgstr "Nachricht \"{}\" kann nicht gesendet werden, weil sie archiviert ist."
 
 #: cms/views/push_notifications/push_notification_form_view.py
 msgid "News \"{}\" could not be sent due to a configuration error."
@@ -11813,15 +11890,15 @@ msgstr ""
 #~ "Übersetzungen. Bitte haben Sie noch ein wenig Geduld."
 
 #~ msgid ""
-#~ "Your pages currently have <b>"
-#~ "%(number_of_missing_or_outdated_translations)s pages </b>that have an "
+#~ "Your pages currently have "
+#~ "<b>%(number_of_missing_or_outdated_translations)s pages </b>that have an "
 #~ "outdated or no translation. In order for the users to benefit from your "
 #~ "content you should translate them or have them translated."
 #~ msgstr ""
-#~ "Ihre Inhalten haben aktuell <b>"
-#~ "%(number_of_missing_or_outdated_translations)s Seiten </b> mit fehlender "
-#~ "oder veralteter Übersetzung. Damit die Nutzer:innen von Ihren Inhalten "
-#~ "profitieren können, sollten Sie diese übersetzen (lassen)."
+#~ "Ihre Inhalten haben aktuell "
+#~ "<b>%(number_of_missing_or_outdated_translations)s Seiten </b> mit "
+#~ "fehlender oder veralteter Übersetzung. Damit die Nutzer:innen von Ihren "
+#~ "Inhalten profitieren können, sollten Sie diese übersetzen (lassen)."
 
 #~ msgid "View location"
 #~ msgstr "Ort ansehen"
@@ -12913,9 +12990,6 @@ msgstr ""
 #~ msgid "Page was successfully created"
 #~ msgstr "Seite wurde erfolgreich erstellt"
 
-#~ msgid "Push notifications"
-#~ msgstr "Push-Benachrichtigungen"
-
 #~ msgid "All language tree nodes"
 #~ msgstr "Alle Sprach-Knoten"
 
@@ -13024,9 +13098,6 @@ msgstr ""
 
 #~ msgid "All push notifications"
 #~ msgstr "Alle Push-Benachrichtigungen"
-
-#~ msgid "Create push notification"
-#~ msgstr "Push-Benachrichtigung verfassen"
 
 #~ msgid "Offers"
 #~ msgstr "Angebote"
@@ -13415,9 +13486,6 @@ msgstr ""
 #~ msgid "Activate events"
 #~ msgstr "Veranstaltungen aktivieren"
 
-#~ msgid "Activate push notifications"
-#~ msgstr "Push-Benachrichtigungen aktivieren"
-
 #~ msgid "Push notification channels"
 #~ msgstr "Push-Benachrichtigungskanäle"
 
@@ -13679,12 +13747,6 @@ msgstr ""
 
 #~ msgid "Insert content in %(language)s here"
 #~ msgstr "Inhalt auf %(language)s hier eingeben"
-
-#~ msgid "Push notification was successfully saved"
-#~ msgstr "Push-Benachrichtigung wurde erfolgreich gespeichert"
-
-#~ msgid "Push notification was successfully created"
-#~ msgstr "Push-Benachrichtigung wurde erfolgreich erstellt"
 
 #~ msgid "All POIs"
 #~ msgstr "Alle POIs"

--- a/integreat_cms/release_notes/current/unreleased/3588.yml
+++ b/integreat_cms/release_notes/current/unreleased/3588.yml
@@ -1,0 +1,2 @@
+en: Add option to archive push notifications
+de: Füge Option hinzu, Push-Benachrichtigungen zu archivieren


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds the option to archive and restore push notification

### Proposed changes
<!-- Describe this PR in more detail. -->

- This PR adds the option to archive and restore a single push notifications
- This PR adds the option to archive and restore many push notifications at once


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

I see two possible problems:
- I introduced a new permission "archive_pushnotifications", but I'm not sure if it's working already or if I need another migration file for it. I haven't figured this part out yet. Maybe a case for @MizukiTemma 
- The goal is not send archived push notifications. This is where my lack of knowledge on push notifications comes in. Do I need to exclude it from more than just the management command? This might be a case for @PeterNerlich 


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3588 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
