### PR TITLE
Fix: pages cannot be deleted even after deleting all the sub-pages

### DIFF
--- a/integreat_cms/cms/views/pages/page_actions.py
+++ b/integreat_cms/cms/views/pages/page_actions.py
@@ -15,6 +15,7 @@ import time
 import uuid
 from typing import TYPE_CHECKING
 
+from cacheops import invalidate_model
 from django.conf import settings
 from django.contrib import messages
 from django.core.exceptions import PermissionDenied
@@ -260,6 +261,7 @@ def delete_page(
         logger.info("%r deleted by %r", page, request.user)
         page.delete()
         messages.success(request, _("Page was successfully deleted"))
+        invalidate_model(Page)
 
     return redirect(
         "pages",

--- a/integreat_cms/release_notes/current/unreleased/3144.yml
+++ b/integreat_cms/release_notes/current/unreleased/3144.yml
@@ -1,0 +1,2 @@
+en: Fix the bug that pages cannot be deleted even with no child page
+de: Behebe den Fehler, dass Seiten nicht gelöscht werden können, auch wenn keine untergeordnete Seite vorhanden ist


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the bug that ghost of deleted child pages are protecting their parent page from delete action.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Use `invalidate_model` after deleting a page
-


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- Should be none.
- 


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3144 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
