### PR TITLE
Change page access statistics loading indication to single indication

### DIFF
--- a/integreat_cms/cms/templates/statistics/statistics_viewed_pages.html
+++ b/integreat_cms/cms/templates/statistics/statistics_viewed_pages.html
@@ -15,6 +15,9 @@
     </div>
 {% endblock collapsible_box_title %}
 {% block collapsible_box_content %}
+    <div id="page-accesses-loading" class="px-4 text-center">
+        <i icon-name="loader" class="animate-spin"></i> {% translate "Loading..." %}
+    </div>
     <form method="post"
           id="statistics-page-access"
           class="table-listing"

--- a/integreat_cms/cms/templates/statistics/statistics_viewed_pages_node.html
+++ b/integreat_cms/cms/templates/statistics/statistics_viewed_pages_node.html
@@ -10,9 +10,6 @@
     {% include "pages/_generic_page_tree_node.html" %}
     <td class="flex items-stretch accesses px-2"
         data-no-data="{% translate "This page has no accesses in the selected time span" %}">
-        <div class="page-accesses-loading px-4">
-            <i icon-name="loader" class="animate-spin"></i> {% translate "Loading..." %}
-        </div>
         {% for language in languages %}
             <span data-language-color="{{ language.language_color }}"
                   data-language-slug="{{ language.slug }}"

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -5184,7 +5184,7 @@ msgstr "Bitte kontaktieren Sie eine:n Administrator:in."
 #: cms/templates/pois/poi_form_sidebar/position_box.html
 #: cms/templates/statistics/_statistics_widget.html
 #: cms/templates/statistics/statistics_chart.html
-#: cms/templates/statistics/statistics_viewed_pages_node.html
+#: cms/templates/statistics/statistics_viewed_pages.html
 msgid "Loading..."
 msgstr "Laden..."
 

--- a/integreat_cms/static/src/js/analytics/statistics-page-accesses.ts
+++ b/integreat_cms/static/src/js/analytics/statistics-page-accesses.ts
@@ -11,7 +11,6 @@ export type Access = {
 };
 
 let chart: Chart | null = null;
-let loaderIsHidden: boolean;
 
 /* Loop over the object containing the accesses over time and count them to a total */
 const countAccesses = (accessesOverTime: object): number => {
@@ -60,21 +59,6 @@ const resetAllAccessesField = (accessFields: HTMLCollectionOf<Element>, isEmpty:
     }
 };
 
-/* Toggle the loader icon */
-const toggleLoader = (show: boolean): boolean => {
-    const loaderIcons = document.getElementsByClassName("page-accesses-loading");
-    if (show) {
-        Array.from(loaderIcons).forEach((loaderIcon) => {
-            loaderIcon.classList.remove("hidden");
-        });
-        return false;
-    }
-    Array.from(loaderIcons).forEach((loaderIcon) => {
-        loaderIcon.classList.add("hidden");
-    });
-    return true;
-};
-
 /* Set the selected date at the top of the table */
 const setDates = () => {
     const unformattedStartDate = (document.getElementById("id_start_date") as HTMLInputElement).value;
@@ -96,8 +80,12 @@ const updatePageAccesses = async (): Promise<void> => {
         };
     }
 
+    const pageAccessesLoading = document.getElementById("page-accesses-loading");
     const pageAccessesURL = document.getElementById("statistics-page-access").getAttribute("data-page-accesses-url");
     const accessFields = document.getElementsByClassName("accesses");
+
+    pageAccessesLoading.classList.remove("hidden");
+
     const response = await fetch(pageAccessesURL, parameters);
     const data = (await response.json()) as AjaxResponse;
     const isEmpty = Object.keys(data).length === 0;
@@ -151,12 +139,11 @@ const updatePageAccesses = async (): Promise<void> => {
             }
         });
     });
-    loaderIsHidden = toggleLoader(loaderIsHidden);
+    pageAccessesLoading.classList.add("hidden");
     setDates();
 };
 
 export const setPageAccessesEventListeners = () => {
-    loaderIsHidden = false;
     if (document.getElementById("statistics-page-access")) {
         chart = Chart.instances[0];
         // Set event handler for updating Page Accesses when date is changed
@@ -165,7 +152,6 @@ export const setPageAccessesEventListeners = () => {
         statisticsForm?.addEventListener("submit", async (event: Event) => {
             // Prevent form submit
             event.preventDefault();
-            loaderIsHidden = toggleLoader(loaderIsHidden);
             await updatePageAccesses();
         });
 
@@ -175,7 +161,6 @@ export const setPageAccessesEventListeners = () => {
             chartLegendElement.addEventListener("change", async (event) => {
                 const targetElement = event.target as HTMLInputElement;
                 if (targetElement.type === "checkbox" && targetElement.getAttribute("data-language-slug")) {
-                    loaderIsHidden = toggleLoader(loaderIsHidden);
                     updatePageAccesses();
                 }
             });


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR changes the loading indication for the page access statistics to a single indication instead of indications for every page in the page list 

### Proposed changes
<!-- Describe this PR in more detail. -->

- Moves the loader Icon from the page nodes to the top of the list


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- The toggleLoader method isn't needed anymore since we don't need to iterate over multiple icons anymore


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this (e.g. specific environment variables and settings to be set, --> 
<!-- and things to pay attention to) -->
To test this you need statistics activated. 
- Go to the region settings of e.g. Augsburg on the test system and copy the matomo auth token
- Run the cms locally and go to the region settings of Augsburg
- Check the statistics Checkbox and paste the matomo auth token
- Run the fetch page accesses management command: `integreat-cms-cli fetch_page_accesses --start-date START_DATE --end-date END_DATE --region-slug augsburg` (start and end date can be the same, good pick would be yesterday)
- Wait for about 30 to 40 sec
- Go to the statistics page for Augsburg
- See single loading indication
- Select/Deselect a language or change the selected dates
- See single loading indication again

It's possible that there are not enough data for the loading time to be significant enough to notice the indication switch. In that case run the command above over a longer timeframe e.g. 2 Weeks

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3869 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
