### PR TITLE
Fix svg upload and thumbnails

### DIFF
--- a/integreat_cms/cms/forms/media/upload_media_file_form.py
+++ b/integreat_cms/cms/forms/media/upload_media_file_form.py
@@ -124,19 +124,20 @@ class UploadMediaFileForm(CustomModelForm):
                 ),
             )
 
-        # If everything looks good until now, generate a thumbnail and an optimized image
         if (
             not self.errors
             and (img_type := cleaned_data.get("type"))
             and img_type.startswith("image")
         ):
-            if optimized_image := generate_thumbnail(
-                file,
-                settings.MEDIA_OPTIMIZED_SIZE,
-                False,
-            ):
-                cleaned_data["file"] = optimized_image
-                cleaned_data["thumbnail"] = generate_thumbnail(file)
+            if thumbnail := generate_thumbnail(file):
+                cleaned_data["thumbnail"] = thumbnail
+                if img_type != "image/svg+xml":
+                    # Generate an optimized image
+                    cleaned_data["file"] = generate_thumbnail(
+                        file,
+                        settings.MEDIA_OPTIMIZED_SIZE,
+                        False,
+                    )
 
             else:
                 self.add_error(

--- a/integreat_cms/cms/models/media/media_file.py
+++ b/integreat_cms/cms/models/media/media_file.py
@@ -77,6 +77,11 @@ def upload_path_thumbnail(
     """
     # Derive the thumbnail name from the original file name
     name, extension = splitext(instance.file.name)
+    if extension.lower() == ".svg":
+        # If we are SVG, the thumbnail will still be PNG.
+        # We could just name it SVG, as browsers use the mime type sent, not the file extension,
+        # but unfortunately the web server itself derives the mime type from the file extension and not the content
+        extension = ".png"
     path = f"{name}_thumbnail{extension}"
     logger.debug("Upload path for thumbnail of %r: %r", instance.thumbnail, path)
     return path

--- a/integreat_cms/cms/utils/media_utils.py
+++ b/integreat_cms/cms/utils/media_utils.py
@@ -41,7 +41,9 @@ def generate_thumbnail(
         if original_image.content_type == "image/svg+xml":
             original_image.seek(0)
             svg_bytes = original_image.read()
-            png_bytes = cairosvg.svg2png(bytestring=svg_bytes)
+            png_bytes = cairosvg.svg2png(
+                bytestring=svg_bytes, output_width=size, output_height=size
+            )
             image = Image.open(BytesIO(png_bytes))
         else:
             image = Image.open(original_image)


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Ensure SVGs are indeed saved as such on the server.
Mimetypes of files handed out by the server seem to be determined by the file extension only, so we need to manually set the extension for thumbnails of SVGs to PNG.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Don't generate an optimized image for SVGs
- Use the normal thumbnail generation *(which we always need)* to determine if the file is corrupted instead of the generation of an optimized image
- Change the file extension for thumbnails to `.png` if the original files are `.svg`

And as a bonus:
- Allow scaling up SVGs for thumbnail generation even if the stored dimensions of the file are smaller, since SVGs do not blur anyway *(unless someone embedded a raster image and defeated the whole purpose)*


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3687 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
