### PR TITLE
Fix: Bulk MT crashes

### DIFF
--- a/integreat_cms/core/utils/machine_translation_api_client.py
+++ b/integreat_cms/core/utils/machine_translation_api_client.py
@@ -429,6 +429,7 @@ class MachineTranslationApiClient(ABC):
                 object_names=iter_to_string(
                     self.failed_because_insufficient_hix_score,
                 ),
+                min_required=settings.HIX_REQUIRED_FOR_MT,
             ),
         )
 

--- a/integreat_cms/release_notes/current/unreleased/3644.yml
+++ b/integreat_cms/release_notes/current/unreleased/3644.yml
@@ -1,0 +1,2 @@
+en: Fix the bug that bulk automatic translation crashes when pages with low HIX score are selected
+de: Behebe den Fehler, dass automatische Bulk-Übersetzung stürzt ab, wenn Seiten mit niedrigem HIX-Wert ausgewählt werden


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the bug that bulk MT crashes when pages with low HIX score are selected

### Proposed changes
<!-- Describe this PR in more detail. -->
- Reintroduce `min_required`, which seems to have been accidentally removed during the refactoring


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- Should be none
- 


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3644 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
