### PR TITLE
Refactor primary contact to manger method

### DIFF
--- a/integreat_cms/api/v3/locations.py
+++ b/integreat_cms/api/v3/locations.py
@@ -79,7 +79,7 @@ def transform_poi_translation(poi_translation: POITranslation) -> dict[str, Any]
 
     # Note(johannes): Remove the primary_contact and the according three fields (phone_number, website, and email) in late 2025
     # https://github.com/digitalfabrik/integreat-cms/issues/3475
-    primary_contact = contacts.filter(area_of_responsibility="").first()
+    primary_contact = contacts.get_primary_contact()
 
     contacts = contacts.filter(archived=False)
 

--- a/integreat_cms/cms/forms/pois/poi_form.py
+++ b/integreat_cms/cms/forms/pois/poi_form.py
@@ -87,7 +87,7 @@ class POIForm(CustomModelForm):
         # as we do not delete non-primary contacts when deactivating contact in a region.
         # "get()" is not used as it raises an exception if there is no primary contact.
         if self.instance.id:
-            contact = self.instance.contacts.filter(area_of_responsibility="").first()
+            contact = self.instance.contacts.get_primary_contact()
             self.fields["primary_phone_number"].initial = (
                 contact.phone_number if contact else ""
             )

--- a/integreat_cms/cms/models/contact/contact.py
+++ b/integreat_cms/cms/models/contact/contact.py
@@ -34,6 +34,20 @@ if TYPE_CHECKING:
     from ..regions.region import Region
 
 
+class ContactQuerySet(models.QuerySet):
+    """
+    A QuerySet class for contact model.
+
+    It extends the standard queryset of Django.
+    """
+
+    def get_primary_contact(self) -> Contact | None:
+        """
+        Returns the primary contact, i.e. the contact with an empty area_of_responsibility.
+        """
+        return self.filter(area_of_responsibility="").first()
+
+
 class Contact(AbstractBaseModel):
     """
     Data model representing a contact
@@ -92,6 +106,7 @@ class Contact(AbstractBaseModel):
             "Link to an external website where an appointment for this contact can be made.",
         ),
     )
+    objects = models.Manager.from_queryset(ContactQuerySet)()
 
     @cached_property
     def region(self) -> Region:

--- a/integreat_cms/cms/views/pois/poi_form_view.py
+++ b/integreat_cms/cms/views/pois/poi_form_view.py
@@ -239,7 +239,7 @@ class POIFormView(
             # Look explicitly for the primary contact, not any first one,
             # as we do not delete non-primary contacts when deactivating contact in a region.
             # "get()" is not used as it raises an exception if there is no primary contact.
-            contact = poi.contacts.filter(area_of_responsibility="").first()
+            contact = poi.contacts.get_primary_contact()
 
             if website != "" or phone_number != "" or email != "":
                 if not contact:


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR is a small refactoring where we use a manager method to find the primary contact of a location. This was not planned for our roadmap, but is a follow up for https://github.com/digitalfabrik/integreat-cms/pull/3727

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add get_primary_contact() method and remove two instances of `self.filter(area_of_responsibility="").first()`


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this (e.g. specific environment variables and settings to be set, --> 
<!-- and things to pay attention to) -->
Check all instances of get_primary_contact() and check if the behavior is expected


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3922


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
