### PR TITLE
Fix internal server error in suggest contacts

### DIFF
--- a/integreat_cms/cms/urls/protected.py
+++ b/integreat_cms/cms/urls/protected.py
@@ -1541,7 +1541,7 @@ urlpatterns: list[URLPattern] = [
                                 ),
                             ),
                             path(
-                                "potential_targets",
+                                "potential-targets",
                                 contacts.PotentialContactSourcesView.as_view(),
                                 name="potential_targets",
                             ),

--- a/integreat_cms/cms/views/contacts/contact_from_existing_data.py
+++ b/integreat_cms/cms/views/contacts/contact_from_existing_data.py
@@ -68,7 +68,7 @@ class PotentialContactSourcesView(TemplateView):
         :return: The rendered template response
         """
 
-        region_links = get_link_query(request.region)
+        region_links = get_link_query([request.region])
         email_or_phone_links = region_links.filter(
             Q(url__url__startswith="mailto") | Q(url__url__startswith="tel")
         )

--- a/integreat_cms/core/management/commands/fix_internal_links.py
+++ b/integreat_cms/core/management/commands/fix_internal_links.py
@@ -115,7 +115,7 @@ class Command(LogCommand):
 
         query = Url.objects.all()
         if region:
-            region_links = get_link_query(region)
+            region_links = get_link_query([region])
             query = Url.objects.filter(links__in=region_links).distinct()
 
         for url in query:

--- a/tests/cms/views/contacts/test_contact_from_existing_data.py
+++ b/tests/cms/views/contacts/test_contact_from_existing_data.py
@@ -1,0 +1,33 @@
+import pytest
+from django.conf import settings
+from django.test.client import Client
+from django.urls import reverse
+
+from tests.conftest import ANONYMOUS
+
+
+@pytest.mark.django_db
+def test_suggest_contacts_is_shown(
+    load_test_data: None,
+    login_role_user: tuple[Client, str],
+) -> None:
+    settings.LANGUAGE_CODE = "en"
+    client, role = login_role_user
+
+    get_potential_targets = reverse(
+        "potential_targets",
+        kwargs={"region_slug": "augsburg"},
+    )
+
+    response = client.get(get_potential_targets)
+
+    if role == ANONYMOUS:
+        assert response.status_code == 302
+        assert (
+            response.headers.get("location")
+            == f"{settings.LOGIN_URL}?next={get_potential_targets}"
+        )
+        return
+
+    assert response.status_code == 200
+    assert "Potential contact data" in response.content.decode("utf-8")


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the `Internal Server Error` on the page `potential-contacts` and in the management command to replace internal links. This bug was caused by #3541. The refactored `get_link_query` tries to access the first item within a Queryset of regions, if only a region is given this causes a `TypeError` which was represented by the `Internal Server Error`.

### Proposed changes
<!-- Describe this PR in more detail. -->

- But two occurrences of region in a list


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- This probably needs a test, right?


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3649


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
