### PR TITLE
Count accesses in the backend

### DIFF
--- a/integreat_cms/static/src/js/analytics/statistics-charts.ts
+++ b/integreat_cms/static/src/js/analytics/statistics-charts.ts
@@ -10,7 +10,7 @@ import {
     Tooltip,
     LegendItem,
 } from "chart.js";
-import { setPageAccessesEventListeners, updatePageAccesses } from "./statistics-page-accesses";
+import { updatePageAccesses } from "./statistics-page-accesses";
 
 export type AjaxResponse = {
     exportLabels: Array<string>;
@@ -298,9 +298,6 @@ window.addEventListener("load", async () => {
 
     // Set event handlers for language legend
     setLegendEventlisteners();
-
-    // Set event handlers for page based statistics
-    setPageAccessesEventListeners();
 
     // Initialize export button
     toggleExportButton();

--- a/integreat_cms/static/src/js/analytics/statistics-page-accesses.ts
+++ b/integreat_cms/static/src/js/analytics/statistics-page-accesses.ts
@@ -1,11 +1,7 @@
 import { Chart } from "chart.js";
 
-type AccessesPerTime = {
-    [date: string]: number;
-};
-
 type AccessesPerLanguage = {
-    [lang: string]: AccessesPerTime;
+    [lang: string]: number;
 };
 
 type AjaxResponse = {
@@ -18,19 +14,10 @@ let statisticsForm: HTMLFormElement;
 let pageAccessesURL: string;
 let pageAccessesForm: HTMLFormElement;
 
-/* Loop over the object containing the accesses over time and count them to a total */
-const countAccesses = (accessesOverTime: object): number => {
-    let accesses: number = 0;
-    Object.values(accessesOverTime).forEach((entry) => {
-        accesses += entry;
-    });
-    return accesses;
-};
-
 const setAccessBarPerLanguage = (
     accessField: Element,
     languageSlug: string,
-    accessesOverTime: AccessesPerTime,
+    accessesOverTime: number,
     allAccesses: number
 ) => {
     const parentElement = accessField as HTMLElement;
@@ -39,12 +26,11 @@ const setAccessBarPerLanguage = (
     ) as HTMLElement;
     const languageColor = childElement.getAttribute("data-language-color");
     const languageTitle = childElement.getAttribute("data-language-title");
-    const accesses = countAccesses(accessesOverTime);
-    const roundedPercentage = ((accesses / allAccesses) * 100).toFixed(2);
-    const width = allAccesses !== 0 ? (accesses / allAccesses) * 100 : 0;
+    const roundedPercentage = ((accessesOverTime / allAccesses) * 100).toFixed(2);
+    const width = allAccesses !== 0 ? (accessesOverTime / allAccesses) * 100 : 0;
     childElement.style.backgroundColor = languageColor;
     childElement.style.width = `${String(width)}%`;
-    childElement.title = `${languageTitle}: ${accesses} (${roundedPercentage} %)`;
+    childElement.title = `${languageTitle}: ${accessesOverTime} (${roundedPercentage} %)`;
 };
 
 const resetTotalAccessesField = (accessFields: HTMLCollectionOf<Element>, isEmpty: boolean) => {
@@ -133,7 +119,7 @@ const updateDOM = (data: AjaxResponse, visibleDatasetSlugs: string[]) => {
         let allAccesses: number = 0;
         visibleDatasetSlugs.forEach((languageSlug) => {
             if (accesses[languageSlug]) {
-                allAccesses += countAccesses(accesses[languageSlug]);
+                allAccesses += accesses[languageSlug];
             }
         });
         if (allAccesses === 0) {
@@ -143,9 +129,9 @@ const updateDOM = (data: AjaxResponse, visibleDatasetSlugs: string[]) => {
         } else {
             allAccessesField.textContent = `${String(allAccesses)} ${allAccessesField.getAttribute("data-translation-plural")}`;
         }
-        Object.entries(accesses).forEach((access) => {
-            const languageSlug = access[0];
-            const accessesOverTime: AccessesPerTime = visibleDatasetSlugs.includes(languageSlug) ? access[1] : {};
+        Object.entries(accesses).forEach((accessesForLanguage) => {
+            const languageSlug = accessesForLanguage[0];
+            const accessesOverTime = visibleDatasetSlugs.includes(languageSlug) ? accessesForLanguage[1] : 0;
             setAccessBarPerLanguage(accessField, languageSlug, accessesOverTime, allAccesses);
         });
     });

--- a/integreat_cms/static/src/js/pages/fetch-subpages.ts
+++ b/integreat_cms/static/src/js/pages/fetch-subpages.ts
@@ -10,6 +10,7 @@ import { addDragAndDropListeners } from "../tree-drag-and-drop";
 import { addConfirmationDialogListeners } from "../confirmation-popups";
 import { addPreviewWindowListeners, openPreviewWindowInPageTree } from "./page-preview";
 import { restorePageTreeLayout } from "./persistent_page_tree";
+import { setPageAccessesEventListeners } from "../analytics/statistics-page-accesses";
 
 /**
  * Function to insert children of selected page into DOM at right position
@@ -92,6 +93,7 @@ window.addEventListener("load", async () => {
 
         console.debug("Finished loading all subpages");
         // Set event handlers
+        setPageAccessesEventListeners();
         setToggleSubpagesEventListeners();
         setBulkActionEventListeners();
         addDragAndDropListeners();


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR moves the `countAccesses` method into the backend as part of the query for page accesses. This allows to reduce the complexity of `get_page_accesses_ajax` and thus hugely decrease loading times for page access statistics.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Change PageAccesses query to count accesses per page and language
- Adapt code to handle the changed format of the returned dict ({page_id: language_slug: total_accesses})
- Move the `setPageAccessesEventListeners` call to `fetch-subpages.ts` since page accesses are now loading faster then the subpages in the page tree


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Hopefully none


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this (e.g. specific environment variables and settings to be set, --> 
<!-- and things to pay attention to) -->
I'm not sure if the effect is that noticeable with test data. Maybe this is best tested with a data dump. Then the effect is very obvious.
To test this without loading a data dump you need statistics to be activated. 
- Go to the region settings of e.g. Augsburg on the test system and copy the matomo auth token
- Run the cms locally and go to the region settings of Augsburg
- Check the statistics Checkbox and paste the matomo auth token
- Run the fetch page accesses management command: `integreat-cms-cli fetch_page_accesses --start-date START_DATE --end-date END_DATE --region-slug augsburg` (start and end date can be the same, good pick would be yesterday)
- Wait for about 30 to 40 sec
- Go to the statistics page for Augsburg
- See fast loading

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3995 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
