### PR TITLE
Fix handling missing DTEND

### DIFF
--- a/integreat_cms/cms/utils/external_calendar_utils.py
+++ b/integreat_cms/cms/utils/external_calendar_utils.py
@@ -79,7 +79,9 @@ class IcalEventData:
             language_slug=language_slug,
         )
         start = event.decoded("DTSTART")
-        end = event.decoded("DTEND")
+        end = event.decoded(
+            "DTEND", start + event.decoded("DURATION", datetime.timedelta(days=1))
+        )
 
         # Categories can be a "vCategory" object, a list of such objects, or be missing
         categories = event.get("categories", [])

--- a/integreat_cms/release_notes/current/unreleased/3958.yml
+++ b/integreat_cms/release_notes/current/unreleased/3958.yml
@@ -1,0 +1,2 @@
+en: Fix importing events from external calendars that don't specify DTEND
+de: Behebe einen Fehler beim Importieren von Veranstaltungen aus externen Kalendern, wenn im iCal-Format DTEND nicht gesetzt ist


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Our system expects events, or specifically Event Components, to always have a `DTEND` – and encounters an exception when it doesn't, failing to import the event and reporting it as faulty to the user. [The spec](https://www.rfc-editor.org/rfc/rfc5545#section-3.6.1) allows the component to have no `DTEND` but a `DURATION` instead, and even none of those, in which case it should be interpreted as lasting exactly one day.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Change the offending line to fall back to either calculating the end using `DURATION`, if given, or one day later otherwise.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- The effect should be isolated to importing iCal events only


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this (e.g. specific environment variables and settings to be set, --> 
<!-- and things to pay attention to) -->

1. Go to *External Calendars*
2. Add a calendar with the URL https://nextcloud.tuerantuer.org/index.php/s/mpKm7MS7XQWS5Cd/download *(leave the category empty)*
3. Save and Import the calendar
4. See error on the command line
5. Move back to the list view of external calendars
6. See the summary of problematic events in the status column

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3958


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
