### PR TITLE
feat: change message status about unchanged translation

### DIFF
--- a/integreat_cms/cms/views/pages/page_bulk_actions.py
+++ b/integreat_cms/cms/views/pages/page_bulk_actions.py
@@ -255,7 +255,7 @@ class CancelTranslationProcess(PageBulkActionMixin, BulkActionView):
                     cancel_failed.append(content_object.best_translation.title)
 
         if not_in_translation:
-            messages.success(
+            messages.info(
                 request,
                 ngettext_lazy(
                     "{model_name} {object_names} was not in translation process.",

--- a/tests/cms/utils/test_cancel_translation.py
+++ b/tests/cms/utils/test_cancel_translation.py
@@ -62,7 +62,7 @@ def test_bulk_cancel_translation_process(
             in response.content.decode("utf-8")
         )
         assert_message_in_log(
-            'SUCCESS  The following pages were not in translation process: "Welcome" and "Willkommen in Augsburg"',
+            'INFO     The following pages were not in translation process: "Welcome" and "Willkommen in Augsburg"',
             caplog,
         )
         assert (


### PR DESCRIPTION
### Short description

Message about unchanged translations changes to type `info` (displayed in blue).

### Faithfulness to issue description and design

There are no intended deviations from the issue and design.


### How to test

1. Go to the page tree of any region in the default language (likely _German_)

2. Select a few pages

3. Mark them as _Currently in translation_ by scrolling to the _Select bulk action_ dropdown below the page tree
   
   * Choose _Export selected pages for multilingual translation (XLIFF-1.2)_
   * Click _Execute_
   * In the resulting popup, check a target language (e.g. _English_)
   * Click _Execute_
   * Shortly, a `.zip` file will be downloaded. We can abort the download or delete it

4. At the top of the page tree, switch to the target language selected before (e.g. _English_)

5. Select a few pages just marked _Currently in translation_ as well as a few that are not _Currently in translation_ for the current target language

6. Reset the _Currently in translation_ status by scrolling to the _Select bulk action_ dropdown below the page tree
   
   * Choose _Cancel translation process_
   * Click _Execute_

7. See the messages displayed at the very top

### Resolved issues

Fixes: #3029

__________________________________________________

[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
