### PR TITLE
Fix word count

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/3858.yml
+++ b/integreat_cms/release_notes/current/unreleased/3858.yml
@@ -1,0 +1,2 @@
+en: Fix the incorrect calculation of total number of words in the translation management
+de: Behebe den Fehler, dass die Gesamtanzahl an Wörter in der Übersicht zu maschineller Übersetzung falsch berechnet wurde


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
We have been using two different methods for counting words in pages for machine translation, which results in different amounts of words to be shown. This PR applies the same method in both places. 


### Proposed changes
<!-- Describe this PR in more detail. -->

- in `translations_management_view.py` we changed the method to be used for word counting. Now it uses also the word_count method.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- hopefully none


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this (e.g. specific environment variables and settings to be set, --> 
<!-- and things to pay attention to) -->
If you are testing locally: Make sure that Machine Translation is activated 
- check in the "machine translation overlay" that pops up when you select for bulk machine translation inside the page tree for all (!) pages the amount of "Benötigtes Budget" (see screenshot)
<img width="2190" height="938" alt="image" src="https://github.com/user-attachments/assets/dd7bd22e-a1a8-40d2-80c5-86ca866eef1b" />

- and compare it with the "Summe Pro Art des Inhalts" in the "Seiten" row (see screenshot)
<img width="2190" height="938" alt="image" src="https://github.com/user-attachments/assets/bacca94c-90b6-4143-9004-537c2dd6963f" />



### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3858


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
