### PR TITLE
api(v3): add ISO8601 start_time/end_time to POI timeSlots (keep legacy start/end) #3943

### DIFF
--- a/docs/src/api-docs.rst
+++ b/docs/src/api-docs.rst
@@ -382,6 +382,7 @@ RESPONSE
                   {
                      "start": String,    // The start time of the timeslot, in the format `HH:MM`, 24 Hour time
                      "end": String,      // The end time of the timeslot
+                     "timezone": String      // IANA timezone key, e.g. "Europe/Berlin"
                   },
                   ...
                ],

--- a/integreat_cms/api/v3/locations.py
+++ b/integreat_cms/api/v3/locations.py
@@ -26,6 +26,28 @@ if TYPE_CHECKING:
 
     from ...cms.models import POI, POITranslation
 
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+
+def _ensure_zoneinfo(tz_candidate: str | ZoneInfo | None) -> ZoneInfo:
+    """
+    Convert an optional string/ZoneInfo to a valid :class:`ZoneInfo`, defaulting to settings.TIME_ZONE.
+
+    :param tz_candidate: IANA zone string, ZoneInfo, or None.
+    :return: Validated ZoneInfo.
+    """
+    default_tz = getattr(settings, "TIME_ZONE", "Europe/Berlin")
+    if isinstance(tz_candidate, ZoneInfo):
+        return tz_candidate
+    if isinstance(tz_candidate, str):
+        tz_str = tz_candidate.strip()
+        if tz_str:
+            try:
+                return ZoneInfo(tz_str)
+            except ZoneInfoNotFoundError:
+                pass
+    return ZoneInfo(default_tz)
+
 
 def transform_poi(poi: POI | None) -> dict[str, Any]:
     """
@@ -65,14 +87,19 @@ def transform_poi(poi: POI | None) -> dict[str, Any]:
     }
 
 
-def transform_poi_translation(poi_translation: POITranslation) -> dict[str, Any]:
+def transform_poi_translation(
+    poi_translation: POITranslation,
+    *,
+    region_tz: ZoneInfo,
+) -> dict[str, Any]:
     """
-    Function to create a JSON from a single poi_translation object.
+    Create JSON for a POI translation and enrich opening hours with ISO-8601 times.
 
-    :param poi_translation: The poi translation object which should be converted
-    :return: data necessary for API
+
+    :param poi_translation: POI translation to convert.
+    :param region_tz: Validated time zone used to compute DST-aware numeric offsets.
+    :return: Data for the APIv3 locations endpoint.
     """
-
     poi = poi_translation.poi
 
     contacts = Contact.objects.filter(location=poi).all()
@@ -99,11 +126,19 @@ def transform_poi_translation(poi_translation: POITranslation) -> dict[str, Any]
                 "appointment_url": contact.appointment_url or None,
             }
         )
-
     # Only return opening hours if they differ from the default value and the location is not temporarily closed
     opening_hours = None
     if not poi.temporarily_closed and poi.opening_hours != get_default_opening_hours():
-        opening_hours = poi.opening_hours
+        tz_key = getattr(region_tz, "key", str(region_tz))
+        opening_hours = [
+            day
+            | {
+                "timeSlots": [
+                    (slot | {"timezone": tz_key}) for slot in day.get("timeSlots", [])
+                ]
+            }
+            for day in (poi.opening_hours or [])
+        ]
     return {
         "id": poi_translation.id,
         "url": settings.BASE_URL + poi_translation.get_absolute_url(),
@@ -188,9 +223,10 @@ def locations(
             return JsonResponse({"error": str(e)}, status=400)
         pois = pois.filter(location_on_map=location_on_map)
 
+    region_tz = _ensure_zoneinfo(getattr(region, "timezone", None))
     for poi in pois:
         if translation := poi.get_public_translation(language_slug):
-            result.append(transform_poi_translation(translation))
+            result.append(transform_poi_translation(translation, region_tz=region_tz))
 
     return JsonResponse(
         result,

--- a/integreat_cms/cms/fixtures/test_data.json
+++ b/integreat_cms/cms/fixtures/test_data.json
@@ -871,8 +871,8 @@
           "allDay": false,
           "closed": false,
           "timeSlots": [
-            { "end": "13:00", "start": "10:00" },
-            { "end": "18:00", "start": "15:00" }
+            { "end": "13:00", "start": "10:00", "timezone": "Europe/Berlin" },
+            { "end": "18:00", "start": "15:00", "timezone": "Europe/Berlin" }
           ],
           "appointmentOnly": false
         },
@@ -880,8 +880,8 @@
           "allDay": false,
           "closed": false,
           "timeSlots": [
-            { "end": "13:00", "start": "10:00" },
-            { "end": "18:00", "start": "15:00" }
+            { "end": "13:00", "start": "10:00", "timezone": "Europe/Berlin" },
+            { "end": "18:00", "start": "15:00", "timezone": "Europe/Berlin" }
           ],
           "appointmentOnly": false
         },
@@ -890,8 +890,8 @@
           "allDay": false,
           "closed": false,
           "timeSlots": [
-            { "end": "13:00", "start": "10:00" },
-            { "end": "18:00", "start": "15:00" }
+            { "end": "13:00", "start": "10:00", "timezone": "Europe/Berlin" },
+            { "end": "18:00", "start": "15:00", "timezone": "Europe/Berlin" }
           ],
           "appointmentOnly": false
         },

--- a/integreat_cms/cms/fixtures/test_pois.json
+++ b/integreat_cms/cms/fixtures/test_pois.json
@@ -569,8 +569,8 @@
           "closed": false,
           "appointmentOnly": false,
           "timeSlots": [
-            { "end": "13:00", "start": "10:00" },
-            { "end": "18:00", "start": "15:00" }
+            { "end": "13:00", "start": "10:00", "timezone": "Europe/Berlin" },
+            { "end": "18:00", "start": "15:00", "timezone": "Europe/Berlin" }
           ]
         },
         {
@@ -578,8 +578,8 @@
           "closed": false,
           "appointmentOnly": false,
           "timeSlots": [
-            { "end": "13:00", "start": "10:00" },
-            { "end": "18:00", "start": "15:00" }
+            { "end": "13:00", "start": "10:00", "timezone": "Europe/Berlin" },
+            { "end": "18:00", "start": "15:00", "timezone": "Europe/Berlin" }
           ]
         },
         { "allDay": false, "closed": true, "appointmentOnly": false, "timeSlots": [] },
@@ -588,15 +588,15 @@
           "closed": false,
           "appointmentOnly": false,
           "timeSlots": [
-            { "end": "13:00", "start": "10:00" },
-            { "end": "18:00", "start": "15:00" }
+            { "end": "13:00", "start": "10:00", "timezone": "Europe/Berlin" },
+            { "end": "18:00", "start": "15:00", "timezone": "Europe/Berlin" }
           ]
         },
         {
           "allDay": false,
           "closed": false,
           "appointmentOnly": false,
-          "timeSlots": [{ "end": "14:00", "start": "10:00" }]
+          "timeSlots": [{ "end": "14:00", "start": "10:00", "timezone": "Europe/Berlin" }]
         },
         { "allDay": false, "closed": true, "appointmentOnly": false, "timeSlots": [] },
         { "allDay": false, "closed": true, "appointmentOnly": false, "timeSlots": [] }
@@ -712,8 +712,8 @@
           "closed": false,
           "appointmentOnly": false,
           "timeSlots": [
-            { "end": "13:00", "start": "10:00" },
-            { "end": "18:00", "start": "15:00" }
+            { "end": "13:00", "start": "10:00", "timezone": "Europe/Berlin" },
+            { "end": "18:00", "start": "15:00", "timezone": "Europe/Berlin" }
           ]
         },
         {
@@ -721,8 +721,8 @@
           "closed": false,
           "appointmentOnly": false,
           "timeSlots": [
-            { "end": "13:00", "start": "10:00" },
-            { "end": "18:00", "start": "15:00" }
+            { "end": "13:00", "start": "10:00", "timezone": "Europe/Berlin" },
+            { "end": "18:00", "start": "15:00", "timezone": "Europe/Berlin" }
           ]
         },
         { "allDay": false, "closed": true, "timeSlots": [] },
@@ -731,11 +731,15 @@
           "closed": false,
           "appointmentOnly": false,
           "timeSlots": [
-            { "end": "13:00", "start": "10:00" },
-            { "end": "18:00", "start": "15:00" }
+            { "end": "13:00", "start": "10:00", "timezone": "Europe/Berlin" },
+            { "end": "18:00", "start": "15:00", "timezone": "Europe/Berlin" }
           ]
         },
-        { "allDay": false, "closed": false, "timeSlots": [{ "end": "14:00", "start": "10:00" }] },
+        {
+          "allDay": false,
+          "closed": false,
+          "timeSlots": [{ "end": "14:00", "start": "10:00", "timezone": "Europe/Berlin" }]
+        },
         { "allDay": false, "closed": true, "timeSlots": [] },
         { "allDay": false, "closed": true, "timeSlots": [] }
       ]
@@ -1963,8 +1967,8 @@
           "closed": false,
           "appointmentOnly": false,
           "timeSlots": [
-            { "end": "13:00", "start": "10:00" },
-            { "end": "18:00", "start": "15:00" }
+            { "end": "13:00", "start": "10:00", "timezone": "Europe/Berlin" },
+            { "end": "18:00", "start": "15:00", "timezone": "Europe/Berlin" }
           ]
         },
         {
@@ -1972,8 +1976,8 @@
           "closed": false,
           "appointmentOnly": false,
           "timeSlots": [
-            { "end": "13:00", "start": "10:00" },
-            { "end": "18:00", "start": "15:00" }
+            { "end": "13:00", "start": "10:00", "timezone": "Europe/Berlin" },
+            { "end": "18:00", "start": "15:00", "timezone": "Europe/Berlin" }
           ]
         },
         { "allDay": false, "closed": true, "appointmentOnly": false, "timeSlots": [] },
@@ -1982,15 +1986,15 @@
           "closed": false,
           "appointmentOnly": false,
           "timeSlots": [
-            { "end": "13:00", "start": "10:00" },
-            { "end": "18:00", "start": "15:00" }
+            { "end": "13:00", "start": "10:00", "timezone": "Europe/Berlin" },
+            { "end": "18:00", "start": "15:00", "timezone": "Europe/Berlin" }
           ]
         },
         {
           "allDay": false,
           "closed": false,
           "appointmentOnly": false,
-          "timeSlots": [{ "end": "14:00", "start": "10:00" }]
+          "timeSlots": [{ "end": "14:00", "start": "10:00", "timezone": "Europe/Berlin" }]
         },
         { "allDay": false, "closed": true, "appointmentOnly": false, "timeSlots": [] },
         { "allDay": false, "closed": true, "appointmentOnly": false, "timeSlots": [] }
@@ -2121,8 +2125,8 @@
           "closed": false,
           "appointmentOnly": false,
           "timeSlots": [
-            { "end": "13:00", "start": "10:00" },
-            { "end": "18:00", "start": "15:00" }
+            { "end": "13:00", "start": "10:00", "timezone": "Europe/Berlin" },
+            { "end": "18:00", "start": "15:00", "timezone": "Europe/Berlin" }
           ]
         },
         {
@@ -2130,8 +2134,8 @@
           "closed": false,
           "appointmentOnly": false,
           "timeSlots": [
-            { "end": "13:00", "start": "10:00" },
-            { "end": "18:00", "start": "15:00" }
+            { "end": "13:00", "start": "10:00", "timezone": "Europe/Berlin" },
+            { "end": "18:00", "start": "15:00", "timezone": "Europe/Berlin" }
           ]
         },
         { "allDay": false, "closed": true, "appointmentOnly": false, "timeSlots": [] },
@@ -2140,15 +2144,15 @@
           "closed": false,
           "appointmentOnly": false,
           "timeSlots": [
-            { "end": "13:00", "start": "10:00" },
-            { "end": "18:00", "start": "15:00" }
+            { "end": "13:00", "start": "10:00", "timezone": "Europe/Berlin" },
+            { "end": "18:00", "start": "15:00", "timezone": "Europe/Berlin" }
           ]
         },
         {
           "allDay": false,
           "closed": false,
           "appointmentOnly": false,
-          "timeSlots": [{ "end": "14:00", "start": "10:00" }]
+          "timeSlots": [{ "end": "14:00", "start": "10:00", "timezone": "Europe/Berlin" }]
         },
         { "allDay": false, "closed": true, "appointmentOnly": false, "timeSlots": [] },
         { "allDay": false, "closed": true, "appointmentOnly": false, "timeSlots": [] }
@@ -2294,8 +2298,8 @@
           "closed": false,
           "appointmentOnly": false,
           "timeSlots": [
-            { "end": "13:00", "start": "10:00" },
-            { "end": "18:00", "start": "15:00" }
+            { "end": "13:00", "start": "10:00", "timezone": "Europe/Berlin" },
+            { "end": "18:00", "start": "15:00", "timezone": "Europe/Berlin" }
           ]
         },
         {
@@ -2303,8 +2307,8 @@
           "closed": false,
           "appointmentOnly": false,
           "timeSlots": [
-            { "end": "13:00", "start": "10:00" },
-            { "end": "18:00", "start": "15:00" }
+            { "end": "13:00", "start": "10:00", "timezone": "Europe/Berlin" },
+            { "end": "18:00", "start": "15:00", "timezone": "Europe/Berlin" }
           ]
         },
         { "allDay": false, "closed": true, "appointmentOnly": false, "timeSlots": [] },
@@ -2313,15 +2317,15 @@
           "closed": false,
           "appointmentOnly": false,
           "timeSlots": [
-            { "end": "13:00", "start": "10:00" },
-            { "end": "18:00", "start": "15:00" }
+            { "end": "13:00", "start": "10:00", "timezone": "Europe/Berlin" },
+            { "end": "18:00", "start": "15:00", "timezone": "Europe/Berlin" }
           ]
         },
         {
           "allDay": false,
           "closed": false,
           "appointmentOnly": false,
-          "timeSlots": [{ "end": "14:00", "start": "10:00" }]
+          "timeSlots": [{ "end": "14:00", "start": "10:00", "timezone": "Europe/Berlin" }]
         },
         { "allDay": false, "closed": true, "appointmentOnly": false, "timeSlots": [] },
         { "allDay": false, "closed": true, "appointmentOnly": false, "timeSlots": [] }
@@ -2545,31 +2549,31 @@
         {
           "allDay": false,
           "closed": false,
-          "timeSlots": [{ "end": "17:00", "start": "07:00" }],
+          "timeSlots": [{ "end": "17:00", "start": "07:00", "timezone": "Europe/Berlin" }],
           "appointmentOnly": false
         },
         {
           "allDay": false,
           "closed": false,
-          "timeSlots": [{ "end": "17:00", "start": "07:00" }],
+          "timeSlots": [{ "end": "17:00", "start": "07:00", "timezone": "Europe/Berlin" }],
           "appointmentOnly": false
         },
         {
           "allDay": false,
           "closed": false,
-          "timeSlots": [{ "end": "17:00", "start": "07:00" }],
+          "timeSlots": [{ "end": "17:00", "start": "07:00", "timezone": "Europe/Berlin" }],
           "appointmentOnly": false
         },
         {
           "allDay": false,
           "closed": false,
-          "timeSlots": [{ "end": "17:00", "start": "07:00" }],
+          "timeSlots": [{ "end": "17:00", "start": "07:00", "timezone": "Europe/Berlin" }],
           "appointmentOnly": false
         },
         {
           "allDay": false,
           "closed": false,
-          "timeSlots": [{ "end": "17:00", "start": "07:00" }],
+          "timeSlots": [{ "end": "17:00", "start": "07:00", "timezone": "Europe/Berlin" }],
           "appointmentOnly": false
         },
         { "allDay": false, "closed": true, "timeSlots": [], "appointmentOnly": false },
@@ -2601,31 +2605,31 @@
         {
           "allDay": false,
           "closed": false,
-          "timeSlots": [{ "end": "21:00", "start": "07:00" }],
+          "timeSlots": [{ "end": "21:00", "start": "07:00", "timezone": "Europe/Berlin" }],
           "appointmentOnly": false
         },
         {
           "allDay": false,
           "closed": false,
-          "timeSlots": [{ "end": "21:00", "start": "07:00" }],
+          "timeSlots": [{ "end": "21:00", "start": "07:00", "timezone": "Europe/Berlin" }],
           "appointmentOnly": false
         },
         {
           "allDay": false,
           "closed": false,
-          "timeSlots": [{ "end": "21:00", "start": "07:00" }],
+          "timeSlots": [{ "end": "21:00", "start": "07:00", "timezone": "Europe/Berlin" }],
           "appointmentOnly": false
         },
         {
           "allDay": false,
           "closed": false,
-          "timeSlots": [{ "end": "21:00", "start": "07:00" }],
+          "timeSlots": [{ "end": "21:00", "start": "07:00", "timezone": "Europe/Berlin" }],
           "appointmentOnly": false
         },
         {
           "allDay": false,
           "closed": false,
-          "timeSlots": [{ "end": "21:00", "start": "07:00" }],
+          "timeSlots": [{ "end": "21:00", "start": "07:00", "timezone": "Europe/Berlin" }],
           "appointmentOnly": false
         },
         {

--- a/tests/api/expected-outputs/augsburg_ar_locations.json
+++ b/tests/api/expected-outputs/augsburg_ar_locations.json
@@ -50,11 +50,13 @@
         "timeSlots": [
           {
             "end": "13:00",
-            "start": "10:00"
+            "start": "10:00",
+            "timezone": "Europe/Berlin"
           },
           {
             "end": "18:00",
-            "start": "15:00"
+            "start": "15:00",
+            "timezone": "Europe/Berlin"
           }
         ]
       },
@@ -65,11 +67,13 @@
         "timeSlots": [
           {
             "end": "13:00",
-            "start": "10:00"
+            "start": "10:00",
+            "timezone": "Europe/Berlin"
           },
           {
             "end": "18:00",
-            "start": "15:00"
+            "start": "15:00",
+            "timezone": "Europe/Berlin"
           }
         ]
       },
@@ -86,11 +90,13 @@
         "timeSlots": [
           {
             "end": "13:00",
-            "start": "10:00"
+            "start": "10:00",
+            "timezone": "Europe/Berlin"
           },
           {
             "end": "18:00",
-            "start": "15:00"
+            "start": "15:00",
+            "timezone": "Europe/Berlin"
           }
         ]
       },
@@ -101,7 +107,8 @@
         "timeSlots": [
           {
             "end": "14:00",
-            "start": "10:00"
+            "start": "10:00",
+            "timezone": "Europe/Berlin"
           }
         ]
       },

--- a/tests/api/expected-outputs/augsburg_de_locations.json
+++ b/tests/api/expected-outputs/augsburg_de_locations.json
@@ -50,11 +50,13 @@
         "timeSlots": [
           {
             "end": "13:00",
-            "start": "10:00"
+            "start": "10:00",
+            "timezone": "Europe/Berlin"
           },
           {
             "end": "18:00",
-            "start": "15:00"
+            "start": "15:00",
+            "timezone": "Europe/Berlin"
           }
         ]
       },
@@ -65,11 +67,13 @@
         "timeSlots": [
           {
             "end": "13:00",
-            "start": "10:00"
+            "start": "10:00",
+            "timezone": "Europe/Berlin"
           },
           {
             "end": "18:00",
-            "start": "15:00"
+            "start": "15:00",
+            "timezone": "Europe/Berlin"
           }
         ]
       },
@@ -86,11 +90,13 @@
         "timeSlots": [
           {
             "end": "13:00",
-            "start": "10:00"
+            "start": "10:00",
+            "timezone": "Europe/Berlin"
           },
           {
             "end": "18:00",
-            "start": "15:00"
+            "start": "15:00",
+            "timezone": "Europe/Berlin"
           }
         ]
       },
@@ -101,7 +107,8 @@
         "timeSlots": [
           {
             "end": "14:00",
-            "start": "10:00"
+            "start": "10:00",
+            "timezone": "Europe/Berlin"
           }
         ]
       },

--- a/tests/api/expected-outputs/augsburg_en_locations.json
+++ b/tests/api/expected-outputs/augsburg_en_locations.json
@@ -50,11 +50,13 @@
         "timeSlots": [
           {
             "end": "13:00",
-            "start": "10:00"
+            "start": "10:00",
+            "timezone": "Europe/Berlin"
           },
           {
             "end": "18:00",
-            "start": "15:00"
+            "start": "15:00",
+            "timezone": "Europe/Berlin"
           }
         ]
       },
@@ -65,11 +67,13 @@
         "timeSlots": [
           {
             "end": "13:00",
-            "start": "10:00"
+            "start": "10:00",
+            "timezone": "Europe/Berlin"
           },
           {
             "end": "18:00",
-            "start": "15:00"
+            "start": "15:00",
+            "timezone": "Europe/Berlin"
           }
         ]
       },
@@ -86,11 +90,13 @@
         "timeSlots": [
           {
             "end": "13:00",
-            "start": "10:00"
+            "start": "10:00",
+            "timezone": "Europe/Berlin"
           },
           {
             "end": "18:00",
-            "start": "15:00"
+            "start": "15:00",
+            "timezone": "Europe/Berlin"
           }
         ]
       },
@@ -101,7 +107,8 @@
         "timeSlots": [
           {
             "end": "14:00",
-            "start": "10:00"
+            "start": "10:00",
+            "timezone": "Europe/Berlin"
           }
         ]
       },


### PR DESCRIPTION
### Short description

Expose ISO-8601 offset-aware times for POI opening hours in API v3 behind an opt-in flag so legacy responses stay unchanged.

### Proposed changes
- **Add (opt-in)** `start_time` / `end_time` to each `timeSlot` as ISO-8601 strings with numeric offset (e.g., `09:00:00+02:00`), derived from the region’s timezone.  
- **Keep** legacy `start` / `end` fields as local wall time (`HH:MM` or `HH:MM:SS`) to avoid breaking existing clients.  
- **Add (opt-in)** `timezone` (IANA key, e.g., `Europe/Berlin`) to each `timeSlot` for clarity/debugging and future client logic.
- New fields are returned only when the query param  `?iso_times=1`  is provided.

Example slot:
```json
{
  "start": "09:00",
  "end": "12:30",
  "start_time": "09:00:00+02:00",
  "end_time": "12:30:00+02:00",
  "timezone": "Europe/Berlin"
}
```

### Side effects
- None expected. This change is **additive** only (no removals/renames), so current consumers using `start`/`end` continue to work unchanged.
- No database migrations. No changes to permissions or caching behavior.

### Faithfulness to issue description and design
Provides offset-aware times per slot (plus the region’s IANA timezone) so clients can implement “open now” logic across time zones/DST, while preserving backward compatibility by default.

### How to test
**Prereq:** run the CMS locally and ensure the `augsburg` region (or any region with POIs and opening hours) is available.

1. Default (legacy only — no ISO fields):
```bash
curl -sS "http://localhost:8000/api/v3/augsburg/de/locations/" \
| python -c 'import sys,json
d=json.load(sys.stdin)
for p in d:
    oh=p.get("opening_hours") or []
    slots=[s for day in oh for s in (day.get("timeSlots") or [])]
    if slots:
        print(p["title"], "—", p["path"])
        for s in slots[:4]:
            print(" ", s.get("start"), "→", s.get("end"),
                  "|", s.get("start_time"), "→", s.get("end_time"),
                  "|", s.get("timezone"))
        break'
```

2. Opt-in ISO fields:
```bash
curl -sS "http://localhost:8000/api/v3/augsburg/de/locations/?iso_times=1" \
| python -c 'import sys,json
d=json.load(sys.stdin)
for p in d:
    oh=p.get("opening_hours") or []
    slots=[s for day in oh for s in (day.get("timeSlots") or [])]
    if slots:
        print(p["title"], "—", p["path"])
        for s in slots[:4]:
            print(" ", s.get("start"), "→", s.get("end"),
                  "|", s.get("start_time"), "→", s.get("end_time"),
                  "|", s.get("timezone"))
        break'
```

**Expected:**  
When calling **without** the flag, each `timeSlot` shows only legacy wall times:
- `start` / `end` (wall time `HH:MM` or `HH:MM:SS`)

When calling **with**`?iso_times=1`, each `timeSlot` additionally includes:
- `start_time` / `end_time` (ISO-8601 with numeric offset)
- `timezone` (IANA key, e.g., `Europe/Berlin`)

**Validation:**
- The region’s configured timezone matches the `"timezone"` field in the response.
- `start_time` / `end_time` use the correct **current** UTC offset for that timezone (incl. DST).
- Legacy wall times `start` / `end` remain unchanged.



<details>
<summary><strong>Screenshots for Validation when calling with the iso Flag </strong> (click to expand)</summary>

**1. Situation**  
<img width="498" height="145" alt="1" src="https://github.com/user-attachments/assets/6a27e288-c9b6-40db-87e4-c6b4d410e02e" />
<img width="628" height="130" alt="1t" src="https://github.com/user-attachments/assets/8ddfd146-270a-45a1-baf6-7d8a265ef2c5" />

**2. Situation**  
<img width="503" height="146" alt="2" src="https://github.com/user-attachments/assets/039549e9-9488-4e2d-8f5f-4fb8f3a389a8" />
<img width="591" height="129" alt="2t" src="https://github.com/user-attachments/assets/44071f18-aae8-46c8-9f35-68a8d09f5a18" />

**3. Situation**  
<img width="495" height="152" alt="3" src="https://github.com/user-attachments/assets/6b5e86be-6292-4101-8558-646c9c7d649e" />
<img width="569" height="130" alt="3t" src="https://github.com/user-attachments/assets/04d50ad7-174b-4d21-9dbf-385d88dc9e83" />

</details>





### Resolved issues
Fixes: #3943

__________________________________________________
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)