### PR TITLE
Add launch.json for vs code debugging

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,35 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Python Debugger: Django (with Docker)",
+      "type": "debugpy",
+      "request": "launch",
+      "args": ["runserver"],
+      "django": true,
+      "autoStartBrowser": false,
+      "program": "${workspaceFolder}/integreat_cms/integreat-cms-cli",
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "INTEGREAT_CMS_DEBUG": "true",
+        "DJANGO_SETTINGS_MODULE": "integreat_cms.core.docker_settings"
+      },
+      "preLaunchTask": "start-docker",
+      "postDebugTask": "stop-docker"
+    },
+    {
+      "name": "Python Debugger: Django (without Docker)",
+      "type": "debugpy",
+      "request": "launch",
+      "args": ["runserver"],
+      "django": true,
+      "autoStartBrowser": false,
+      "program": "${workspaceFolder}/integreat_cms/integreat-cms-cli",
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "INTEGREAT_CMS_DEBUG": "true",
+        "DJANGO_SETTINGS_MODULE": "integreat_cms.core.settings"
+      }
+    }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -91,6 +91,16 @@
         "kind": "test",
         "isDefault": true
       }
+    },
+    {
+      "label": "start-docker",
+      "type": "shell",
+      "command": "docker start integreat_django_postgres"
+    },
+    {
+      "label": "stop-docker",
+      "type": "shell",
+      "command": "docker stop integreat_django_postgres"
     }
   ]
 }

--- a/docs/src/debugging.rst
+++ b/docs/src/debugging.rst
@@ -46,32 +46,13 @@ VSCode/VSCodium
 
 The VSCode ``Python Extension`` should automaticly contain the ``Python Debugger Extension``. You can check and install it via the Extensions view.
 
-For being able to run in Debug mode, you will need a ``launch.json`` file in which you define the settings under which you want to run and debug the CMS.
+In your ``.vscode/launch.json`` two Debugging modes are defined: With or without Docker.
 
-#. Create a ``launch.json`` file in the ``.vscode/`` folder
-#. Populate the file with the desired settings. The code below should work (at least for the Dev Container)
+You might need to change the ``"program"`` variable to your local location of the ``integreat_cms/`` folder. With the ``"env"`` variable, you can set environment variables with settings for the CMS like ``"INTERGREAT_CMS_DEBUG"``. For more options, check the VSCode `documentation <https://code.visualstudio.com/docs/python/debugging>`
 
-.. code-block:: lua
+When you go to ``Run and Debug``, select ``Python Debugger: Django (with Docker)`` or ``Python Debugger: Django (without Docker)`` from the drop-down and hit ``Start Debugging``.
 
-   {
-      "version": "0.2.0",
-      "configurations": [
-         {
-            "name": "Python Debugger: Django",
-            "type": "debugpy",
-            "request": "launch",
-            "args": ["runserver"],
-            "django": true,
-            "autoStartBrowser": false,
-            "program": "${workspaceFolder}/integreat_cms/integreat-cms-cli"
-            "env": {"INTEGREAT_CMS_DEBUG": "true"}
-         }
-      ]
-   }
-
-You might need to change the ``"program"`` variable to your local location of the ``integreat_cms/`` folder. With the ``"env"`` variable, you can set environment variables with settings for the CMS like ``"INTERGREAT_CMS_DEBUG"``. For more options, check the VSCode `documentation <https://code.visualstudio.com/docs/python/debugging>` 
-
-Now debugging should work when you go to ``Run and Debug`` and hit ``Start Debugging``. The local server should start and you should be able to use the CMS like after running ``run.sh``.
+The local server should start and you should be able to use the CMS like after running ``run.sh``.
 
 For VSCodium it should work the same as long as you use the official ``Python Extension``, though I never tested this at this point (8th May 2025).
 


### PR DESCRIPTION
### Short description
This is a setup where we commit the launch.json and have optional configuration for debugging with docker and without docker

### Proposed changes
- start stracking launch.json
- add start docker and stop docker tasks to task.json
- edit the documenation to explain the setup



### Side effects
- individual changes to launch.json won't be possible anymore, but from my understanding it is currently only Jarl and Me who use VSCode. And we use launch.json only for the debugging setup


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

If this works, this is an improvement since launch.json won't have to be carried around all the time and new developers who use vs code can just start debugging straight away


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
