### PR TITLE
Remove (0) from phone number formatting

### DIFF
--- a/integreat_cms/cms/migrations/0137_adopt_new_phone_number_format.py
+++ b/integreat_cms/cms/migrations/0137_adopt_new_phone_number_format.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from django.db import migrations
+
+if TYPE_CHECKING:
+    from django.apps.registry import Apps
+    from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+
+logger = logging.getLogger(__name__)
+
+
+def migrate_phone_number_format(
+    apps: Apps,
+    _schema_editor: BaseDatabaseSchemaEditor,
+) -> None:
+    """
+    Adopt existing phone numbers into the new format (remove "(0)")
+    :param apps: The configuration of installed applications
+    """
+
+    Contact = apps.get_model("cms", "Contact")
+    for contact in Contact.objects.all():
+        phone_number = contact.phone_number
+        if phone_number and phone_number.startswith("+49 (0) "):
+            contact.phone_number = f"+49{phone_number[8:]}"
+        mobile_phone_number = contact.mobile_phone_number
+        if mobile_phone_number and mobile_phone_number.startswith("+49 (0) "):
+            contact.mobile_phone_number = f"+49{mobile_phone_number[8:]}"
+        contact.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("cms", "0136_event_online_link"),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_phone_number_format, migrations.RunPython.noop),
+    ]

--- a/integreat_cms/cms/utils/link_utils.py
+++ b/integreat_cms/cms/utils/link_utils.py
@@ -49,4 +49,4 @@ def format_phone_number(phone_number: str) -> str:
         prefix = phone_number[0:3]
         phone_number = phone_number[3:]
 
-    return f"{prefix} (0) {phone_number}"
+    return f"{prefix}{phone_number}"

--- a/integreat_cms/release_notes/current/unreleased/3712.yml
+++ b/integreat_cms/release_notes/current/unreleased/3712.yml
@@ -1,0 +1,2 @@
+en: Format phone numbers without (0)
+de: Formatiere Telefonnummer ohne (0)

--- a/integreat_cms/static/src/js/tinymce-plugins/autolink_tel/plugin.js
+++ b/integreat_cms/static/src/js/tinymce-plugins/autolink_tel/plugin.js
@@ -87,7 +87,7 @@
         /* eslint-enable no-magic-numbers */
 
         return [
-            `<span class="notranslate" translate="no" dir="ltr">${countryCode} (0) ${phoneNumberBody}</span>`,
+            `<span class="notranslate" translate="no" dir="ltr">${countryCode}${phoneNumberBody}</span>`,
             `tel:${phoneNumberCallable}`,
         ];
     };

--- a/tests/cms/views/contacts/test_contact_form.py
+++ b/tests/cms/views/contacts/test_contact_form.py
@@ -341,4 +341,4 @@ def test_phone_number_conversion(
         )
         form.is_valid()  # this is not an assert, because it would fail. calling is_valid() is required to populate cleaned_data.
         cleaned = form.clean()
-        assert cleaned["phone_number"] == "+49 (0) 123456789"
+        assert cleaned["phone_number"] == "+49123456789"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR changes the behaviour of phone number formatting

### Proposed changes
<!-- Describe this PR in more detail. -->
- Remove ` (0) ` from the formatting
- Add a migration to adopt the (mobile) phone numbers of the existing contacts into the new format
- Adjust the test


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- I hope none 🙈 
- 


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3712 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
