### PR TITLE
Fix phone number autolink on space key

### DIFF
--- a/integreat_cms/release_notes/2025/2025.6.3/3693.yml
+++ b/integreat_cms/release_notes/2025/2025.6.3/3693.yml
@@ -1,2 +1,2 @@
 en: Fix phone number autolinking behavior by space key
-de: Behebt das Verhalten der automatischen Telefonnummernverlinkung indem Links korrekt bei Leerzeichen erstellt werden und das do-not-translate-Tag keinen nachfolgenden Text mehr beeinflusst
+de: Korrigiert das Verhalten der automatischen Verlinkung von Telefonnummern, indem Links nach einem Leerzeichen korrekt erstellt werden

--- a/integreat_cms/release_notes/2025/2025.6.3/3693.yml
+++ b/integreat_cms/release_notes/2025/2025.6.3/3693.yml
@@ -1,0 +1,2 @@
+en: Fix phone number autolinking behavior by ensuring proper link creation on space key and preventing unwanted do-not-translate tags from affecting following text
+de: Behebt das Verhalten der automatischen Telefonnummernverlinkung indem Links korrekt bei Leerzeichen erstellt werden und das do-not-translate-Tag keinen nachfolgenden Text mehr beeinflusst

--- a/integreat_cms/release_notes/2025/2025.6.3/3693.yml
+++ b/integreat_cms/release_notes/2025/2025.6.3/3693.yml
@@ -1,2 +1,2 @@
-en: Fix phone number autolinking behavior by ensuring proper link creation on space key and preventing unwanted do-not-translate tags from affecting following text
+en: Fix phone number autolinking behavior by space key
 de: Behebt das Verhalten der automatischen Telefonnummernverlinkung indem Links korrekt bei Leerzeichen erstellt werden und das do-not-translate-Tag keinen nachfolgenden Text mehr beeinflusst

--- a/integreat_cms/release_notes/2025/2025.6.3/3713.yml
+++ b/integreat_cms/release_notes/2025/2025.6.3/3713.yml
@@ -1,2 +1,2 @@
 en: Prevent do-not-translate from affecting following text
-de: Behebt das Problem bei der Telefonnummernerkennung Erstellt jetzt auch bei Leerzeichen automatisch einen Link und verhindert, dass das "do-not-translate"-Tag auf nachfolgenden Text übergeht
+de: Behebt das Problem bei der Telefonnummernerkennung, dass das "do-not-translate"-Tag den nachfolgenden Text beeinflusst

--- a/integreat_cms/release_notes/2025/2025.6.3/3713.yml
+++ b/integreat_cms/release_notes/2025/2025.6.3/3713.yml
@@ -1,0 +1,2 @@
+en: Fix phone number autolinking ensure link creation on space key and prevent do-not-translate from affecting following text
+de: Behebt das Problem bei der Telefonnummernerkennung Erstellt jetzt auch bei Leerzeichen automatisch einen Link und verhindert, dass das "do-not-translate"-Tag auf nachfolgenden Text übergeht

--- a/integreat_cms/release_notes/2025/2025.6.3/3713.yml
+++ b/integreat_cms/release_notes/2025/2025.6.3/3713.yml
@@ -1,2 +1,2 @@
-en: Fix phone number autolinking ensure link creation on space key and prevent do-not-translate from affecting following text
+en: Prevent do-not-translate from affecting following text
 de: Behebt das Problem bei der Telefonnummernerkennung Erstellt jetzt auch bei Leerzeichen automatisch einen Link und verhindert, dass das "do-not-translate"-Tag auf nachfolgenden Text übergeht

--- a/integreat_cms/static/src/js/tinymce-plugins/autolink_tel/plugin.js
+++ b/integreat_cms/static/src/js/tinymce-plugins/autolink_tel/plugin.js
@@ -193,7 +193,9 @@
                 editor.dom.setAttrib(editor.selection.getNode(), "target", defaultLinkTarget);
                 editor.selection.setContent(prettyPrintedNumber);
             }
-            editor.selection.moveToBookmark(bookmark);
+            const link = editor.selection.getNode();
+            editor.selection.select(link, false);
+            editor.selection.collapse(false);
             editor.nodeChanged();
         }
     };
@@ -201,7 +203,7 @@
         parseCurrentLine(editor, -1, "(");
     };
     const handleSpacebar = (editor) => {
-        parseCurrentLine(editor, 0, "");
+        parseCurrentLine(editor, -1, "");
     };
     const handleEnter = (editor) => {
         parseCurrentLine(editor, -1, "");
@@ -210,12 +212,28 @@
         const KEY_CODE_ENTER = 13;
         const KEY_CODE_SPACE = 32;
         const KEY_CODE_SELECT = 41;
+        const NODE_TYPE_TEXT = 3;
 
         let autoUrlDetectState;
         /* eslint-disable-next-line consistent-return */
         editor.on("keydown", (e) => {
+            if (e.keyCode === KEY_CODE_SPACE) {
+                const rng = editor.selection.getRng();
+                const node = rng.startContainer;
+                if (
+                    node.nodeType === NODE_TYPE_TEXT &&
+                    node.parentNode &&
+                    node.parentNode.tagName === "A" &&
+                    rng.startOffset === node.length
+                ) {
+                    return;
+                }
+                handleSpacebar(editor);
+                return;
+            }
+
             if (e.keyCode === KEY_CODE_ENTER) {
-                return handleEnter(editor);
+                handleEnter(editor);
             }
         });
         if (global$1.browser.isIE()) {
@@ -233,12 +251,6 @@
         editor.on("keypress", (e) => {
             if (e.keyCode === KEY_CODE_SELECT) {
                 return handleEclipse(editor);
-            }
-        });
-        /* eslint-disable-next-line consistent-return */
-        editor.on("keyup", (e) => {
-            if (e.keyCode === KEY_CODE_SPACE) {
-                return handleSpacebar(editor);
             }
         });
         return "";


### PR DESCRIPTION
### Short description

Fix phone-number autolinking in TinyMCE: creates the `<a href>` on space-press and stops the `do-not-translate` span from leaking to later text.

---

### Proposed changes

- Move space-key handler from `keyup` to `keydown`  
- Guard: skip formatter when caret is after the newly created link (keeps user’s space)  
- Call `parseCurrentLine(editor, -1, '')` so the full number is wrapped  
- Collapse selection outside the span after link creation

---

### Side effects

- Touches only the custom `autolink_tel` plugin → could affect other automatic-link cases inside TinyMCE  
- Tested with Enter/Space, multiple numbers, mixed content – no regressions found

---

### Faithfulness to issue description and design

No intentional deviations.

---

### Resolved issues

Fixes: #3693, #3713
