### PR TITLE
Exclude archived push notifications from the API result

### DIFF
--- a/integreat_cms/api/v3/push_notifications.py
+++ b/integreat_cms/api/v3/push_notifications.py
@@ -37,7 +37,8 @@ def sent_push_notifications(
     """
     channel = request.GET.get("channel", "all")
     query_result = (
-        PushNotificationTranslation.objects.filter(
+        PushNotificationTranslation.objects.filter(push_notification__archived=False)
+        .filter(
             push_notification__regions__slug=region_slug,
         )
         .filter(

--- a/tests/api/test_pushnotification_api.py
+++ b/tests/api/test_pushnotification_api.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+from dateutil.relativedelta import relativedelta
+from django.test.client import Client
+from django.urls import reverse
+
+from integreat_cms.cms.models import (
+    Language,
+    PushNotification,
+    PushNotificationTranslation,
+    Region,
+)
+
+REGION_SLUG = "artland"
+
+
+def create_a_pushnotification(region_slug: str) -> tuple[int, int]:
+    """
+    A function to create a new push notification and a translation in the default language of the region.
+    """
+    region = Region.objects.get(slug=region_slug)
+    default_language = Language.objects.get(slug=region.default_language.slug)
+    pushnotification = PushNotification.objects.create(
+        channel="news",
+        draft=False,
+        sent_date=datetime.now() - relativedelta(days=1),
+        created_date=datetime.now() - relativedelta(days=1),
+        scheduled_send_date=None,
+        is_template=False,
+        template_name=None,
+    )
+    pushnotification.regions.add(region)
+    pushnotification.save()
+    pushnotification_translation = PushNotificationTranslation.objects.create(
+        title="German Traslation",
+        text="Hello World",
+        language=default_language,
+        push_notification=pushnotification,
+        last_updated=datetime.now() - relativedelta(days=1),
+    )
+    pushnotification_translation.save()
+
+    return pushnotification.id, pushnotification_translation.id
+
+
+@pytest.mark.django_db
+def test_no_archived_pushnotification(load_test_data: None) -> None:
+    """
+    Check that archived push notifications are excluded from the API result
+
+    :param load_test_data: The fixture providing the test data (see :meth:`~tests.conftest.load_test_data`)
+    """
+
+    client = Client()
+
+    kwargs = {"region_slug": REGION_SLUG, "language_slug": "de"}
+    api = reverse("api:sent_push_notifications", kwargs=kwargs)
+    start_response = client.get(api)
+    start_result = start_response.content.decode("utf-8")
+
+    pushnotification_id, pushnotification_translation_id = create_a_pushnotification(
+        REGION_SLUG
+    )
+
+    response_after_new_pn = client.get(api)
+    result_after_new_pn = response_after_new_pn.content.decode("utf-8")
+    assert (
+        f'"id": {pushnotification_translation_id}, "title": "German Traslation", "message": "Hello World"'
+        in result_after_new_pn
+    )
+
+    pushnotification = PushNotification.objects.get(id=pushnotification_id)
+    pushnotification.archived = True
+    pushnotification.save()
+
+    response_after_archiving = client.get(api)
+    result_after_archiving = response_after_archiving.content.decode("utf-8")
+    assert result_after_archiving == start_result


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixses the bug that archived push notifications still appear in the app.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Filter archived push notifications ways
- Add a test


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- should be none
- 


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3680 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
