### PR TITLE
do not override existing content object slugs unless explicitely updated

### DIFF
--- a/integreat_cms/cms/constants/machine_translatable_attributes.py
+++ b/integreat_cms/cms/constants/machine_translatable_attributes.py
@@ -2,4 +2,4 @@
 This module defines all attributes which can be machine-translated.
 """
 
-TRANSLATABLE_ATTRIBUTES = ["title", "content", "meta_description"]
+TRANSLATABLE_ATTRIBUTES = ["title", "content", "meta_description", "slug"]

--- a/integreat_cms/cms/utils/slug_utils.py
+++ b/integreat_cms/cms/utils/slug_utils.py
@@ -68,7 +68,8 @@ def generate_unique_slug_helper(
     :return: An unique slug identifier
     """
     kwargs: SlugKwargs = {
-        "slug": form_object.cleaned_data["slug"],
+        "slug": form_object.cleaned_data["slug"]
+        or getattr(form_object.instance, "slug", ""),
         "cleaned_data": form_object.cleaned_data,
         "manager": form_object.Meta.model.objects,
         "object_instance": form_object.instance,

--- a/integreat_cms/cms/views/utils/slugify_ajax.py
+++ b/integreat_cms/cms/views/utils/slugify_ajax.py
@@ -63,6 +63,12 @@ def slugify_ajax(
     ):
         raise PermissionDenied
 
+    if object_instance and getattr(object_instance, "slug", None):
+        # if a content object already has an existing slug
+        # we don't want to override it by accident when changing e.g. the title
+        existing_slug = object_instance.slug
+        return JsonResponse({"unique_slug": existing_slug})
+
     form_title = slugify(json_data["title"], allow_unicode=True)
     kwargs: SlugKwargs = {
         "slug": form_title,


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Content object slugs are generated based on attributes, i.e. title or name. If an object already exists and its title is changed, this also changes the slug. If this object is referenced somewhere, this generates broken links. Especially in combination with automatic translations, this can result in a large amount of broken links.


### Proposed changes
<!-- Describe this PR in more detail. -->

- Changing the title of objects still triggers the slugify function, but if the object instance already exists and has a slug, the existing slug is used instead of generating a new one


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- It is now possible to have a mismatch between slugs and titles of objects. This should be communicated to users carefully.


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3856 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
