### PR TITLE
Fix internal server error when no event start time is given

### DIFF
--- a/integreat_cms/cms/forms/events/event_form.py
+++ b/integreat_cms/cms/forms/events/event_form.py
@@ -170,9 +170,14 @@ class EventForm(CustomModelForm):
                         code="required",
                     ),
                 )
-            elif cleaned_data["start_time"] == time.min and cleaned_data[
-                "end_time"
-            ] == time.max.replace(second=0, microsecond=0):
+            if (
+                cleaned_data.get("start_time")
+                and cleaned_data.get("end_time")
+                and cleaned_data["start_time"] == time.min
+                and cleaned_data["end_time"]
+                == time.max.replace(second=0, microsecond=0)
+            ):
+                # Client didn't set is_all_day, but time is effectively one day – normalize this to make things simple
                 self.data["is_all_day"] = True
 
         if not cleaned_data.get("is_long_term") and not cleaned_data.get(

--- a/integreat_cms/release_notes/current/unreleased/3945.yml
+++ b/integreat_cms/release_notes/current/unreleased/3945.yml
@@ -1,0 +1,2 @@
+en: Fix internal server error caused by empty start time of event
+de: Behebe Internen Server Fehler, der durch eine fehlende Startzeit einer Veranstaltung verursacht wurde


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the bug that users face the internal server error screen when start time is empty but end time is given in the event form.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Adjust condition check


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- should be none


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.

(This issue was originally not scheduled in the mile stone T40K but I decided to open a PR as I found by chance the bug source 😅)

### How to test
<!-- Non-trivial prerequisites and notes on how to test this (e.g. specific environment variables and settings to be set, --> 
<!-- and things to pay attention to) -->
Reproduce as written in the issue in the branch `develop`, test whether it is solved on this branch

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3945



__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
