### PR TITLE
Add privacy policy and imprint link

### DIFF
--- a/integreat_cms/cms/templates/_base.html
+++ b/integreat_cms/cms/templates/_base.html
@@ -115,7 +115,7 @@
                 </div>
             </a>
         </div>
-        <div id="menu" class="pb-10 overflow-y-auto {{ BRANDING }}-branding">
+        <div id="menu" class="pb-[66px] overflow-y-auto {{ BRANDING }}-branding">
             {% if request.region %}
                 <a href="{% url 'dashboard' region_slug=request.region.slug %}"
                    class="{% if current_menu_item == 'region_dashboard' %} active{% endif %}">
@@ -342,7 +342,16 @@
         </div>
         <div class="p-2 text-center absolute inset-x-0 bottom-0 bg-gray-600">
             <a href="{% if request.region %}{% url "release_notes" region_slug=request.region.slug %}{% else %}{% url "release_notes" %}{% endif %}"
-               class="hover:underline">{% translate "Version" %}: {{ version }}</a>
+               class="hover:underline pb-2">{% translate "Version" %}: {{ version }}</a>
+            <div>
+                <a href="{{ PRIVACY_POLICY_URL }}" class="hover:underline text-sm">
+                    {% translate "Privacy policy" %}
+                </a>
+                <i icon-name="dot" class="inline-block mx-1"></i>
+                <a href="{{ IMPRINT_URL }}" class="hover:underline text-sm">
+                    {% translate "Imprint" %}
+                </a>
+            </div>
         </div>
     </nav>
     <main class="relative min-h-screen flex lg:pl-72 {% if TEST %}pt-20{% else %}pt-14{% endif %} bg-gray-100">

--- a/integreat_cms/cms/templates/authentication/_base.html
+++ b/integreat_cms/cms/templates/authentication/_base.html
@@ -26,6 +26,20 @@
                     {{ COMPANY }}
                 </a>
             </p>
+            <div class="mt-2 flex justify-center space-x-4 text-sm">
+                <a href="{{ PRIVACY_POLICY_URL }}"
+                   class=" text-gray-400 hover:text-gray-800"
+                   target="_blank"
+                   rel="noopener noreferrer">
+                    {% trans "Privacy policy" %}
+                </a>
+                <a href="{{ IMPRINT_URL }}"
+                   class="text-center text-gray-400 hover:text-gray-800"
+                   target="_blank"
+                   rel="noopener noreferrer">
+                    {% trans "Imprint" %}
+                </a>
+            </div>
         </div>
     </div>
 {% endblock raw_content %}

--- a/integreat_cms/cms/urls/public.py
+++ b/integreat_cms/cms/urls/public.py
@@ -35,6 +35,8 @@ app_name: Final = "public"
 auth_context: dict[str, str] = {
     "COMPANY": settings.COMPANY,
     "COMPANY_URL": settings.COMPANY_URL,
+    "PRIVACY_POLICY_URL": settings.PRIVACY_POLICY_URL,
+    "IMPRINT_URL": settings.IMPRINT_URL,
 }
 
 #: The url patterns of this module (see :doc:`django:topics/http/urls`)

--- a/integreat_cms/core/context_processors.py
+++ b/integreat_cms/core/context_processors.py
@@ -45,6 +45,8 @@ def settings_processor(request: HttpRequest) -> dict[str, Any]:
         "TEXTLAB_API_ENABLED": settings.TEXTLAB_API_ENABLED,
         "TEST": settings.TEST,
         "INTEGREAT_CHAT_TICKET_GROUP": settings.INTEGREAT_CHAT_TICKET_GROUP,
+        "PRIVACY_POLICY_URL": settings.PRIVACY_POLICY_URL,
+        "IMPRINT_URL": settings.IMPRINT_URL,
     }
 
 

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -149,6 +149,18 @@ COMPANY_URL: Final[str] = os.environ.get(
     "https://tuerantuer.de/digitalfabrik/",
 )
 
+#: The URL to the privacy policy
+PRIVACY_POLICY_URL: Final[str] = os.environ.get(
+    "INTEGREAT_CMS_PRIVACY_POLICY_URL",
+    "https://example.com/",
+)
+
+#: The URL to the imprint
+IMPRINT_URL: Final[str] = os.environ.get(
+    "INTEGREAT_CMS_IMPRINT_URL",
+    "https://example.com/",
+)
+
 #: The available inbuilt brandings of the CMS
 AVAILABLE_BRANDINGS: Final[dict[str, str]] = {
     "integreat": "Integreat",

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -3184,6 +3184,7 @@ msgid "feedback"
 msgstr "Feedback"
 
 #: cms/models/feedback/imprint_page_feedback.py cms/templates/_base.html
+#: cms/templates/authentication/_base.html
 msgid "Imprint"
 msgstr "Impressum"
 
@@ -4776,6 +4777,10 @@ msgstr "Ortskategorien"
 #: cms/templates/pois/poi_form.html
 msgid "Version"
 msgstr "Version"
+
+#: cms/templates/_base.html cms/templates/authentication/_base.html
+msgid "Privacy policy"
+msgstr "Datenschutzerklärung"
 
 #: cms/templates/_content_edit_lock.html
 msgid "{} is already editing this content"
@@ -12336,15 +12341,15 @@ msgstr ""
 #~ "Übersetzungen. Bitte haben Sie noch ein wenig Geduld."
 
 #~ msgid ""
-#~ "Your pages currently have "
-#~ "<b>%(number_of_missing_or_outdated_translations)s pages </b>that have an "
+#~ "Your pages currently have <b>"
+#~ "%(number_of_missing_or_outdated_translations)s pages </b>that have an "
 #~ "outdated or no translation. In order for the users to benefit from your "
 #~ "content you should translate them or have them translated."
 #~ msgstr ""
-#~ "Ihre Inhalten haben aktuell "
-#~ "<b>%(number_of_missing_or_outdated_translations)s Seiten </b> mit "
-#~ "fehlender oder veralteter Übersetzung. Damit die Nutzer:innen von Ihren "
-#~ "Inhalten profitieren können, sollten Sie diese übersetzen (lassen)."
+#~ "Ihre Inhalten haben aktuell <b>"
+#~ "%(number_of_missing_or_outdated_translations)s Seiten </b> mit fehlender "
+#~ "oder veralteter Übersetzung. Damit die Nutzer:innen von Ihren Inhalten "
+#~ "profitieren können, sollten Sie diese übersetzen (lassen)."
 
 #~ msgid "View location"
 #~ msgstr "Ort ansehen"

--- a/integreat_cms/release_notes/current/unreleased/3882.yml
+++ b/integreat_cms/release_notes/current/unreleased/3882.yml
@@ -1,0 +1,2 @@
+en: Add privacy policy and imprint links
+de: Füge Links zum Impressum und zur Datenschutzerklärung hinzu


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds links to the page of privacy policy and imprint

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add two environment variables, each to the privacy policy and imprint
- Add links to them in the log-in page and the user menu (hover-on menu at the upper right corner)

We can wait if the pages for privacy policy and imprint are not yet ready.
Prio low, I just started before we forget this thema.

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- Our CMS satisfying a legal requirement


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this (e.g. specific environment variables and settings to be set, --> 
<!-- and things to pay attention to) -->
Set in `integreat-cms.ini` the new variables
See the links work

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3882 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
