### PR TITLE
Fix hover on not showing details after PNG export

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/3197.yml
+++ b/integreat_cms/release_notes/current/unreleased/3197.yml
@@ -1,0 +1,2 @@
+en: Fix hover on does not show detail after exporting PNG image of statistics
+de: Behebe den Fehler, durch den nach dem Export von PNG-Bildern in den Statistiken beim Mouseover-Effekt die detaillierten Informationen nicht mehr angezeigt werden."

--- a/integreat_cms/static/src/js/analytics/statistics-charts.ts
+++ b/integreat_cms/static/src/js/analytics/statistics-charts.ts
@@ -190,6 +190,7 @@ const exportStatisticsData = (): void => {
                 downloadFile(`${filename}.png`, image);
 
                 chart.options.plugins.legend.display = false;
+                ctx.globalCompositeOperation = "source-over";
                 chart.update();
             }
         }, timeoutDuration);


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the bug that details of each node in the statistics graph won't be shown after once exporting as PNG

### Proposed changes
<!-- Describe this PR in more detail. -->

- Set `globalCompositeOperation` to the original value after export
- 


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- I hope none 🙈 
- 


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3197 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
