### PR TITLE
Add bulk delete to entries

### DIFF
--- a/integreat_cms/cms/models/events/event.py
+++ b/integreat_cms/cms/models/events/event.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, time
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 from django.db import models
 from django.db.models import Q
@@ -336,6 +336,14 @@ class Event(AbstractContentModel):
         for translation in self.translations.distinct("event__pk", "language__pk"):
             # The post_save signal will create link objects from the content
             translation.save(update_timestamp=False)
+
+    def delete(self, *args: Any, **kwargs: Any) -> tuple[int, dict[str, int]]:
+        """
+        Deletes the event and its recurrence rule
+        """
+        if self.recurrence_rule:
+            self.recurrence_rule.delete()
+        return super().delete(*args, **kwargs)
 
     class Meta:
         #: The verbose name of the model

--- a/integreat_cms/cms/models/pages/page.py
+++ b/integreat_cms/cms/models/pages/page.py
@@ -310,6 +310,18 @@ class Page(AbstractTreeNode, AbstractBasePage):
             return self._relative_depth
         return self.depth
 
+    def can_be_deleted(self) -> tuple[bool, str | None]:
+        """
+        Checks whether the page can be deleted
+        """
+        if self.children.exists():
+            return False, _("you cannot delete a page which has subpages.")
+        if self.mirroring_pages.exists():
+            return False, _(
+                "you cannot delete a page that is embedded as live content by another page."
+            )
+        return True, None
+
     def move(self, target: Page, pos: str | None = None) -> None:
         """
         Moving tree nodes potentially causes changes to the fields tree_id, lft and rgt in :class:`~treebeard.ns_tree.NS_Node`

--- a/integreat_cms/cms/models/pois/poi.py
+++ b/integreat_cms/cms/models/pois/poi.py
@@ -130,21 +130,13 @@ class POI(AbstractContentModel):
         """
         return POITranslation
 
-    def delete(self, *args: list, **kwargs: dict) -> bool:
-        r"""
-        Deletes the poi
-        :param \*args: The supplied arguments
-        :param \**kwargs: The supplied keyword arguments
+    def can_be_deleted(self) -> tuple[bool, str | None]:
         """
-        was_successful = False
-        if not self.is_used:
-            super().delete(*args, **kwargs)
-            was_successful = True
-        else:
-            logger.debug(
-                "Can't be deleted because this poi is used by an event or a contact",
-            )
-        return was_successful
+        Checks if poi can be deleted
+        """
+        if self.is_used:
+            return False, _("a poi used by an event or a contact cannot be deleted.")
+        return True, None
 
     def archive(self) -> bool:
         """

--- a/integreat_cms/cms/templates/events/event_list.html
+++ b/integreat_cms/cms/templates/events/event_list.html
@@ -208,6 +208,17 @@
                         {% translate "Restore events" %}
                     </option>
                 {% endif %}
+                {% if perms.cms.delete_event %}
+                    <option class="bulk-confirmation-dialog"
+                            data-bulk-action="{% url 'delete_multiple_events' region_slug=request.region.slug language_slug=language.slug %}"
+                            data-popup-title="{% blocktranslate %}You are about to delete multiple selected {{content_type}}{% endblocktranslate %}"
+                            data-popup-subject="{% blocktranslate %}This action cannot be undone{% endblocktranslate %}"
+                            data-popup-text="{% blocktranslate %}Do you want to continue?{% endblocktranslate %}">
+                        {% blocktranslate trimmed %}
+                            Delete {{ content_type }}
+                        {% endblocktranslate %}
+                    </option>
+                {% endif %}
             </select>
             <button form="bulk-action-form" id="bulk-action-execute" class="btn" disabled>
                 {% translate "Execute" %}

--- a/integreat_cms/cms/templates/languagetreenodes/languagetreenode_list.html
+++ b/integreat_cms/cms/templates/languagetreenodes/languagetreenode_list.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load static %}
 {% block content %}
+    {% translate "Language tree nodes" as content_type %}
     <div class="table-header flex flex-wrap justify-between">
         <h1 class="heading">
             {% translate "Language tree" %}
@@ -85,6 +86,17 @@
                 <option data-bulk-action="{% url 'bulk_disable_languagetreenodes' region_slug=request.region.slug %}">
                     {% translate "Disable languages in content management system" %}
                 </option>
+                {% if perms.cms.delete_languagetreenode %}
+                    <option class="bulk-confirmation-dialog"
+                            data-bulk-action="{% url 'bulk_delete_languagetreenodes' region_slug=request.region.slug %}"
+                            data-popup-title="{% blocktranslate %}You are about to delete multiple selected {{content_type}}{% endblocktranslate %}"
+                            data-popup-subject="{% blocktranslate %}This action cannot be undone{% endblocktranslate %}"
+                            data-popup-text="{% blocktranslate %}Do you want to continue?{% endblocktranslate %}">
+                        {% blocktranslate trimmed %}
+                            Delete {{ content_type }}
+                        {% endblocktranslate %}
+                    </option>
+                {% endif %}
             </select>
             <button id="bulk-action-execute" class="btn" disabled>
                 {% translate "Execute" %}

--- a/integreat_cms/cms/templates/pages/pages_page_tree.html
+++ b/integreat_cms/cms/templates/pages/pages_page_tree.html
@@ -270,6 +270,17 @@
                         </option>
                     {% endif %}
                 {% endif %}
+                {% if perms.cms.delete_page %}
+                    <option class="bulk-confirmation-dialog"
+                            data-bulk-action="{% url 'bulk_delete_pages' region_slug=request.region.slug language_slug=language.slug %}"
+                            data-popup-title="{% blocktranslate %}You are about to delete multiple selected {{content_type}}{% endblocktranslate %}"
+                            data-popup-subject="{% blocktranslate %}This action cannot be undone{% endblocktranslate %}"
+                            data-popup-text="{% blocktranslate %}Do you want to continue?{% endblocktranslate %}">
+                        {% blocktranslate trimmed %}
+                            Delete {{ content_type }}
+                        {% endblocktranslate %}
+                    </option>
+                {% endif %}
             </select>
             <button id="bulk-action-execute" class="btn" disabled>
                 {% translate "Execute" %}

--- a/integreat_cms/cms/templates/pois/poi_list.html
+++ b/integreat_cms/cms/templates/pois/poi_list.html
@@ -164,6 +164,17 @@
                         </option>
                     {% endif %}
                 {% endif %}
+                {% if perms.cms.delete_poi %}
+                    <option class="bulk-confirmation-dialog"
+                            data-bulk-action="{% url 'bulk_delete_pois' region_slug=request.region.slug language_slug=language.slug %}"
+                            data-popup-title="{% blocktranslate %}You are about to delete multiple selected {{content_type}}{% endblocktranslate %}"
+                            data-popup-subject="{% blocktranslate %}This action cannot be undone{% endblocktranslate %}"
+                            data-popup-text="{% blocktranslate %}Do you want to continue?{% endblocktranslate %}">
+                        {% blocktranslate trimmed %}
+                            Delete {{ content_type }}
+                        {% endblocktranslate %}
+                    </option>
+                {% endif %}
             </select>
             <button form="bulk-action-form" id="bulk-action-execute" class="btn" disabled>
                 {% translate "Execute" %}

--- a/integreat_cms/cms/urls/protected.py
+++ b/integreat_cms/cms/urls/protected.py
@@ -22,6 +22,7 @@ from ..forms import (
 from ..models import (
     Event,
     Language,
+    LanguageTreeNode,
     OfferTemplate,
     Page,
     POI,
@@ -990,6 +991,13 @@ urlpatterns: list[URLPattern] = [
                                             name="bulk_restore_pages",
                                         ),
                                         path(
+                                            "bulk-delete/",
+                                            bulk_action_views.BulkDeletingView.as_view(
+                                                model=Page,
+                                            ),
+                                            name="bulk_delete_pages",
+                                        ),
+                                        path(
                                             "machine-translate/",
                                             bulk_action_views.BulkMachineTranslationView.as_view(
                                                 model=Page,
@@ -1276,6 +1284,13 @@ urlpatterns: list[URLPattern] = [
                                             name="draft_multiple_events",
                                         ),
                                         path(
+                                            "bulk-delete/",
+                                            bulk_action_views.BulkDeletingView.as_view(
+                                                model=Event,
+                                            ),
+                                            name="delete_multiple_events",
+                                        ),
+                                        path(
                                             "<int:event_id>/",
                                             include(
                                                 [
@@ -1389,6 +1404,13 @@ urlpatterns: list[URLPattern] = [
                                                 model=POI,
                                             ),
                                             name="draft_multiple_pois",
+                                        ),
+                                        path(
+                                            "bulk-delete/",
+                                            bulk_action_views.BulkDeletingView.as_view(
+                                                model=POI,
+                                            ),
+                                            name="bulk_delete_pois",
                                         ),
                                         path(
                                             "show-poi-form-ajax/<str:poi_title>/",
@@ -1713,6 +1735,13 @@ urlpatterns: list[URLPattern] = [
                                 "bulk-disable/",
                                 language_tree.BulkDisableView.as_view(),
                                 name="bulk_disable_languagetreenodes",
+                            ),
+                            path(
+                                "bulk-delete/",
+                                bulk_action_views.BulkDeletingView.as_view(
+                                    model=LanguageTreeNode,
+                                ),
+                                name="bulk_delete_languagetreenodes",
                             ),
                             path(
                                 "<int:pk>/",

--- a/integreat_cms/cms/views/events/event_actions.py
+++ b/integreat_cms/cms/views/events/event_actions.py
@@ -156,8 +156,6 @@ def delete(
 
     logger.info("%r deleted by %r", event, request.user)
 
-    if event.recurrence_rule:
-        event.recurrence_rule.delete()
     event.delete()
     messages.success(request, _("Event was successfully deleted"))
 

--- a/integreat_cms/cms/views/pages/page_actions.py
+++ b/integreat_cms/cms/views/pages/page_actions.py
@@ -248,13 +248,12 @@ def delete_page(
     region = request.region
     page = get_object_or_404(region.pages, id=page_id)
 
-    if page.children.exists():
-        messages.error(request, _("You cannot delete a page which has subpages."))
-    elif page.mirroring_pages.exists():
+    can_delete, error_msg = page.can_be_deleted()
+    if not can_delete:
         messages.error(
             request,
-            _(
-                "This page cannot be deleted because it was embedded as live content from another page.",
+            _("The page could not be deleted, because {failure_reason}").format(
+                failure_reason=error_msg
             ),
         )
     else:

--- a/integreat_cms/cms/views/pois/poi_actions.py
+++ b/integreat_cms/cms/views/pois/poi_actions.py
@@ -115,14 +115,18 @@ def delete_poi(
     """
 
     poi = POI.objects.get(id=poi_id)
-    if poi.delete():
+    can_delete, error_msg = poi.can_be_deleted()
+    if can_delete:
+        poi.delete()
         logger.info("%r deleted by %r", poi, request.user)
         messages.success(request, _("Location was successfully deleted"))
     else:
         logger.info("%r couldn't be deleted by %r", poi, request.user)
         messages.error(
             request,
-            _("Location couldn't be deleted as it's used by an event or contact"),
+            _("Location couldn't be deleted, because {failure_reason}").format(
+                failure_reason=error_msg
+            ),
         )
 
     return redirect(

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -3423,6 +3423,10 @@ msgid "Preferred provider for translations into this language"
 msgstr "Bevorzugter Anbieter für Übersetzungen in diese Sprache"
 
 #: cms/models/languages/language_tree_node.py
+msgid "a source language of other language(s) cannot be deleted."
+msgstr "eine Quell-Sprache für andere Sprachen nicht löschbar ist."
+
+#: cms/models/languages/language_tree_node.py
 msgid "language tree node"
 msgstr "Sprach-Knoten"
 
@@ -3719,6 +3723,18 @@ msgstr ""
 "Wählen Sie einen Anbieter aus, dessen Angebote auf dieser Seite angezeigt "
 "werden sollen."
 
+#: cms/models/pages/page.py
+msgid "you cannot delete a page which has subpages."
+msgstr "keine Seiten gelöscht werden können, die Unterseiten haben."
+
+#: cms/models/pages/page.py
+msgid ""
+"you cannot delete a page that is embedded as live content by another page."
+msgstr ""
+"eine Seite, die von einer anderen Seite als "
+"Live-Inhalt eingebunden wurde, nicht gelöscht "
+"werden kann."
+
 #: cms/models/pages/page.py cms/models/pages/page_translation.py
 msgid "page"
 msgstr "Seite"
@@ -3880,6 +3896,10 @@ msgstr "barrierefrei"
 #: cms/models/pois/poi.py
 msgid "Indicate if the location is barrier free."
 msgstr "Geben Sie an, ob dieser Ort barrierefrei ist."
+
+#: cms/models/pois/poi.py
+msgid "a poi used by an event or a contact cannot be deleted."
+msgstr "ein Ort, der von einer Veranstaltung oder einem Kontakt verwendet wird, nicht gelöscht werden kann."
 
 #: cms/models/pois/poi.py cms/templates/pois/poi_list.html
 msgid "locations"
@@ -6445,6 +6465,32 @@ msgstr "%(content_type)s maschinell auf %(language)s übersetzen"
 msgid "Restore events"
 msgstr "Veranstaltungen wiederherstellen"
 
+#: cms/templates/events/event_list.html
+#: cms/templates/languagetreenodes/languagetreenode_list.html
+#: cms/templates/pages/pages_page_tree.html cms/templates/pois/poi_list.html
+#, python-format
+msgid "You are about to delete multiple selected %(content_type)s"
+msgstr "Sie sind dabei mehrere %(content_type)s zu löschen."
+
+#: cms/templates/events/event_list.html
+#: cms/templates/languagetreenodes/languagetreenode_list.html
+#: cms/templates/pages/pages_page_tree.html cms/templates/pois/poi_list.html
+msgid "This action cannot be undone"
+msgstr "Diese Handlung kann nicht rückgängig gemacht werden"
+
+#: cms/templates/events/event_list.html
+#: cms/templates/languagetreenodes/languagetreenode_list.html
+#: cms/templates/pages/pages_page_tree.html cms/templates/pois/poi_list.html
+msgid "Do you want to continue?"
+msgstr "Möchten Sie fortfahren?"
+
+#: cms/templates/events/event_list.html
+#: cms/templates/languagetreenodes/languagetreenode_list.html
+#: cms/templates/pages/pages_page_tree.html cms/templates/pois/poi_list.html
+#, python-format
+msgid "Delete %(content_type)s"
+msgstr "%(content_type)s löschen"
+
 #: cms/templates/events/event_list_row.html
 msgid "Not specified"
 msgstr "Nicht festgelegt"
@@ -7041,6 +7087,10 @@ msgid "Language tree node"
 msgstr "Sprach-Knoten"
 
 #: cms/templates/languagetreenodes/languagetreenode_list.html
+msgid "Language tree nodes"
+msgstr "Sprach-Knoten"
+
+#: cms/templates/languagetreenodes/languagetreenode_list.html
 msgid "Language tree"
 msgstr "Sprach-Baum"
 
@@ -7570,7 +7620,6 @@ msgstr "Seite löschen"
 
 #: cms/templates/pages/page_form_sidebar/actions_box.html
 #: cms/templates/pages/pages_page_tree_node.html
-#: cms/views/pages/page_actions.py
 msgid "You cannot delete a page which has subpages."
 msgstr "Sie können keine Seite löschen, die Unterseiten besitzt."
 
@@ -7587,7 +7636,6 @@ msgstr[1] ""
 
 #: cms/templates/pages/page_form_sidebar/actions_box.html
 #: cms/templates/pages/pages_page_tree_node.html
-#: cms/views/pages/page_actions.py
 msgid ""
 "This page cannot be deleted because it was embedded as live content from "
 "another page."
@@ -9604,6 +9652,29 @@ msgstr[1] ""
 "Die folgenden Seiten konnten nicht wiederhergestellt werden, weil mindestens "
 "eine übergeordnete Seite archiviert ist: {}"
 
+#: cms/views/bulk_action_views.py cms/views/contacts/contact_bulk_actions.py
+#: cms/views/organizations/organization_bulk_actions.py
+#, python-brace-format
+msgid "{model_name} {object_names} was successfully deleted."
+msgid_plural ""
+"The following {model_name} were successfully deleted: {object_names}"
+msgstr[0] "{model_name} {object_names} wurde erfolgreich gelöscht."
+msgstr[1] ""
+"Die folgenden {model_name} wurden erfolgreich gelöscht: {object_names}"
+
+#: cms/views/bulk_action_views.py
+#, python-brace-format
+msgid ""
+"{model_name} {object_names} could not be deleted, because {failure_reason}"
+msgid_plural ""
+"The following {model_name} could not be deleted: {object_names}, because "
+"{failure_reason}"
+msgstr[0] ""
+"{model_name} {object_names} kann nicht gelöscht werden, da {failure_reason}"
+msgstr[1] ""
+"Die folgenden {model_name} konnten nicht gelöscht werden: {object_names}, da "
+"{failure_reason}"
+
 #: cms/views/contacts/contact_actions.py
 #, python-brace-format
 msgid "Contact {0} was successfully archived"
@@ -9647,16 +9718,6 @@ msgstr[0] ""
 "ihn verweisen."
 msgstr[1] ""
 "Die folgenden {model_name} konnten nicht archiviert werden: {object_names}"
-
-#: cms/views/contacts/contact_bulk_actions.py
-#: cms/views/organizations/organization_bulk_actions.py
-#, python-brace-format
-msgid "{model_name} {object_names} was successfully deleted."
-msgid_plural ""
-"The following {model_name} were successfully deleted: {object_names}"
-msgstr[0] "{model_name} {object_names} wurde erfolgreich gelöscht."
-msgstr[1] ""
-"Die folgenden {model_name} wurden erfolgreich gelöscht: {object_names}"
 
 #: cms/views/contacts/contact_bulk_actions.py
 #, python-brace-format
@@ -10082,20 +10143,31 @@ msgid "The language tree node \"{}\" was successfully moved."
 msgstr "Der Sprach-Knoten \"{}\" wurde erfolgreich verschoben."
 
 #: cms/views/language_tree/language_tree_actions.py
+#, python-brace-format
 msgid ""
-"The language tree node \"{}\" cannot be deleted because it is the source "
-"language of other language(s)."
+"The language tree node \"{model_name}\" cannot be deleted because it is the "
+"source language of other language(s)."
 msgstr ""
-"Der Sprach-Knoten \"{}\" kann nicht gelöscht werden, da er die Quell-Sprache "
-"anderer Sprachen ist."
+"Der Sprach-Knoten \"{model_name}\" kann nicht gelöscht werden, da er die "
+"Quell-Sprache anderer Sprachen ist."
 
 #: cms/views/language_tree/language_tree_actions.py
+#, python-brace-format
 msgid ""
-"The language tree node \"{}\" and all corresponding translations were "
-"successfully deleted."
+"The language tree node \"{model_name}\" cannot be deleted because "
+"{failure_reason}"
 msgstr ""
-"Der Sprach-Knoten \"{}\" und alle entsprechenden Übersetzungen wurden "
-"erfolgreich gelöscht."
+"Der Sprach-Knoten \"{model_name}\" kann nicht gelöscht werden, da "
+"{failure_reason}"
+
+#: cms/views/language_tree/language_tree_actions.py
+#, python-brace-format
+msgid ""
+"The language tree node \"{model_name}\" and all corresponding translations "
+"were successfully deleted."
+msgstr ""
+"Der Sprach-Knoten \"{model_name}\" und alle entsprechenden Übersetzungen "
+"wurden erfolgreich gelöscht."
 
 #: cms/views/language_tree/language_tree_bulk_actions.py
 msgid "made visible"
@@ -10515,6 +10587,11 @@ msgstr ""
 "archiviert ist."
 
 #: cms/views/pages/page_actions.py
+#, python-brace-format
+msgid "The page could not be deleted, because {failure_reason}"
+msgstr "Der Ort konnte nicht gelöscht werden, da {failure_reason}"
+
+#: cms/views/pages/page_actions.py
 msgid "Page was successfully deleted"
 msgstr "Seite wurde erfolgreich gelöscht"
 
@@ -10835,10 +10912,9 @@ msgid "Location was successfully deleted"
 msgstr "Ort wurde erfolgreich gelöscht"
 
 #: cms/views/pois/poi_actions.py
-msgid "Location couldn't be deleted as it's used by an event or contact"
-msgstr ""
-"Der Ort konnte nicht gelöscht werden, da er von einer Veranstaltung oder "
-"einem Kontakt verwendet wird"
+#, python-brace-format
+msgid "Location couldn't be deleted, because {failure_reason}"
+msgstr "Der Ort konnte nicht gelöscht werden, da {failure_reason}"
 
 #: cms/views/pois/poi_actions.py
 msgid "Location service is disabled"
@@ -11724,6 +11800,9 @@ msgstr ""
 "Diese Seite konnte nicht importiert werden, da sie zu einer anderen Region "
 "gehört ({})."
 
+#~ msgid "it was embedded as live content from another page."
+#~ msgstr "sie als Live Inhalt in anderen Seiten eingebettet ist."
+
 #~ msgid "Has translation package been booked?"
 #~ msgstr "Wurde das Add-On für Übersetzungen gebucht?"
 
@@ -11842,6 +11921,9 @@ msgstr ""
 #~ msgid "Number of pages with at least one outdated translation"
 #~ msgstr ""
 #~ "Anzahl Seiten mit mindestens einer fehlenden oder veralteten Übersetzung"
+
+#~ msgid "Language Tree Nodes"
+#~ msgstr "Sprach-Knoten"
 
 #~ msgid "attachment map"
 #~ msgstr "Anhangs-Mapping"
@@ -12036,15 +12118,15 @@ msgstr ""
 #~ "Übersetzungen. Bitte haben Sie noch ein wenig Geduld."
 
 #~ msgid ""
-#~ "Your pages currently have <b>"
-#~ "%(number_of_missing_or_outdated_translations)s pages </b>that have an "
+#~ "Your pages currently have "
+#~ "<b>%(number_of_missing_or_outdated_translations)s pages </b>that have an "
 #~ "outdated or no translation. In order for the users to benefit from your "
 #~ "content you should translate them or have them translated."
 #~ msgstr ""
-#~ "Ihre Inhalten haben aktuell <b>"
-#~ "%(number_of_missing_or_outdated_translations)s Seiten </b> mit fehlender "
-#~ "oder veralteter Übersetzung. Damit die Nutzer:innen von Ihren Inhalten "
-#~ "profitieren können, sollten Sie diese übersetzen (lassen)."
+#~ "Ihre Inhalten haben aktuell "
+#~ "<b>%(number_of_missing_or_outdated_translations)s Seiten </b> mit "
+#~ "fehlender oder veralteter Übersetzung. Damit die Nutzer:innen von Ihren "
+#~ "Inhalten profitieren können, sollten Sie diese übersetzen (lassen)."
 
 #~ msgid "View location"
 #~ msgstr "Ort ansehen"
@@ -13505,9 +13587,6 @@ msgstr ""
 #~ msgstr ""
 #~ "Die URL, die Sie eingegeben haben, ist inkorrekt. Bitte prüfen Sie die "
 #~ "Einstellungen."
-
-#~ msgid "What do you want to do?"
-#~ msgstr "Was möchten Sie tun?"
 
 #~ msgid "Confirm your new password here"
 #~ msgstr "Ihr neues Passwort erneut eingeben"

--- a/integreat_cms/release_notes/current/unreleased/3122.yml
+++ b/integreat_cms/release_notes/current/unreleased/3122.yml
@@ -1,0 +1,2 @@
+en: Add bulk delete option to locations, events, language nodes, pages
+de: Füge Mehrfach-Löschoption zu Orten, Veranstaltungen, Sprachknoten, Seiten hinzu

--- a/integreat_cms/static/src/js/bulk-actions.ts
+++ b/integreat_cms/static/src/js/bulk-actions.ts
@@ -27,6 +27,7 @@
  *     page_ids = request.POST.getlist("selected_ids[]")
  *
  */
+import { showConfirmationPopupWithData } from "./confirmation-popups";
 
 /*
  * Update the selection count after a checkbox has been toggled
@@ -84,11 +85,19 @@ export const bulkActionExecute = (event: Event) => {
     form.action = selectedAction.getAttribute("data-bulk-action");
     // Set form target in case action is to be opened in a new tab
     const target = selectedAction.getAttribute("data-target");
+    const showDialog = selectedAction.classList.contains("bulk-confirmation-dialog");
     if (target !== null) {
         form.target = target;
     }
-    // Submit form and execute bulk action
-    form.submit();
+    if (showDialog) {
+        const text = selectedAction.getAttribute("data-popup-text");
+        const subject = selectedAction.getAttribute("data-popup-subject");
+        const title = selectedAction.getAttribute("data-popup-title");
+        showConfirmationPopupWithData(subject, title, text, () => form.submit());
+    } else {
+        // Submit form and execute bulk action
+        form.submit();
+    }
 };
 
 /*

--- a/tests/cms/views/bulk_actions.py
+++ b/tests/cms/views/bulk_actions.py
@@ -1,0 +1,118 @@
+import html
+from typing import TypedDict
+
+from _pytest.logging import LogCaptureFixture
+from django.db.models import Model
+from django.test.client import Client
+from pytest_django.fixtures import SettingsWrapper
+
+from integreat_cms.cms.utils.stringify_list import iter_to_string
+from tests.conftest import (
+    ANONYMOUS,
+    HIGH_PRIV_STAFF_ROLES,
+)
+from tests.utils import assert_message_in_log
+
+
+class BulkActionIDs(TypedDict):
+    deletable: list[int]
+    undeletable: list[list[int]]
+
+
+def assert_bulk_delete(
+    test_model: type[Model],
+    instance_ids: BulkActionIDs,
+    url: str,
+    role_user: tuple[Client, str],
+    caplog: LogCaptureFixture,
+    settings: SettingsWrapper,
+    fail_reasons: list[str],
+) -> None:
+    """
+    Helper Function to Test whether bulk deleting of content_type works as expected
+    """
+    client, role = role_user
+
+    # Set the language setting to English so assertion does not fail because of corresponding German sentence appearing instead the english one.
+    settings.LANGUAGE_CODE = "en"
+
+    flat_undeletable_ids = [
+        object_id for sublist in instance_ids["undeletable"] for object_id in sublist
+    ]
+    all_selected_ids = instance_ids["deletable"] + flat_undeletable_ids
+
+    deletable_instances_names = iter_to_string(
+        test_model.objects.filter(id__in=instance_ids["deletable"])
+    )
+    response = client.post(
+        url,
+        data={"selected_ids[]": all_selected_ids},
+    )
+    model_name = test_model._meta.verbose_name.title()
+    model_name_plural = test_model._meta.verbose_name_plural
+
+    if role in HIGH_PRIV_STAFF_ROLES:
+        assert response.status_code == 302
+        redirect_url = response.headers.get("location")
+        redirect_page = client.get(redirect_url).content.decode("utf-8")
+        if len(instance_ids["deletable"]) > 1:
+            assert (
+                html.escape(
+                    f"The following {model_name_plural} were successfully deleted: {deletable_instances_names}"
+                )
+                in redirect_page
+            )
+            assert_message_in_log(
+                f"SUCCESS  The following {model_name_plural} were successfully deleted: {deletable_instances_names}",
+                caplog,
+            )
+        elif len(instance_ids["deletable"]) == 1:
+            assert (
+                html.escape(
+                    f"{model_name} {deletable_instances_names} was successfully deleted."
+                )
+                in redirect_page
+            )
+            assert_message_in_log(
+                f"SUCCESS  {model_name} {deletable_instances_names} was successfully deleted.",
+                caplog,
+            )
+
+        if len(flat_undeletable_ids) > 1:
+            for index, sublist in enumerate(instance_ids["undeletable"]):
+                undeletable_sub_instances_names = iter_to_string(
+                    test_model.objects.filter(id__in=sublist)
+                )
+                if len(sublist) == 1:
+                    assert (
+                        html.escape(
+                            f"{model_name} {undeletable_sub_instances_names} could not be deleted, because {fail_reasons[index]}"
+                        )
+                        in redirect_page
+                    )
+                    assert_message_in_log(
+                        f"ERROR    {model_name} {undeletable_sub_instances_names} could not be deleted, because {fail_reasons[index]}",
+                        caplog,
+                    )
+                elif len(sublist) > 1:
+                    print(
+                        html.escape(
+                            f"The following {model_name_plural} could not be deleted: {undeletable_sub_instances_names}, because {fail_reasons[index]}"
+                        )
+                    )
+                    assert (
+                        html.escape(
+                            f"The following {model_name_plural} could not be deleted: {undeletable_sub_instances_names}, because {fail_reasons[index]}"
+                        )
+                        in redirect_page
+                    )
+                    assert_message_in_log(
+                        f"ERROR    The following {model_name_plural} could not be deleted: {undeletable_sub_instances_names}, because {fail_reasons[index]}",
+                        caplog,
+                    )
+
+    elif role == ANONYMOUS:
+        assert response.status_code == 302
+        assert response.headers.get("location") == f"{settings.LOGIN_URL}?next={url}"
+    else:
+        assert response.status_code == 403

--- a/tests/cms/views/language_nodes/test_language_tree_node_actions.py
+++ b/tests/cms/views/language_nodes/test_language_tree_node_actions.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from _pytest.logging import LogCaptureFixture
+    from django.test.client import Client
+    from pytest_django.fixtures import SettingsWrapper
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from integreat_cms.cms.models import Language, LanguageTreeNode, Region
+from tests.cms.views.bulk_actions import assert_bulk_delete, BulkActionIDs
+
+
+def create_language_tree_node(
+    region_slug: str,
+    language_id: int,
+    parent: LanguageTreeNode | None = None,
+) -> int:
+    """
+    A helper function to create a Language Tree Node
+
+    Returns the language tree node ID
+    """
+    region = Region.objects.get(slug=region_slug)
+    ltn = LanguageTreeNode.add_root(
+        region=region, language=Language.objects.get(id=language_id), parent=parent
+    )
+    return ltn.id
+
+
+def create_language_tree_node_with_children(
+    region_slug: str,
+    language_id: int,
+    num_children: int = 2,
+    start_lft: int = 1,
+    tree_id: int = 1,
+) -> int:
+    """
+    A helper function to create a root languageTreeNode with `num_children` child languageTreeNodes
+
+    Returns the root ID.
+    """
+    region = Region.objects.get(slug=region_slug)
+    # Create root node
+    root_ltn = LanguageTreeNode.add_root(
+        region=region,
+        language=Language.objects.get(id=language_id),
+        parent=None,
+    )
+
+    for i in range(num_children):
+        root_ltn.add_child(
+            region=region,
+            language=Language.objects.get(id=language_id + i + 1),
+            parent=root_ltn,
+        )
+
+    return root_ltn.id
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("role", ["ROOT", "AUTHOR"])
+@pytest.mark.parametrize(
+    "num_deletable, num_undeletable",
+    [
+        pytest.param(1, 1, id="deletable_node=1_undeletable_node=1"),
+        pytest.param(2, 0, id="deletable_nodes=2"),
+        pytest.param(0, 2, id="undeletable_nodes=2"),
+        pytest.param(2, 2, id="deletable_nodes=2_undeletable_nodes=2"),
+    ],
+)
+def test_bulk_delete_language_tree_nodes(
+    role: str,
+    client: Client,
+    load_test_data: None,
+    settings: SettingsWrapper,
+    caplog: LogCaptureFixture,
+    num_deletable: int,
+    num_undeletable: int,
+) -> None:
+    """
+    Test whether bulk deleting of pois works as expected
+    """
+    user = get_user_model().objects.get(username=role.lower())
+    client.force_login(user)
+
+    deletable_nodes = [
+        create_language_tree_node("empty-region", language_id=i + 1)
+        for i in range(num_deletable)
+    ]
+    undeletable_nodes = [
+        create_language_tree_node_with_children(
+            "empty-region", language_id=i * 2 + 1 + num_deletable, num_children=1
+        )
+        for i in range(num_undeletable)
+    ]
+    instance_ids: BulkActionIDs = {
+        "deletable": deletable_nodes,
+        "undeletable": [undeletable_nodes],
+    }
+    fail_reason = ["a source language of other language(s) cannot be deleted."]
+    url = reverse(
+        "bulk_delete_languagetreenodes",
+        kwargs={"region_slug": "empty-region"},
+    )
+    assert_bulk_delete(
+        LanguageTreeNode,
+        instance_ids,
+        url,
+        (client, role),
+        caplog,
+        settings,
+        fail_reason,
+    )

--- a/tests/cms/views/pages/test_page_actions.py
+++ b/tests/cms/views/pages/test_page_actions.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from _pytest.logging import LogCaptureFixture
+    from django.test.client import Client
+    from pytest_django.fixtures import SettingsWrapper
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from integreat_cms.cms.constants import status
+from integreat_cms.cms.models import Page, PageTranslation, Region
+from tests.cms.views.bulk_actions import assert_bulk_delete, BulkActionIDs
+
+
+def create_page(
+    region_slug: str,
+    name_add: str = "",
+    parent: Page | None = None,
+) -> int:
+    """
+    A helper function to create a page
+
+    Returns the page ID
+    """
+    region = Region.objects.get(slug=region_slug)
+    page = parent.add_child(region=region) if parent else Page.add_root(region=region)
+
+    PageTranslation.objects.create(
+        page=page,
+        language=region.default_language,
+        title="Test Page" + name_add,
+        slug="test-page" + name_add,
+        status=status.PUBLIC,
+    )
+    return page.id
+
+
+def create_page_with_children(
+    region_slug: str,
+    root_name_add: str = "",
+    num_children: int = 2,
+) -> int:
+    """
+    A helper function to create a root page with `num_children` child pages, manually assigning tree structure.
+
+    Returns the root page ID and the parents rgt.
+    """
+
+    region = Region.objects.get(slug=region_slug)
+
+    # Create root node
+    root_page = Page.add_root(
+        region=region,
+    )
+
+    PageTranslation.objects.create(
+        page=root_page,
+        language=root_page.region.default_language,
+        title=f"Root Page{root_name_add}",
+        slug=f"root-page{root_name_add}",
+        status=status.PUBLIC,
+    )
+
+    for i in range(num_children):
+        print("creating child page")
+        child_page = root_page.add_child(region=root_page.region, parent=root_page)
+        PageTranslation.objects.create(
+            page=child_page,
+            language=root_page.region.default_language,
+            title=f"Child {i}{root_name_add}",
+            slug=f"child-{i}{root_name_add}",
+            status=status.PUBLIC,
+        )
+
+    return root_page.id
+
+
+def create_page_with_mirror(
+    region_slug: str,
+    name_add: str = "",
+    start_lft: int = 1,
+    tree_id: int = 1,
+) -> tuple[int, int]:
+    """
+    A helper function to create a test page with a mirror page
+
+    Returns the page ID and the mirrored page ID
+    """
+    region = Region.objects.get(slug=region_slug)
+    original_page = Page.objects.get(
+        id=create_page(
+            region_slug,
+            name_add=f"{name_add}-original",
+        )
+    )
+
+    mirrored_page = Page.add_root(
+        region=region,
+        mirrored_page=original_page,
+        mirrored_page_first=True,
+    )
+
+    PageTranslation.objects.create(
+        page=mirrored_page,
+        language=region.default_language,
+        title="Mirrored Page" + name_add,
+        slug="mirrored-page" + name_add,
+        status=status.PUBLIC,
+    )
+    return original_page.id, mirrored_page.id
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("role", ["ROOT", "AUTHOR"])
+@pytest.mark.parametrize(
+    "num_deletable, num_undeletable_1, num_undeletable_2",
+    [
+        pytest.param(
+            1, 1, 1, id="deletable_page=1-page_with_children=1-page_with_mirror=1"
+        ),
+        pytest.param(2, 0, 0, id="deletable_pages=2"),
+        pytest.param(0, 2, 2, id="pages_with_children=2-pages_with_mirror=2"),
+        pytest.param(
+            2, 2, 2, id="deletable_pages=2-pages_with_children=2-pages_with_mirror=2"
+        ),
+    ],
+)
+def test_bulk_delete_pages(
+    role: str,
+    client: Client,
+    load_test_data: None,
+    settings: SettingsWrapper,
+    caplog: LogCaptureFixture,
+    num_deletable: int,
+    num_undeletable_1: int,
+    num_undeletable_2: int,
+) -> None:
+    """
+    Test whether bulk deleting of pois works as expected
+    """
+    user = get_user_model().objects.get(username=role.lower())
+    client.force_login(user)
+
+    deletable_pages = [
+        create_page(
+            "augsburg",
+            name_add=f"-{i}",
+        )
+        for i in range(num_deletable)
+    ]
+    undeletable_pages_1 = [
+        create_page_with_mirror(
+            region_slug="augsburg",
+            name_add=f"-{i}",
+        )[0]
+        for i in range(num_undeletable_1)
+    ]
+    undeletable_pages_2 = [
+        create_page_with_children(
+            region_slug="augsburg",
+            root_name_add=f"-{i}",
+            num_children=1,
+        )
+        for i in range(num_undeletable_2)
+    ]
+    instance_ids: BulkActionIDs = {
+        "deletable": deletable_pages,
+        "undeletable": [undeletable_pages_1, undeletable_pages_2],
+    }
+    fail_reason = [
+        "you cannot delete a page that is embedded as live content by another page.",
+        "you cannot delete a page which has subpages.",
+    ]
+    url = reverse(
+        "bulk_delete_pages",
+        kwargs={"region_slug": "augsburg", "language_slug": "en"},
+    )
+    assert_bulk_delete(
+        Page, instance_ids, url, (client, role), caplog, settings, fail_reason
+    )


### PR DESCRIPTION
### Short description
This adds a bulk delete option to events, pages, pois and language tree nodes


### Proposed changes
<!-- Describe this PR in more detail. -->

- On the list form template for pois, events, pages and language tree nodes you can now select to delete multiple entries
- After chosing to execute a confirmation dialogue will show that asks you to confirm the action
- the functionality is bundled in a general bulk_action_delete function that is used in the view of the entries
- I have added to the models of the entries (where necessary) a helper method "canBeDeleted" and adjusted the delete methods, so that the general bulk_action_delete can reuse those
- for the tests I have aimed for more self-containment as such that the entries (pois, pages, ...) are dynamically generated and not inserted into test_data.json


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- there have been some changes to the models of poi, event, languagetreenode and page (as mentionded above)


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3122


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
