### PR TITLE
Fix linkcheck tests for CI pipeline

### DIFF
--- a/integreat_cms/cms/fixtures/test_data.json
+++ b/integreat_cms/cms/fixtures/test_data.json
@@ -5700,7 +5700,7 @@
       "title": "Wichtige Kontakte",
       "slug": "wichtige-kontakte",
       "status": "PUBLIC",
-      "content": "<div class=\"contact-card notranslate\" dir=\"ltr\" contenteditable=\"false\" translate=\"no\" data-contact-id=\"5\" data-contact-url=\"/augsburg/contact/5/?details=address,area_of_responsibility,name\"><a style=\"display: none;\" href=\"/augsburg/contact/5/?details=address,area_of_responsibility,name\">Contact</a>\r\n<h4>referred to in a page | Testkontakt</h4>\r\n<p><img src=\"http://localhost:8000/static/svg/pin.svg\" alt=\"Address: \" width=\"15\" height=\"15\"><a href=\"https://www.google.com/maps/search/?api=1&amp;query=Viktoriastra%C3%9Fe%201,Augsburg,Deutschland\" class=\"link-external\">Viktoriastraße 1, 86150 Augsburg</a></p>\r\n</div>",
+      "content": "<div class=\"contact-card notranslate\" dir=\"ltr\" contenteditable=\"false\" translate=\"no\" data-contact-id=\"5\" data-contact-url=\"/augsburg/contact/5/?details=address,area_of_responsibility,name\"><a style=\"display: none;\" href=\"/augsburg/contact/5/?details=address,area_of_responsibility,name\">Contact</a>\r\n<h4>referred to in a page | Testkontakt</h4>\r\n<p><a href=\"https://www.google.com/maps/search/?api=1&amp;query=Viktoriastra%C3%9Fe%201,Augsburg,Deutschland\" class=\"link-external\">Viktoriastraße 1, 86150 Augsburg</a></p>\r\n</div>",
       "language": 1,
       "currently_in_translation": false,
       "machine_translated": false,

--- a/tests/api/expected-outputs/augsburg_de_children.json
+++ b/tests/api/expected-outputs/augsburg_de_children.json
@@ -238,7 +238,7 @@
     "modified_gmt": "2025-01-11T07:07:46.642Z",
     "last_updated": "2025-01-11T08:07:46.642+01:00",
     "excerpt": "Contact\r\nreferred to in a page | Testkontakt\r\nViktoriastraße 1, 86150 Augsburg\r\n",
-    "content": "<div class=\"contact-card notranslate\" dir=\"ltr\" contenteditable=\"false\" translate=\"no\" data-contact-id=\"5\" data-contact-url=\"/augsburg/contact/5/?details=address,area_of_responsibility,name\"><a style=\"display: none;\" href=\"/augsburg/contact/5/?details=address,area_of_responsibility,name\">Contact</a>\r\n<h4>referred to in a page | Testkontakt</h4>\r\n<p><img src=\"http://localhost:8000/static/svg/pin.svg\" alt=\"Address: \" width=\"15\" height=\"15\"><a href=\"https://www.google.com/maps/search/?api=1&amp;query=Viktoriastra%C3%9Fe%201,Augsburg,Deutschland\" class=\"link-external\">Viktoriastraße 1, 86150 Augsburg</a></p>\r\n</div>",
+    "content": "<div class=\"contact-card notranslate\" dir=\"ltr\" contenteditable=\"false\" translate=\"no\" data-contact-id=\"5\" data-contact-url=\"/augsburg/contact/5/?details=address,area_of_responsibility,name\"><a style=\"display: none;\" href=\"/augsburg/contact/5/?details=address,area_of_responsibility,name\">Contact</a>\r\n<h4>referred to in a page | Testkontakt</h4>\r\n<p><a href=\"https://www.google.com/maps/search/?api=1&amp;query=Viktoriastra%C3%9Fe%201,Augsburg,Deutschland\" class=\"link-external\">Viktoriastraße 1, 86150 Augsburg</a></p>\r\n</div>",
     "parent": {
       "id": 0,
       "url": null,

--- a/tests/api/expected-outputs/augsburg_de_children_depth_2.json
+++ b/tests/api/expected-outputs/augsburg_de_children_depth_2.json
@@ -574,7 +574,7 @@
     "modified_gmt": "2025-01-11T07:07:46.642Z",
     "last_updated": "2025-01-11T08:07:46.642+01:00",
     "excerpt": "Contact\r\nreferred to in a page | Testkontakt\r\nViktoriastraße 1, 86150 Augsburg\r\n",
-    "content": "<div class=\"contact-card notranslate\" dir=\"ltr\" contenteditable=\"false\" translate=\"no\" data-contact-id=\"5\" data-contact-url=\"/augsburg/contact/5/?details=address,area_of_responsibility,name\"><a style=\"display: none;\" href=\"/augsburg/contact/5/?details=address,area_of_responsibility,name\">Contact</a>\r\n<h4>referred to in a page | Testkontakt</h4>\r\n<p><img src=\"http://localhost:8000/static/svg/pin.svg\" alt=\"Address: \" width=\"15\" height=\"15\"><a href=\"https://www.google.com/maps/search/?api=1&amp;query=Viktoriastra%C3%9Fe%201,Augsburg,Deutschland\" class=\"link-external\">Viktoriastraße 1, 86150 Augsburg</a></p>\r\n</div>",
+    "content": "<div class=\"contact-card notranslate\" dir=\"ltr\" contenteditable=\"false\" translate=\"no\" data-contact-id=\"5\" data-contact-url=\"/augsburg/contact/5/?details=address,area_of_responsibility,name\"><a style=\"display: none;\" href=\"/augsburg/contact/5/?details=address,area_of_responsibility,name\">Contact</a>\r\n<h4>referred to in a page | Testkontakt</h4>\r\n<p><a href=\"https://www.google.com/maps/search/?api=1&amp;query=Viktoriastra%C3%9Fe%201,Augsburg,Deutschland\" class=\"link-external\">Viktoriastraße 1, 86150 Augsburg</a></p>\r\n</div>",
     "parent": {
       "id": 0,
       "url": null,

--- a/tests/api/expected-outputs/augsburg_de_pages.json
+++ b/tests/api/expected-outputs/augsburg_de_pages.json
@@ -659,7 +659,7 @@
     "modified_gmt": "2025-01-11T07:07:46.642Z",
     "last_updated": "2025-01-11T08:07:46.642+01:00",
     "excerpt": "Contact\r\nreferred to in a page | Testkontakt\r\nViktoriastraße 1, 86150 Augsburg\r\n",
-    "content": "<div class=\"contact-card notranslate\" dir=\"ltr\" contenteditable=\"false\" translate=\"no\" data-contact-id=\"5\" data-contact-url=\"/augsburg/contact/5/?details=address,area_of_responsibility,name\"><a style=\"display: none;\" href=\"/augsburg/contact/5/?details=address,area_of_responsibility,name\">Contact</a>\r\n<h4>referred to in a page | Testkontakt</h4>\r\n<p><img src=\"http://localhost:8000/static/svg/pin.svg\" alt=\"Address: \" width=\"15\" height=\"15\"><a href=\"https://www.google.com/maps/search/?api=1&amp;query=Viktoriastra%C3%9Fe%201,Augsburg,Deutschland\" class=\"link-external\">Viktoriastraße 1, 86150 Augsburg</a></p>\r\n</div>",
+    "content": "<div class=\"contact-card notranslate\" dir=\"ltr\" contenteditable=\"false\" translate=\"no\" data-contact-id=\"5\" data-contact-url=\"/augsburg/contact/5/?details=address,area_of_responsibility,name\"><a style=\"display: none;\" href=\"/augsburg/contact/5/?details=address,area_of_responsibility,name\">Contact</a>\r\n<h4>referred to in a page | Testkontakt</h4>\r\n<p><a href=\"https://www.google.com/maps/search/?api=1&amp;query=Viktoriastra%C3%9Fe%201,Augsburg,Deutschland\" class=\"link-external\">Viktoriastraße 1, 86150 Augsburg</a></p>\r\n</div>",
     "parent": {
       "id": 0,
       "url": null,

--- a/tests/cms/test_duplicate_regions.py
+++ b/tests/cms/test_duplicate_regions.py
@@ -140,10 +140,10 @@ def test_duplicate_regions(
     ), "Links should exist in the source region"
     # Check if links have been cloned (except ignored ones)
     assert get_url_count(target_region.slug) == {
-        "number_all_urls": 20,
+        "number_all_urls": 19,
         "number_email_urls": 0,
         "number_ignored_urls": 0,
-        "number_invalid_urls": 10,
+        "number_invalid_urls": 9,
         "number_phone_urls": 0,
         "number_unchecked_urls": 0,
         "number_valid_urls": 10,

--- a/tests/cms/views/link_replace/test_link_actions.py
+++ b/tests/cms/views/link_replace/test_link_actions.py
@@ -342,6 +342,9 @@ def test_bulk_recheck_links(
 
     target_url_object = Url.objects.filter(url=RECHECK_TARGET_URL).first()
     assert target_url_object
+    target_url_object.last_checked = None
+    target_url_object.status = None
+    target_url_object.save()
 
     region_slug = region if region != "network_management" else None
     unchecked_url, _ = filter_urls(region_slug, "unchecked")


### PR DESCRIPTION
### Short description

#### Problem 1
There is a broken link to an SVG in one page. This image does not exist in the known links for Augsburg. Depending on how tests are split, sometimes this link is discovered before the region clone test is being executed. In that case the clone region test fails because one additional failing URL is found. The total number of expected links in the source region does not include this "unknown" link.

This link is obviously discovered when all pages in the cloned region are being saved. Therefore we need to decrease the known failing and total links there by one.

#### Problem 2

Okay, the issue is this: `filter_urls("augsburg", "unchecked")` requires a few other conditions to be met to have the URL sorted into "unchecked". Most importantly, the `status` attribute has to be `None`. If for any reason the other conditions in the long list of conditions are not met in the filter_urls() method, tests fail. To avoid this problem, we can force these attributes before continuing with the test.

### Proposed changes
- Remove the link in the test data and expected test output.

### Side effects
- None, I think.


### Faithfulness to issue description and design
:100: 

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: :rocket: 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
