### PR TITLE
Fetch page accesses with celery

### DIFF
--- a/docs/src/management-commands.rst
+++ b/docs/src/management-commands.rst
@@ -231,6 +231,24 @@ Update ALL link text of links of the given URL:
 * ``USERNAME``: Associate any new created translations with ``USERNAME``
 
 
+``fetch_page_accesses``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Fetches page accesses from Matomo and store them in the database
+
+    integreat-cms-cli fetch_page_accesses --start-date START_DATE --end-date END_DATE --period PERIOD [--region-slug REGION_SLUG] [--sync SYNC]
+
+**Arguments:**
+
+* ``START_DATE``: Earliest date to fetch, format should be yyyy-mm-dd
+* ``END_DATE``: Latest date to fetch, format should be yyyy-mm-dd
+
+**Options:**
+
+* ``REGION_SLUG``: Region to fetch page accesses for, must have statistics activated. If non provided, page accesses from all regions with statistics activated will be fetched
+* ``SYNC``: When True page accesses will be fetched as a synchronous process. If not provided or False, page accesses are fetched via celery.
+
+
 Create new commands
 -------------------
 

--- a/integreat_cms/core/management/commands/fetch_page_accesses.py
+++ b/integreat_cms/core/management/commands/fetch_page_accesses.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from django.core.management.base import CommandError
+
+from integreat_cms.cms.constants.region_status import ACTIVE
+from integreat_cms.cms.views.statistics.statistics_actions import (
+    async_fetch_page_accesses,
+    fetch_page_accesses,
+)
+
+from ....cms.models import Region
+from ..log_command import LogCommand
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from django.core.management.base import CommandParser
+
+logger = logging.getLogger(__name__)
+
+
+class Command(LogCommand):
+    """
+    Management command to fetch page accesses from matomo
+    """
+
+    help: str = (
+        "Fetches page accesses from Matomo and store them in them in the database"
+    )
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        """
+        Define the arguments of this command
+
+        :param parser: The argument parser
+        """
+        parser.add_argument("--start-date", required=True, help="Earliest date")
+        parser.add_argument("--end-date", required=True, help="Latest date")
+        parser.add_argument(
+            "--region-slug",
+            help="The slug of the region to fetch page accesses from. Statistics need to be activatet",
+        )
+        parser.add_argument("--sync")
+
+    def handle(
+        self,
+        *args: Any,
+        start_date: str,
+        end_date: str,
+        region_slug: str | None,
+        sync: bool | None,
+        **options: Any,
+    ) -> None:
+        r"""
+        Try to run the command
+
+        :param \*args: The supplied arguments
+        :param start_date: The earliest date
+        :param end_date: The latest date
+        :param period: The period (one of :attr:`~integreat_cms.cms.constants.matomo_periods.CHOICES`)
+        :param region_slug: The slug of the given region
+        :param \**options: The supplied keyword options
+        """
+        self.set_logging_stream()
+        regions = []
+        try:
+            starting_date = datetime.strptime(start_date, "%Y-%m-%d").date()
+            ending_date = datetime.strptime(end_date, "%Y-%m-%d").date()
+        except ValueError as e:
+            raise CommandError("Wrong date format, please use YYYY-MM-DD") from e
+        if region_slug is not None:
+            try:
+                regions.append(Region.objects.get(slug=region_slug))
+            except Region.DoesNotExist as e:
+                raise CommandError(
+                    f'Region with slug "{region_slug}" does not exist.',
+                ) from e
+            if not regions[0].statistics_enabled:
+                logger.error("Statistics are not enabled for this region.")
+                raise CommandError(f"Statistics are disabled in {regions[0].slug}.")
+        else:
+            regions = list(
+                Region.objects.filter(statistics_enabled=True, status=ACTIVE)
+            )
+        for region in regions:
+            if sync:
+                fetch_page_accesses(starting_date, ending_date, region)
+            else:
+                async_fetch_page_accesses.apply_async(
+                    args=[starting_date, ending_date, region.id]
+                )

--- a/integreat_cms/integreat_celery/celery.py
+++ b/integreat_cms/integreat_celery/celery.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import configparser
 import os
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
 from celery import Celery
@@ -65,13 +66,33 @@ def wrapper_import_events_from_external_calendars() -> None:
     call_command("import_events")
 
 
+@app.task
+def wrapper_fetch_page_accesses() -> None:
+    """
+    Periodic task to fetch page accesses of the previous day from Matomo
+    """
+    fetch_date = datetime.today() - timedelta(days=1)
+    fetch_date_str = fetch_date.strftime("%Y-%m-%d")
+    call_command(
+        "fetch_page_accesses",
+        start_date=fetch_date_str,
+        end_date=fetch_date_str,
+    )
+
+
 @app.on_after_configure.connect
 def setup_periodic_tasks(sender: Any, **kwargs: Any) -> None:
     """
-    Set up a periodic job to import evens from the external calendars at 0:23 every day
+    Set up periodic jobs
     """
     sender.add_periodic_task(
         crontab(hour=0, minute=23),
         wrapper_import_events_from_external_calendars.s(),
         name="wrapper_import_events_from_external_calendars",
+    )
+
+    sender.add_periodic_task(
+        crontab(hour=0, minute=30),
+        wrapper_fetch_page_accesses.s(),
+        name="wrapper_fetch_page_accesses",
     )

--- a/integreat_cms/matomo_api/utils.py
+++ b/integreat_cms/matomo_api/utils.py
@@ -1,34 +1,73 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
-from asgiref.sync import sync_to_async
+import logging
+from collections import defaultdict
+from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from ..cms.models import Language, Page
+    from ..cms.models.pages.page_translation import PageTranslation
+
+logger = logging.getLogger(__name__)
 
 
 def get_translation_slug(
-    pages: list[Page], languages: list[Language]
+    region_slug: str,
+    prefetched_translations: list[PageTranslation],
 ) -> dict[int, dict[str, str]]:
     """
     Produce mapping of page ids and language slugs to the absolute url of the corresponding translation.
     In detail, we need to construct a slug in the foreign language, for example /en/lebensmittel-und-einkaufen needs to become /en/groceries-and-shopping.
 
-    :param pages: The list of pages for which we want the absolute url of
-    :param languages: The list of languages for which we want the absolute url of
+    :param region_slug: Slug of the region we want the absolute url of
+    :param prefetched_translations: List of prefetched Pagetranslations that we want the absolute urls of
     :return: A dictionary of page ids, language slugs and the absolute url of the corresponding translation.
     """
-    translation_slugs: dict = {}
-    for page in pages:
-        for language in languages:
-            if page_translation := page.get_translation(language.slug):
-                if page.id not in translation_slugs:
-                    translation_slugs[page.id] = {}
-                translation_slugs[page.id][language.slug] = (
-                    page_translation.get_absolute_url().rstrip("/")
-                )
-    return translation_slugs
+    translation_slugs: defaultdict[int, dict[str, str]] = defaultdict(dict)
+    for page_translation in prefetched_translations:
+        page_id = page_translation.page.id
+        language_slug = page_translation.language.slug
+        absolute_url = page_translation.slug
+        translations_lookup = {
+            (t.page.id, t.language.slug): t for t in prefetched_translations
+        }
+        absolute_url = build_infix_recursively(
+            absolute_url=absolute_url,
+            language_slug=language_slug,
+            current_page_translation=page_translation,
+            translations_lookup=translations_lookup,
+        )
+        absolute_url = "/" + region_slug + "/" + language_slug + "/" + absolute_url
+        translation_slugs[page_id][language_slug] = absolute_url
+
+    return dict(translation_slugs)
 
 
-async_get_translation_slug = sync_to_async(get_translation_slug, thread_sensitive=False)
+def build_infix_recursively(
+    absolute_url: str,
+    language_slug: str,
+    current_page_translation: PageTranslation,
+    translations_lookup: dict[tuple[Any, str], PageTranslation],
+) -> str:
+    """
+    Build infix of the absolute url of a PageTranslation object from the prefetched PageTranslations recursively. This is a workaround to avoid calling the cache, which is needed when page accesses are fetched with celery.
+
+    :param absolut_url: absolute url build at hte point of calling
+    :param language_slug: Language slug of the current page translation
+    :param current_page_translation: Page translation for that we want the parent slug of
+    :param prefetched_translations: List with prefetched page translations we select from
+    :return: A string containing the url build until the point of calling. At the end of the recursion it returns the absolute url of the page translation from the first call
+    """
+    if current_page_translation.page.parent:
+        parent = current_page_translation.page.parent
+        page_translation = translations_lookup.get((parent.id, language_slug))
+        if page_translation:
+            parent_translation_slug = page_translation.slug
+            absolute_url = parent_translation_slug + "/" + absolute_url
+            current_page_translation = page_translation
+            return build_infix_recursively(
+                absolute_url=absolute_url,
+                language_slug=language_slug,
+                current_page_translation=current_page_translation,
+                translations_lookup=translations_lookup,
+            )
+    return absolute_url


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds fetching and saving page accesses with celery and a daily celery job to fetch the latest accesses

### Proposed changes
<!-- Describe this PR in more detail. -->

- Fetch page accesses from Matomo with celery
- Add management command to start fetching page accesses
- Add a daily celery job to start fetching latest page accesses 


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- There is a small possibility that the daily job interferes with the daily import of calendars, during local testing it seemed fine since the calendar import seemed to be a really fast job
- Probably the easiest way to test this is by activating statistics for a region e.g. Stadt Augsburg. You can find the needed token in the test system. Then run the here introduced management command. With only a couple of pages it doesn't take that long.
- The daily job is probably best tested on the test server. While testing with a database dump I ran into issues with my local redis-server. I think they are corralated with the settings of the server on how to deal with memory, so I hope on the test server this isn't a problem 


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3674 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
