### PR TITLE
restrict restoring pages to users that have publishing permissions

### DIFF
--- a/integreat_cms/cms/templates/pages/page_form.html
+++ b/integreat_cms/cms/templates/pages/page_form.html
@@ -59,7 +59,6 @@
                     <button name="preview_page" type="button" data-preview-page data-edit-page-mode data-right-to-left={{ right_to_left }} class="btn btn-ghost">
                         {% translate "Preview" %}
                     </button>
-                    {% has_perm 'cms.publish_page_object' request.user page as can_publish_page %}
                     {% if can_publish_page %}
                         <button name="status"
                                 value="{{ DRAFT }}"
@@ -214,7 +213,7 @@
                 {% if page %}
                     <div id="right-sidebar-column"
                          class="md:w-full 3xl:col-end-3 4xl:col-end-auto flex flex-wrap flex-col">
-                        {% if can_edit_page %}
+                        {% if show_actions_box %}
                             {% include "./page_form_sidebar/actions_box.html" with box_id="page-actions" %}
                         {% endif %}
                         {% include "./page_form_sidebar/translator_view_box.html" with box_id="page-side-by-side" %}

--- a/integreat_cms/cms/templates/pages/page_form_sidebar/actions_box.html
+++ b/integreat_cms/cms/templates/pages/page_form_sidebar/actions_box.html
@@ -9,7 +9,7 @@
     {% translate "Actions" %}
 {% endblock collapsible_box_title %}
 {% block collapsible_box_content %}
-    {% has_perm 'cms.publish_page_object' request.user as can_publish_pages %}
+    {% has_perm 'cms.publish_page_object' request.user page as can_publish_pages %}
     {% if page_form.instance.id and can_edit_page and not page.archived %}
         <label class="mt-0">
             {% translate "Refresh date" %}
@@ -22,92 +22,94 @@
             {% translate "Mark this page as up-to-date" %}
         </button>
     {% endif %}
-    {% if page.explicitly_archived %}
-        <label>
-            {% translate "Restore page" %}
-        </label>
-        <button title="{% translate "Restore page" %}"
-                class="btn confirmation-button w-full"
-                data-confirmation-title="{{ restore_dialog_title }}"
-                data-confirmation-text="{{ restore_dialog_text }}"
-                data-confirmation-subject="{{ page_translation_form.instance.title }}"
-                data-action="{% url 'restore_page' page_id=page_form.instance.id region_slug=request.region.slug language_slug=language.slug %}">
-            <i icon-name="refresh-ccw" class="mr-2"></i> {% translate "Restore this page" %}
-        </button>
-    {% elif page.implicitly_archived %}
-        <label>
-            {% translate "Restore page" %}
-        </label>
-        <div class="bg-orange-100 border-l-4 border-orange-500 text-orange-700 px-4 py-3 mb-5"
-             role="alert">
-            <p>
-                {% blocktranslate count counter=page.explicitly_archived_ancestors|length trimmed %}
-                    To restore this page, you have to restore its parent page:
-                {% plural %}
-                    To restore this page, you have to restore all its archived parent pages:
-                {% endblocktranslate %}
-            </p>
-        </div>
-        {% for ancestor in page.explicitly_archived_ancestors %}
-            <a href="{% url 'edit_page' page_id=ancestor.id region_slug=request.region.slug language_slug=language.slug %}"
-               class="block pt-2 hover:underline">
-                <i icon-name="pen-square" class="mr-2"></i> {{ ancestor.best_translation.title }}
-            </a>
-        {% endfor %}
-    {% elif can_publish_pages %}
-        <label>
-            {% translate "Archive page" %}
-        </label>
-        {% if not page.mirroring_pages.exists %}
-            <button title="{% translate "Archive page" %}"
+    {% if can_publish_pages %}
+        {% if page.explicitly_archived %}
+            <label>
+                {% translate "Restore page" %}
+            </label>
+            <button title="{% translate "Restore page" %}"
                     class="btn confirmation-button w-full"
-                    data-confirmation-title="{{ archive_dialog_title }}"
-                    data-confirmation-text="{{ archive_dialog_text }}"
+                    data-confirmation-title="{{ restore_dialog_title }}"
+                    data-confirmation-text="{{ restore_dialog_text }}"
                     data-confirmation-subject="{{ page_translation_form.instance.title }}"
-                    data-action="{% url 'archive_page' page_id=page_form.instance.id region_slug=request.region.slug language_slug=language.slug %}">
-                <i icon-name="archive" class="mr-2"></i>
-                {% translate "Archive this page" %}
+                    data-action="{% url 'restore_page' page_id=page_form.instance.id region_slug=request.region.slug language_slug=language.slug %}">
+                <i icon-name="refresh-ccw" class="mr-2"></i> {% translate "Restore this page" %}
             </button>
-        {% else %}
-            {% with page.mirroring_pages.all.prefetch_translations as mirroring_pages %}
-                <div class="bg-orange-100 border-l-4 border-orange-500 text-orange-700 px-4 py-3 mb-5"
-                     role="alert">
-                    <p>
-                        {% translate "You cannot archive a page which is embedded as live content from another page." %}
-                    </p>
-                </div>
+        {% elif page.implicitly_archived %}
+            <label>
+                {% translate "Restore page" %}
+            </label>
+            <div class="bg-orange-100 border-l-4 border-orange-500 text-orange-700 px-4 py-3 mb-5"
+                 role="alert">
                 <p>
-                    {% blocktranslate count counter=mirroring_pages|length trimmed %}
-                        To archive this page, you have to remove the embedded live content from this page first:
+                    {% blocktranslate count counter=page.explicitly_archived_ancestors|length trimmed %}
+                        To restore this page, you have to restore its parent page:
                     {% plural %}
-                        To archive this page, you have to remove the embedded live content from these pages first:
+                        To restore this page, you have to restore all its archived parent pages:
                     {% endblocktranslate %}
                 </p>
-                {% for mirroring_page in mirroring_pages %}
-                    {% has_perm 'cms.change_page_object' request.user mirroring_page as can_change_page_object %}
-                    {% if can_change_page_object %}
-                        <a href="{% url 'edit_page' page_id=mirroring_page.id region_slug=mirroring_page.region.slug language_slug=language.slug %}"
-                           class="block pt-2 hover:underline">
-                            <i icon-name="pen-square" class="mr-2"></i>
-                            {{ mirroring_page.best_translation.title }}
-                            {% if mirroring_page.region != request.region %}
-                                ({{ mirroring_page.region }})
-                            {% endif %}
-                        </a>
-                    {% else %}
-                        <a href="{{ WEBAPP_URL }}{{ mirroring_page.best_translation.get_absolute_url }}"
-                           class="block pt-2 hover:underline"
-                           target="_blank"
-                           rel="noopener noreferrer">
-                            <i icon-name="external-link" class="mr-2"></i>
-                            {{ mirroring_page.best_translation.title }}
-                            {% if mirroring_page.region != request.region %}
-                                ({{ mirroring_page.region }})
-                            {% endif %}
-                        </a>
-                    {% endif %}
-                {% endfor %}
-            {% endwith %}
+            </div>
+            {% for ancestor in page.explicitly_archived_ancestors %}
+                <a href="{% url 'edit_page' page_id=ancestor.id region_slug=request.region.slug language_slug=language.slug %}"
+                   class="block pt-2 hover:underline">
+                    <i icon-name="pen-square" class="mr-2"></i> {{ ancestor.best_translation.title }}
+                </a>
+            {% endfor %}
+        {% else %}
+            <label>
+                {% translate "Archive page" %}
+            </label>
+            {% if not page.mirroring_pages.exists %}
+                <button title="{% translate "Archive page" %}"
+                        class="btn confirmation-button w-full"
+                        data-confirmation-title="{{ archive_dialog_title }}"
+                        data-confirmation-text="{{ archive_dialog_text }}"
+                        data-confirmation-subject="{{ page_translation_form.instance.title }}"
+                        data-action="{% url 'archive_page' page_id=page_form.instance.id region_slug=request.region.slug language_slug=language.slug %}">
+                    <i icon-name="archive" class="mr-2"></i>
+                    {% translate "Archive this page" %}
+                </button>
+            {% else %}
+                {% with page.mirroring_pages.all.prefetch_translations as mirroring_pages %}
+                    <div class="bg-orange-100 border-l-4 border-orange-500 text-orange-700 px-4 py-3 mb-5"
+                         role="alert">
+                        <p>
+                            {% translate "You cannot archive a page which is embedded as live content from another page." %}
+                        </p>
+                    </div>
+                    <p>
+                        {% blocktranslate count counter=mirroring_pages|length trimmed %}
+                            To archive this page, you have to remove the embedded live content from this page first:
+                        {% plural %}
+                            To archive this page, you have to remove the embedded live content from these pages first:
+                        {% endblocktranslate %}
+                    </p>
+                    {% for mirroring_page in mirroring_pages %}
+                        {% has_perm 'cms.change_page_object' request.user mirroring_page as can_change_page_object %}
+                        {% if can_change_page_object %}
+                            <a href="{% url 'edit_page' page_id=mirroring_page.id region_slug=mirroring_page.region.slug language_slug=language.slug %}"
+                               class="block pt-2 hover:underline">
+                                <i icon-name="pen-square" class="mr-2"></i>
+                                {{ mirroring_page.best_translation.title }}
+                                {% if mirroring_page.region != request.region %}
+                                    ({{ mirroring_page.region }})
+                                {% endif %}
+                            </a>
+                        {% else %}
+                            <a href="{{ WEBAPP_URL }}{{ mirroring_page.best_translation.get_absolute_url }}"
+                               class="block pt-2 hover:underline"
+                               target="_blank"
+                               rel="noopener noreferrer">
+                                <i icon-name="external-link" class="mr-2"></i>
+                                {{ mirroring_page.best_translation.title }}
+                                {% if mirroring_page.region != request.region %}
+                                    ({{ mirroring_page.region }})
+                                {% endif %}
+                            </a>
+                        {% endif %}
+                    {% endfor %}
+                {% endwith %}
+            {% endif %}
         {% endif %}
     {% endif %}
     {% if perms.cms.delete_page %}

--- a/integreat_cms/cms/templates/pages/pages_page_tree.html
+++ b/integreat_cms/cms/templates/pages/pages_page_tree.html
@@ -264,7 +264,7 @@
                         </option>
                     {% endif %}
                 {% else %}
-                    {% if can_edit_pages %}
+                    {% if can_publish_pages %}
                         <option data-bulk-action="{% url 'bulk_restore_pages' region_slug=request.region.slug language_slug=language.slug %}">
                             {% translate "Restore pages" %}
                         </option>

--- a/integreat_cms/cms/templates/pages/pages_page_tree_node.html
+++ b/integreat_cms/cms/templates/pages/pages_page_tree_node.html
@@ -143,8 +143,8 @@
                 <i icon-name="pencil"></i>
             </a>
         {% endif %}
-        {% has_perm 'cms.publish_page_object' request.user as can_publish_pages %}
-        {% if not is_archive and can_publish_pages %}
+        {% has_perm 'cms.publish_page_object' request.user page as can_publish_page %}
+        {% if not is_archive and can_publish_page %}
             {% if page.mirroring_pages.exists %}
                 <button title="{% translate "This page cannot be archived because it was embedded as live content from another page." %}"
                         class="btn-icon"
@@ -162,7 +162,7 @@
                 </button>
             {% endif %}
         {% endif %}
-        {% if is_archive and can_edit_pages %}
+        {% if is_archive and can_publish_page %}
             {% if page.explicitly_archived %}
                 <button title="{% translate "Restore page" %}"
                         class="confirmation-button btn-icon"

--- a/integreat_cms/cms/urls/protected.py
+++ b/integreat_cms/cms/urls/protected.py
@@ -985,9 +985,7 @@ urlpatterns: list[URLPattern] = [
                                         ),
                                         path(
                                             "bulk-restore/",
-                                            bulk_action_views.BulkRestoreView.as_view(
-                                                model=Page,
-                                            ),
+                                            pages.PageBulkRestoreView.as_view(),
                                             name="bulk_restore_pages",
                                         ),
                                         path(

--- a/integreat_cms/cms/views/pages/__init__.py
+++ b/integreat_cms/cms/views/pages/__init__.py
@@ -24,6 +24,7 @@ from .page_bulk_actions import (
     ExportXliffView,
     GeneratePdfView,
     PageBulkArchiveView,
+    PageBulkRestoreView,
 )
 from .page_form_view import PageFormView
 from .page_permission_actions import (

--- a/integreat_cms/cms/views/pages/page_actions.py
+++ b/integreat_cms/cms/views/pages/page_actions.py
@@ -119,7 +119,7 @@ def restore_page(
     region = request.region
     page = get_object_or_404(region.pages, id=page_id)
 
-    if not request.user.has_perm("cms.change_page_object", page):
+    if not request.user.has_perm("cms.publish_page_object", page):
         raise PermissionDenied(
             f"{request.user!r} does not have the permission to restore {page!r}",
         )

--- a/integreat_cms/cms/views/pages/page_bulk_actions.py
+++ b/integreat_cms/cms/views/pages/page_bulk_actions.py
@@ -18,7 +18,7 @@ from ...utils.pdf_utils import generate_pdf
 from ...utils.stringify_list import iter_to_string
 from ...utils.translation_utils import gettext_many_lazy as __
 from ...utils.translation_utils import translate_link
-from ..bulk_action_views import BulkActionView, BulkArchiveView
+from ..bulk_action_views import BulkActionView, BulkArchiveView, BulkRestoreView
 from .page_actions import cancel_translation_process_ajax
 
 if TYPE_CHECKING:
@@ -75,6 +75,15 @@ class GeneratePdfView(PageBulkActionMixin, BulkActionView):
 class PageBulkArchiveView(PageBulkActionMixin, BulkArchiveView):
     """
     Bulk action for archiving multiple pages at once
+    """
+
+    def get_permission_required(self) -> tuple[str]:
+        return ("cms.publish_page_object",)
+
+
+class PageBulkRestoreView(PageBulkActionMixin, BulkRestoreView):
+    """
+    Bulk action for restoring multiple pages at once
     """
 
     def get_permission_required(self) -> tuple[str]:

--- a/integreat_cms/cms/views/pages/page_form_view.py
+++ b/integreat_cms/cms/views/pages/page_form_view.py
@@ -530,3 +530,19 @@ class PageFormView(
                     },
                 )
         return side_by_side_language_options
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+        region = self.request.region
+        page_instance = region.pages.filter(id=kwargs.get("page_id")).first()
+        if page_instance is None:
+            return context
+        # users without publish permission don't have any actions in archived pages
+        # thus we hide the action box for these cases
+        context["show_actions_box"] = self.request.user.has_perm(
+            "cms.publish_page_object", page_instance
+        ) or (
+            self.request.user.has_perm("cms.change_page_object", page_instance)
+            and not page_instance.archived
+        )
+        return context

--- a/integreat_cms/release_notes/current/unreleased/3512.yml
+++ b/integreat_cms/release_notes/current/unreleased/3512.yml
@@ -1,0 +1,2 @@
+en: Fix that users without publishing rights for pages could restore pages.
+de: Behebe das Problem, dass Benutzer:innen ohne Veröffentlichungsrechte Seiten wiederherstellen können.

--- a/tests/cms/views/view_config.py
+++ b/tests/cms/views/view_config.py
@@ -451,7 +451,7 @@ VIEWS: ViewConfig = [
             ),
             (
                 "bulk_restore_pages",
-                [*PRIV_STAFF_ROLES, MANAGEMENT, EDITOR, AUTHOR],
+                [*PRIV_STAFF_ROLES, MANAGEMENT, EDITOR],
                 {"selected_ids[]": [1, 2, 3]},
             ),
             (
@@ -1286,7 +1286,7 @@ VIEWS: ViewConfig = [
             ),
             (
                 "restore_page",
-                [*PRIV_STAFF_ROLES, MANAGEMENT, EDITOR, AUTHOR],
+                [*PRIV_STAFF_ROLES, MANAGEMENT, EDITOR],
                 {"post_data": True},
             ),
         ],


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Users without publish rights are not able to archive pages, but thus far have been able to restore pages. To adhere to the principle of coherent responsibility, users that can't archive pages should not be able to restore pages.

### Proposed changes
<!-- Describe this PR in more detail. -->

- check publish page permissions when restoring pages
- hide restore page icon in forms and tree views


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Due to an error in the page_tree_node, users with publish rights to specific pages (author role) were not able to archive these pages, even though they had the appropriate permissions, because the icon was always hidden. With this PR, icons for archiving and restoring are shown as expected


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3512


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
