### PR TITLE
Use different queues for Celery tasks, fix #4004

### DIFF
--- a/example-configs/integreat-celery.service
+++ b/example-configs/integreat-celery.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Celery worker for the Integreat CMS
+After=syslog.target network.target
+
+[Service]
+Type=simple
+User=www-data
+WorkingDirectory=/opt/integreat-cms
+ExecStart=/opt/integreat-cms/.venv/bin/celery -A integreat_cms.integreat_celery worker -l INFO -B --concurrency=10 -Q default,chat,statistics
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/integreat_cms/integreat_celery/celery.py
+++ b/integreat_cms/integreat_celery/celery.py
@@ -56,6 +56,10 @@ def config_loggers(*args: Any, **kwags: Any) -> None:
 
 
 app.autodiscover_tasks()
+app.conf.task_routes = {
+    "integreat_cms.cms.views.statistics.statistics_actions": {"queue": "statistics"},
+    "integreat_cms.api.v3.chat.utils.chat_bot.*": {"queue": "chat"},
+}
 
 
 @app.task

--- a/tools/run.sh
+++ b/tools/run.sh
@@ -48,7 +48,7 @@ listen_for_devserver &
 
 # Run Celery worker process
 if [ "$INTEGREAT_CMS_REDIS_CACHE" == "1" ]; then
-  deescalate_privileges celery -A integreat_cms.integreat_celery worker -l INFO -B --concurrency=4 &
+  deescalate_privileges celery -A integreat_cms.integreat_celery worker -l INFO -B --concurrency=4 -Q default,chat,statistics &
 fi
 
 # Start Integreat CMS development webserver


### PR DESCRIPTION
### Short description

Split task queue. Use dedicated queues for the chat and statistics tasks.

Fixes: #4004


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
