### PR TITLE
Improve error message of ajax contact form

### DIFF
--- a/integreat_cms/cms/templates/pois/poi_form_sidebar/related_contacts_box.html
+++ b/integreat_cms/cms/templates/pois/poi_form_sidebar/related_contacts_box.html
@@ -50,8 +50,10 @@
                  class="bg-green-100 border-l-4 border-green-500 text-green-800 px-4 py-3 hidden">
                 {% trans "The new contact was successfully created." %}
             </div>
-            <div id="contact-ajax-error-message"
-                 class="bg-red-100 border-l-4 border-red-500 text-red-700 px-4 py-3 hidden">
+            <div id="contact-ajax-error-message">
+            </div>
+            <div id="contact-ajax-unexpected-error-message"
+                 class="bg-red-100 border-l-4 border-red-500 text-red-700 px-4 py-3 my-1 hidden">
                 {% trans "An error occurred." %}
             </div>
             <div id="contact-form-widget" class="hidden">

--- a/integreat_cms/cms/views/contacts/contact_form_ajax_view.py
+++ b/integreat_cms/cms/views/contacts/contact_form_ajax_view.py
@@ -83,7 +83,7 @@ class ContactFormAjaxView(TemplateView, ContactContextMixin):
 
         return JsonResponse(
             data={
-                "success": "Successfully created location",
+                "success": "Successfully created contact",
                 "contact_label": contact.label_in_reference_list(),
                 "edit_url": contact.backend_edit_link,
             }

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -2913,7 +2913,7 @@ msgstr "Kontakte"
 #: cms/models/contact/contact.py
 msgid "Only one contact per location can have an empty area of responsibility."
 msgstr ""
-"Pro Ort darf nur einen Kontakt ohne Angabe des Zuständigkeitsbereichs geben."
+"Pro Ort darf es nur einen Kontakt ohne Angabe des Zuständigkeitsbereichs geben."
 
 #: cms/models/contact/contact.py
 msgid ""

--- a/integreat_cms/release_notes/current/unreleased/3840.yml
+++ b/integreat_cms/release_notes/current/unreleased/3840.yml
@@ -1,0 +1,2 @@
+en: Show more detailed error message when contact creation from the location form failed
+de: Zeige ausführlichere Fehlermeldung an, wenn die Erstellung von Kontakten aus dem Ortsformular fehlschlägt

--- a/integreat_cms/static/src/js/ajax-contact-form.ts
+++ b/integreat_cms/static/src/js/ajax-contact-form.ts
@@ -22,22 +22,34 @@ const addNewContactToList = (label: string, url: string) => {
 };
 
 const showMessage = (data: any) => {
-    const timeoutDuration = 10000;
     if (data.success) {
         hideContactFormWidget();
         addNewContactToList(data.contact_label, data.edit_url);
         const successMessageField = document.getElementById("contact-ajax-success-message");
         successMessageField.classList.remove("hidden");
-        setTimeout(() => {
-            successMessageField.classList.add("hidden");
-        }, timeoutDuration);
-    } else {
+    } else if (data.contact_form.length > 0) {
         const errorMessageField = document.getElementById("contact-ajax-error-message");
-        errorMessageField.classList.remove("hidden");
-        setTimeout(() => {
-            errorMessageField.classList.add("hidden");
-        }, timeoutDuration);
+        data.contact_form.forEach((error: any) => {
+            const node = document.createElement("div");
+            node.classList.add("bg-red-100", "border-l-4", "border-red-500", "text-red-700", "px-4", "py-3", "my-1");
+            node.innerText = error.text;
+            errorMessageField.append(node);
+        });
+    } else {
+        const unexpectedErrorMessageField = document.getElementById("contact-ajax-unexpected-error-message");
+        unexpectedErrorMessageField.classList.remove("hidden");
     }
+};
+
+const clearPreviousMessages = () => {
+    const successMessageField = document.getElementById("contact-ajax-success-message");
+    successMessageField.classList.add("hidden");
+
+    const errorMessageField = document.getElementById("contact-ajax-error-message");
+    errorMessageField.replaceChildren();
+
+    const unexpectedErrorMessageField = document.getElementById("contact-ajax-unexpected-error-message");
+    unexpectedErrorMessageField.classList.add("hidden");
 };
 
 const createContact = async (event: Event) => {
@@ -49,6 +61,8 @@ const createContact = async (event: Event) => {
     if (!form.reportValidity()) {
         return;
     }
+
+    clearPreviousMessages();
 
     const response = await fetch(btn.getAttribute("data-url"), {
         method: "POST",
@@ -80,6 +94,7 @@ const renderContactForm = async () => {
 window.addEventListener("load", () => {
     document.getElementById("show-contact-form-button")?.addEventListener("click", (event) => {
         event.preventDefault();
+        clearPreviousMessages();
         renderContactForm();
     });
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR improves the error message of the ajax contat form in the POI form, so users can know what exactly the cause was.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Read the error message and show them all 
- Leave the generic message "An error occured" for a case when no detail is provided but something didn't work.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Less confusion 
- 


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.
There is a similar ajax form to create a POI in the event form. There we do not need such changes like this PR, as it contains only mandatory fields and warns user to fill them all before letting them send a form.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3840


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
