### PR TITLE
Disable online event link field for archived events

### DIFF
--- a/integreat_cms/cms/forms/events/event_form.py
+++ b/integreat_cms/cms/forms/events/event_form.py
@@ -128,6 +128,8 @@ class EventForm(CustomModelForm):
             self.fields["external_event_id"].initial = self.instance.external_event_id
             if self.instance.start_local.date() != self.instance.end_local.date():
                 self.fields["is_long_term"].initial = True
+            if self.instance.archived:
+                self.fields["meeting_url"].widget.attrs["readonly"] = True
 
     def clean(self) -> dict[str, Any]:
         """

--- a/integreat_cms/release_notes/current/unreleased/3064.yml
+++ b/integreat_cms/release_notes/current/unreleased/3064.yml
@@ -1,0 +1,2 @@
+en: Disable the online event link field when viewing archived events
+de: Deaktiviere das Feld für den Online-Veranstaltungslink beim Ansehen archivierter Veranstaltungen


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR disables the input field for online event link if the event is archived

### Proposed changes
<!-- Describe this PR in more detail. -->
- Show the URL simply, instead of rendering an input field
(In case there is no URL, nothing will be shown. This might look a bit odd but it's the same behavior with the icon box. Improvement for this aspect would be a separate issue, if we would).
<img width="424" height="348" alt="image" src="https://github.com/user-attachments/assets/f8614c55-775d-4d4c-9a77-4c68028777de" />



### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- None?


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this (e.g. specific environment variables and settings to be set, --> 
<!-- and things to pay attention to) -->


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3064 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
