### PR TITLE
Remove duplicates from the search suggestion list

### DIFF
--- a/integreat_cms/cms/models/events/event_translation.py
+++ b/integreat_cms/cms/models/events/event_translation.py
@@ -137,12 +137,16 @@ class EventTranslation(AbstractContentTranslation):
         query = kwargs["query"]
         archived_flag = kwargs["archived_flag"]
         language_slug = kwargs["language_slug"]
+        link_suggestion_flag = kwargs["link_suggestion_flag"]
 
         event_translations = (
             cls.search(region, language_slug, query)
             .filter(event__archived=archived_flag, status=status.PUBLIC)
             .select_related("event__region", "language")
         )
+
+        if not link_suggestion_flag:
+            event_translations = event_translations.order_by("title").distinct("title")
 
         results.extend(
             format_object_translation(obj, "event", language_slug)

--- a/integreat_cms/cms/models/feedback/feedback.py
+++ b/integreat_cms/cms/models/feedback/feedback.py
@@ -177,15 +177,23 @@ class Feedback(PolymorphicModel, AbstractBaseModel):
         query = kwargs["query"]
         archived_flag = kwargs["archived_flag"]
 
+        feedback_comments = (
+            cls.search(region, query)
+            .filter(
+                archived=archived_flag,
+            )
+            .order_by("comment")
+            .distinct("comment")
+            .values_list("comment", flat=True)
+        )
+
         results.extend(
             {
-                "title": feedback.comment,
+                "title": feedback_comment,
                 "url": None,
                 "type": "feedback",
             }
-            for feedback in cls.search(region, query).filter(
-                archived=archived_flag,
-            )
+            for feedback_comment in feedback_comments
         )
 
         return results

--- a/integreat_cms/cms/models/pages/page.py
+++ b/integreat_cms/cms/models/pages/page.py
@@ -416,17 +416,27 @@ class Page(AbstractTreeNode, AbstractBasePage):
         query = kwargs["query"]
         archived_flag = kwargs["archived_flag"]
         language_slug = kwargs["language_slug"]
+        link_suggestion_flag = kwargs["link_suggestion_flag"]
 
         pages = region.pages.all().cache_tree(archived=archived_flag)
+        title_already_in_result: set[str] = set()
+
         for page in pages:
             page_translation = page.get_translation(language_slug)
             if page_translation and (
                 query.lower() in page_translation.slug
                 or query.lower() in page_translation.title.lower()
             ):
+                if (
+                    not link_suggestion_flag
+                    and page_translation.title in title_already_in_result
+                ):
+                    continue
+
                 results.append(
                     format_object_translation(page_translation, "page", language_slug),
                 )
+                title_already_in_result.add(page_translation.title)
 
         return results
 

--- a/integreat_cms/cms/models/pois/poi_translation.py
+++ b/integreat_cms/cms/models/pois/poi_translation.py
@@ -158,12 +158,17 @@ class POITranslation(AbstractContentTranslation):
         query = kwargs["query"]
         archived_flag = kwargs["archived_flag"]
         language_slug = kwargs["language_slug"]
+        link_suggestion_flag = kwargs["link_suggestion_flag"]
 
         poi_translations = (
             cls.search(region, language_slug, query)
             .filter(poi__archived=archived_flag, status=status.PUBLIC)
             .select_related("poi__region", "language")
         )
+
+        if not link_suggestion_flag:
+            poi_translations = poi_translations.order_by("title").distinct("title")
+
         results.extend(
             format_object_translation(obj, "poi", language_slug)
             for obj in poi_translations

--- a/integreat_cms/cms/models/push_notifications/push_notification_translation.py
+++ b/integreat_cms/cms/models/push_notifications/push_notification_translation.py
@@ -82,9 +82,12 @@ class PushNotificationTranslation(AbstractBaseModel):
         archived_flag = kwargs["archived_flag"]
         language_slug = kwargs["language_slug"]
 
-        push_notifications = PushNotificationTranslation.search(
-            region, language_slug, query
-        ).filter(push_notification__archived=archived_flag)
+        push_notifications = (
+            PushNotificationTranslation.search(region, language_slug, query)
+            .filter(push_notification__archived=archived_flag)
+            .order_by("title")
+            .distinct("title")
+        )
 
         results.extend(
             {

--- a/integreat_cms/cms/models/regions/region.py
+++ b/integreat_cms/cms/models/regions/region.py
@@ -924,11 +924,13 @@ class Region(AbstractBaseModel):
 
         results.extend(
             {
-                "title": region.name,
+                "title": region_name,
                 "url": None,
                 "type": "region",
             }
-            for region in regions
+            for region_name in regions.order_by("name")
+            .distinct("name")
+            .values_list("name", flat=True)
         )
         return results
 

--- a/integreat_cms/cms/views/utils/search_content_ajax.py
+++ b/integreat_cms/cms/views/utils/search_content_ajax.py
@@ -57,7 +57,8 @@ def search_content_ajax(
     body = json.loads(request.body.decode("utf-8"))
     query = body["query_string"]
     # whether to return only archived object, ignored if not applicable
-    archived_flag = body["archived"]
+    archived_flag = body.get("archived", False)
+    link_suggestion_flag = body.get("is_link_suggestion", False)
     object_types = set(body.get("object_types", []))
 
     logger.debug("Ajax call: Live search for %r with query %r", object_types, query)
@@ -66,11 +67,18 @@ def search_content_ajax(
 
     user = request.user
 
+    # This function is used for the search window in a content list view and to suggest targets for internal links in the "Insert link" menu in the editor.
+    # For the former we only care about the plain text representation and don't want any duplicates
+    # (e.g. if we have two events titled "Community kitchen" we only want one suggestion to search for this string –
+    # both events will still show in the list view as soon as the user submits his actual search).
+    # For the latter we need the information uniquely identifying each object (such as the url).
+    # `link_suggestion_flag` is set to True if we want all unique objects, even if there are multiple with the same title.
     kwargs = {
         "region": region,
         "query": query,
         "archived_flag": archived_flag,
         "language_slug": language_slug,
+        "link_suggestion_flag": link_suggestion_flag,
     }
 
     for object_type in object_types:

--- a/integreat_cms/static/src/js/tinymce-plugins/custom_link_input/plugin.js
+++ b/integreat_cms/static/src/js/tinymce-plugins/custom_link_input/plugin.js
@@ -14,6 +14,7 @@ import { getCsrfToken } from "../../utils/csrf-token";
                 query_string: query,
                 object_types: ["event", "page", "poi"],
                 archived: false,
+                is_link_suggestion: true,
             }),
         });
         const HTTP_STATUS_OK = 200;


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the bug that search keywords can appear multiple times in the suggestion list when user uses search window.


This bug has existed since a long time, but will be really a problem if #3727 is merged as is (it makes all primary contacts named after the related POI)


### Proposed changes
<!-- Describe this PR in more detail. -->
- Use `.distinct()` or check whether a search keyword is already in the suggestion list
- 


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- should be none
- 


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.
There is no fix implemented for languages, as it is unlikely that we have more than one language with the same name and implementation is not so trivial due to translation of language names into the system languages user is using

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3839 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
