### PR TITLE
Fix spacing in contact card in RTL languages

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/3709.yml
+++ b/integreat_cms/release_notes/current/unreleased/3709.yml
@@ -1,0 +1,2 @@
+en: Fix different spacing in contact card in RTL languages
+de: Korrigiere abweichende Abstände in der Kontaktkarte in RTL-Sprachen

--- a/integreat_cms/static/src/css/tinymce_custom.css
+++ b/integreat_cms/static/src/css/tinymce_custom.css
@@ -16,4 +16,6 @@
 }
 .contact-card {
     cursor: default !important;
+    font-family: "Open Sans" !important;
+    font-size: 1rem !important;
 }


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the bug that spacing is different in contact cards in Arabic.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Apply the same font and font size to the contact cards regardless of the language
- 


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- Font setting per language ("Lateef" for Arabic and Farsi, "Open Sans" for most european languages) is ignored whithing the contact cards. Contact cards will look the same (as in the german translations) in all languages. @laravoelk @hauf-toni is this okay? I personally like it as the contact cards (which are "do not translate") look consistently.

This is how it will look in Arabic translations after this PR
![after ar](https://github.com/user-attachments/assets/ce9f4c81-400d-409a-bd84-5df1438e9e3a)



### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3709 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
