### PR TITLE
Support debug messages for specific users

### DIFF
--- a/integreat_cms/core/logging_filter.py
+++ b/integreat_cms/core/logging_filter.py
@@ -1,0 +1,30 @@
+import logging
+
+from django.conf import settings
+
+
+class DebugRequestFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        """
+        Filter log records based on the current request.
+
+        If REQUEST_DEBUG_USERS is set in the Django settings,
+        this filter will only allow log records with level INFO or higher,
+        or if the current user's username is in the REQUEST_DEBUG_USERS setting.
+
+        :param record: The log record to filter
+        :return: True if the record should be logged, False otherwise
+        """
+        if settings.REQUEST_DEBUG_USERS:
+            from integreat_cms.core.middleware.debug_request import get_request
+
+            request = get_request()
+
+            if (
+                request is not None
+                and request.user.username in settings.REQUEST_DEBUG_USERS
+            ):
+                record.msg = f"Debug User: {request.user.username} - {record.msg}"
+                return True
+            return record.levelno >= getattr(settings, "LOG_LEVEL_NORMAL", logging.INFO)
+        return True

--- a/integreat_cms/core/middleware/__init__.py
+++ b/integreat_cms/core/middleware/__init__.py
@@ -5,5 +5,6 @@ This package contains custom middlewares, see :doc:`django:topics/http/middlewar
 from __future__ import annotations
 
 from .access_control_middleware import AccessControlMiddleware
+from .debug_request import DebugRequestMiddleware
 from .region_middleware import RegionMiddleware
 from .timezone_middleware import TimezoneMiddleware

--- a/integreat_cms/core/middleware/debug_request.py
+++ b/integreat_cms/core/middleware/debug_request.py
@@ -1,0 +1,46 @@
+import threading
+from collections.abc import Callable
+
+from django.http import HttpRequest, HttpResponse
+
+_request_local = threading.local()
+
+
+def set_request(request: HttpRequest) -> None:
+    """
+    Set the current request in the thread-local storage.
+
+    :param request: The current request object
+    :return: None
+    """
+    _request_local.request = request
+
+
+def get_request() -> HttpRequest | None:
+    """
+    Get the current request from the thread-local storage.
+
+    :return: The current request object, or None if not set
+    """
+    return getattr(_request_local, "request", None)
+
+
+class DebugRequestMiddleware:
+    def __init__(self, get_response: Callable) -> None:
+        """
+        Initialize the middleware instance.
+
+        :param get_response: The function to call to get the response
+        :return: None
+        """
+        self.get_response = get_response
+
+    def __call__(self, request: HttpRequest) -> HttpResponse:
+        """
+        Call the middleware for the given request.
+
+        :param request: The current request object
+        :return: The response object
+        """
+        set_request(request)
+        return self.get_response(request)

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -607,6 +607,17 @@ LOGOUT_REDIRECT_URL: Final[str] = "/login/"
 #: The log level for integreat-cms django apps
 LOG_LEVEL: str = os.environ.get("INTEGREAT_CMS_LOG_LEVEL", "DEBUG" if DEBUG else "INFO")
 
+#: List of usersnames for which DEBUG logs are enabled
+REQUEST_DEBUG_USERS = [
+    item.strip()
+    for item in os.environ.get("INTEGREAT_CMS_REQUEST_DEBUG_USERS", "").split(",")
+]
+
+if REQUEST_DEBUG_USERS:
+    LOG_LEVEL_NORMAL = LOG_LEVEL
+    LOG_LEVEL = "DEBUG"
+    MIDDLEWARE.append("integreat_cms.core.middleware.DebugRequestMiddleware")
+
 #: The log level for the syslog
 SYS_LOG_LEVEL: Final[str] = "INFO"
 
@@ -669,6 +680,9 @@ LOGGING: dict[str, Any] = {
         },
     },
     "filters": {
+        "debug_request": {
+            "()": "integreat_cms.core.logging_filter.DebugRequestFilter",
+        },
         "require_debug_true": {
             "()": "django.utils.log.RequireDebugTrue",
         },
@@ -706,6 +720,7 @@ LOGGING: dict[str, Any] = {
             "level": "WARNING",
         },
         "logfile": {
+            "filters": ["debug_request"] if REQUEST_DEBUG_USERS else [],
             "class": "logging.FileHandler",
             "filename": LOGFILE,
             "formatter": "logfile",


### PR DESCRIPTION
### Short description

To help debugging issues on production services and avoid the log file being spammed with thousands of debug messages by all requests, we want an option to log only requests made by specific users.


### Proposed changes
- Add a setting (list of usernames) for which debug messages should be logged
- The middleware provides the request as context for a logger filter
- the logger filter throws away all debug messages except for the list of users that should have debug messages logged

### Side effects
- If this functionality would be enabled by default, there would be added compute for each incoming request. Therefore, if disabled, I tried to skip over all relevant code paths.

### Faithfulness to issue description and design
:100: 

### Resolved issues

Fixes: https://chat.tuerantuer.org/digitalfabrik/pl/j7bh4qmd3b8amp3et56rw3bfwe


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
