### PR TITLE
Fix plural and singular wording

### DIFF
--- a/integreat_cms/cms/templates/statistics/statistics_viewed_pages_node.html
+++ b/integreat_cms/cms/templates/statistics/statistics_viewed_pages_node.html
@@ -14,12 +14,13 @@
             <span data-language-color="{{ language.language_color }}"
                   data-language-slug="{{ language.slug }}"
                   data-language-title="{{ language.translated_name }}"
-                  data-access-translation="{% translate "Accesses" %}"
                   class="cursor-pointer bg-[{{ language.language_color }}] h-9">
             </span>
         {% endfor %}
     </td>
     <td class="total-accesses font-bold ml-4"
-        data-translation="{% translate "Accesses in total" %}">
+        data-translation-plural="{% translate "Accesses in total" %}"
+        data-translation-singular="{% translate "Access in total" %}"
+        data-translation-no-accesses="{% translate "No Accesses" %}">
     </td>
 </tr>

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -9018,7 +9018,6 @@ msgstr "Angezeigte Sprachen"
 
 #: cms/templates/statistics/_statistics_legend.html
 #: cms/templates/statistics/statistics_viewed_pages.html
-#: cms/templates/statistics/statistics_viewed_pages_node.html
 msgid "Accesses"
 msgstr "Zugriffe"
 
@@ -9078,6 +9077,14 @@ msgstr "Diese Seite hat keine Zugriffe für den ausgewählten Zeitraum"
 #: cms/templates/statistics/statistics_viewed_pages_node.html
 msgid "Accesses in total"
 msgstr "Zugriffe insgesamt"
+
+#: cms/templates/statistics/statistics_viewed_pages_node.html
+msgid "Access in total"
+msgstr "Zugriff insgesamt"
+
+#: cms/templates/statistics/statistics_viewed_pages_node.html
+msgid "No Accesses"
+msgstr "Keine Zugriffe"
 
 #: cms/templates/translations/translations_management.html
 msgid "Manage machine translations"

--- a/integreat_cms/static/src/js/analytics/statistics-page-accesses.ts
+++ b/integreat_cms/static/src/js/analytics/statistics-page-accesses.ts
@@ -45,7 +45,7 @@ const setAccessBarPerLanguage = (
     const width = allAccesses !== 0 ? (accesses / allAccesses) * 100 : 0;
     childElement.style.backgroundColor = languageColor;
     childElement.style.width = `${String(width)}%`;
-    childElement.title = `${languageTitle}: ${accesses} ${childElement.getAttribute("data-access-translation")} (${roundedPercentage} %)`;
+    childElement.title = `${languageTitle}: ${accesses} (${roundedPercentage} %)`;
 };
 
 const resetTotalAccessesField = (accessFields: HTMLCollectionOf<Element>, isEmpty: boolean) => {
@@ -55,7 +55,7 @@ const resetTotalAccessesField = (accessFields: HTMLCollectionOf<Element>, isEmpt
                 (el) => el !== accessField && el.classList.contains("total-accesses")
             );
             const editableAllAccessField = allAccessesField;
-            editableAllAccessField.textContent = `0 ${editableAllAccessField.getAttribute("data-translation")}`;
+            editableAllAccessField.textContent = `${editableAllAccessField.getAttribute("data-translation-no-accesses")}`;
         });
     }
 };
@@ -137,7 +137,13 @@ const updateDOM = (data: AjaxResponse, visibleDatasetSlugs: string[]) => {
                 allAccesses += countAccesses(accesses[languageSlug]);
             }
         });
-        allAccessesField.textContent = `${String(allAccesses)} ${allAccessesField.getAttribute("data-translation")}`;
+        if (allAccesses === 0) {
+            allAccessesField.textContent = `${allAccessesField.getAttribute("data-translation-no-accesses")}`;
+        } else if (allAccesses === 1) {
+            allAccessesField.textContent = `${String(allAccesses)} ${allAccessesField.getAttribute("data-translation-singular")}`;
+        } else {
+            allAccessesField.textContent = `${String(allAccesses)} ${allAccessesField.getAttribute("data-translation-plural")}`;
+        }
         Object.entries(accesses).forEach((access) => {
             const languageSlug = access[0];
             const accessesOverTime: AccessesPerTime = visibleDatasetSlugs.includes(languageSlug) ? access[1] : {};


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the singular and plural wording fot page access statistics and tweeks the tooltip/title for page access details

### Proposed changes
<!-- Describe this PR in more detail. -->

- Pages without any Accesses show "No accesses" / "Keine Zugriffe"
- If there is just one access the text is singular: "1 Access in total"
- When hovering over information, format is "Language: Amount (Percentage%)" similar to hover of 'Total Accesses' graph


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
Originally it was intended to include #3964 but it turned out to be a lot more complicated to implement then originally thought. It was decided to implement this later.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this (e.g. specific environment variables and settings to be set, --> 
<!-- and things to pay attention to) -->
To test this you need statistics activated. 
- Go to the region settings of e.g. Augsburg on the test system and copy the matomo auth token
- Run the cms locally and go to the region settings of Augsburg
- Check the statistics Checkbox and paste the matomo auth token
- Run the fetch page accesses management command: `integreat-cms-cli fetch_page_accesses --start-date START_DATE --end-date END_DATE --region-slug augsburg` (start and end date can be the same, good pick would be yesterday)
- Wait for about 30 to 40 sec
- Go to the statistics page for Augsburg
- See fixed wording/format

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3861 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
