### PR TITLE
Save and load page accesses

### DIFF
--- a/integreat_cms/cms/migrations/0133_add_page_accesses.py
+++ b/integreat_cms/cms/migrations/0133_add_page_accesses.py
@@ -1,0 +1,71 @@
+import django.db.models.deletion
+import django.utils.timezone
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """
+    Initial migration file for the Page Accesses model
+    """
+
+    dependencies = [
+        ("cms", "0132_archive_pushnotification"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="PageAccesses",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "access_date",
+                    models.DateTimeField(verbose_name="Date of the page accesses"),
+                ),
+                (
+                    "language",
+                    models.ForeignKey(
+                        on_delete=models.CASCADE,
+                        to="cms.language",
+                        verbose_name="Languages of the page that was accessed",
+                    ),
+                ),
+                (
+                    "page",
+                    models.ForeignKey(
+                        on_delete=models.CASCADE,
+                        to="cms.page",
+                        verbose_name="Accessed page",
+                    ),
+                ),
+                (
+                    "accesses",
+                    models.IntegerField(
+                        validators=[django.core.validators.MinValueValidator(0)],
+                        verbose_name="Page accesses",
+                    ),
+                ),
+            ],
+            options={
+                "default_permissions": ("change", "delete", "view"),
+                "default_related_name": "page_accesses",
+                "ordering": ["pk"],
+                "verbose_name": "page accesses",
+                "verbose_name_plural": "page accesses",
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="PageAccesses",
+            constraint=models.UniqueConstraint(
+                fields=("page", "language", "access_date"),
+                name="pageaccesses_unique_version",
+            ),
+        ),
+    ]

--- a/integreat_cms/cms/models/__init__.py
+++ b/integreat_cms/cms/models/__init__.py
@@ -43,6 +43,7 @@ from .push_notifications.push_notification_translation import (
     PushNotificationTranslation,
 )
 from .regions.region import Region
+from .statistics.page_accesses import PageAccesses
 from .users.organization import Organization
 from .users.role import Role
 from .users.user import User

--- a/integreat_cms/cms/models/regions/region.py
+++ b/integreat_cms/cms/models/regions/region.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import uuid
-from datetime import datetime
+from datetime import date, datetime, timedelta
 from html import escape
 from typing import TYPE_CHECKING
 
@@ -47,6 +47,7 @@ from ...constants import (
 from ...utils.translation_utils import gettext_many_lazy as __
 from ..abstract_base_model import AbstractBaseModel
 from ..offers.offer_template import OfferTemplate
+from ..statistics.page_accesses import PageAccesses
 
 logger = logging.getLogger(__name__)
 
@@ -1037,6 +1038,29 @@ class Region(AbstractBaseModel):
             latest_imprint_update,
             self.last_updated,
         )
+
+    def get_page_accesses_by_language(
+        self,
+        pages: list[Page],
+        start_date: date,
+        end_date: date,
+        languages: list[Language],
+    ) -> dict:
+        """
+        Get the page accesses of the requested pages of this region during the specified timerange
+        :param pages: List of requested pages
+        :param start_date: Earliest date
+        :param end_date: Latest date
+        :param languages: List of requested languages
+
+        :return: Page accesses of the requested pages
+        """
+        return PageAccesses.objects.filter(
+            page__region=self,
+            page__in=pages,
+            access_date__range=(start_date, end_date + timedelta(days=1)),
+            language__in=languages,
+        ).values()
 
     def __str__(self) -> SafeString:
         """

--- a/integreat_cms/cms/models/statistics/__init__.py
+++ b/integreat_cms/cms/models/statistics/__init__.py
@@ -1,0 +1,3 @@
+"""
+This package contains only the :class:`~integreat_cms.cms.models.statistics.page_accesses.PageAccesses` model.
+"""

--- a/integreat_cms/cms/models/statistics/page_accesses.py
+++ b/integreat_cms/cms/models/statistics/page_accesses.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from django.core.validators import MinValueValidator
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+from ..abstract_base_model import AbstractBaseModel
+
+
+class PageAccesses(AbstractBaseModel):
+    """
+    Data Model representing the accesses of a page
+    """
+
+    access_date = models.DateTimeField(
+        verbose_name="Date of the page accesses",
+    )
+    language = models.ForeignKey(
+        "cms.Language",
+        on_delete=models.CASCADE,
+        verbose_name="Languages of the page that was accessed",
+    )
+    page = models.ForeignKey(
+        "cms.Page",
+        on_delete=models.CASCADE,
+        verbose_name="Accessed page",
+    )
+    accesses = models.IntegerField(
+        validators=[MinValueValidator(0)], verbose_name="Page accesses"
+    )
+
+    class Meta:
+        verbose_name = _("page accesses")
+        default_related_name = "page_accesses"
+        verbose_name_plural = _("page accesses")
+        default_permissions = ("change", "delete", "view")
+        ordering = ["pk"]
+
+        constraints = [
+            models.UniqueConstraint(
+                fields=["page", "language", "access_date"],
+                name="%(class)s_unique_version",
+            ),
+        ]

--- a/integreat_cms/cms/models/statistics/page_accesses.py
+++ b/integreat_cms/cms/models/statistics/page_accesses.py
@@ -29,6 +29,9 @@ class PageAccesses(AbstractBaseModel):
         validators=[MinValueValidator(0)], verbose_name="Page accesses"
     )
 
+    def __str__(self) -> str:
+        return f"{self.page} - Accesses: {self.accesses}, language: {self.language}, date: {self.access_date}"
+
     class Meta:
         verbose_name = _("page accesses")
         default_related_name = "page_accesses"

--- a/integreat_cms/cms/views/statistics/statistics_actions.py
+++ b/integreat_cms/cms/views/statistics/statistics_actions.py
@@ -11,12 +11,18 @@ from typing import TYPE_CHECKING
 from django.http import JsonResponse
 from django.views.decorators.http import require_POST
 
+from integreat_cms.cms.models.languages.language import Language
+from integreat_cms.cms.models.pages.page import Page
+from integreat_cms.cms.models.statistics.page_accesses import PageAccesses
+
 from ....matomo_api.matomo_api_client import MatomoException
 from ...decorators import permission_required
 from ...forms import StatisticsFilterForm
 
 if TYPE_CHECKING:
     from django.http import HttpRequest
+
+    from integreat_cms.cms.models.regions.region import Region
 
 logger = logging.getLogger(__name__)
 
@@ -144,7 +150,7 @@ def get_page_accesses_ajax(request: HttpRequest, region_slug: str) -> JsonRespon
         )
 
     try:
-        result = region.statistics.get_page_accesses(
+        result = load_page_accesses(
             start_date=statistics_form.cleaned_data["start_date"],
             end_date=statistics_form.cleaned_data["end_date"],
             period=statistics_form.cleaned_data["period"],
@@ -161,3 +167,33 @@ def get_page_accesses_ajax(request: HttpRequest, region_slug: str) -> JsonRespon
         return JsonResponse(
             {"error": "The request to the Matomo API failed."}, status=500
         )
+
+
+def load_page_accesses(start_date: date, end_date: date, period: str, region: Region):
+    """
+    Load page accesses from Matomo and save them to page accesses model
+    """
+    result = region.statistics.get_page_accesses(
+        start_date=start_date,
+        end_date=end_date,
+        period=period,
+        region=region,
+    )
+    accesses = [
+        PageAccesses(
+            access_date=access_date,
+            language=Language.objects.get(slug=language),
+            page=Page.objects.get(id=page),
+            accesses=result[page][language][access_date],
+        )
+        for page in result
+        for language in result[page]
+        for access_date in result[page][language]
+    ]
+    PageAccesses.objects.bulk_create(
+        accesses,
+        update_conflicts=True,
+        unique_fields=["page", "language", "access_date"],
+        update_fields=["accesses"],
+    )
+    return result

--- a/integreat_cms/cms/views/statistics/statistics_actions.py
+++ b/integreat_cms/cms/views/statistics/statistics_actions.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 from datetime import date, timedelta
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 from django.http import JsonResponse
 from django.views.decorators.http import require_POST
@@ -149,46 +149,60 @@ def get_page_accesses_ajax(request: HttpRequest, region_slug: str) -> JsonRespon
             status=400,
         )
 
-    try:
-        result = load_page_accesses(
-            start_date=statistics_form.cleaned_data["start_date"],
-            end_date=statistics_form.cleaned_data["end_date"],
-            period=statistics_form.cleaned_data["period"],
-            region=region,
-        )
-    except TimeoutError:
-        logger.exception("Timeout during request to Matomo API")
-        return JsonResponse(
-            {"error": "Timeout during request to Matomo API"}, status=504
-        )
-    except MatomoException:
-        logger.exception("The request to the Matomo API failed.")
-        return JsonResponse(
-            {"error": "The request to the Matomo API failed."}, status=500
-        )
-
     region_pages = Page.objects.filter(region=region)
-    languages = region.language_tree
-    region.get_page_accesses_by_language(
+    languages = region.languages
+    page_accesses = region.get_page_accesses_by_language(
         pages=region_pages,
         start_date=statistics_form.cleaned_data["start_date"],
         end_date=statistics_form.cleaned_data["end_date"],
         languages=languages,
     )
 
-    return JsonResponse(result, safe=False)
+    language_slug_table = Language.objects.only("id", "slug")
+
+    page_accesses_dict: dict[Any, Any] = {}
+    for access in page_accesses:
+        page_id = str(access["page_id"])
+        language_slug = language_slug_table.filter(id=access["language_id"]).values(
+            "slug"
+        )[0]["slug"]
+        if page_id in page_accesses_dict:
+            if language_slug in page_accesses_dict[page_id]:
+                page_accesses_dict[page_id][language_slug][
+                    access["access_date"].strftime("%Y-%m-%d")
+                ] = access["accesses"]
+            else:
+                page_accesses_dict[page_id][language_slug] = {
+                    access["access_date"].strftime("%Y-%m-%d"): access["accesses"]
+                }
+        else:
+            page_accesses_dict[page_id] = {
+                language_slug: {
+                    access["access_date"].strftime("%Y-%m-%d"): access["accesses"]
+                }
+            }
+
+    return JsonResponse(page_accesses_dict, safe=False)
 
 
-def load_page_accesses(start_date: date, end_date: date, period: str, region: Region):
+def save_page_accesses(start_date: date, end_date: date, period: str, region: Region):
     """
     Load page accesses from Matomo and save them to page accesses model
+
+    :param start_date: Earliest date
+    :param end_date: Latest date
+    :param period: The period (one of :attr:`~integreat_cms.cms.constants.matomo_periods.CHOICES`)
+    :param region: The region for which we want our page based accesses
     """
+    # Get page accesses from the matomo api client
     result = region.statistics.get_page_accesses(
         start_date=start_date,
         end_date=end_date,
         period=period,
         region=region,
     )
+
+    # Create PageAccess Objects
     accesses = [
         PageAccesses(
             access_date=access_date,
@@ -206,4 +220,3 @@ def load_page_accesses(start_date: date, end_date: date, period: str, region: Re
         unique_fields=["page", "language", "access_date"],
         update_fields=["accesses"],
     )
-    return result

--- a/integreat_cms/cms/views/statistics/statistics_actions.py
+++ b/integreat_cms/cms/views/statistics/statistics_actions.py
@@ -156,7 +156,6 @@ def get_page_accesses_ajax(request: HttpRequest, region_slug: str) -> JsonRespon
             period=statistics_form.cleaned_data["period"],
             region=region,
         )
-        return JsonResponse(result, safe=False)
     except TimeoutError:
         logger.exception("Timeout during request to Matomo API")
         return JsonResponse(
@@ -167,6 +166,17 @@ def get_page_accesses_ajax(request: HttpRequest, region_slug: str) -> JsonRespon
         return JsonResponse(
             {"error": "The request to the Matomo API failed."}, status=500
         )
+
+    region_pages = Page.objects.filter(region=region)
+    languages = region.language_tree
+    region.get_page_accesses_by_language(
+        pages=region_pages,
+        start_date=statistics_form.cleaned_data["start_date"],
+        end_date=statistics_form.cleaned_data["end_date"],
+        languages=languages,
+    )
+
+    return JsonResponse(result, safe=False)
 
 
 def load_page_accesses(start_date: date, end_date: date, period: str, region: Region):

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -4376,6 +4376,10 @@ msgstr ""
 "Prozentsatz der Nutzer, die als Beta-Tester für den öffentlichen Chat "
 "ausgewählt werden sollen"
 
+#: cms/models/statistics/page_accesses.py
+msgid "page accesses"
+msgstr "Seitenzugriffe"
+
 #: cms/models/users/organization.py
 msgid "organizations"
 msgstr "Organisationen"
@@ -11901,15 +11905,15 @@ msgstr ""
 #~ "Übersetzungen. Bitte haben Sie noch ein wenig Geduld."
 
 #~ msgid ""
-#~ "Your pages currently have <b>"
-#~ "%(number_of_missing_or_outdated_translations)s pages </b>that have an "
+#~ "Your pages currently have "
+#~ "<b>%(number_of_missing_or_outdated_translations)s pages </b>that have an "
 #~ "outdated or no translation. In order for the users to benefit from your "
 #~ "content you should translate them or have them translated."
 #~ msgstr ""
-#~ "Ihre Inhalten haben aktuell <b>"
-#~ "%(number_of_missing_or_outdated_translations)s Seiten </b> mit fehlender "
-#~ "oder veralteter Übersetzung. Damit die Nutzer:innen von Ihren Inhalten "
-#~ "profitieren können, sollten Sie diese übersetzen (lassen)."
+#~ "Ihre Inhalten haben aktuell "
+#~ "<b>%(number_of_missing_or_outdated_translations)s Seiten </b> mit "
+#~ "fehlender oder veralteter Übersetzung. Damit die Nutzer:innen von Ihren "
+#~ "Inhalten profitieren können, sollten Sie diese übersetzen (lassen)."
 
 #~ msgid "View location"
 #~ msgstr "Ort ansehen"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds the saving and loading of page accesses into the `statistics_actions.py`

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add `save_page_accesses` which loads page accesses via the matomo api client and saves them to the database
- Add loading of page accesses from the `database in get_page_accesses_ajax`


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Statistics no longer loads page accesses directly via matomomo, so opening statistcs on the testserver doesn't break matomo anymore
- To test the saving to the database, you can call `save_page_accesses` directly in `get_page_accesses_ajax`
- When there are page accesses in the database, you can see statistics again (and a lot faster) :partying_face: 


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3673 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
