### PR TITLE
Add to documentation handling pyhon3.12 during installation

### DIFF
--- a/docs/src/installation.rst
+++ b/docs/src/installation.rst
@@ -15,7 +15,7 @@ Following packages are required before installing the project (install them with
 * `git <https://git-scm.com/>`_
 * `npm <https://www.npmjs.com/>`_ version 7 or later
 * `nodejs <https://nodejs.org/>`_ version 18 or later
-* `python3 <https://www.python.org/>`_ version 3.9 or later
+* `python3 <https://www.python.org/>`_ version 3.9 to 3.11 (for above 3.11 see below)
 * `python3-pip <https://packages.ubuntu.com/search?keywords=python3-pip>`_ (`Debian-based distributions <https://en.wikipedia.org/wiki/Category:Debian-based_distributions>`_, e.g. `Ubuntu <https://ubuntu.com>`__) / `python-pip <https://www.archlinux.de/packages/extra/x86_64/python-pip>`_ (`Arch-based distributions <https://wiki.archlinux.org/index.php/Arch-based_distributions>`_)
 * `python3-venv <https://packages.ubuntu.com/search?keywords=python3+venv>`_ (Only `Debian-based distributions <https://en.wikipedia.org/wiki/Category:Debian-based_distributions>`_, e.g. `Ubuntu <https://ubuntu.com>`__)
 * Either `postgresql <https://www.postgresql.org/>`_ **or** `docker <https://www.docker.com/>`_ to run a local database server
@@ -128,5 +128,8 @@ And install it using our developer tool :github-source:`tools/install.sh`::
 
 .. Note::
 
-    This script checks whether the required system-dependencies are installed and installs the project-dependencies via npm and pip.
-    If only one of both dependency-managers should be invoked, run ``npm ci`` or ``pip install -e .[dev-pinned,pinned]`` directly.
+    - This script checks whether the required system-dependencies are installed and installs the project-dependencies via npm and pip.
+      If only one of both dependency-managers should be invoked, run ``npm ci`` or ``pip install -e .[dev-pinned,pinned]`` directly.
+
+    - If your system uses Python 3.12 as the default (e.g., Ubuntu 24.04 or similar), you need to install Python 3.11 alongside it, without changing the default python3 symlink.
+      Then, to ensure the CMS uses Python 3.11, run the installation script with the appropriate interpreter: ``./tools/install.sh --python python3.11``


### PR DESCRIPTION
### Short description
I ran into this problem with python 3.12 during development environment setup on my Ubuntu laptop. These additions to the documentation might be helpful for the next person


### Proposed changes
- install.sh needs python 3.9 to 3.11 (3.12 fails)
- so best way is to install python3.11 alongside, but keep python3 pointing at 3.12
- end then run install.sh by setting the python parameter to python 3.11


### Side effects
none


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
