### PR TITLE
Fix the test coverage reporting failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,25 +241,6 @@ jobs:
       - run:
           name: Check for missing migrations
           command: integreat-cms-cli makemigrations cms --check --settings=integreat_cms.core.circleci_settings
-  setup-test-reporter:
-    docker:
-      - image: cimg/base:stable
-    resource_class: small
-    steps:
-      - attach_workspace:
-          at: .
-      #- run:
-       #   name: Install CodeClimate Test Reporter
-       #   command: |
-       #     curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-       #     chmod +x ./cc-test-reporter
-      #- run:
-      #    name: Notify CodeClimate of a pending report
-      #    command: ./cc-test-reporter before-build
-      #- persist_to_workspace:
-      #    root: .
-      #    paths:
-      #      - cc-test-reporter
   test:
     docker:
       - image: cimg/python:3.11.7
@@ -286,9 +267,9 @@ jobs:
       - run:
           name: Run tests
           command: pytest --circleci-parallelize --disable-warnings --cov=integreat_cms --cov-report=xml --junitxml=test-results/junit.xml  --ds=integreat_cms.core.circleci_settings
-      #- run:
-      #    name: Format test coverage
-      #    command: ./cc-test-reporter format-coverage -t coverage.py -o "coverage/codeclimate.$CIRCLE_NODE_INDEX.json"
+      - run:
+          name: Move coverage file to unique name
+          command: mv coverage.xml coverage_$CIRCLE_NODE_INDEX.xml
       - store_test_results:
           path: test-results
       - store_artifacts:
@@ -296,30 +277,25 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-          #  - cc-test-reporter
-            - coverage
+            - coverage_*.xml
+  upload-test-coverage:
+    docker:
+      - image: cimg/base:stable
+    steps:
+      - attach_workspace:
+          at: .
+      - run:
+          name: Install Qlty CLI
+          command: curl -s https://get.qlty.sh | bash
+      - run:
+          name: Upload coverage to Qlty
+          command: ./qlty report coverage --path "coverage_*.xml"
       - run:
           name: Copy CMS log
           command: cp integreat_cms/integreat-cms.log integreat-cms.log
           when: on_fail
       - store_artifacts:
           path: integreat-cms.log
-  upload-test-coverage:
-    docker:
-      - image: cimg/base:stable
-    resource_class: small
-    steps:
-      - attach_workspace:
-          at: .
-      #- run:
-      #    name: Install CodeClimate Test Reporter
-      #    command: |
-      #      curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-      #      chmod +x ./cc-test-reporter
-      #- run:
-      #    name: Sum coverage data and upload to CodeClimate
-      #    command: |
-      #      ./cc-test-reporter sum-coverage -o - coverage/codeclimate.*.json | ./cc-test-reporter upload-coverage --debug --input -
   build-package:
     docker:
       - image: cimg/python:3.11.7
@@ -597,17 +573,11 @@ workflows:
       - check-migrations:
           requires:
             - pip-install
-      - setup-test-reporter:
-          context: codeclimate
-          filters:
-            branches:
-              ignore: main
       - test:
           requires:
             - pip-install
             - webpack
             - compile-translations
-            - setup-test-reporter
       - upload-test-coverage:
           context: codeclimate
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,7 @@ jobs:
       - attach_workspace:
           at: .
       - qlty/coverage_publish:
-          files: coverage.xml 
+          files: coverage.xml
   build-package:
     docker:
       - image: cimg/python:3.11.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   shellcheck: circleci/shellcheck@3.2.0
-  qlty: qlty/qlty@1.0.0
+  qlty: qltysh/qlty-orb@0.0.10
 jobs:
   pip-install:
     docker:
@@ -285,6 +285,12 @@ jobs:
           at: .
       - qlty/coverage_publish:
           files: coverage.xml
+      - run:
+          name: Copy CMS log
+          command: cp integreat_cms/integreat-cms.log integreat-cms.log
+          when: on_fail
+      - store_artifacts:
+          path: integreat-cms.log
   build-package:
     docker:
       - image: cimg/python:3.11.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   shellcheck: circleci/shellcheck@3.2.0
+  qlty: qlty/qlty@1.0.0
 jobs:
   pip-install:
     docker:
@@ -266,10 +267,7 @@ jobs:
           command: integreat-cms-cli migrate --settings=integreat_cms.core.circleci_settings
       - run:
           name: Run tests
-          command: pytest --circleci-parallelize --disable-warnings --cov=integreat_cms --cov-report=xml --junitxml=test-results/junit.xml  --ds=integreat_cms.core.circleci_settings
-      - run:
-          name: Move coverage file to unique name
-          command: mv coverage.xml coverage_$CIRCLE_NODE_INDEX.xml
+          command: pytest --circleci-parallelize --disable-warnings --cov=integreat_cms --cov-report=xml:coverage.xml --junitxml=test-results/junit.xml  --ds=integreat_cms.core.circleci_settings
       - store_test_results:
           path: test-results
       - store_artifacts:
@@ -277,25 +275,16 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - coverage_*.xml
+            - coverage.xml
   upload-test-coverage:
     docker:
       - image: cimg/base:stable
+    resource_class: small
     steps:
       - attach_workspace:
           at: .
-      - run:
-          name: Install Qlty CLI
-          command: curl -s https://get.qlty.sh | bash
-      - run:
-          name: Upload coverage to Qlty
-          command: ./qlty report coverage --path "coverage_*.xml"
-      - run:
-          name: Copy CMS log
-          command: cp integreat_cms/integreat-cms.log integreat-cms.log
-          when: on_fail
-      - store_artifacts:
-          path: integreat-cms.log
+      - qlty/coverage_publish:
+          files: coverage.xml 
   build-package:
     docker:
       - image: cimg/python:3.11.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,18 +248,18 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - run:
-          name: Install CodeClimate Test Reporter
-          command: |
-            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-            chmod +x ./cc-test-reporter
-      - run:
-          name: Notify CodeClimate of a pending report
-          command: ./cc-test-reporter before-build
-      - persist_to_workspace:
-          root: .
-          paths:
-            - cc-test-reporter
+      #- run:
+       #   name: Install CodeClimate Test Reporter
+       #   command: |
+       #     curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+       #     chmod +x ./cc-test-reporter
+      #- run:
+      #    name: Notify CodeClimate of a pending report
+      #    command: ./cc-test-reporter before-build
+      #- persist_to_workspace:
+      #    root: .
+      #    paths:
+      #      - cc-test-reporter
   test:
     docker:
       - image: cimg/python:3.11.7
@@ -285,10 +285,10 @@ jobs:
           command: integreat-cms-cli migrate --settings=integreat_cms.core.circleci_settings
       - run:
           name: Run tests
-          command: pytest --circleci-parallelize --disable-warnings --cov=integreat_cms --cov-report xml --junitxml=test-results/junit.xml  --ds=integreat_cms.core.circleci_settings
-      - run:
-          name: Format test coverage
-          command: ./cc-test-reporter format-coverage -t coverage.py -o "coverage/codeclimate.$CIRCLE_NODE_INDEX.json"
+          command: pytest --circleci-parallelize --disable-warnings --cov=integreat_cms --cov-report=xml --junitxml=test-results/junit.xml  --ds=integreat_cms.core.circleci_settings
+      #- run:
+      #    name: Format test coverage
+      #    command: ./cc-test-reporter format-coverage -t coverage.py -o "coverage/codeclimate.$CIRCLE_NODE_INDEX.json"
       - store_test_results:
           path: test-results
       - store_artifacts:
@@ -296,7 +296,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - cc-test-reporter
+          #  - cc-test-reporter
             - coverage
       - run:
           name: Copy CMS log
@@ -311,15 +311,15 @@ jobs:
     steps:
       - attach_workspace:
           at: .
-      - run:
-          name: Install CodeClimate Test Reporter
-          command: |
-            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-            chmod +x ./cc-test-reporter
-      - run:
-          name: Sum coverage data and upload to CodeClimate
-          command: |
-            ./cc-test-reporter sum-coverage -o - coverage/codeclimate.*.json | ./cc-test-reporter upload-coverage --debug --input -
+      #- run:
+      #    name: Install CodeClimate Test Reporter
+      #    command: |
+      #      curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+      #      chmod +x ./cc-test-reporter
+      #- run:
+      #    name: Sum coverage data and upload to CodeClimate
+      #    command: |
+      #      ./cc-test-reporter sum-coverage -o - coverage/codeclimate.*.json | ./cc-test-reporter upload-coverage --debug --input -
   build-package:
     docker:
       - image: cimg/python:3.11.7


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Since the 18th of July the API for CodeClimates test coverage has been discontinued. All PRs are failing on the CircleCI `upload-test-coverage` job

### Proposed changes
<!-- Describe this PR in more detail. -->

- follow Code Climates guide for migrating from the Code Climate Quality to using their Qlty Cloud ( https://docs.qlty.sh/migration/coverage ) using their (uncertified) qlty CircleCI orb 
   - delete all jobs referrring to old API in config.yml
   - set up coverage reporting with qlty in config.yml
- register qlty as an app for our repo (has to be undone manually if PR rejected)
- allow uncertified orbs in our circle ci setup

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- might be potentially risky using the qlty orb (even if recommended by codeclimate) as it is not certified by CircleCI
- please also refer to this thread: https://chat.tuerantuer.org/digitalfabrik/pl/cabg6tt8p3yd5xqqbjztqm5jzw


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
