### PR TITLE
Experiment: Clone DB to isolate tests

### DIFF
--- a/tests/api/test_api_chat.py
+++ b/tests/api/test_api_chat.py
@@ -26,7 +26,10 @@ default_kwargs = {
 
 
 @pytest.mark.django_db
-def test_api_is_chat_enabled_for_user(load_test_data: None) -> None:
+def test_api_is_chat_enabled_for_user(
+    test_data_db_snapshot: None,
+    db_snapshot: None,
+) -> None:
     """
     Check that whether a user is chat beta tester is stored in the DB
 
@@ -48,7 +51,9 @@ def test_api_is_chat_enabled_for_user(load_test_data: None) -> None:
 @pytest.mark.django_db
 @patch("integreat_cms.api.v3.chat.user_chat.UserChat.zammad_request")
 def test_api_chat_missing_auth_error(
-    zammad_request: Mock, load_test_data: None
+    zammad_request: Mock,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
 ) -> None:
     """
     Check that missing/wrong auth information leads to an error
@@ -79,7 +84,8 @@ def test_api_chat_missing_auth_error(
 )
 def test_api_chat_incorrect_server_error(
     mock_zammad_url: Mock,
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
 ) -> None:
     """
     Check that incorrect server url leads to an error
@@ -124,7 +130,8 @@ def test_api_chat_first_chat(
     messages: Mock,
     create_ticket: Mock,
     get_zammad_user_mail: Mock,
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
 ) -> None:
     """
     Check that sending a message from a never seen-before device_id creates a new chat
@@ -171,7 +178,8 @@ def test_api_chat_set_evaluation_consent(
     save_evaluation_consent: Mock,
     messages: Mock,
     get_zammad_user_mail: Mock,
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
 ) -> None:
     """
     Check that sending a message from a never seen-before device_id creates a new chat
@@ -211,7 +219,8 @@ def test_api_chat_send_message(
     messages: Mock,
     save_message: Mock,
     get_zammad_user_mail: Mock,
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
 ) -> None:
     """
     Check that sending a message with a known device_id works and does not create a new chat
@@ -256,7 +265,8 @@ def test_api_chat_get_messages_success(
     evaluation_consent: Mock,
     messages: Mock,
     get_zammad_user_mail: Mock,
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
 ) -> None:
     """
     Check that GET-ing messages works for an existing chat
@@ -279,7 +289,9 @@ def test_api_chat_get_messages_success(
     return_value="tech@tuerantuer.org",
 )
 def test_api_chat_get_messages_failure(
-    get_zammad_user_mail: Mock, load_test_data: None
+    get_zammad_user_mail: Mock,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
 ) -> None:
     """
     Check that GET-ing messages for a non-existing chat returns an error
@@ -321,7 +333,8 @@ def test_api_chat_ratelimiting(
     evaluation_consent: Mock,
     messages: Mock,
     get_zammad_user_mail: Mock,
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
 ) -> None:
     """
     Check that the ratelimiting correctly prevents further API requests
@@ -383,7 +396,8 @@ def test_api_chat_ratelimiting_trusted_ip_header(
     evaluation_consent: Mock,
     messages: Mock,
     get_zammad_user_mail: Mock,
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
 ) -> None:
     """
     Check that ratelimiting kicks in when a trusted IP header is configured but not set in the request.

--- a/tests/api/test_api_feedback.py
+++ b/tests/api/test_api_feedback.py
@@ -46,7 +46,8 @@ feedback_type_dict: Final[dict[str, ModelBase]] = {
 @pytest.mark.django_db
 @pytest.mark.parametrize("view_name,post_data", API_FEEDBACK_VIEWS)
 def test_api_feedback_success(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     view_name: str,
     post_data: dict[str, str],
 ) -> None:
@@ -95,7 +96,8 @@ def test_api_feedback_success(
     API_FEEDBACK_ERRORS,
 )
 def test_api_feedback_errors(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     view_name: str,
     kwargs: dict[str, str],
     post_data: dict[str, str],
@@ -121,7 +123,10 @@ def test_api_feedback_errors(
 
 
 @pytest.mark.django_db
-def test_api_feedback_invalid_method(load_test_data: None) -> None:
+def test_api_feedback_invalid_method(
+    test_data_db_snapshot: None,
+    db_snapshot: None,
+) -> None:
     """
     Check error when request method is not POST
 

--- a/tests/api/test_api_push_page.py
+++ b/tests/api/test_api_push_page.py
@@ -8,7 +8,10 @@ from integreat_cms.cms.models import Page
 
 
 @pytest.mark.django_db
-def test_api_push_page_content(load_test_data: None) -> None:
+def test_api_push_page_content(
+    test_data_db_snapshot: None,
+    db_snapshot: None,
+) -> None:
     """
     This test class checks all endpoints defined in :attr:`~tests.api.api_config.API_ENDPOINTS`.
     It verifies that the content delivered by the endpoint is equivalent with the data

--- a/tests/api/test_api_result.py
+++ b/tests/api/test_api_result.py
@@ -18,7 +18,8 @@ from .api_config import API_ENDPOINTS
     API_ENDPOINTS,
 )
 def test_api_result(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     django_assert_num_queries: Callable,
     endpoint: str,
     wp_endpoint: str,

--- a/tests/api/test_api_social.py
+++ b/tests/api/test_api_social.py
@@ -17,7 +17,8 @@ from .api_config import API_SOCIAL_ENDPOINTS
     API_SOCIAL_ENDPOINTS,
 )
 def test_api_result(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     django_assert_num_queries: Callable,
     endpoint: str,
     expected_result: str,

--- a/tests/cms/models/contacts/test_contacts.py
+++ b/tests/cms/models/contacts/test_contacts.py
@@ -13,7 +13,8 @@ from integreat_cms.cms.models import Contact
 
 @pytest.mark.django_db
 def test_contact_string(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     settings: SettingsWrapper,
 ) -> None:
     """
@@ -37,7 +38,8 @@ def test_contact_string(
 
 @pytest.mark.django_db
 def test_copying_contact_works(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
 ) -> None:
     assert Contact.objects.all().count() == 5
 
@@ -49,7 +51,8 @@ def test_copying_contact_works(
 
 @pytest.mark.django_db
 def test_deleting_contact_works(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
 ) -> None:
     assert Contact.objects.all().count() == 5
 
@@ -61,7 +64,8 @@ def test_deleting_contact_works(
 
 @pytest.mark.django_db
 def test_archiving_contact_works(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
 ) -> None:
     assert Contact.objects.all().count() == 5
 
@@ -75,7 +79,8 @@ def test_archiving_contact_works(
 
 @pytest.mark.django_db
 def test_restoring_contact_works(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
 ) -> None:
     assert Contact.objects.all().count() == 5
 

--- a/tests/cms/models/push_notifications/test_push_notification.py
+++ b/tests/cms/models/push_notifications/test_push_notification.py
@@ -8,7 +8,10 @@ from integreat_cms.cms.models import (
 
 
 @pytest.mark.django_db
-def test_best_translation(load_test_data: None) -> None:
+def test_best_translation(
+    test_data_db_snapshot: None,
+    db_snapshot: None,
+) -> None:
     """
     Test whether the `best_translation` method functions correctly. This is to prevent the following bug: https://github.com/digitalfabrik/integreat-cms/issues/2726
     :param load_test_data: The fixture providing the test data (see :meth:`~tests.conftest.load_test_data`)

--- a/tests/cms/test_duplicate_regions.py
+++ b/tests/cms/test_duplicate_regions.py
@@ -17,9 +17,10 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.order("last")
-@pytest.mark.django_db(transaction=True, serialized_rollback=True)
+@pytest.mark.django_db(transaction=True)
 def test_duplicate_regions(
-    load_test_data_transactional: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     admin_client: Client,
 ) -> None:
     """
@@ -202,9 +203,10 @@ def test_duplicate_regions(
 
 
 @pytest.mark.order("last")
-@pytest.mark.django_db(transaction=True, serialized_rollback=True)
+@pytest.mark.django_db(transaction=True)
 def test_duplicate_regions_no_translations(
-    load_test_data_transactional: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     admin_client: Client,
 ) -> None:
     """

--- a/tests/cms/test_language.py
+++ b/tests/cms/test_language.py
@@ -19,7 +19,8 @@ if TYPE_CHECKING:
 
 @pytest.mark.django_db
 def test_create_new_language_node(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     # Log the user in
@@ -83,7 +84,8 @@ def test_create_new_language_node(
 
 @pytest.mark.django_db
 def test_update_language_node(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     # Log the user in
@@ -137,7 +139,8 @@ def test_update_language_node(
 
 @pytest.mark.django_db
 def test_move_language_node(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     # Log the user in
@@ -182,7 +185,8 @@ def test_move_language_node(
 
 @pytest.mark.django_db
 def test_delete_language_node(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     # Log the user in

--- a/tests/cms/test_login.py
+++ b/tests/cms/test_login.py
@@ -17,7 +17,8 @@ if TYPE_CHECKING:
     ["root", "root@root.root", "management", "management@example.com"],
 )
 def test_login_success(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     client: Client,
     settings: SettingsWrapper,
     username: str,
@@ -68,7 +69,8 @@ def test_login_success(
     ],
 )
 def test_login_failure(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     client: Client,
     settings: SettingsWrapper,
     username: str,

--- a/tests/cms/test_media_library.py
+++ b/tests/cms/test_media_library.py
@@ -23,7 +23,8 @@ if TYPE_CHECKING:
 
 @pytest.mark.django_db
 def test_directory_path(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     # Log the user in
@@ -56,7 +57,8 @@ def test_directory_path(
 
 @pytest.mark.django_db
 def test_get_directory_content(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     # Log the user in
@@ -89,7 +91,8 @@ def test_get_directory_content(
 
 @pytest.mark.django_db
 def test_create_directory(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     # Log the user in
@@ -129,7 +132,8 @@ def test_create_directory(
 
 @pytest.mark.django_db
 def test_edit_directory(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     # Log the user in
@@ -180,7 +184,8 @@ def test_edit_directory(
 
 @pytest.mark.django_db
 def test_delete_directory(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     # Log the user in
@@ -210,7 +215,8 @@ def test_delete_directory(
 
 @pytest.mark.django_db
 def test_upload_file(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     # Log the user in
@@ -253,7 +259,8 @@ def test_upload_file(
 
 @pytest.mark.django_db
 def test_replace_file(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     # Log the user in
@@ -293,7 +300,8 @@ def test_replace_file(
 
 @pytest.mark.django_db
 def test_edit_file(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     # Log the user in
@@ -346,7 +354,8 @@ def test_edit_file(
 
 @pytest.mark.django_db
 def test_move_file(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     # Log the user in
@@ -395,7 +404,8 @@ def test_move_file(
 
 @pytest.mark.django_db
 def test_delete_file(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     # Log the user in
@@ -421,7 +431,8 @@ def test_delete_file(
 
 @pytest.mark.django_db
 def test_get_file_usages(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     # Log the user in
@@ -454,7 +465,8 @@ def test_get_file_usages(
 
 @pytest.mark.django_db
 def test_get_search_result(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     # Log the user in

--- a/tests/cms/test_page_filters.py
+++ b/tests/cms/test_page_filters.py
@@ -11,7 +11,11 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.django_db
-def test_page_filters(load_test_data: None, admin_client: Client) -> None:
+def test_page_filters(
+    test_data_db_snapshot: None,
+    db_snapshot: None,
+    admin_client: Client
+) -> None:
     """
     Test whether duplicating regions works as expected
 

--- a/tests/cms/utils/test_cancel_translation.py
+++ b/tests/cms/utils/test_cancel_translation.py
@@ -23,7 +23,8 @@ REGION_SLUG = "augsburg"
 
 @pytest.mark.django_db
 def test_bulk_cancel_translation_process(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     caplog: LogCaptureFixture,
     settings: SettingsWrapper,

--- a/tests/cms/utils/test_content_utils.py
+++ b/tests/cms/utils/test_content_utils.py
@@ -12,8 +12,8 @@ from tests.conftest import EDITOR, MANAGEMENT, PRIV_STAFF_ROLES
 )
 @pytest.mark.django_db
 def test_clean_content(
-    load_test_data: None,
     login_role_user: tuple[Client, str],
+    db_snapshot: None,
 ) -> None:
     raw_content = '<h1>Das ist eine H1</h1><pre>Das ist vordefinierter Text</pre><code>Das ist vordefinierter Code</code><a href="https://www.integreat-app.de"></a><a href="http://localhost:8000/augsburg/pages/de/5" class="link-external"></a>'
     cleaned_content = clean_content(raw_content, "de")

--- a/tests/cms/utils/test_internal_link_checker.py
+++ b/tests/cms/utils/test_internal_link_checker.py
@@ -88,7 +88,8 @@ def prepage_url(link: str, trailing_slash: bool) -> Url:
 @pytest.mark.parametrize("link", VALID_INTERNAL_LINKS)
 @pytest.mark.parametrize("trailing_slash", [True, False])
 def test_check_internal_valid(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     link: str,
     trailing_slash: bool,
 ) -> None:
@@ -107,7 +108,8 @@ def test_check_internal_valid(
 @pytest.mark.parametrize("link", INVALID_INTERNAL_LINKS)
 @pytest.mark.parametrize("trailing_slash", [True, False])
 def test_check_internal_invalid(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     link: str,
     trailing_slash: bool,
 ) -> None:
@@ -128,7 +130,8 @@ def test_check_internal_invalid(
 @pytest.mark.parametrize("link", SKIPPED_INTERNAL_LINKS)
 @pytest.mark.parametrize("trailing_slash", [True, False])
 def test_check_internal_skipped(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     link: str,
     trailing_slash: bool,
 ) -> None:

--- a/tests/cms/utils/test_slug_utils.py
+++ b/tests/cms/utils/test_slug_utils.py
@@ -17,7 +17,8 @@ if TYPE_CHECKING:
 @pytest.mark.django_db
 def test_generate_unique_slug_fallback(
     settings: SettingsWrapper,
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
 ) -> None:
     """
     Test whether the :meth:`~integreat_cms.cms.utils.slug_utils.generate_unique_slug_helper` function correctly uses the fallback property
@@ -39,7 +40,8 @@ def test_generate_unique_slug_fallback(
 @pytest.mark.django_db
 def test_generate_unique_slug_reserved_region_slug(
     settings: SettingsWrapper,
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
 ) -> None:
     """
     Test whether the :meth:`~integreat_cms.cms.utils.slug_utils.generate_unique_slug_helper` function returns the correct unique slug
@@ -62,7 +64,8 @@ def test_generate_unique_slug_reserved_region_slug(
 @pytest.mark.django_db
 def test_generate_unique_slug_reserved_page_slug(
     settings: SettingsWrapper,
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
 ) -> None:
     """
     Test whether the :meth:`~integreat_cms.cms.utils.slug_utils.generate_unique_slug_helper` function  function returns the correct unique slug

--- a/tests/cms/utils/test_tree_mutex.py
+++ b/tests/cms/utils/test_tree_mutex.py
@@ -25,6 +25,8 @@ from treebeard.exceptions import InvalidMoveToDescendant
 from integreat_cms.cms.models import Page
 from integreat_cms.cms.utils.tree_mutex import tree_mutex
 
+from ...conftest import test_data_db_snapshot
+
 if TYPE_CHECKING:
     from collections.abc import Callable
 
@@ -36,8 +38,9 @@ after_tests = (
 
 
 @pytest.mark.order("last", after=after_tests)
-@pytest.mark.django_db(transaction=True, serialized_rollback=True)
-def test_tree_mutex(load_test_data_transactional: None) -> None:
+@pytest.mark.django_db(transaction=True)
+#@pytest.mark.django_db(transaction=True, serialized_rollback=True)
+def test_tree_mutex(test_data_db_snapshot: None, db_snapshot: None) -> None:
     """
     Check whether :func:`~integreat_cms.cms.utils.tree_mutex.tree_mutex` is actually preventing collisions.
     See :func:`run_mutex_test` for details.
@@ -46,8 +49,9 @@ def test_tree_mutex(load_test_data_transactional: None) -> None:
 
 
 @pytest.mark.order("last", after=(*after_tests, "test_tree_mutex"))
-@pytest.mark.django_db(transaction=True, serialized_rollback=True)
-def test_rule_out_false_positive(load_test_data_transactional: None) -> None:
+@pytest.mark.django_db(transaction=True)
+#@pytest.mark.django_db(transaction=True, serialized_rollback=True)
+def test_rule_out_false_positive(test_data_db_snapshot: None, db_snapshot: None) -> None:
     """
     Rule out that :func:`~integreat_cms.cms.utils.tree_mutex.tree_mutex` is just doing nothing and :func:`test_tree_mutex`
     only succeeded because the system magically worked without it.
@@ -83,6 +87,9 @@ def run_mutex_test(use_mutex: bool) -> None:
     directly running raw SQL commands, without database transactions.
     """
     exception = None
+
+    assert Page.objects.get(id=19)
+    assert Page.objects.get(id=21)
 
     def handle_exception(e: Exception) -> None:
         nonlocal exception

--- a/tests/cms/views/contacts/test_contact_actions.py
+++ b/tests/cms/views/contacts/test_contact_actions.py
@@ -35,7 +35,8 @@ test_archive_parameters = [(NOT_USED_CONTACT_ID, True), (USED_CONTACT_ID, False)
 @pytest.mark.parametrize("parameter", test_archive_parameters)
 @pytest.mark.django_db
 def test_archive_contact(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,
@@ -100,7 +101,8 @@ test_delete_parameters = [(NOT_USED_CONTACT_ID, True), (USED_CONTACT_ID, False)]
 @pytest.mark.parametrize("parameter", test_delete_parameters)
 @pytest.mark.django_db
 def test_delete_contact(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,
@@ -160,7 +162,8 @@ def test_delete_contact(
 
 @pytest.mark.django_db
 def test_restore_contact(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,
@@ -214,7 +217,8 @@ BULK_ARCHIVE_SELECTED_IDS = [NOT_USED_CONTACT_ID, USED_CONTACT_ID]
 
 @pytest.mark.django_db
 def test_bulk_archive_contacts(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,
@@ -280,7 +284,8 @@ BULK_DELETE_SELECTED_IDS = [NOT_USED_CONTACT_ID, USED_CONTACT_ID]
 
 @pytest.mark.django_db
 def test_bulk_delete_contacts(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,
@@ -346,7 +351,8 @@ BULK_RESTORE_SELECTED_IDS = [ARCHIVED_CONTACT_ID]
 
 @pytest.mark.django_db
 def test_bulk_restore_contacts(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,

--- a/tests/cms/views/contacts/test_contact_form.py
+++ b/tests/cms/views/contacts/test_contact_form.py
@@ -23,7 +23,8 @@ POI_ID = 6
 
 @pytest.mark.django_db
 def test_create_a_new_contact(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,
@@ -78,7 +79,8 @@ def test_create_a_new_contact(
 
 @pytest.mark.django_db
 def test_edit_a_contact(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,
@@ -137,7 +139,8 @@ def test_edit_a_contact(
 
 @pytest.mark.django_db
 def test_no_contact_without_poi(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,
@@ -186,7 +189,8 @@ def test_no_contact_without_poi(
 
 @pytest.mark.django_db
 def test_at_least_one_field_filled(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,
@@ -240,7 +244,8 @@ def test_at_least_one_field_filled(
 
 @pytest.mark.django_db
 def test_one_primary_contact_per_poi(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,

--- a/tests/cms/views/contacts/test_contact_utils.py
+++ b/tests/cms/views/contacts/test_contact_utils.py
@@ -52,7 +52,8 @@ def strip(arg: str | object) -> str:
 
 @pytest.mark.django_db
 def test_search_contact_single(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
 ) -> None:
@@ -87,7 +88,8 @@ def test_search_contact_single(
 
 @pytest.mark.django_db
 def test_search_contact_multiple(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
 ) -> None:
@@ -124,7 +126,8 @@ def test_search_contact_multiple(
 
 @pytest.mark.django_db
 def test_get_contact_card(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
 ) -> None:
@@ -155,7 +158,8 @@ def test_get_contact_card(
 
 @pytest.mark.django_db
 def test_get_contact_card_raw(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
 ) -> None:
@@ -185,7 +189,8 @@ def test_get_contact_card_raw(
 
 @pytest.mark.django_db
 def test_update_contact_card_single(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
 ) -> None:
     """
     Test that a contact card is correctly recognized,
@@ -202,7 +207,8 @@ def test_update_contact_card_single(
 
 @pytest.mark.django_db
 def test_update_contact_card_multiple(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
 ) -> None:
     """
     Test that multiple contact cards are correctly recognized,

--- a/tests/cms/views/dashboard/test_dashboard.py
+++ b/tests/cms/views/dashboard/test_dashboard.py
@@ -22,7 +22,8 @@ from tests.conftest import (
 
 @pytest.mark.django_db
 def test_permission_to_view_chat(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     client, role = login_role_user
@@ -57,7 +58,8 @@ def test_permission_to_view_chat(
 
 @pytest.mark.django_db
 def test_permission_to_view_news(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     client, role = login_role_user
@@ -82,7 +84,8 @@ def test_permission_to_view_news(
 
 @pytest.mark.django_db
 def test_permission_to_view_to_do_board(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     client, role = login_role_user
@@ -119,7 +122,8 @@ def test_permission_to_view_to_do_board(
 
 @pytest.mark.django_db
 def test_permission_to_view_admin_dashboard(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     client, role = login_role_user
@@ -150,7 +154,8 @@ def test_permission_to_view_admin_dashboard(
 @pytest.mark.django_db
 @freeze_time("2024-01-01")
 def test_number_of_outdated_pages_is_correct(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     client, role = login_role_user
@@ -187,7 +192,8 @@ def test_number_of_outdated_pages_is_correct(
 @pytest.mark.django_db
 @freeze_time("2024-01-01")
 def test_most_outdated_page_is_correct(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     client, role = login_role_user
@@ -218,7 +224,8 @@ def test_most_outdated_page_is_correct(
 )
 @pytest.mark.django_db
 def test_link_to_most_outdated_page_is_valid(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     client, _ = login_role_user
@@ -254,7 +261,8 @@ def assert_button_leads_to_valid_page(client: Client) -> None:
 )
 @pytest.mark.django_db
 def test_number_of_drafted_pages_is_correct(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     client, role = login_role_user
@@ -290,7 +298,8 @@ def test_number_of_drafted_pages_is_correct(
 )
 @pytest.mark.django_db
 def test_single_drafted_page_is_correct(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     client, role = login_role_user

--- a/tests/cms/views/events/events.py
+++ b/tests/cms/views/events/events.py
@@ -10,7 +10,8 @@ from integreat_cms.cms.models.events.event import CouldNotBeCopied
 
 @pytest.mark.django_db
 def test_copying_imported_event_is_unsucessful(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     _, role = login_role_user

--- a/tests/cms/views/events/external_calendar.py
+++ b/tests/cms/views/events/external_calendar.py
@@ -9,7 +9,8 @@ from tests.conftest import ANONYMOUS, CMS_TEAM, ROOT, SERVICE_TEAM
 
 @pytest.mark.django_db
 def test_permissions_for_external_calendar_list(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     client, role = login_role_user
@@ -34,7 +35,8 @@ def test_permissions_for_external_calendar_list(
 
 @pytest.mark.django_db
 def test_permissions_for_creating_new_external_calendar(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     client, role = login_role_user
@@ -59,7 +61,8 @@ def test_permissions_for_creating_new_external_calendar(
 
 @pytest.mark.django_db
 def test_creating_new_external_calendar(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     client, role = login_role_user

--- a/tests/cms/views/events/test_event_filter.py
+++ b/tests/cms/views/events/test_event_filter.py
@@ -16,7 +16,8 @@ data = [
 
 @pytest.mark.django_db
 def test_filtering_by_single_selected_recurrence_is_successful(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     client, role = login_role_user

--- a/tests/cms/views/events/test_event_form.py
+++ b/tests/cms/views/events/test_event_form.py
@@ -37,7 +37,8 @@ location_test_parameters = [
 @pytest.mark.django_db
 @pytest.mark.parametrize("parameter", location_test_parameters)
 def test_create_event_location_check(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,
@@ -129,7 +130,8 @@ event_creation_test_parameters = [
 @pytest.mark.django_db
 @pytest.mark.parametrize("parameter", event_creation_test_parameters)
 def test_create_event(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,
@@ -223,7 +225,8 @@ def test_create_event(
 
 @pytest.mark.django_db
 def test_no_daily_event_created(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,
@@ -287,7 +290,8 @@ recurrence_rule_change_parameters = [None, "2030-12-31"]
 @pytest.mark.django_db
 @pytest.mark.parametrize("parameter", recurrence_rule_change_parameters)
 def test_no_orpahned_recurrence_rule(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,
@@ -389,7 +393,8 @@ end_date_change_parameters = [True, False]
 @pytest.mark.django_db
 @pytest.mark.parametrize("parameter", end_date_change_parameters)
 def test_end_date_changed(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,

--- a/tests/cms/views/feedback/test_admin_feedback_actions.py
+++ b/tests/cms/views/feedback/test_admin_feedback_actions.py
@@ -18,7 +18,8 @@ from tests.utils import assert_message_in_log
 
 @pytest.mark.django_db
 def test_mark_admin_feedback_as_read(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     caplog: LogCaptureFixture,
 ) -> None:
@@ -65,7 +66,8 @@ def test_mark_admin_feedback_as_read(
 
 @pytest.mark.django_db
 def test_mark_admin_feedback_as_unread(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     caplog: LogCaptureFixture,
 ) -> None:
@@ -112,7 +114,8 @@ def test_mark_admin_feedback_as_unread(
 
 @pytest.mark.django_db
 def test_archive_admin_feedback(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     caplog: LogCaptureFixture,
 ) -> None:
@@ -156,7 +159,8 @@ def test_archive_admin_feedback(
 
 @pytest.mark.django_db
 def test_restore_admin_feedback(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     caplog: LogCaptureFixture,
 ) -> None:
@@ -200,7 +204,8 @@ def test_restore_admin_feedback(
 
 @pytest.mark.django_db
 def test_delete_admin_feedback(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     caplog: LogCaptureFixture,
 ) -> None:

--- a/tests/cms/views/feedback/test_region_feedback_actions.py
+++ b/tests/cms/views/feedback/test_region_feedback_actions.py
@@ -29,7 +29,8 @@ region_slug_param = {"region_slug": "augsburg"}
 
 @pytest.mark.django_db
 def test_mark_region_feedback_as_read(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     caplog: LogCaptureFixture,
 ) -> None:
@@ -79,7 +80,8 @@ def test_mark_region_feedback_as_read(
 
 @pytest.mark.django_db
 def test_mark_region_feedback_as_unread(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     caplog: LogCaptureFixture,
 ) -> None:
@@ -129,7 +131,8 @@ def test_mark_region_feedback_as_unread(
 
 @pytest.mark.django_db
 def test_archive_region_feedback(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     caplog: LogCaptureFixture,
 ) -> None:
@@ -176,7 +179,8 @@ def test_archive_region_feedback(
 
 @pytest.mark.django_db
 def test_restore_region_feedback(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     caplog: LogCaptureFixture,
 ) -> None:
@@ -223,7 +227,8 @@ def test_restore_region_feedback(
 
 @pytest.mark.django_db
 def test_delete_region_feedback(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     caplog: LogCaptureFixture,
 ) -> None:
@@ -266,7 +271,8 @@ def test_delete_region_feedback(
 
 @pytest.mark.django_db
 def test_csv_export_feedback(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     caplog: LogCaptureFixture,
 ) -> None:

--- a/tests/cms/views/link_replace/test_link_actions.py
+++ b/tests/cms/views/link_replace/test_link_actions.py
@@ -34,7 +34,8 @@ url_replace_parameters = [("network_management", 4, 0), ("augsburg", 4, 1)]
 @pytest.mark.django_db
 @pytest.mark.parametrize("parameter", url_replace_parameters)
 def test_url_replace(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,
@@ -128,7 +129,8 @@ search_replace_parameters = [("network_management", 4, 0), ("augsburg", 4, 1)]
 @pytest.mark.django_db
 @pytest.mark.parametrize("parameter", search_replace_parameters)
 def test_search_and_replace_links(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,
@@ -229,7 +231,8 @@ ignore_unignore_parameters = [
 @pytest.mark.django_db
 @pytest.mark.parametrize("parameter", ignore_unignore_parameters)
 def test_bulk_ignore_unignore_links(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,
@@ -327,7 +330,8 @@ recheck_parameters = ["network_management", "augsburg"]
 @pytest.mark.django_db
 @pytest.mark.parametrize("region", recheck_parameters)
 def test_bulk_recheck_links(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,

--- a/tests/cms/views/link_replace/test_link_replace.py
+++ b/tests/cms/views/link_replace/test_link_replace.py
@@ -38,7 +38,8 @@ parameters = [
 @pytest.mark.django_db
 @pytest.mark.parametrize("parameter", parameters)
 def test_find_target_url_per_content_invalid_links(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     parameter: tuple[list[str], list[str], tuple[ContentType, int]],
 ) -> None:
     """

--- a/tests/cms/views/organizations/test_organization_actions.py
+++ b/tests/cms/views/organizations/test_organization_actions.py
@@ -29,7 +29,8 @@ test_archive_parameters = [
 @pytest.mark.django_db
 @pytest.mark.parametrize("parameter", test_archive_parameters)
 def test_archive_organization(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,
@@ -98,7 +99,8 @@ test_delete_parameters = [
 @pytest.mark.django_db
 @pytest.mark.parametrize("parameter", test_delete_parameters)
 def test_delete_organization(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,
@@ -159,7 +161,8 @@ def test_delete_organization(
 
 @pytest.mark.django_db
 def test_restore_organization(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,
@@ -220,7 +223,8 @@ BULK_ARCHIVE_SELECTED_IDS = [REFERENCED_ORGANIZATION_ID, NOT_REFERENCED_ORGANIZA
 
 @pytest.mark.django_db
 def test_bulk_archive_organizations(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,
@@ -290,7 +294,8 @@ BULK_DELETE_SELECTED_IDS = [REFERENCED_ORGANIZATION_ID, NOT_REFERENCED_ORGANIZAT
 
 @pytest.mark.django_db
 def test_bulk_delete_organizations(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,
@@ -354,7 +359,8 @@ BULK_RESTORE_SELECTED_IDS = [ARCHIVED_ORGANIZATION_ID]
 
 @pytest.mark.django_db
 def test_bulk_restore_organizations(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,

--- a/tests/cms/views/organizations/test_organization_form.py
+++ b/tests/cms/views/organizations/test_organization_form.py
@@ -26,7 +26,8 @@ NEW_ORGANIZATION_NAME = "New Organization"
 
 @pytest.mark.django_db
 def test_organization_form_shows_no_contents(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
 ) -> None:
@@ -69,7 +70,8 @@ def test_organization_form_shows_no_contents(
 
 @pytest.mark.django_db
 def test_organization_form_shows_associated_contents(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
 ) -> None:
@@ -147,7 +149,8 @@ def test_organization_form_shows_associated_contents(
 
 @pytest.mark.django_db
 def test_create_new_organization(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,
@@ -203,7 +206,8 @@ def test_create_new_organization(
 
 @pytest.mark.django_db
 def test_cannot_create_organization_with_duplicate_name(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,
@@ -259,7 +263,8 @@ def test_cannot_create_organization_with_duplicate_name(
 
 @pytest.mark.django_db
 def test_edit_organization(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,

--- a/tests/cms/views/pages/test_page_translations.py
+++ b/tests/cms/views/pages/test_page_translations.py
@@ -14,7 +14,8 @@ from tests.conftest import EDITOR, MANAGEMENT, PRIV_STAFF_ROLES
 )
 @pytest.mark.django_db
 def test_cleanup_autosaves(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     client, role = login_role_user

--- a/tests/cms/views/poi/test_poi_form.py
+++ b/tests/cms/views/poi/test_poi_form.py
@@ -36,7 +36,8 @@ from tests.utils import assert_message_in_log
 
 @pytest.mark.django_db
 def test_barrier_free_and_organization_box_appear(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     barrier_free_box = '<div id="poi-barrier-free"'
@@ -103,7 +104,8 @@ def create_used_poi(region_slug: str) -> int:
 
 @pytest.mark.django_db
 def test_poi_in_use_cannot_be_archived(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     caplog: LogCaptureFixture,
     settings: SettingsWrapper,
@@ -144,7 +146,8 @@ def test_poi_in_use_cannot_be_archived(
 
 @pytest.mark.django_db
 def test_poi_in_use_not_deleted(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     caplog: LogCaptureFixture,
     login_role_user: tuple[Client, str],
 ) -> None:
@@ -185,7 +188,8 @@ def test_poi_in_use_not_deleted(
 
 @pytest.mark.django_db
 def test_poi_in_use_not_bulk_archived(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     caplog: LogCaptureFixture,
     settings: SettingsWrapper,
@@ -226,7 +230,8 @@ def test_poi_in_use_not_bulk_archived(
 
 @pytest.mark.django_db
 def test_poi_form_shows_associated_contacts(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
 ) -> None:
@@ -280,7 +285,8 @@ def test_poi_form_shows_associated_contacts(
 
 @pytest.mark.django_db
 def test_poi_form_shows_no_associated_contacts(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
 ) -> None:

--- a/tests/cms/views/poi_categories/test_poi_category_form_view.py
+++ b/tests/cms/views/poi_categories/test_poi_category_form_view.py
@@ -29,7 +29,8 @@ DEFAULT_POST_DATA = {
 
 @pytest.mark.django_db
 def test_permission_to_view_poi_categories_list(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     client, role = login_role_user
@@ -52,7 +53,8 @@ def test_permission_to_view_poi_categories_list(
 @pytest.mark.parametrize("login_role_user", STAFF_ROLES, indirect=True)
 @pytest.mark.django_db
 def test_poicategories_list_shows_all_items(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     client, _ = login_role_user
@@ -74,7 +76,8 @@ def test_correct_number_of_poicategories_in_database() -> None:
 
 @pytest.mark.django_db
 def test_permission_to_create_new_poicategory(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     client, role = login_role_user
@@ -104,7 +107,8 @@ def test_permission_to_create_new_poicategory(
 )
 @pytest.mark.django_db
 def test_create_poi_category_with_missing_translation_was_not_successful(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     client, role = login_role_user
@@ -132,7 +136,8 @@ def test_create_poi_category_with_missing_translation_was_not_successful(
 )
 @pytest.mark.django_db
 def test_create_poi_category_was_successful(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     client, _ = login_role_user
@@ -165,7 +170,8 @@ def test_create_poi_category_was_successful(
 )
 @pytest.mark.django_db
 def test_edit_poi_category_was_successful(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     client, _ = login_role_user
@@ -229,7 +235,8 @@ def test_edit_poi_category_was_successful(
 )
 @pytest.mark.django_db
 def test_no_changes_were_made_message(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     client, _ = login_role_user
@@ -289,7 +296,8 @@ def test_no_changes_were_made_message(
 )
 @pytest.mark.django_db
 def test_delete_unused_poi_category_was_successful(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     current_amount_of_poicategories = POICategory.objects.count()
@@ -327,7 +335,8 @@ def test_delete_unused_poi_category_was_successful(
 )
 @pytest.mark.django_db
 def test_delete_used_poi_category_was_not_successful(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     current_amount_of_poicategories = POICategory.objects.count()

--- a/tests/cms/views/push_notifications/test_push_notification_form_view.py
+++ b/tests/cms/views/push_notifications/test_push_notification_form_view.py
@@ -17,7 +17,8 @@ from tests.conftest import ANONYMOUS, PRIV_STAFF_ROLES, STAFF_ROLES
 
 @pytest.mark.django_db
 def test_validate_forms_with_no_german_title(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
 ) -> None:
@@ -72,7 +73,8 @@ def test_validate_forms_with_no_german_title(
 
 @pytest.mark.django_db
 def test_validate_forms_with_only_german_title(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
 ) -> None:

--- a/tests/cms/views/regions/delete_region.py
+++ b/tests/cms/views/regions/delete_region.py
@@ -22,7 +22,8 @@ PAGE_FEEDBACK_AUGSBURG_ID = 2
 
 @pytest.mark.django_db
 def test_delete_all_regions_is_successful(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     current_number_of_regions = Region.objects.count()
@@ -89,7 +90,8 @@ def test_delete_all_regions_is_successful(
 
 @pytest.mark.django_db
 def test_deleting_mirrored_region_is_unsucessful(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     client, role = login_role_user

--- a/tests/cms/views/regions/test_region_mt_management.py
+++ b/tests/cms/views/regions/test_region_mt_management.py
@@ -22,7 +22,8 @@ parameters = [
 @pytest.mark.django_db
 @pytest.mark.parametrize("parameter", parameters)
 def test_region_mt_budget_calc(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     parameter: tuple[int, bool, int, int],
 ) -> None:
     """

--- a/tests/cms/views/test_public_view_status_code.py
+++ b/tests/cms/views/test_public_view_status_code.py
@@ -18,7 +18,8 @@ if TYPE_CHECKING:
 @pytest.mark.django_db
 @pytest.mark.parametrize("view_name,post_data", PARAMETRIZED_PUBLIC_VIEWS)
 def test_public_view_status_code(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     caplog: LogCaptureFixture,
     view_name: ViewNameStr,
     post_data: PostData,

--- a/tests/core/management/commands/test_duplicate_pages.py
+++ b/tests/core/management/commands/test_duplicate_pages.py
@@ -47,7 +47,11 @@ def test_duplicate_pages_non_existing_region(settings: SettingsWrapper) -> None:
 
 
 @pytest.mark.django_db
-def test_duplicate_pages(settings: SettingsWrapper, load_test_data: None) -> None:
+def test_duplicate_pages(
+    settings: SettingsWrapper,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
+) -> None:
     """
     Ensure that pages are really duplicated
     """

--- a/tests/core/management/commands/test_find_missing_versions.py
+++ b/tests/core/management/commands/test_find_missing_versions.py
@@ -31,7 +31,11 @@ def test_find_missing_versions_invalid_model() -> None:
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("model", ["page", "event", "poi"])
-def test_find_missing_versions_success(load_test_data: None, model: str) -> None:
+def test_find_missing_versions_success(
+    test_data_db_snapshot: None,
+    db_snapshot: None,
+    model: str
+) -> None:
     """
     Ensure no errors are found in default test data
     """
@@ -41,7 +45,10 @@ def test_find_missing_versions_success(load_test_data: None, model: str) -> None
 
 
 @pytest.mark.django_db
-def test_find_missing_versions_failure(load_test_data: None) -> None:
+def test_find_missing_versions_failure(
+    test_data_db_snapshot: None,
+    db_snapshot: None,
+) -> None:
     """
     Ensure that inconsistencies are listed
     """

--- a/tests/core/management/commands/test_fix_internal_links.py
+++ b/tests/core/management/commands/test_fix_internal_links.py
@@ -15,7 +15,10 @@ from ..utils import get_command_output
 
 
 @pytest.mark.django_db
-def test_fix_internal_links_non_existing_region(load_test_data: None) -> None:
+def test_fix_internal_links_non_existing_region(
+    test_data_db_snapshot: None,
+    db_snapshot: None,
+) -> None:
     """
     Ensure that a non existing region slug throws an error
 
@@ -30,7 +33,8 @@ def test_fix_internal_links_non_existing_region(load_test_data: None) -> None:
 
 @pytest.mark.django_db
 def test_fix_internal_links_non_existing_username(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
 ) -> None:
     """
     Ensure that a non existing username throws an error
@@ -62,9 +66,10 @@ new_urls = [
 
 
 @pytest.mark.order("last")
-@pytest.mark.django_db(transaction=True, serialized_rollback=True)
+@pytest.mark.django_db(transaction=True)
 def test_fix_internal_links_dry_run(
-    load_test_data_transactional: Any | None,
+    test_data_db_snapshot: Any | None,
+    db_snapshot: None,
 ) -> None:
     """
     Ensure that dry run works as expected
@@ -109,8 +114,8 @@ def test_fix_internal_links_dry_run(
 
 
 @pytest.mark.order("last")
-@pytest.mark.django_db(transaction=True, serialized_rollback=True)
-def test_fix_internal_links_commit(load_test_data_transactional: Any | None) -> None:
+@pytest.mark.django_db(transaction=True)
+def test_fix_internal_links_commit(test_data_db_snapshot: Any | None, db_snapshot: None) -> None:
     """
     Ensure that committing changes to the database works as expected
 

--- a/tests/core/management/commands/test_import_events.py
+++ b/tests/core/management/commands/test_import_events.py
@@ -124,7 +124,8 @@ def test_import_without_calendars() -> None:
 @pytest.mark.django_db
 def test_import_successful(
     httpserver: HTTPServer,
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     calendar_data: tuple[str, list[str], set[str]],
 ) -> None:
     """
@@ -165,7 +166,11 @@ def test_import_successful(
 
 
 @pytest.mark.django_db
-def test_update_event(httpserver: HTTPServer, load_test_data: None) -> None:
+def test_update_event(
+    httpserver: HTTPServer,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
+) -> None:
     """
     Tests that an event gets updated if it is updated in the ical file
     :param httpserver: The server
@@ -195,7 +200,11 @@ def test_update_event(httpserver: HTTPServer, load_test_data: None) -> None:
 
 
 @pytest.mark.django_db
-def test_delete_event(httpserver: HTTPServer, load_test_data: None) -> None:
+def test_delete_event(
+    httpserver: HTTPServer,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
+) -> None:
     """
     Tests that an event gets deleted if it is deleted in the ical file
     :param httpserver: The server
@@ -224,7 +233,11 @@ def test_delete_event(httpserver: HTTPServer, load_test_data: None) -> None:
 
 
 @pytest.mark.django_db
-def test_import_corrupted_event(httpserver: HTTPServer, load_test_data: None) -> None:
+def test_import_corrupted_event(
+    httpserver: HTTPServer,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
+) -> None:
     """
     Tests that an invalid event gets handled correctly and does not cause the command to crash
     :param httpserver: The server
@@ -240,7 +253,8 @@ def test_import_corrupted_event(httpserver: HTTPServer, load_test_data: None) ->
 @pytest.mark.django_db
 def test_import_event_without_tags(
     httpserver: HTTPServer,
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
 ) -> None:
     """
     Tests that an event does not get imported if it does not have tags, but tags are required
@@ -261,7 +275,8 @@ def test_import_event_without_tags(
 @pytest.mark.django_db
 def test_import_event_with_wrong_tag(
     httpserver: HTTPServer,
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
 ) -> None:
     """
     Tests that an event does not get imported if it does not have the right tag
@@ -285,7 +300,8 @@ def test_import_event_with_wrong_tag(
 @pytest.mark.django_db
 def test_import_event_with_correct_tag(
     httpserver: HTTPServer,
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
 ) -> None:
     """
     Tests that an event gets imported if it has the right tag
@@ -316,7 +332,8 @@ def test_import_event_with_correct_tag(
 @pytest.mark.django_db
 def test_import_event_with_multiple_categories(
     httpserver: HTTPServer,
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
 ) -> None:
     """
     Tests that an event does not get imported if it has multiple category definitions
@@ -335,7 +352,8 @@ def test_import_event_with_multiple_categories(
 @pytest.mark.django_db
 def test_import_and_remove_recurrence_rule(
     httpserver: HTTPServer,
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
 ) -> None:
     """
     Imports an event with a recurrence rule and later the same event without recurrence rule.
@@ -368,7 +386,11 @@ def test_import_and_remove_recurrence_rule(
 
 
 @pytest.mark.django_db
-def test_daily_event_not_imported(httpserver: HTTPServer, load_test_data: None) -> None:
+def test_daily_event_not_imported(
+    httpserver: HTTPServer,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
+) -> None:
     """
     Tests that an event with daily recurrence is not imported
     :param httpserver: The server

--- a/tests/core/management/commands/test_repair_tree.py
+++ b/tests/core/management/commands/test_repair_tree.py
@@ -29,8 +29,8 @@ after_tests = (
 
 
 @pytest.mark.order("last", after=after_tests)
-@pytest.mark.django_db(transaction=True, serialized_rollback=True)
-def test_check_clean_tree_fields(load_test_data_transactional: None) -> None:
+@pytest.mark.django_db(transaction=True)
+def test_check_clean_tree_fields(test_data_db_snapshot: None, db_snapshot: None) -> None:
     """
     Ensure no errors are found in default test data.
     """
@@ -48,8 +48,8 @@ def test_check_clean_tree_fields(load_test_data_transactional: None) -> None:
 
 
 @pytest.mark.order("last", after=after_tests)
-@pytest.mark.django_db(transaction=True, serialized_rollback=True)
-def test_fix_clean_tree_fields(load_test_data_transactional: None) -> None:
+@pytest.mark.django_db(transaction=True)
+def test_fix_clean_tree_fields(test_data_db_snapshot: None, db_snapshot: None) -> None:
     """
     Ensure no errors need to be fixed in default test data.
     """
@@ -64,8 +64,8 @@ def test_fix_clean_tree_fields(load_test_data_transactional: None) -> None:
 
 
 @pytest.mark.order("last", after=after_tests)
-@pytest.mark.django_db(transaction=True, serialized_rollback=True)
-def test_check_broken_tree_fields(load_test_data_transactional: None) -> None:
+@pytest.mark.django_db(transaction=True)
+def test_check_broken_tree_fields(test_data_db_snapshot: None, db_snapshot: None) -> None:
     """
     Introduce an error to the test data and ensure it is found.
     """
@@ -84,8 +84,8 @@ def test_check_broken_tree_fields(load_test_data_transactional: None) -> None:
 
 
 @pytest.mark.order("last", after=after_tests)
-@pytest.mark.django_db(transaction=True, serialized_rollback=True)
-def test_fix_broken_tree_fields(load_test_data_transactional: None) -> None:
+@pytest.mark.django_db(transaction=True)
+def test_fix_broken_tree_fields(test_data_db_snapshot: None, db_snapshot: None) -> None:
     """
     Introduce an error to the test data and ensure it is fixed.
     """

--- a/tests/core/management/commands/test_replace_links.py
+++ b/tests/core/management/commands/test_replace_links.py
@@ -36,7 +36,10 @@ def test_replace_links_missing_replace() -> None:
 
 
 @pytest.mark.django_db
-def test_replace_links_non_existing_region(load_test_data: None) -> None:
+def test_replace_links_non_existing_region(
+    test_data_db_snapshot: None,
+    db_snapshot: None,
+) -> None:
     """
     Ensure that a non existing region slug throws an error
 
@@ -55,7 +58,10 @@ def test_replace_links_non_existing_region(load_test_data: None) -> None:
 
 
 @pytest.mark.django_db
-def test_replace_links_non_existing_username(load_test_data: None) -> None:
+def test_replace_links_non_existing_username(
+    test_data_db_snapshot: None,
+    db_snapshot: None,
+) -> None:
     """
     Ensure that a non existing username throws an error
 
@@ -74,8 +80,11 @@ def test_replace_links_non_existing_username(load_test_data: None) -> None:
 
 
 @pytest.mark.order("last")
-@pytest.mark.django_db(transaction=True, serialized_rollback=True)
-def test_replace_links_dry_run(load_test_data_transactional: Any | None) -> None:
+@pytest.mark.django_db(transaction=True)
+def test_replace_links_dry_run(
+    test_data_db_snapshot: Any | None,
+    db_snapshot: None,
+) -> None:
     """
     Ensure that dry run works as expected
 
@@ -120,8 +129,11 @@ def test_replace_links_dry_run(load_test_data_transactional: Any | None) -> None
 
 
 @pytest.mark.order("last")
-@pytest.mark.django_db(transaction=True, serialized_rollback=True)
-def test_replace_links_commit(load_test_data_transactional: Any | None) -> None:
+@pytest.mark.django_db(transaction=True)
+def test_replace_links_commit(
+    test_data_db_snapshot: Any | None,
+    db_snapshot: None,
+) -> None:
     """
     Ensure that committing changes to the database works as expected
 

--- a/tests/core/management/commands/test_reset_deepl_budget.py
+++ b/tests/core/management/commands/test_reset_deepl_budget.py
@@ -46,8 +46,8 @@ def test_not_first_day() -> None:
 
 
 @pytest.mark.order("last")
-@pytest.mark.django_db(transaction=True, serialized_rollback=True)
-def test_reset_mt_budget(load_test_data_transactional: Any | None) -> None:
+@pytest.mark.django_db(transaction=True)
+def test_reset_mt_budget(empty_db_snapshot: Any | None, db_snapshot: None) -> None:
     """
     Ensure that MT budget gets reset successfully
     """

--- a/tests/core/management/commands/test_summ_ai_bulk.py
+++ b/tests/core/management/commands/test_summ_ai_bulk.py
@@ -37,7 +37,11 @@ def test_summ_ai_bulk_missing_username() -> None:
 
 
 @pytest.mark.django_db
-def test_summ_ai_bulk_disabled(settings: SettingsWrapper, load_test_data: None) -> None:
+def test_summ_ai_bulk_disabled(
+    settings: SettingsWrapper,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
+) -> None:
     """
     Ensure that calling when globally disabled throws an error
     """
@@ -58,7 +62,10 @@ def test_summ_ai_bulk_non_existing_region() -> None:
 
 
 @pytest.mark.django_db
-def test_summ_ai_bulk_disabled_region(load_test_data: None) -> None:
+def test_summ_ai_bulk_disabled_region(
+    test_data_db_snapshot: None,
+    db_snapshot: None,
+) -> None:
     """
     Ensure that calling when disabled in a region throws an error
     """
@@ -71,7 +78,10 @@ def test_summ_ai_bulk_disabled_region(load_test_data: None) -> None:
 
 
 @pytest.mark.django_db
-def test_summ_ai_bulk_non_existing_username(load_test_data: None) -> None:
+def test_summ_ai_bulk_non_existing_username(
+    test_data_db_snapshot: None,
+    db_snapshot: None,
+) -> None:
     """
     Ensure that a non existing username throws an error
     """

--- a/tests/firebase_api/test_firebase_api_client.py
+++ b/tests/firebase_api/test_firebase_api_client.py
@@ -67,7 +67,8 @@ class TestFirebaseApiClient:
     def test_client_throws_exception_when_fcm_disabled(
         self,
         settings: SettingsWrapper,
-        load_test_data: None,
+        test_data_db_snapshot: None,
+        db_snapshot: None,
     ) -> None:
         """
         Tests that an ImproperlyConfigured exception is thrown, if firebase API is disabled in settings
@@ -81,7 +82,12 @@ class TestFirebaseApiClient:
             FirebaseApiClient(notification)
 
     @pytest.mark.django_db
-    def test_is_valid(self, settings: SettingsWrapper, load_test_data: None) -> None:
+    def test_is_valid(
+        self,
+        settings: SettingsWrapper,
+        test_data_db_snapshot: None,
+        db_snapshot: None,
+    ) -> None:
         """
         Tests that :meth:`~integreat_cms.firebase_api.firebase_api_client.FirebaseApiClient.is_valid` is ``True``,
         when FCM_ENABLED and pushNotification valid (with title and translation)
@@ -97,7 +103,8 @@ class TestFirebaseApiClient:
     def test_is_invalid_when_no_translation(
         self,
         settings: SettingsWrapper,
-        load_test_data: None,
+        test_data_db_snapshot: None,
+        db_snapshot: None,
     ) -> None:
         """
         Tests that :meth:`~integreat_cms.firebase_api.firebase_api_client.FirebaseApiClient.is_valid` is ``False``,
@@ -116,7 +123,8 @@ class TestFirebaseApiClient:
     def test_is_invalid_when_no_title(
         self,
         settings: SettingsWrapper,
-        load_test_data: None,
+        test_data_db_snapshot: None,
+        db_snapshot: None,
     ) -> None:
         """
         Tests that :meth:`~integreat_cms.firebase_api.firebase_api_client.FirebaseApiClient.is_valid` is ``False``,
@@ -135,7 +143,8 @@ class TestFirebaseApiClient:
     def test_firebase_api_200_success(
         self,
         settings: SettingsWrapper,
-        load_test_data: None,
+        test_data_db_snapshot: None,
+        db_snapshot: None,
         requests_mock: Mocker,
         caplog: LogCaptureFixture,
     ) -> None:
@@ -162,7 +171,8 @@ class TestFirebaseApiClient:
     def test_firebase_api_200_unexpected_api_response(
         self,
         settings: SettingsWrapper,
-        load_test_data: None,
+        test_data_db_snapshot: None,
+        db_snapshot: None,
         requests_mock: Mocker,
         caplog: LogCaptureFixture,
     ) -> None:
@@ -188,7 +198,8 @@ class TestFirebaseApiClient:
     def test_firebase_api_403_wrong_token(
         self,
         settings: SettingsWrapper,
-        load_test_data: None,
+        test_data_db_snapshot: None,
+        db_snapshot: None,
         requests_mock: Mocker,
         caplog: LogCaptureFixture,
     ) -> None:
@@ -214,7 +225,8 @@ class TestFirebaseApiClient:
     def test_firebase_api_404(
         self,
         settings: SettingsWrapper,
-        load_test_data: None,
+        test_data_db_snapshot: None,
+        db_snapshot: None,
         requests_mock: Mocker,
         caplog: LogCaptureFixture,
     ) -> None:
@@ -267,7 +279,8 @@ class TestFirebaseApiClient:
     def test_region_notification_send(
         self,
         settings: SettingsWrapper,
-        load_test_data: None,
+        test_data_db_snapshot: None,
+        db_snapshot: None,
         requests_mock: Mocker,
     ) -> None:
         targets = set()
@@ -294,7 +307,8 @@ class TestFirebaseApiClient:
     def test_multiple_regions_notification_send(
         self,
         settings: SettingsWrapper,
-        load_test_data: None,
+        test_data_db_snapshot: None,
+        db_snapshot: None,
         requests_mock: Mocker,
     ) -> None:
         targets = set()

--- a/tests/firebase_api/test_firebase_data_client.py
+++ b/tests/firebase_api/test_firebase_data_client.py
@@ -312,7 +312,8 @@ class TestFirebaseDataClient:
     def test_client_throws_exception_when_fcm_disabled(
         self,
         settings: SettingsWrapper,
-        load_test_data: None,
+        test_data_db_snapshot: None,
+        db_snapshot: None,
         mock_firebase_credentials: None,
     ) -> None:
         """
@@ -331,7 +332,8 @@ class TestFirebaseDataClient:
     def test_avg_per_region(
         self,
         settings: SettingsWrapper,
-        load_test_data: None,
+        test_data_db_snapshot: None,
+        db_snapshot: None,
         requests_mock: Mocker,
         mock_firebase_credentials: None,
     ) -> None:
@@ -450,7 +452,8 @@ class TestFirebaseDataClient:
     def test_without_analytics_labels(
         self,
         settings: SettingsWrapper,
-        load_test_data: None,
+        test_data_db_snapshot: None,
+        db_snapshot: None,
         requests_mock: Mocker,
         mock_firebase_credentials: None,
     ) -> None:

--- a/tests/mt_api/deepl_api_test.py
+++ b/tests/mt_api/deepl_api_test.py
@@ -74,7 +74,8 @@ api_errors = [404, 413, 429, 456, 500]
 )
 @pytest.mark.parametrize("error", api_errors)
 def test_deepl_bulk_mt_api_error(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     error: int,
     settings: SettingsWrapper,

--- a/tests/mt_api/mt_api_test.py
+++ b/tests/mt_api/mt_api_test.py
@@ -108,7 +108,8 @@ content_role_id_combination = [
 @pytest.mark.parametrize("provider_language_combination", provider_language_combination)
 @pytest.mark.parametrize("content_role_id_combination", content_role_id_combination)
 def test_bulk_mt(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     provider_language_combination: tuple[str, str, str],
     content_role_id_combination: tuple[Any, list, list[int]],
@@ -226,7 +227,8 @@ def test_bulk_mt(
 )
 @pytest.mark.parametrize("provider_language_combination", provider_language_combination)
 def test_bulk_mt_exceeds_limit(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     provider_language_combination: tuple[str, str, str],
     settings: SettingsWrapper,
@@ -315,7 +317,8 @@ def test_bulk_mt_exceeds_limit(
 )
 @pytest.mark.parametrize("provider_language_combination", provider_language_combination)
 def test_bulk_mt_up_to_date(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     provider_language_combination: tuple[str, str, str],
     settings: SettingsWrapper,
@@ -387,7 +390,8 @@ def test_bulk_mt_up_to_date(
 )
 @pytest.mark.parametrize("provider_language_combination", provider_language_combination)
 def test_bulk_mt_up_to_date_and_ready_for_mt(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     provider_language_combination: tuple[str, str, str],
     settings: SettingsWrapper,
@@ -528,7 +532,8 @@ content_role_id_data_combination = [
     content_role_id_data_combination,
 )
 def test_automatic_translation(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     provider_language_combination: tuple[str, str, str],
     content_role_id_data_combination: tuple[Any, list, int, dict],
@@ -656,7 +661,8 @@ def test_automatic_translation(
 )
 @pytest.mark.parametrize("provider_language_combination", provider_language_combination)
 def test_bulk_mt_no_source_language(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     provider_language_combination: tuple[str, str, str],
     settings: SettingsWrapper,
@@ -738,7 +744,8 @@ def test_bulk_mt_no_source_language(
 )
 @pytest.mark.parametrize("provider_language_combination", provider_language_combination)
 def test_deepl_bulk_mt_no_target_language(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     provider_language_combination: tuple[str, str, str],
     settings: SettingsWrapper,
@@ -818,7 +825,8 @@ do_not_translate_title = [True, False]
 @pytest.mark.django_db
 @pytest.mark.parametrize("do_not_translate_title", do_not_translate_title)
 def test_do_not_translate_title(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     do_not_translate_title: bool,
     settings: SettingsWrapper,

--- a/tests/mt_api/mt_provider_assignment_test.py
+++ b/tests/mt_api/mt_provider_assignment_test.py
@@ -50,7 +50,8 @@ def check_mt_provider(
 
 @pytest.mark.django_db
 def test_no_available_provider(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     caplog: LogCaptureFixture,
 ) -> None:
     """
@@ -72,7 +73,8 @@ def test_no_available_provider(
 
 @pytest.mark.django_db
 def test_only_deepl_available(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     caplog: LogCaptureFixture,
 ) -> None:
     """
@@ -94,7 +96,8 @@ def test_only_deepl_available(
 
 @pytest.mark.django_db
 def test_only_google_translate_available(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     caplog: LogCaptureFixture,
 ) -> None:
     """
@@ -116,7 +119,8 @@ def test_only_google_translate_available(
 
 @pytest.mark.django_db
 def test_both_providers_available(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     caplog: LogCaptureFixture,
 ) -> None:
     """
@@ -140,7 +144,8 @@ def test_both_providers_available(
 
 @pytest.mark.django_db
 def test_change_to_supporting_provider(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,
@@ -192,7 +197,8 @@ def test_change_to_supporting_provider(
 
 @pytest.mark.django_db
 def test_change_to_not_supporting_provider(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
     settings: SettingsWrapper,
     caplog: LogCaptureFixture,

--- a/tests/mt_api/test_mt_button_visibility.py
+++ b/tests/mt_api/test_mt_button_visibility.py
@@ -16,7 +16,8 @@ from ..conftest import EDITOR, MANAGEMENT, PRIV_STAFF_ROLES
 
 @pytest.mark.django_db
 def test_mt_button_visibility(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     login_role_user: tuple[Client, str],
 ) -> None:
     """

--- a/tests/pdf/test_pdf_export.py
+++ b/tests/pdf/test_pdf_export.py
@@ -86,7 +86,8 @@ if TYPE_CHECKING:
     ],
 )
 def test_pdf_export(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     client: Client,
     admin_client: Client,
     language_slug: str,
@@ -143,7 +144,8 @@ def test_pdf_export(
 # Override urls to serve PDF files
 @pytest.mark.urls("tests.pdf.dummy_django_app.static_urls")
 def test_pdf_export_invalid(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     client: Client,
     admin_client: Client,
 ) -> None:

--- a/tests/sitemap/test_sitemap.py
+++ b/tests/sitemap/test_sitemap.py
@@ -14,7 +14,8 @@ from .sitemap_config import SITEMAPS
 @pytest.mark.django_db
 @pytest.mark.parametrize("url,expected_sitemap,expected_queries", SITEMAPS)
 def test_sitemap(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     django_assert_num_queries: Callable,
     url: str,
     expected_sitemap: str,

--- a/tests/textlab_api/textlab_api_test.py
+++ b/tests/textlab_api/textlab_api_test.py
@@ -76,7 +76,8 @@ def create_page(
 
 @pytest.mark.django_db
 def test_hix_score_create(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     admin_client: Client,
     settings: SettingsWrapper,
     mock_server: MockServer,
@@ -134,7 +135,8 @@ def test_hix_score_create(
 
 @pytest.mark.django_db
 def test_hix_score_create_content_empty(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     admin_client: Client,
     settings: SettingsWrapper,
     mock_server: MockServer,
@@ -172,7 +174,8 @@ def test_hix_score_create_content_empty(
 
 @pytest.mark.django_db
 def test_ignore_hix_on_page_create(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     admin_client: Client,
     settings: SettingsWrapper,
     mock_server: MockServer,
@@ -215,7 +218,8 @@ def test_ignore_hix_on_page_create(
 
 @pytest.mark.django_db
 def test_hix_disabled_on_region_on_page_create(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     admin_client: Client,
     settings: SettingsWrapper,
     mock_server: MockServer,
@@ -257,7 +261,8 @@ def test_hix_disabled_on_region_on_page_create(
 
 @pytest.mark.django_db
 def test_hix_response_400_on_page_create(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     admin_client: Client,
     settings: SettingsWrapper,
     mock_server: MockServer,
@@ -379,7 +384,8 @@ dummy_hix_result = {
 
 @pytest.mark.django_db
 def test_hix_score_update(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     admin_client: Client,
     settings: SettingsWrapper,
     mock_server: MockServer,
@@ -434,7 +440,8 @@ def test_hix_score_update(
 
 @pytest.mark.django_db
 def test_hix_disable_on_region(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     admin_client: Client,
     settings: SettingsWrapper,
     mock_server: MockServer,
@@ -477,7 +484,8 @@ def test_hix_disable_on_region(
 
 @pytest.mark.django_db
 def test_ignore_hix_on_page_update(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     admin_client: Client,
     settings: SettingsWrapper,
     mock_server: MockServer,
@@ -522,7 +530,8 @@ def test_ignore_hix_on_page_update(
 
 @pytest.mark.django_db
 def test_hix_page_content_empty(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     admin_client: Client,
     settings: SettingsWrapper,
     mock_server: MockServer,
@@ -566,7 +575,8 @@ def test_hix_page_content_empty(
 
 @pytest.mark.django_db
 def test_hix_no_content_changes(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     admin_client: Client,
     settings: SettingsWrapper,
     mock_server: MockServer,
@@ -621,7 +631,8 @@ def test_hix_no_content_changes(
 
 @pytest.mark.django_db
 def test_hix_response_400_on_page_update(
-    load_test_data: None,
+    test_data_db_snapshot: None,
+    db_snapshot: None,
     admin_client: Client,
     settings: SettingsWrapper,
     mock_server: MockServer,


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This is one ongoing experiment trying to reign in the growing chaos in our tests

### Proposed changes
<!-- Describe this PR in more detail. -->

- Implement a function `snapshot_db()` to clone the current database and switch out djangos connection, and reverting it afterwards
- Provide a *session* scoped fixture to make an empty database snapshot *(all other fixtures depend on this one way or another so we can be sure that this will actually be an empty one)*
- Provide a *session* scoped fixture to make a snapshot and fill it with the test data
- Provide a *function* scoped fixture to just make a snapshot. This is what every test needing the db should use, and replaces the `load_test_data` fixture for tests

This experiment is still **Work In Progress**.

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Side effects between tests should be mitigated with this


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3777


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
