### PR TITLE
Improve contact search for contact card insertion

### DIFF
--- a/integreat_cms/cms/models/contact/contact.py
+++ b/integreat_cms/cms/models/contact/contact.py
@@ -122,6 +122,7 @@ class Contact(AbstractBaseModel):
             Contact.objects.filter(location__region=region, archived=False)
             .annotate(rank=SearchRank(vector, query))
             .order_by("-rank")
+            .distinct()
         )
 
     @classmethod

--- a/integreat_cms/cms/views/utils/contact_utils.py
+++ b/integreat_cms/cms/views/utils/contact_utils.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-MAX_RESULT_COUNT: int = 20
+MAX_RESULT_COUNT: int = 50
 
 
 @require_POST

--- a/integreat_cms/release_notes/current/unreleased/3626.yml
+++ b/integreat_cms/release_notes/current/unreleased/3626.yml
@@ -1,0 +1,2 @@
+en: Improve contact search for contact card insertion
+de: Verbessere die Kontaktsuche für das Einfügen von Kontaktkarten


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR improves search suggestion for users inserting a contact card

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add `.distinct()` to prevent a contact object appearing multiple times in the result
- Increase `MAX_RESULT_COUNT` so matches in rear positions will not be cut off

Those changes seem to have solved the reported cases and not bring side effects, but I cannot provide logical explanation that they are generally an improvement. See the explanation below.

** What I have observed **
- Sometimes one contact object appeared multiple times in the search result -> use `.distinct()`
- Contact objects that are actually matched with `query` string were not shown to users -> use `.distinct()` and increase `MAX_RESULT_COUNT`

** What I tried but did not work**
- Weight the search vectors (`name`, `area_of_responsibility` and `location__title` with `weight="A"`, other fields with `weight="B"`, `website` with `weight="C"`) -> Still objects that are matched by website ULR are shown higher than those matched by name or location name.
- Remove `website` from the vector -> Objects are still matched by website URL and shown in the result

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- 
- 


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3626 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
