### PR TITLE
Change CircleCI bumpver resource class

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -391,7 +391,7 @@ jobs:
   bump-dev-version:
     docker:
       - image: cimg/python:3.11.7
-    resource_class: large
+    resource_class: xlarge
     steps:
       - checkout
       - attach_workspace:
@@ -441,7 +441,7 @@ jobs:
   bump-version:
     docker:
       - image: cimg/python:3.11.7
-    resource_class: large
+    resource_class: xlarge
     steps:
       - checkout
       - attach_workspace:


### PR DESCRIPTION
### Short description
Change the resource class for the bumpver job as it runs out of memory while generating the SBOM.


### Proposed changes
- Change CircleCI bumpver resource class to xlarge

### Side effects
- costs :dollar: :sob: 

### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this (e.g. specific environment variables and settings to be set, --> 
<!-- and things to pay attention to) -->


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
