### PR TITLE
Change Zammad privacy policy attr in region endpoint

### DIFF
--- a/integreat_cms/api/v3/regions.py
+++ b/integreat_cms/api/v3/regions.py
@@ -44,7 +44,9 @@ def transform_region(region: Region) -> dict[str, Any]:
         "aliases": region.aliases,
         "tunews": region.external_news_enabled,
         "external_news": region.external_news_enabled,
-        "zammad_privacy_policy": region.zammad_privacy_policy,
+        "zammad_privacy_policy": region.zammad_privacy_policy
+        if region.zammad_privacy_policy
+        else None,
         "languages": list(map(transform_language, region.visible_languages)),
         "is_chat_enabled": bool(
             region.integreat_chat_enabled

--- a/tests/api/expected-outputs/regions.json
+++ b/tests/api/expected-outputs/regions.json
@@ -29,7 +29,7 @@
     "prefix": "Samtgemeinde",
     "push_notifications": true,
     "tunews": false,
-    "zammad_privacy_policy": "",
+    "zammad_privacy_policy": null,
     "is_chat_enabled": false
   },
   {
@@ -99,7 +99,7 @@
     ],
     "aliases": {},
     "tunews": false,
-    "zammad_privacy_policy": "",
+    "zammad_privacy_policy": null,
     "external_news": false,
     "languages": [{ "id": 2, "code": "en", "bcp47_tag": "en-GB", "native_name": "English", "dir": "LEFT_TO_RIGHT" }],
     "is_chat_enabled": false
@@ -134,7 +134,7 @@
     "prefix": "",
     "push_notifications": true,
     "tunews": false,
-    "zammad_privacy_policy": "",
+    "zammad_privacy_policy": null,
     "is_chat_enabled": false
   },
   {
@@ -157,7 +157,7 @@
     ],
     "aliases": { "Nuernberg": { "longitude": 11.075269, "latitude": 49.450938 } },
     "tunews": false,
-    "zammad_privacy_policy": "",
+    "zammad_privacy_policy": null,
     "external_news": false,
     "languages": [
       { "id": 1, "code": "de", "bcp47_tag": "de-DE", "native_name": "Deutsch", "dir": "LEFT_TO_RIGHT" },
@@ -199,7 +199,7 @@
     ],
     "aliases": {},
     "tunews": false,
-    "zammad_privacy_policy": "",
+    "zammad_privacy_policy": null,
     "external_news": false,
     "languages": [
       {

--- a/tests/api/expected-outputs/regions_berlin.json
+++ b/tests/api/expected-outputs/regions_berlin.json
@@ -15,7 +15,7 @@
   "bounding_box": [],
   "aliases": {},
   "tunews": false,
-  "zammad_privacy_policy": "",
+  "zammad_privacy_policy": null,
   "external_news": false,
   "languages": [
     { "id": 1, "code": "en", "bcp47_tag": "en-GB", "native_name": "English", "dir": "LEFT_TO_RIGHT" },

--- a/tests/api/expected-outputs/regions_nurnberg.json
+++ b/tests/api/expected-outputs/regions_nurnberg.json
@@ -18,7 +18,7 @@
   ],
   "aliases": { "Nuernberg": { "latitude": 49.450938, "longitude": 11.075269 } },
   "tunews": false,
-  "zammad_privacy_policy": "",
+  "zammad_privacy_policy": null,
   "external_news": false,
   "languages": [
     { "id": 1, "code": "de", "bcp47_tag": "de-DE", "native_name": "Deutsch", "dir": "LEFT_TO_RIGHT" },


### PR DESCRIPTION
### Short description
As requested by the app, let the zammad_privacy_policy return null if no policy is set.


### Proposed changes
- Convert empty zammad_privacy_policy string to None / null


### Side effects
- None, this attribute is not yet in use.


### Faithfulness to issue description and design
N/A


### Resolved issues
https://chat.tuerantuer.org/digitalfabrik/pl/57n4hipbuty8dx85sntajof6no


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
