### PR TITLE
Let linkcheck run inline

### DIFF
--- a/integreat_cms/core/management/commands/loaddata.py
+++ b/integreat_cms/core/management/commands/loaddata.py
@@ -1,0 +1,30 @@
+from typing import Any
+
+from django.core.management.commands.loaddata import Command as LoaddataCommand
+from django.dispatch import Signal
+
+pre_loaddata = Signal()
+post_loaddata = Signal()
+
+
+class Command(LoaddataCommand):
+    __doc__ = f"""
+    Wrapper around djangos loaddata command to emit signals before and after loading data.
+    This command acts as a drop-in replacement by shadowing the original one.
+
+    {LoaddataCommand.__doc__}
+    """
+
+    def handle(self, *fixture_labels: Any, **options: Any) -> None:
+        pre_loaddata.send(sender=self.__class__, fixture_labels=fixture_labels)
+
+        super().handle(*fixture_labels, **options)
+
+        post_loaddata.send(sender=self.__class__, fixture_labels=fixture_labels)
+
+
+Command.handle.__doc__ = f"""
+{LoaddataCommand.handle.__doc__}
+
+Emits a signal before and after loading.
+"""

--- a/integreat_cms/core/management/commands/migrate.py
+++ b/integreat_cms/core/management/commands/migrate.py
@@ -1,0 +1,32 @@
+from typing import Any
+
+from django.core.management.commands.migrate import Command as MigrateCommand
+from django.dispatch import Signal
+
+pre_full_migration = Signal()
+post_full_migration = Signal()
+
+
+class Command(MigrateCommand):
+    __doc__ = f"""
+    Wrapper around djangos migrate command to emit signals when a migration starts or ends.
+    There exist the ``pre_migrate`` and ``post_migrate`` signals,
+    but the latter are emitted multiple times during migration without any way to tell when the process has actually concluded.
+    This command acts as a drop-in replacement by shadowing the original one.
+
+    {MigrateCommand.__doc__}
+    """
+
+    def handle(self, *fixture_labels: Any, **options: Any) -> None:
+        pre_full_migration.send(sender=self.__class__, fixture_labels=fixture_labels)
+
+        super().handle(*fixture_labels, **options)
+
+        post_full_migration.send(sender=self.__class__, fixture_labels=fixture_labels)
+
+
+Command.handle.__doc__ = f"""
+{MigrateCommand.handle.__doc__}
+
+Emits a signal before and after migration.
+"""


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
While investigating #3781, we discovered that the background worker thread of linkcheck does not work well with WSGI processes *(see https://github.com/DjangoAdminHackers/django-linkcheck/issues/208)*. We decided to manipulate linkcheck to think it is being run in its test environment, which skips adding changed content objects to the queue and immediately processes them inline.
~~While a patch is already applied in production~~, this is the PR to bring a fix to our code base as well. It is a bit more involved than the one-liner in production since we not only need to set the value in linkcheck from our code base but also need to avoid the side effect of messing things up during migration or calls to djangos `loaddata` management command.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Implement two functions fit as signal handlers to manipulate the value in the linkcheck library to `True` or `False`
- On module loading, immediately set the value such that linkcheck runs inline
- Since there are no similar built-in signals for `loaddata`, create our own custom `loaddata` management command shadowing and simply wrapping djangos original. Emit the `pre_` and `post_loaddata` signals before and after loading the data, respectively, and connect the handler functions
    - Do some shenanigans to re-use and supplement the docstrings of the original class
- Do the same to creating custom signals for `migrate`. While the original `pre_` and `post_migrate` signals are emitted multiple times, not allowing to deduce when the whole migration is actually finished, our custom `pre_` and `post_full_migration` signals do fulfill that role.
  See the note in *Side effects*


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Since linkcheck will now always run inline after saving a model involving links, this will add *(possibly significantly)* to the processing time for incoming requests. While this is fine for requests that only require e.g. saving a new page translation, requests that process and save many content objects at a time will now be very problematic
- There was hope that this resolves most or all of the problems that haunt our CI. A first data point indicates otherwise.
- `pre_` and `post_full_migration` might not actually be emitted on every migration django does. At least when manually executing the `migrate` command, on server startup using `tools/run.sh` and in `tools/tests.sh` this does seem to be the case. However, we should be careful to assume it universally valid that all migrations always execute via the `migrate` management command.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->
Fixes: #3831
*(though not the long-term solution we wish for)*
__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
