### PR TITLE
Bugfix update_links_to()

### DIFF
--- a/integreat_cms/cms/utils/content_translation_utils.py
+++ b/integreat_cms/cms/utils/content_translation_utils.py
@@ -72,7 +72,7 @@ def get_referencing_translations(
     :param content_translation: The `content_translation` for which links should be searched
     :return: All referencing content translations
     """
-    result = set()
+    result: set[AbstractContentTranslation] = set()
 
     public_translation = content_translation.public_version
 
@@ -108,12 +108,13 @@ def get_referencing_translations(
         url__startswith=f"{settings.WEBAPP_URL.removesuffix('/')}/{region_slug}/{language_slug}/"
     )
 
-    urls = (url for url in Url.objects.filter(filter_query) if url.internal)
+    urls = Url.objects.filter(filter_query)
     for url in urls:
         if linked_translation := get_public_translation_for_link(url.url):
             if linked_translation != public_translation:
                 continue
 
-            for link in url.links.all():
-                result.add(link.content_object.latest_version)
+            result.update(
+                link.content_object.latest_version for link in url.links.all()
+            )
     return result

--- a/integreat_cms/release_notes/current/unreleased/3781.yml
+++ b/integreat_cms/release_notes/current/unreleased/3781.yml
@@ -1,0 +1,2 @@
+en: Fix bug in saving a page that could cause system instability
+de: Fehler beim Speichern einer Seite behoben, der zu Systeminstabilität führen konnte


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This is the bugfix PR to fix the issue that occurred on production the past week. While a similar patch is already applied in production, this is the PR to bring a fix to our code base as well.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Further limit any URLs to be considered to end in the slug instead of just containing it
- Require the slug to be delimited with slashes
- Eliminate the extra call to `url.internal` by directly requiring any URL to start with the `WEBAPP_URL` configured in the settings
- Even further limit any URLs to contain the fitting region and language slug


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- If there are multiple possible domains, this implementation will no longer suffice and using linkchecks `url.internal` would be more complete. However, our `settings.py` clearly only intends one domain and so skipping the extra roundtrip through python seems a more than justified improvement to me.


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3781


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
