### PR TITLE
Separate fix for failing test_find_missing_versions_failure

### DIFF
--- a/tests/core/management/commands/test_find_missing_versions.py
+++ b/tests/core/management/commands/test_find_missing_versions.py
@@ -59,10 +59,11 @@ def test_find_missing_versions_failure(load_test_data: None) -> None:
         out
         == "\x1b[0;34mChecking the model PageTranslation for version inconsistencies...\x1b[0m\n"
     )
+
+    page = page_translation.foreign_object.get_repr()
+    language = page_translation.language.get_repr()
     assert err == (
-        "\x1b[0;31mThe latest version of <Page (id: 1, region: augsburg, slug: willkommen)>"
-        " in <Language (id: 1, slug: de, name: German)>"
-        " is 3, but there are only 2 translation objects!\x1b[0m\n"
+        f"\x1b[0;31mThe latest version of {page} in {language} is 3, but there are only 2 translation objects!\x1b[0m\n"
     )
     # restore previous state to not interfere with other tests.
     page_translation.version -= 1


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the test `test_find_missing_versions_failure` which failed in #3876 even though the changes did not affect it

See this [comment](https://github.com/digitalfabrik/integreat-cms/pull/3876#issuecomment-3312456511)

It was originally fixed in #3876 but packed into this branch to separate from the main part of #3876 

### Proposed changes
<!-- Describe this PR in more detail. -->
- Do not hard code the representation of page object and language


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- more stable test 


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this (e.g. specific environment variables and settings to be set, --> 
<!-- and things to pay attention to) -->


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #N/A


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
