### PR TITLE
Fix addOpeningHoursListener null error when element is not there

### DIFF
--- a/integreat_cms/static/src/js/pois/opening-hours/index.tsx
+++ b/integreat_cms/static/src/js/pois/opening-hours/index.tsx
@@ -112,35 +112,47 @@ export const addOpeningHoursListener = () => {
 
     let updateLatch = 0;
 
-    document.getElementById("id_use_location_opening_hours").addEventListener("change", (e) => {
-        // Only reset if we changed to adopt the opening hours from the location
-        if ((e.target as HTMLInputElement).checked) {
-            updateLatch += 1;
-            const thisTimeAround = updateLatch;
-            setTimeout(() => {
-                if (updateLatch === thisTimeAround) {
-                    updateLatch = 0;
-                }
-            }, 1);
-            resetOpeningHoursListener();
-        }
-    });
+    const useLocationOpeningHours: HTMLElement | null = document.getElementById(
+        "id_use_location_opening_hours"
+    ) as HTMLInputElement | null;
+    if (useLocationOpeningHours) {
+        useLocationOpeningHours.addEventListener("change", (e) => {
+            // Only reset if we changed to adopt the opening hours from the location
+            if ((e.target as HTMLInputElement).checked) {
+                updateLatch += 1;
+                const thisTimeAround = updateLatch;
+                setTimeout(() => {
+                    if (updateLatch === thisTimeAround) {
+                        updateLatch = 0;
+                    }
+                }, 1);
+                resetOpeningHoursListener();
+            }
+        });
+    }
 
-    const observer = new MutationObserver((mutations) => {
-        for (const mutation of mutations) {
-            if (mutation.type === "childList" || mutation.type === "attributes" || mutation.type === "characterData") {
-                if (updateLatch === 0) {
-                    addOpeningHoursDataChangedListener();
+    const openingHoursTextarea = document.getElementById("id_opening_hours");
+    if (openingHoursTextarea) {
+        const observer = new MutationObserver((mutations) => {
+            for (const mutation of mutations) {
+                if (
+                    mutation.type === "childList" ||
+                    mutation.type === "attributes" ||
+                    mutation.type === "characterData"
+                ) {
+                    if (updateLatch === 0) {
+                        addOpeningHoursDataChangedListener();
+                    }
                 }
             }
-        }
-    });
+        });
 
-    observer.observe(document.getElementById("id_opening_hours"), {
-        childList: true,
-        characterData: true,
-        subtree: true,
-    });
+        observer.observe(document.getElementById("id_opening_hours"), {
+            childList: true,
+            characterData: true,
+            subtree: true,
+        });
+    }
 };
 
 document.addEventListener("DOMContentLoaded", addOpeningHoursListener);


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
We are trying to attach the eventListener to the `useLocationOpeningHours`-element without making sure first that it is really there. Additionally we also do not check if `openingHoursTextarea` is there afterwards, which is also fixed in this PR.


### Proposed changes
<!-- Describe this PR in more detail. -->

- we check that `useLocationOpeningHours` is there and only attach the eventListener if it is there
- we check that `openingHoursTextarea`  is there before the MutationObserver is created in which it is used


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- N/A


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->

- After fixing the error reported in the issue the creation of MutationObserver threw another error, that we decided to fix here as well, as it was just "hidden" by the first error

### How to test

- check that the error in the console of your browser is gone
- check in the contact form that everything is still working (especially the eventListener & MutationObserver)

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3773 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
