### PR TITLE
Add UserNameForm to user settings

### DIFF
--- a/integreat_cms/cms/forms/__init__.py
+++ b/integreat_cms/cms/forms/__init__.py
@@ -52,5 +52,6 @@ from .users.region_user_form import RegionUserForm
 from .users.user_email_form import UserEmailForm
 from .users.user_filter_form import UserFilterForm
 from .users.user_form import UserForm
+from .users.user_name_form import UserNameForm
 from .users.user_password_form import UserPasswordForm
 from .users.user_preferences_form import UserPreferencesForm

--- a/integreat_cms/cms/forms/users/user_name_form.py
+++ b/integreat_cms/cms/forms/users/user_name_form.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import logging
+
+from django.contrib.auth import get_user_model
+
+from ..custom_model_form import CustomModelForm
+
+logger = logging.getLogger(__name__)
+
+
+class UserNameForm(CustomModelForm):
+    """
+    Form for modifying user name addresses
+    """
+
+    class Meta:
+        """
+        This class contains additional meta configuration of the form class, see the :class:`django.forms.ModelForm`
+        for more information.
+        """
+
+        #: The model of this :class:`django.forms.ModelForm`
+        model = get_user_model()
+        #: The fields of the model which should be handled by this form
+        fields = ["first_name", "last_name"]

--- a/integreat_cms/cms/forms/users/user_name_form.py
+++ b/integreat_cms/cms/forms/users/user_name_form.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 
 from django.contrib.auth import get_user_model
+from django.utils.translation import gettext_lazy as _
 
 from ..custom_model_form import CustomModelForm
 
@@ -11,16 +12,33 @@ logger = logging.getLogger(__name__)
 
 class UserNameForm(CustomModelForm):
     """
-    Form for modifying user name addresses
+    Form for modifying user name including username, first name, and last name.
     """
 
     class Meta:
         """
-        This class contains additional meta configuration of the form class, see the :class:`django.forms.ModelForm`
-        for more information.
+        This class contains additional meta configuration of the form class,
+        see the :class:`django.forms.ModelForm` for more information.
         """
 
         #: The model of this :class:`django.forms.ModelForm`
         model = get_user_model()
         #: The fields of the model which should be handled by this form
-        fields = ["first_name", "last_name"]
+        fields = ["username", "first_name", "last_name"]
+
+    def clean_username(self) -> str:
+        """
+        Ensure that the username is unique across all users except the one being edited.
+
+        :return: The validated username
+        """
+        username = self.cleaned_data.get("username")
+        if (
+            username
+            and get_user_model()
+            .objects.filter(username=username)
+            .exclude(pk=self.instance.pk)
+            .exists()
+        ):
+            self.add_error("username", _("This username is already taken."))
+        return username

--- a/integreat_cms/cms/templates/settings/user_settings.html
+++ b/integreat_cms/cms/templates/settings/user_settings.html
@@ -121,6 +121,29 @@
                 </div>
             </div>
         </div>
+        <div class="w-full mb-4 rounded border border-solid border-blue-500 shadow-2xl bg-white">
+            <div class="w-full p-4 rounded bg-water-500">
+                <h3 class="font-bold text-black">
+                    <i icon-name="user" class="mr-2"></i> {% translate "My Name" %}
+                </h3>
+            </div>
+            <div class="px-4 pb-4">
+                <form method="post">
+                    {% csrf_token %}
+                    <label for="{{ user_name_form.first_name.id_for_label }}">
+                        {{ user_name_form.first_name.label }}
+                    </label>
+                    {% render_field user_name_form.first_name|add_error_class:"border-red-500" %}
+                    <label for="{{ user_name_form.last_name.id_for_label }}">
+                        {{ user_name_form.last_name.label }}
+                    </label>
+                    {% render_field user_name_form.last_name|add_error_class:"border-red-500" %}
+                    <button name="submit_form" value="name_form" class="btn mt-4">
+                        {% translate "Change name" %}
+                    </button>
+                </form>
+            </div>
+        </div>
         <div class="mb-4 rounded border border-solid border-blue-500 shadow-xl bg-white flex flex-wrap">
             <div class="w-full p-4 rounded bg-water-500">
                 <h3 class="heading font-bold text-black">

--- a/integreat_cms/cms/templates/settings/user_settings.html
+++ b/integreat_cms/cms/templates/settings/user_settings.html
@@ -68,6 +68,33 @@
             <div class="w-full mb-4 rounded border border-solid border-blue-500 shadow-2xl bg-white">
                 <div class="w-full p-4 rounded bg-water-500">
                     <h3 class="font-bold text-black">
+                        <i icon-name="user" class="mr-2"></i> {% translate "My Username and Name" %}
+                    </h3>
+                </div>
+                <div class="px-4 pb-4">
+                    <form method="post">
+                        {% csrf_token %}
+                        <label for="{{ user_name_form.username.id_for_label }}">
+                            {{ user_name_form.username.label }}
+                        </label>
+                        {% render_field user_name_form.username|add_error_class:"border-red-500" %}
+                        <label for="{{ user_name_form.first_name.id_for_label }}">
+                            {{ user_name_form.first_name.label }}
+                        </label>
+                        {% render_field user_name_form.first_name|add_error_class:"border-red-500" %}
+                        <label for="{{ user_name_form.last_name.id_for_label }}">
+                            {{ user_name_form.last_name.label }}
+                        </label>
+                        {% render_field user_name_form.last_name|add_error_class:"border-red-500" %}
+                        <button name="submit_form" value="name_form" class="btn mt-4">
+                            {% translate "Change name" %}
+                        </button>
+                    </form>
+                </div>
+            </div>
+            <div class="w-full mb-4 rounded border border-solid border-blue-500 shadow-2xl bg-white">
+                <div class="w-full p-4 rounded bg-water-500">
+                    <h3 class="font-bold text-black">
                         <i icon-name="mail" class="mr-2"></i> {% translate "My E-mail-address" %}
                     </h3>
                 </div>
@@ -119,29 +146,6 @@
                         </button>
                     </form>
                 </div>
-            </div>
-        </div>
-        <div class="w-full mb-4 rounded border border-solid border-blue-500 shadow-2xl bg-white">
-            <div class="w-full p-4 rounded bg-water-500">
-                <h3 class="font-bold text-black">
-                    <i icon-name="user" class="mr-2"></i> {% translate "My Name" %}
-                </h3>
-            </div>
-            <div class="px-4 pb-4">
-                <form method="post">
-                    {% csrf_token %}
-                    <label for="{{ user_name_form.first_name.id_for_label }}">
-                        {{ user_name_form.first_name.label }}
-                    </label>
-                    {% render_field user_name_form.first_name|add_error_class:"border-red-500" %}
-                    <label for="{{ user_name_form.last_name.id_for_label }}">
-                        {{ user_name_form.last_name.label }}
-                    </label>
-                    {% render_field user_name_form.last_name|add_error_class:"border-red-500" %}
-                    <button name="submit_form" value="name_form" class="btn mt-4">
-                        {% translate "Change name" %}
-                    </button>
-                </form>
             </div>
         </div>
         <div class="mb-4 rounded border border-solid border-blue-500 shadow-xl bg-white flex flex-wrap">

--- a/integreat_cms/cms/views/settings/user_settings_view.py
+++ b/integreat_cms/cms/views/settings/user_settings_view.py
@@ -9,7 +9,7 @@ from django.shortcuts import redirect, render
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import TemplateView
 
-from ...forms import UserEmailForm, UserPasswordForm, UserPreferencesForm
+from ...forms import UserEmailForm, UserNameForm, UserPasswordForm, UserPreferencesForm
 
 if TYPE_CHECKING:
     from typing import Any
@@ -44,6 +44,7 @@ class UserSettingsView(TemplateView):
                 "user_preferences_form": UserPreferencesForm(
                     instance=self.request.user,
                 ),
+                "user_name_form": UserNameForm(instance=self.request.user),
             },
         )
         return context
@@ -126,6 +127,24 @@ class UserSettingsView(TemplateView):
             else:
                 user_preferences_form.save()
                 messages.success(request, _("Preferences were successfully saved"))
+
+        elif request.POST.get("submit_form") == "name_form":
+            user_name_form = UserNameForm(data=request.POST, instance=user)
+            if not user_name_form.is_valid():
+                user_name_form.add_error_messages(request)
+                return render(
+                    request,
+                    self.template_name,
+                    {
+                        **self.get_context_data(**kwargs),
+                        "user_name_form": user_name_form,
+                    },
+                )
+            if not user_name_form.has_changed():
+                messages.info(request, _("No changes made"))
+            else:
+                user_name_form.save()
+                messages.success(request, _("Name was successfully updated"))
 
         kwargs = {"region_slug": region.slug} if region else {}
         return redirect("user_settings", **kwargs)

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8750,6 +8750,14 @@ msgid "Change password"
 msgstr "Passwort ändern"
 
 #: cms/templates/settings/user_settings.html
+msgid "My Name"
+msgstr "Mein Name"
+
+#: cms/templates/settings/user_settings.html
+msgid "Change name"
+msgstr "Name ändern"
+
+#: cms/templates/settings/user_settings.html
 msgid "My 2-Factor-Authentication methods"
 msgstr "Meine 2-Faktor-Authentifizierungs-Methoden"
 
@@ -11175,6 +11183,10 @@ msgstr "Passwort wurde erfolgreich geändert"
 #: cms/views/settings/user_settings_view.py
 msgid "Preferences were successfully saved"
 msgstr "Einstellungen wurden erfolgreich gespeichert"
+
+#: cms/views/settings/user_settings_view.py
+msgid "Name was successfully updated"
+msgstr "Name wurde erfolgreich aktualisiert"
 
 #: cms/views/settings/webauthn/authenticate_modify_mfa_view.py
 msgid "The provided password is not correct"

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -2591,6 +2591,10 @@ msgstr ""
 "Benutzer:innen können nur Mitglieder von Organisationen in Regionen sein, "
 "auf die sie Zugriff haben"
 
+#: cms/forms/users/user_name_form.py
+msgid "This username is already taken."
+msgstr "Dieser Benutzername ist bereits vergeben."
+
 #: cms/forms/users/user_password_form.py
 msgid "My old password"
 msgstr "Mein bisheriges Passwort"
@@ -8730,6 +8734,14 @@ msgid "Save preferences"
 msgstr "Einstellungen speichern"
 
 #: cms/templates/settings/user_settings.html
+msgid "My Username and Name"
+msgstr "Mein Benutzername und Name"
+
+#: cms/templates/settings/user_settings.html
+msgid "Change name"
+msgstr "Namen ändern"
+
+#: cms/templates/settings/user_settings.html
 msgid "My E-mail-address"
 msgstr "Meine E-Mail-Adresse"
 
@@ -8748,14 +8760,6 @@ msgstr "Mein neues Passwort hier erneut eingeben"
 #: cms/templates/settings/user_settings.html
 msgid "Change password"
 msgstr "Passwort ändern"
-
-#: cms/templates/settings/user_settings.html
-msgid "My Name"
-msgstr "Mein Name"
-
-#: cms/templates/settings/user_settings.html
-msgid "Change name"
-msgstr "Name ändern"
 
 #: cms/templates/settings/user_settings.html
 msgid "My 2-Factor-Authentication methods"

--- a/integreat_cms/release_notes/2025/2025.6.3/1124.yml
+++ b/integreat_cms/release_notes/2025/2025.6.3/1124.yml
@@ -1,0 +1,2 @@
+en: Allow users to change their first name, last name, and username in the user settings page
+de: Benutzer können jetzt ihren Vor- und Nachnamen sowie ihren Benutzernamen auf der Einstellungsseite ändern


### PR DESCRIPTION
### Short description
Adds a form to allow users to update their first and last name from the user settings page.

### Proposed changes
- Created a `UserNameForm` extending `CustomModelForm`
- Added `user_name_form` to the `UserSettingsView`
- Updated `user_settings_view.py` to handle name form submission with validation and success messaging
- Integrated the form into the `user_settings.html` template with proper styling and localization

### Side effects
- Touches user form rendering logic in the settings template
- Extends view context and POST handling logic, which could affect other forms on that page

Closes #1124