### PR TITLE
Fix pcregrep install in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/python:3.11
+FROM mcr.microsoft.com/vscode/devcontainers/python:3.11-bookworm
 
 RUN apt-get update && \
     apt-get install -y nodejs npm && \


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
It seems that pcregrep does not exist in a stable version for Debian 13 (Trixie) yet. So to circumvent this, this PR binds the Devcontainer to the Debian 12 (bookworm) image. The Devcontainer ran on Debian 12 until recently.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Bind the Devcontainer to Debian 12 Image instead of latest Debian image


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- 


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this (e.g. specific environment variables and settings to be set, --> 
<!-- and things to pay attention to) -->
Since I'm the only one who is currently using the devcontainer, not realy testable. When you are using VSCode you can look if it interferes with your setup.
In case you should use the devcontainer: checkout the develop branch, rebuild the devcontainer, see that it install of pcregrep does not work. Then checkout the PR, rebuild devconainer, see that it builds and install pcregrep


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: # n.a.


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
