### PR TITLE
Rework page accesses typesript

### DIFF
--- a/integreat_cms/cms/templates/statistics/statistics_viewed_pages.html
+++ b/integreat_cms/cms/templates/statistics/statistics_viewed_pages.html
@@ -21,16 +21,6 @@
           data-page-accesses-url="{% url 'statistics_page_based_accesses' region_slug=request.region.slug %}">
         {% csrf_token %}
         <div class="overflow-x-auto">
-            <div id="page-accesses-network-error" class="text-red-500 px-4 hidden">
-                <i icon-name="alert-triangle"></i> {% translate "A network error has occurred." %} {% translate "Please try again later." %}
-            </div>
-            <div id="page-accesses-heavy-traffic-error"
-                 class="text-red-500 px-4 hidden">
-                <i icon-name="alert-triangle"></i> {% translate "The statistics network is currently experiencing heavy traffic." %} {% translate "Please try again later." %}
-            </div>
-            <div id="page-accesses-server-error" class="text-red-500 px-4 hidden">
-                <i icon-name="alert-triangle"></i> {% translate "A server error has occurred." %} {% translate "Please contact the administrator." %}
-            </div>
             <table data-delay-event-handlers
                    data-activate-tree-drag-drop
                    data-descendants-url="{% url 'get_page_tree_ajax' region_slug=request.region.slug language_slug=language.slug is_archive=False is_statistics=is_statistics %}"

--- a/integreat_cms/cms/templates/statistics/statistics_viewed_pages_node.html
+++ b/integreat_cms/cms/templates/statistics/statistics_viewed_pages_node.html
@@ -16,6 +16,7 @@
         {% for language in languages %}
             <span data-language-color="{{ language.language_color }}"
                   data-language-slug="{{ language.slug }}"
+                  data-language-title="{{ language.translated_name }}"
                   data-access-translation="{% translate "Accesses" %}"
                   class="cursor-pointer bg-[{{ language.language_color }}] h-9">
             </span>

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -5130,7 +5130,6 @@ msgstr "Detailansicht"
 #: cms/templates/chat/_chat_widget.html
 #: cms/templates/statistics/_statistics_widget.html
 #: cms/templates/statistics/statistics_chart.html
-#: cms/templates/statistics/statistics_viewed_pages.html
 #: cms/views/media/media_context_mixin.py
 msgid "A network error has occurred."
 msgstr "Ein Netzwerkfehler ist aufgetreten."
@@ -5139,7 +5138,6 @@ msgstr "Ein Netzwerkfehler ist aufgetreten."
 #: cms/templates/chat/_chat_widget.html cms/templates/hix_widget.html
 #: cms/templates/statistics/_statistics_widget.html
 #: cms/templates/statistics/statistics_chart.html
-#: cms/templates/statistics/statistics_viewed_pages.html
 #: cms/views/media/media_context_mixin.py
 msgid "Please try again later."
 msgstr "Bitte versuchen Sie es später erneut."
@@ -5148,15 +5146,13 @@ msgstr "Bitte versuchen Sie es später erneut."
 #: cms/templates/chat/_chat_widget.html
 #: cms/templates/statistics/_statistics_widget.html
 #: cms/templates/statistics/statistics_chart.html
-#: cms/templates/statistics/statistics_viewed_pages.html
 msgid "A server error has occurred."
 msgstr "Ein Serverfehler ist aufgetreten."
 
 #: cms/templates/analytics/_broken_links_widget.html
 #: cms/templates/chat/_chat_widget.html
 #: cms/templates/statistics/_statistics_widget.html
-#: cms/templates/statistics/statistics_chart.html
-#: cms/templates/statistics/statistics_viewed_pages.html xliff/utils.py
+#: cms/templates/statistics/statistics_chart.html xliff/utils.py
 msgid "Please contact the administrator."
 msgstr "Bitte kontaktieren Sie eine:n Administrator:in."
 
@@ -8940,7 +8936,6 @@ msgstr "Anzahl der Gesamtzugriffe der letzten 14 Tage."
 
 #: cms/templates/statistics/_statistics_widget.html
 #: cms/templates/statistics/statistics_chart.html
-#: cms/templates/statistics/statistics_viewed_pages.html
 msgid "The statistics network is currently experiencing heavy traffic."
 msgstr "Der Statistik-Server hat aktuell eine hohe Auslastung."
 

--- a/integreat_cms/static/src/js/analytics/statistics-charts.ts
+++ b/integreat_cms/static/src/js/analytics/statistics-charts.ts
@@ -9,6 +9,7 @@ import {
     Legend,
     Tooltip,
 } from "chart.js";
+import { setPageAccessesEventListeners } from "./statistics-page-accesses";
 
 export type AjaxResponse = {
     exportLabels: Array<string>;
@@ -252,6 +253,9 @@ window.addEventListener("load", async () => {
 
     // Initialize chart data
     await updateChart();
+
+    // Set event handlers for page based statistics
+    setPageAccessesEventListeners();
 
     // Initialize export button
     toggleExportButton();


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR makes some changes to `statistics-page-accesses.ts` to accommodate the changed loading process of page accesses. Also a couple of bugs are fixed.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Remove the Network Error handling since page accesses are loaded from our own database
- Add reset of page accesses bars when being updatet (this prevents bars from not being changed when there are no page accesses in the selected time frame)
- Add Event-listeners to listen to changes in the statisticsForm and the language check boxes
- Remove listening to changes in the chart (this caused #3703)
- Show loader icon when page accesses bars are being updated


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- There was a hard to notice Issue that page accesses were fetched double every time. This should be gone now.


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
The changes of the page access bars wasn't part of the initial Issue descriptions but since I already was working on the action listeners it seemed a good addition.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3759 #3703 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
