### PR TITLE
Disable hix signals during cleanup_autosaves()

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/3819.yml
+++ b/integreat_cms/release_notes/current/unreleased/3819.yml
@@ -1,0 +1,2 @@
+en: Fix bug where saving a page could take forever and time out
+de: Behebe den Fehler, bei dem das Speichern einer Seite zu einer Zeitüberschreitung führen konnte


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
During `cleanup_autosaves()`, a number of content translation objects get their `.version` modified. During the save, the `pre_save` hook is executed that re-evaluates the HIX score, even though the content has not changed, taking a lot of time per object changed. 

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add `disable_listeners()` and `enable_listeners()` context managers *(inspired by how `linkcheck` does it)*
- Disable HIX listeners along with linkcheck ones during `cleanup_autosaves()`


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- 

### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3819 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
