### PR TITLE
Fix opening hours of contact created together with a new POI

### DIFF
--- a/integreat_cms/cms/views/pois/poi_form_view.py
+++ b/integreat_cms/cms/views/pois/poi_form_view.py
@@ -209,7 +209,9 @@ class POIFormView(
                     )
 
             data = request.POST.dict()
-            data.update({"location": poi.id})
+            # Flush opening_hours which is meant for the location
+            # The contact can also have opening hours itself, but here we want it to always mirror those of the location
+            data.update({"location": poi.id, "opening_hours": ""})
             contact_form = ContactForm(
                 request=request,
                 data=data,


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the bug that contacts that are created during a new POI being created automatically receive the opening hours of the POI.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Flush `opening_hours` from the data, when creating a contact following the POI


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- None?


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this (e.g. specific environment variables and settings to be set, --> 
<!-- and things to pay attention to) -->


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3729


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
