### PR TITLE
FCM Subscriptions endpoint

### DIFF
--- a/integreat_cms/api/urls.py
+++ b/integreat_cms/api/urls.py
@@ -37,7 +37,7 @@ from .v3.pages import (
     single_page,
 )
 from .v3.pdf_export import pdf_export
-from .v3.push_notifications import sent_push_notifications
+from .v3.push_notifications import query_subscriptions, sent_push_notifications
 from .v3.regions import region_by_slug, regions
 from .v3.social_media_headers import (
     event_social_media_headers,
@@ -265,5 +265,10 @@ urlpatterns: list[URLPattern] = [
                 ),
             ],
         ),
+    ),
+    path(
+        "api/v3/fcm-subscriptions/",
+        query_subscriptions,
+        name="query_fcm_subscriptions",
     ),
 ]

--- a/integreat_cms/api/v3/push_notifications.py
+++ b/integreat_cms/api/v3/push_notifications.py
@@ -13,6 +13,7 @@ from django.http import JsonResponse
 from django.utils import timezone
 
 from ...cms.models import PushNotificationTranslation
+from ...firebase_api.firebase_data_client import FirebaseDataClient
 from ..decorators import json_response
 
 if TYPE_CHECKING:
@@ -79,3 +80,16 @@ def transform_notification(pnt: PushNotificationTranslation) -> dict[str, Any]:
         "channel": pnt.push_notification.channel,
         "available_languages": available_languages_dict,
     }
+
+
+@json_response
+def query_subscriptions(
+    request: HttpRequest,
+) -> dict[str, dict[str, str]]:
+    """
+    Fetches active subscriptions for a given device from the Firebase API.
+    See `the FCM documentation by Google <https://developers.google.com/instance-id/reference/server#get_information_about_app_instances>`_
+    (return value is ``.rel.topics`` of the fcm response)
+    """
+    iid_token = request.POST.get("iid_token")
+    return FirebaseDataClient().fetch_subscriptions(iid_token)

--- a/integreat_cms/firebase_api/firebase_data_client.py
+++ b/integreat_cms/firebase_api/firebase_data_client.py
@@ -88,3 +88,27 @@ class FirebaseDataClient:
                     )
 
         return statistics_list
+
+    def fetch_subscriptions(self, iid_token: str) -> dict[str, dict[str, str]]:
+        """
+        Fetches active subscriptions for a given device from the Firebase API.
+        See `the FCM documentation by Google <https://developers.google.com/instance-id/reference/server#get_information_about_app_instances>`_
+        (return value is ``.rel.topics`` of the fcm response)
+        """
+        endpoint_url = f"https://iid.googleapis.com/iid/info/{iid_token}?details=true"
+        headers = {
+            "Authorization": f"Bearer {FirebaseSecurityService.get_data_access_token()}",
+            # "Content-Type": "application/json; UTF-8",
+            "access_token_auth": "true",
+        }
+
+        response = requests.get(
+            endpoint_url,
+            headers=headers,
+            timeout=settings.DEFAULT_REQUEST_TIMEOUT,
+        )
+
+        if response.status_code != 200:
+            return {}
+
+        return response.json().get("rel", {}).get("topics", {})


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Add API endpoint to query active push notification subscriptions for a given device from firebase cloud messaging

This is not yet tested code, as I have not obtained an `IID_TOKEN` yet to try.

**More importantly, this builds on a solution that seems to have been *deprecated* in or before January of this year. It will stop working sooner or later. See #1043 for more details**

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add function to fetch active subscriptions for a given device from the Firebase API (using our FCM credentials)
- Expose function via our API

**TODO:**
- maybe add a test, mocking the FCM API? *(might be too trivial, though trivial is not necessarily a bad thing)*
- save data to database in some form in this PR already? But how do we ensure we have a fair sample of subscribed devices?

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

None, this is an addition only.
The most I can envision is that we somehow end up DDOSing the FCM API and getting all of our requests rate limited *(also sending push notifications)*, but that seems unlikely. We might want to implement caching, then we could also get an approximation of some statistics about device subscriptions. Then again, since the app likely will want to use this to make accurate decisions about (un)subscribe actions, this should probably request the FCM API even if we already did a request about the same device less than a minute ago. So if we are worried about sending a flood of requests, we should rather implement a limit of something like *maximum **n** requests per hour*. Though we will still want to cache the data somehow for #589


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
Instead of a list of subscribed channels, I opted to just return the `.rel.topics` of the fcm response, which is a dictionary where each topic is mapped to a dictionary containing the date the subscription was made:
```json
{
    "topicname1":{"addDate":"2015-07-30"},
    "topicname2":{"addDate":"2015-07-30"}
}
```


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1043


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
