### PR TITLE
Fix phone number spacing to prevent phone number breaking across lines

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/3694.yml
+++ b/integreat_cms/release_notes/current/unreleased/3694.yml
@@ -1,0 +1,2 @@
+en: Fix phone number spacing to prevent phone number breaking in two lines
+de: Der Abstand zwischen den Telefonnummern wurde korrigiert, um zu verhindern, dass die Telefonnummern in zwei Zeilen aufgeteilt werden.

--- a/integreat_cms/static/src/js/tinymce-plugins/autolink_tel/plugin.js
+++ b/integreat_cms/static/src/js/tinymce-plugins/autolink_tel/plugin.js
@@ -87,7 +87,7 @@
         /* eslint-enable no-magic-numbers */
 
         return [
-            `<span class="notranslate" translate="no" dir="ltr">${countryCode} (0) ${phoneNumberBody}</span>`,
+            `<span class="notranslate" translate="no" dir="ltr">${countryCode}&nbsp;(0)&nbsp;${phoneNumberBody}</span>`,
             `tel:${phoneNumberCallable}`,
         ];
     };


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fix phone number spacing to prevent phone number breaking across lines

### Proposed changes
<!-- Describe this PR in more detail. -->

- Replace ordinary spaces in phone numbers with non-breaking space `&nbsp;`


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Not sure


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3694 

### GIF

![integreat-phone-number](https://github.com/user-attachments/assets/a7b07628-5939-45d6-96e2-5c2cd4ffbc3b)



__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
