### PR TITLE
Persist SBOM in CircleCI workspace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -438,6 +438,7 @@ jobs:
           paths:
             - pyproject.toml
             - integreat_cms/__init__.py
+            - integreat_cms/_manifest
   bump-version:
     docker:
       - image: cimg/python:3.11.7


### PR DESCRIPTION
### Short description
Johannes and Sven are learning CirlceCI ... :see_no_evil: Uploading of test packages works again, but the SBOM was not included.


### Proposed changes
- persist the SBOM between CI steps.


### Side effects
- More used credits and commits.

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
