### PR TITLE
Prevent unnecessary new windows at bulk action after PDF export

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/3265.yml
+++ b/integreat_cms/release_notes/current/unreleased/3265.yml
@@ -1,0 +1,2 @@
+en: Prevent unnecessary new windows from opening at bulk action
+de: Verhindere, dass sich unnötige neue Fenster bei einer Mehrfachaktion öffnen

--- a/integreat_cms/static/src/js/bulk-actions.ts
+++ b/integreat_cms/static/src/js/bulk-actions.ts
@@ -80,6 +80,7 @@ export const bulkActionExecute = (event: Event) => {
     event.preventDefault();
     const bulkAction = document.getElementById("bulk-action") as HTMLSelectElement;
     const form = event.target as HTMLFormElement;
+    const initialTarget = form.target;
     const selectedAction = bulkAction.options[bulkAction.selectedIndex];
     // Set form action to url of the bulk action
     form.action = selectedAction.getAttribute("data-bulk-action");
@@ -98,6 +99,9 @@ export const bulkActionExecute = (event: Event) => {
         // Submit form and execute bulk action
         form.submit();
     }
+    // Reset the target to prevent a new tab from always opening regardless of the next actions
+    // after once PDF export is used
+    form.target = initialTarget;
 };
 
 /*


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the bug that a new window always opens at every bulk action event if it is not PDF export, if once PDF export was used.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Reset the value of `form.target` after each bulk action
- 


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- Should be none
- 


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3265 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
