### PR TITLE
Refactor dummy_region fixture as function

### DIFF
--- a/tests/cms/views/utils/test_hix.py
+++ b/tests/cms/views/utils/test_hix.py
@@ -27,38 +27,35 @@ from tests.utils import disable_hix_post_save_signal
 
 if TYPE_CHECKING:
     from pytest_django.fixtures import SettingsWrapper
-    from pytest_django.plugin import _DatabaseBlocker  # type: ignore[attr-defined]
 
 
-@pytest.fixture(scope="session")
-def dummy_region(django_db_setup: None, django_db_blocker: _DatabaseBlocker) -> Region:
+def create_dummy_region() -> tuple[Language, Region]:
     """
-    Fixture to create a hix enabled dummy region, along with a dummy language.
+    Function to create a hix enabled dummy region, along with a dummy language.
     """
-    with django_db_blocker.unblock():
-        dummy_language = Language.objects.create(
-            slug="du",
-            bcp47_tag="du_DU",
-            primary_country_code="de",
-        )
-        dummy_language.save()
-        dummy_region = Region.objects.create(
-            name="HIX Test",
-            slug="hix-test",
-            status=ACTIVE,
-            administrative_division=MUNICIPALITY,
-            postal_code="12345",
-            admin_mail="admin@example.com",
-            hix_enabled=True,
-        )
-        dummy_region.save()
-        dummy_tree_node = LanguageTreeNode.add_root(
-            language=dummy_language,
-            region=dummy_region,
-        )
-        dummy_tree_node.save()
+    dummy_language = Language.objects.create(
+        slug="du",
+        bcp47_tag="du_DU",
+        primary_country_code="de",
+    )
+    dummy_language.save()
+    dummy_region = Region.objects.create(
+        name="HIX Test",
+        slug="hix-test",
+        status=ACTIVE,
+        administrative_division=MUNICIPALITY,
+        postal_code="12345",
+        admin_mail="admin@example.com",
+        hix_enabled=True,
+    )
+    dummy_region.save()
+    dummy_tree_node = LanguageTreeNode.add_root(
+        language=dummy_language,
+        region=dummy_region,
+    )
+    dummy_tree_node.save()
 
-    return dummy_region
+    return (dummy_language, dummy_region)
 
 
 def test_hix_rounding(settings: SettingsWrapper) -> None:
@@ -88,9 +85,8 @@ def test_hix_rounding(settings: SettingsWrapper) -> None:
 @pytest.mark.django_db
 def test_disregard_archived_pages(
     settings: SettingsWrapper,
-    dummy_region: Region,
 ) -> None:
-    dummy_language = dummy_region.default_language
+    dummy_language, dummy_region = create_dummy_region()
     settings.TEXTLAB_API_LANGUAGES = [dummy_language.slug]
 
     with disable_hix_post_save_signal():
@@ -151,9 +147,8 @@ def test_disregard_archived_pages(
 @pytest.mark.django_db
 def test_disregard_pages_with_hix_ignore(
     settings: SettingsWrapper,
-    dummy_region: Region,
 ) -> None:
-    dummy_language = dummy_region.default_language
+    dummy_language, dummy_region = create_dummy_region()
     settings.TEXTLAB_API_LANGUAGES = [dummy_language.slug]
 
     with disable_hix_post_save_signal():
@@ -217,8 +212,8 @@ def test_disregard_pages_with_hix_ignore(
 
 
 @pytest.mark.django_db
-def test_hix_values(settings: SettingsWrapper, dummy_region: Region) -> None:
-    dummy_language = dummy_region.default_language
+def test_hix_values(settings: SettingsWrapper) -> None:
+    dummy_language, dummy_region = create_dummy_region()
     settings.TEXTLAB_API_LANGUAGES = [dummy_language.slug]
 
     HIX_ROUNDING_PRECISION = 0.01
@@ -295,8 +290,8 @@ def test_hix_values(settings: SettingsWrapper, dummy_region: Region) -> None:
 
 
 @pytest.mark.django_db
-def test_versions_of_hix_page(settings: SettingsWrapper, dummy_region: Region) -> None:
-    dummy_language = dummy_region.default_language
+def test_versions_of_hix_page(settings: SettingsWrapper) -> None:
+    dummy_language, dummy_region = create_dummy_region()
     settings.TEXTLAB_API_LANGUAGES = [dummy_language.slug]
 
     with disable_hix_post_save_signal():


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Inside `test_hix.py` we use a dummy region with a dummy language in some tests. If this module is executed before the test `test_no_changes_were_made_message` inside `test_poi_category_form_view.py` the test fails because of an extra language in the db.


### Proposed changes
<!-- Describe this PR in more detail. -->

- refactor the dummy_region fixture as a simple function to be used inside the tests, this way the dummy_region and dummy_language are not committed to the db (only fixtures are persisted in the db)

### Alternative Solution
- keep the fixture and mark all tests that use the fixture as last, so that I are executed with tests that use `transactional_db`, where the db is flushed after every tests


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- hopefully none, as no test should rely on the dummy region to be there


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this (e.g. specific environment variables and settings to be set, --> 
<!-- and things to pay attention to) -->

Make sure that `test_no_changes_were_made_message` does not fail again on the CircleCi Pipeline in the coming weeks,  with this kind of error-message
``` 
FAILED tests/cms/views/poi_categories/test_poi_category_form_view.py::test_no_changes_were_made_message[CMS_TEAM] - assert 'Keine Änderungen vorgenommen' in '\n\n\n<!DOCTYPE html>\n\n<html lang="de">\n    <head>\n        <meta charset="utf-8" />\n        <meta http-equiv="X-...      </div>\n        </div>\n    </form>\n\n        </div>\n    </main>\n\n        \n        \n    </body>\n</html>\n'
 +  where '\n\n\n<!DOCTYPE html>\n\n<html lang="de">\n    <head>\n        <meta charset="utf-8" />\n        <meta http-equiv="X-...      </div>\n        </div>\n    </form>\n\n        </div>\n    </main>\n\n        \n        \n    </body>\n</html>\n' = <built-in method decode of bytes object at 0x557bab37e500>('utf-8')
 +    where <built-in method decode of bytes object at 0x557bab37e500> = b'\n\n\n<!DOCTYPE html>\n\n<html lang="de">\n    <head>\n        <meta charset="utf-8" />\n        <meta http-equiv="X...      </div>\n        </div>\n    </form>\n\n        </div>\n    </main>\n\n        \n        \n    </body>\n</html>\n'.decode
 +      where b'\n\n\n<!DOCTYPE html>\n\n<html lang="de">\n    <head>\n        <meta charset="utf-8" />\n        <meta http-equiv="X...      </div>\n        </div>\n    </form>\n\n        </div>\n    </main>\n\n        \n        \n    </body>\n</html>\n' = <TemplateResponse status_code=200, "text/html; charset=utf-8">.content
FAILED tests/cms/views/poi_categories/test_poi_category_form_view.py::test_no_changes_were_made_message[ROOT] - assert 'Keine Änderungen vorgenommen' in '\n\n\n<!DOCTYPE html>\n\n<html lang="de">\n    <head>\n        <meta charset="utf-8" />\n        <meta http-equiv="X-...      </div>\n        </div>\n    </form>\n\n        </div>\n    </main>\n\n        \n        \n    </body>\n</html>\n'
 +  where '\n\n\n<!DOCTYPE html>\n\n<html lang="de">\n    <head>\n        <meta charset="utf-8" />\n        <meta http-equiv="X-...      </div>\n        </div>\n    </form>\n\n        </div>\n    </main>\n\n        \n        \n    </body>\n</html>\n' = <built-in method decode of bytes object at 0x557ba9d5ae00>('utf-8')
 +    where <built-in method decode of bytes object at 0x557ba9d5ae00> = b'\n\n\n<!DOCTYPE html>\n\n<html lang="de">\n    <head>\n        <meta charset="utf-8" />\n        <meta http-equiv="X...      </div>\n        </div>\n    </form>\n\n        </div>\n    </main>\n\n        \n        \n    </body>\n</html>\n'.decode
 +      where b'\n\n\n<!DOCTYPE html>\n\n<html lang="de">\n    <head>\n        <meta charset="utf-8" />\n        <meta http-equiv="X...      </div>\n        </div>\n    </form>\n\n        </div>\n    </main>\n\n        \n        \n    </body>\n</html>\n' = <TemplateResponse status_code=200, "text/html; charset=utf-8">.content
FAILED tests/cms/views/poi_categories/test_poi_category_form_view.py::test_no_changes_were_made_message[SERVICE_TEAM] - assert 'Keine Änderungen vorgenommen' in '\n\n\n<!DOCTYPE html>\n\n<html lang="de">\n    <head>\n        <meta charset="utf-8" />\n        <meta http-equiv="X-...      </div>\n        </div>\n    </form>\n\n        </div>\n    </main>\n\n        \n        \n    </body>\n</html>\n'
 +  where '\n\n\n<!DOCTYPE html>\n\n<html lang="de">\n    <head>\n        <meta charset="utf-8" />\n        <meta http-equiv="X-...      </div>\n        </div>\n    </form>\n\n        </div>\n    </main>\n\n        \n        \n    </body>\n</html>\n' = <built-in method decode of bytes object at 0x557baae71b40>('utf-8')
 +    where <built-in method decode of bytes object at 0x557baae71b40> = b'\n\n\n<!DOCTYPE html>\n\n<html lang="de">\n    <head>\n        <meta charset="utf-8" />\n        <meta http-equiv="X...      </div>\n        </div>\n    </form>\n\n        </div>\n    </main>\n\n        \n        \n    </body>\n</html>\n'.decode
 +      where b'\n\n\n<!DOCTYPE html>\n\n<html lang="de">\n    <head>\n        <meta charset="utf-8" />\n        <meta http-equiv="X...      </div>\n        </div>\n    </form>\n\n        </div>\n    </main>\n\n        \n        \n    </body>\n</html>\n' = <TemplateResponse status_code=200, "text/html; charset=utf-8">.content
 ```


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Related to: #3949 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
