### PR TITLE
Log Celery into service journal

### DIFF
--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -701,7 +701,11 @@ LOGGING: dict[str, Any] = {
     },
     "handlers": {
         "console": {
+            "class": "logging.StreamHandler",
+            "formatter": "console",
             "filters": ["require_debug_true"],
+        },
+        "console-service": {
             "class": "logging.StreamHandler",
             "formatter": "console",
         },
@@ -776,8 +780,8 @@ LOGGING: dict[str, Any] = {
             "level": DEPS_LOG_LEVEL,
         },
         "celery": {
-            "handlers": ["console", "logfile"],
-            "level": DEPS_LOG_LEVEL,
+            "handlers": ["console-service", "logfile"],
+            "level": "INFO" if DEPS_LOG_LEVEL == "DEBUG" else DEPS_LOG_LEVEL,
         },
         "deepl": {
             "handlers": ["console", "logfile"],


### PR DESCRIPTION
### Short description
Log celery message into systemd journal.



### Proposed changes
- Log Celery messages to console to be captured by systemd journal.

### Side effects
- None


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### How to test
```
journalctl -xef -u integreat-celery.service
```

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3991


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
