### PR TITLE
Fix test_find_missing_versions_failure

### DIFF
--- a/tests/core/management/commands/test_find_missing_versions.py
+++ b/tests/core/management/commands/test_find_missing_versions.py
@@ -47,6 +47,11 @@ def test_find_missing_versions_failure(load_test_data: None) -> None:
     """
     # Create version inconsistency
     page_translation = Page.objects.get(id=1).get_translation("de")
+
+    # Ensure that the title is as expected in the output later. Some other test seems
+    # to change the title, which results in flaky CI tests.
+    page_translation.slug = "willkommen"
+
     page_translation.version += 1
     page_translation.save()
     out, err = get_command_output("find_missing_versions", "page")
@@ -59,3 +64,6 @@ def test_find_missing_versions_failure(load_test_data: None) -> None:
         " in <Language (id: 1, slug: de, name: German)>"
         " is 3, but there are only 2 translation objects!\x1b[0m\n"
     )
+    # restore previous state to not interfere with other tests.
+    page_translation.version -= 1
+    page_translation.save()


### PR DESCRIPTION
### Short description
It seems that some other previously running test manipulates the slug of version 1 of the augsburg/de/willkommen page. In order for this test to successfully complete, we need to ensure that the slug is correct.

### Proposed changes
- Set the slug of version 1 to `willkommen` before the test starts.


### Side effects
- Some other COULD depend on the slug being `welcome`? But I doubt that currently.


### Faithfulness to issue description and design
:100: :joy: 

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3669 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
