### PR TITLE
API events: Fix internal server error

### DIFF
--- a/integreat_cms/api/v3/locations.py
+++ b/integreat_cms/api/v3/locations.py
@@ -49,7 +49,11 @@ def transform_poi(poi: POI | None) -> dict[str, Any]:
         }
     return {
         "id": poi.id,
-        "name": poi.default_public_translation.title,
+        "name": (
+            poi.default_public_translation.title
+            if poi.default_public_translation
+            else None
+        ),
         "address": poi.address,
         "town": poi.city,
         "state": None,

--- a/integreat_cms/release_notes/current/unreleased/3776.yml
+++ b/integreat_cms/release_notes/current/unreleased/3776.yml
@@ -1,0 +1,2 @@
+en: Fix bug where the existence of an event referencing an unpublished location resulted in an internal server error
+de: Behebe den Fehler, bei dem das Vorhandensein eines Ereignisses, das auf einen unveröffentlichten Standort verweist, zu einem internen Serverfehler führte


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the bug on the events endpoint of our API leading to an internal server error when handling an event referencing a location that is set to draft, meaning that the user sees no events at all.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Expose the name of a location as `null` if it does not have a `best_public_translation`


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- This might not be the correct strategy. Maybe we don't want to show locations set as draft and anything connected to it at all
- We need to check with the app team whether this is a change that makes sense in their context


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3776 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
