### PR TITLE
Log sources for Chat RAG responses

### DIFF
--- a/integreat_cms/api/v3/chat/utils/chat_bot.py
+++ b/integreat_cms/api/v3/chat/utils/chat_bot.py
@@ -150,6 +150,18 @@ def celery_translate_and_answer_question(
                 words_generated=answer["length_generated_answer"],
             )
             zammad_chat.save_automatic_answers(answer["automatic_answers"])
+            zammad_chat.save_message(
+                message="Used Sources\n<ul>"
+                + "\n".join(
+                    [
+                        f"<li><a href='{source['source']}'>{source['source'].split('/')[-2]}</a>: {source['reason_inclusion']}</li>"
+                        for source in answer["details"]
+                    ]
+                )
+                + "</ul>",
+                internal=True,
+                automatic_message=True,
+            )
 
 
 async def async_process_translate(


### PR DESCRIPTION
### Short description

To help editors understand why certain pages are used for generating RAG responses, we want to post a sources list as an internal note to Zammad.


### Proposed changes
- Use the reason_inclusion statement from the `extract_answer` endpoint
- Format reasons as list
- save as internal Zammad note


### Side effects
 - Longer Zammad tickets. In the future, we can make this optional by setting an additional Zammad flag. Right now it seems it is better to have this always on.


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this (e.g. specific environment variables and settings to be set, --> 
<!-- and things to pay attention to) -->


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: https://github.com/digitalfabrik/integreat-chat/issues/336

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
