### PR TITLE
Allow app users to change chat language

### DIFF
--- a/integreat_cms/api/v3/chat/user_chat.py
+++ b/integreat_cms/api/v3/chat/user_chat.py
@@ -62,7 +62,7 @@ def is_chat_enabled_for_user(
 
 
 def get_or_create_user_chat(
-    request: HttpRequest, device_id: str, language_slug: str
+    request: HttpRequest, device_id: str, language: Language
 ) -> UserChat | None:
     """
     Get existing UserChat or create a new one if the HTTP method is POST.
@@ -77,7 +77,7 @@ def get_or_create_user_chat(
         return UserChat.objects.create(
             region=request.region,
             device_id=device_id,
-            language=Language.objects.get(slug=language_slug),
+            language=language,
         )
     return None
 
@@ -93,14 +93,15 @@ def process_chat_payload(
     :param device_id: UUID of the app device
     :param language_slug: slug of language that is used by the app
     """
-    if (
-        user_chat := get_or_create_user_chat(request, device_id, language_slug)
-    ) is None:
+    language = Language.objects.get(slug=language_slug)
+    if (user_chat := get_or_create_user_chat(request, device_id, language)) is None:
         return JsonResponse({"error": "Chat not found."}, status=404)
     if request.POST.get("message"):
         user_chat.save_message(
             message=request.POST.get("message"), internal=False, automatic_message=False
         )
+        user_chat.language = language
+        user_chat.save()
     if request.POST.get("evaluation_consent"):
         user_chat.save_evaluation_consent(request.POST.get("evaluation_consent"))
     return JsonResponse(user_chat.as_dict())


### PR DESCRIPTION
### Short description
Allow app users to change the language of automatically generated chat answers and translations.


### Proposed changes
- Update the user chat language based to the latest app chat request. This represents the currently selected app language.


### Side effects
- The answers will be mixed language. However, this is wanted. The chat back end should be stable enough to handle mixed input languages.


### Resolved issues


Fixes: https://github.com/digitalfabrik/integreat-chat/issues/354


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
