### PR TITLE
Mark `test_copy_pois_succeeds` as last

### DIFF
--- a/tests/core/management/commands/test_copy_pois.py
+++ b/tests/core/management/commands/test_copy_pois.py
@@ -43,7 +43,8 @@ parameters = tuple(
 @pytest.mark.parametrize(
     "parameters", parameters, ids=[" ".join(x) for x in parameters]
 )
-@pytest.mark.django_db
+@pytest.mark.order("last")
+@pytest.mark.django_db(transaction=True, serialized_rollback=True)
 def test_copy_pois_succeeds(
     load_test_data_transactional: None,
     parameters: tuple[str],


### PR DESCRIPTION
### Short description
Our test were failing with errors such as `User matching query does not exist` etc. because the test `test_copy_pois_succeeds` was not marked as last. That resulted in non-transactional tests (aka those that use the fixture `load_test_data`) that were executed after that test, starting with an empty database and therefore failing with errors.


### Proposed changes
<!-- Describe this PR in more detail. -->

- added the marker to be last to the test
- also set the database to `transaction=True, serialized_rollback=True` (I am not entirely sure that is necessary, but since we do that everwhere else where we use `load_test_data_transactional`, I added it here for consistency


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- I hope none


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
This PR has no issue

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: This PR has no issue


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
