### PR TITLE
Add management command to copy pois

### DIFF
--- a/docs/src/management-commands.rst
+++ b/docs/src/management-commands.rst
@@ -76,6 +76,22 @@ Duplicate all currently existing pages to make it easier to create production-li
     This command inherits from :class:`~integreat_cms.core.management.debug_command.DebugCommand`, so it is only available in debug mode.
 
 
+
+``copy_pois``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Duplicate all POIs of the template region, also all events and contacts if specified, into the target regions
+
+    integreat-cms-cli copy_pois TEMPLATE-SLUG TARGET-SLUG [TARGET-SLUG ...] [--username USERNAME] [--contacts] [--events] [--add-suffix]
+
+**Options:**
+
+* ``--username``: The user as which to create the objects
+* ``--contacts``: Whether contacts should be copied too
+* ``--events``: Whether events should be copied too
+* ``--add-suffix``: Whether the suffix ' (Copy)' should be added to copied objects
+
+
 ``find_large_files``
 ~~~~~~~~~~~~~~~~~~~~
 

--- a/integreat_cms/core/management/commands/copy_pois.py
+++ b/integreat_cms/core/management/commands/copy_pois.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import logging
+import os
+import re
+from copy import deepcopy
+from typing import TYPE_CHECKING
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.utils.translation import gettext_lazy as _
+
+from integreat_cms.cms.models import Event, POI, Region, User
+
+if TYPE_CHECKING:
+    from typing import Any
+
+    from django.core.management.base import CommandParser
+    from django.db.models import FileField
+
+
+logger = logging.getLogger(__name__)
+
+
+def make_hardlink(file_field: FileField, region_id: int) -> FileField:
+    """
+    Create a hardlink to the original file in the media path for the target region
+    """
+    base = file_field.storage.base_location
+    orig_path = file_field.name
+    new_path = re.sub(r"^regions/[0-9]+/", f"regions/{region_id}/", orig_path)
+    # make the directory
+    os.makedirs(os.path.dirname(os.path.join(base, new_path)), exist_ok=True)
+    # create the hard link
+    try:
+        os.link(os.path.join(base, orig_path), os.path.join(base, new_path))
+    except FileExistsError as e:
+        if (
+            os.stat(os.path.join(base, orig_path)).st_ino
+            == os.stat(os.path.join(base, new_path)).st_ino
+        ):
+            logger.info(
+                "Hard link already exists between %r and %r",
+                new_path,
+                orig_path,
+            )
+        else:
+            raise FileExistsError("Failed to create hard link") from e
+    # modify the file information
+    file_field.name = new_path
+    return file_field
+
+
+def copy_icon(region: Region, obj: POI | Event) -> None:
+    """
+    Ensure the icon of an object is accessible from the target region as well
+    """
+    if obj.icon and obj.icon.region is not None:
+        # Theoretically, there might be orphaned media files
+        obj.icon.pk = None
+        obj.icon.region = region
+        try:
+            obj.icon.file = make_hardlink(obj.icon.file, region.pk)
+        except FileNotFoundError:
+            logger.info("Could not copy icon for %r: FileNotFound", obj)
+        obj.icon.save()
+
+
+def get_user(username: str) -> User:
+    """
+    Get a user by username or raise an error if not found
+
+    :param username: Username
+    :return: User
+    """
+    try:
+        return get_user_model().objects.get(username=username)
+    except get_user_model().DoesNotExist as e:
+        raise CommandError(f'User with username "{username}" does not exist.') from e
+
+
+class Command(BaseCommand):
+    help = "Duplicate POIs into target regions"
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        """
+        Define the arguments of this command
+
+        :param parser: The argument parser
+        """
+        parser.add_argument(
+            "template-slug", type=str, help=_("The slug of the template region")
+        )
+        parser.add_argument(
+            "target-slug",
+            type=str,
+            nargs="+",
+            help=_("The slugs of the target regions"),
+        )
+        parser.add_argument("--username", help="The username of the creator")
+        parser.add_argument(
+            "--contacts",
+            action="store_true",
+            help="Whether contacts should be copied too",
+        )
+        parser.add_argument(
+            "--events",
+            action="store_true",
+            help="Whether events should be copied too",
+        )
+        parser.add_argument(
+            "--add-suffix",
+            action="store_true",
+            help="Whether the suffix ' (Copy)' should be appended",
+        )
+
+    def handle(
+        self,
+        *args: Any,
+        username: str,
+        contacts: bool,
+        events: bool,
+        add_suffix: bool,
+        **options: Any,
+    ) -> None:
+        r"""
+        Try to run the command
+
+        :param \*args: The supplied arguments
+        :param contact: Whether contacts should be copied too
+        :param \**options: The supplied keyword options
+
+        """
+        template_slug = options["template-slug"]
+        target_slug = options["target-slug"]
+        user = get_user(username) if username else None
+        template_region = Region.objects.get(slug=template_slug)
+        target_regions = [Region.objects.get(slug=slug) for slug in target_slug]
+
+        with transaction.atomic():
+            for source_poi in POI.objects.filter(region=template_region):
+                source_events = list(source_poi.events.all())
+                source_contacts = list(source_poi.contacts.all())
+
+                for target_region in target_regions:
+                    # Create a deep copy per region so we don't somehow mess up the template object for the next target region
+                    poi = deepcopy(source_poi)
+
+                    copy_icon(target_region, poi)
+
+                    poi.region = target_region
+                    poi.copy(user=user, add_suffix=add_suffix)
+
+                    if contacts:
+                        for source_contact in source_contacts:
+                            contact = deepcopy(source_contact)
+
+                            contact.location = poi
+                            contact.copy(add_suffix=add_suffix)
+
+                    if events:
+                        for source_event in source_events:
+                            event = deepcopy(source_event)
+
+                            event.location = poi
+                            event.region = target_region
+                            event.copy(user=user, add_suffix=add_suffix)
+
+            if events:
+                events_without_poi = Event.objects.filter(
+                    location_id=None, region=template_region
+                )
+                for source_event in events_without_poi:
+                    for target_region in target_regions:
+                        event = deepcopy(source_event)
+
+                        event.region = target_region
+                        event.copy(user=user, add_suffix=add_suffix)

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -3731,9 +3731,8 @@ msgstr "keine Seiten gelöscht werden können, die Unterseiten haben."
 msgid ""
 "you cannot delete a page that is embedded as live content by another page."
 msgstr ""
-"eine Seite, die von einer anderen Seite als "
-"Live-Inhalt eingebunden wurde, nicht gelöscht "
-"werden kann."
+"eine Seite, die von einer anderen Seite als Live-Inhalt eingebunden wurde, "
+"nicht gelöscht werden kann."
 
 #: cms/models/pages/page.py cms/models/pages/page_translation.py
 msgid "page"
@@ -3899,7 +3898,9 @@ msgstr "Geben Sie an, ob dieser Ort barrierefrei ist."
 
 #: cms/models/pois/poi.py
 msgid "a poi used by an event or a contact cannot be deleted."
-msgstr "ein Ort, der von einer Veranstaltung oder einem Kontakt verwendet wird, nicht gelöscht werden kann."
+msgstr ""
+"ein Ort, der von einer Veranstaltung oder einem Kontakt verwendet wird, "
+"nicht gelöscht werden kann."
 
 #: cms/models/pois/poi.py cms/templates/pois/poi_list.html
 msgid "locations"
@@ -11513,6 +11514,14 @@ msgstr[1] ""
 #: core/apps.py
 msgid "Core"
 msgstr "Core"
+
+#: core/management/commands/copy_pois.py
+msgid "The slug of the template region"
+msgstr "Der Slug der Template-Region"
+
+#: core/management/commands/copy_pois.py
+msgid "The slugs of the target regions"
+msgstr "Die Slugs der Ziel-Regionen"
 
 #: core/settings.py
 msgid "English"

--- a/tests/core/management/commands/test_copy_pois.py
+++ b/tests/core/management/commands/test_copy_pois.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import itertools
+
+import pytest
+from django.core.management.base import CommandError
+
+from integreat_cms.cms.models import Contact, Event, POI, Region
+
+from ..utils import get_command_output
+
+
+@pytest.mark.django_db
+def test_no_argument_fails() -> None:
+    """
+    Tests that the command fails when no argument is supplied.
+    """
+    with pytest.raises(CommandError) as exc_info:
+        get_command_output("copy_pois")
+
+    assert (
+        str(exc_info.value)
+        == "Error: the following arguments are required: template-slug, target-slug"
+    )
+
+
+flags = (
+    "--contacts",
+    "--events",
+    "--add-suffix",
+)
+# create all possible flag combinations, from none to all of them
+parameters = tuple(
+    itertools.chain(
+        *[
+            itertools.combinations(flags, r)
+            for r in range(len(flags) + 1)  # up to how many there are + zero
+        ]
+    )
+)
+
+
+@pytest.mark.parametrize(
+    "parameters", parameters, ids=[" ".join(x) for x in parameters]
+)
+@pytest.mark.django_db
+def test_copy_pois_succeeds(
+    load_test_data_transactional: None,
+    parameters: tuple[str],
+) -> None:
+    """
+    Tests whether POIs are duplicated as expected
+    """
+    template_region_slug = "augsburg"
+    target_region_slug = "artland"
+
+    target_region = Region.objects.get(slug=target_region_slug)
+    original_number_of_pois = POI.objects.filter(region=target_region).count()
+    original_number_of_contacts = Contact.objects.filter(
+        location__region=target_region
+    ).count()
+    original_number_of_events = Event.objects.filter(region=target_region).count()
+
+    get_command_output(
+        "copy_pois", template_region_slug, target_region_slug, *parameters
+    )
+    template_region = Region.objects.get(slug=template_region_slug)
+    number_of_pois = POI.objects.filter(region=template_region).count()
+    number_of_contacts = (
+        Contact.objects.filter(location__region=template_region).count()
+        if "--contacts" in parameters
+        else 0
+    )
+    number_of_events = (
+        Event.objects.filter(region=template_region).count()
+        if "--events" in parameters
+        else 0
+    )
+    # Ensure test is valid with the given template region
+    if number_of_pois == 0:
+        pytest.skip("No pois in template region, invalid test")
+    if "--contacts" in parameters and number_of_contacts == 0:
+        pytest.skip("No contacts in template region, invalid test")
+    if "--events" in parameters and number_of_events == 0:
+        pytest.skip("No events in template region, invalid test")
+
+    assert (
+        POI.objects.filter(region=target_region).count()
+        == original_number_of_pois + number_of_pois
+    )
+    assert (
+        Contact.objects.filter(location__region=target_region).count()
+        == original_number_of_contacts + number_of_contacts
+    )
+    assert (
+        Event.objects.filter(region=target_region).count()
+        == original_number_of_events + number_of_events
+    )


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds management commands to copy pois, optionally along with events and/or contacts.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Management command to copy pois
- Through `--events` and `--contacts` it will also copy events and contacts, respectively
- If `--add-suffix` is given, created duplicates will get the suffix ` (Copy)` appended to their name/title/…
- With `--user` the user can be specified that will be recorded as the creator of the duplicates
- Internally, the new implementation of `.copy()` on `AbstractContentModel`s is leveraged


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3760
Fixes: #3764


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
