### PR TITLE
Fix empty entry in the languages in which mirrored content is available

### DIFF
--- a/integreat_cms/cms/models/pages/page_translation.py
+++ b/integreat_cms/cms/models/pages/page_translation.py
@@ -156,10 +156,15 @@ class PageTranslation(AbstractBasePageTranslation):
             return content
 
         # Get all translations of this page which have a corresponding translation of the mirrored page
-        languages = self.page.mirrored_page.prefetched_major_public_translations_by_language_slug.keys()
+        available_source_languages = self.page.mirrored_page.prefetched_major_public_translations_by_language_slug.keys()
+        available_page_languages = (
+            self.page.prefetched_major_public_translations_by_language_slug.keys()
+        )
+        availabe_languages = available_source_languages & available_page_languages
+
         translations = [
             self.page.get_public_translation(language_slug)
-            for language_slug in languages
+            for language_slug in availabe_languages
             if (
                 translation := self.page.get_mirrored_page_translation(language_slug)
             ).content

--- a/integreat_cms/release_notes/current/unreleased/2712.yml
+++ b/integreat_cms/release_notes/current/unreleased/2712.yml
@@ -1,0 +1,2 @@
+en: Fix empty entry in the list of languages in which the mirrored content is available
+de: Korrigiere leeren Eintrag in der Liste der Sprachen, in denen der gespiegelte Inhalt verfügbar ist


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the bug that empty entries appear in the list of alternative languages for the mirrored content.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Check which languages are available for the mirrored content
- Check which languages are available for the mirroring content
- List only the languages that are available in both of the above sets


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Happier user experience?
- 


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2712 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
