### PR TITLE
Add dev server documentation about setting permissions for PostgreSQL

### DIFF
--- a/docs/src/dev-server.rst
+++ b/docs/src/dev-server.rst
@@ -29,6 +29,8 @@ Two different types of local database servers are supported:
     + Username: ``integreat``
     + Password: ``password``
 
+  - Set the permissions to create a database manually (needed for tests) inside the PostrgreSQL shell with ``ALTER ROLE integreat CREATE_DB``
+
 .. Note::
 
     If you want to remove all contents of your database, use :github-source:`tools/prune_database.sh`.


### PR DESCRIPTION
### Short description
 - a little addition that explains how to add create-database permissions in PostrgreSQL


### Proposed changes
<!-- Describe this PR in more detail. -->

- I ran into this problem when running automated tests for the first time (see here: https://chat.tuerantuer.org/digitalfabrik/pl/hfekidjn63yamkmf3o8fcy9x7o): -> The tests were not able to create a database.
- and setting the permissions in the way described in the documentation solved this for me


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
