### PR TITLE
Deactivate visibility checkbox for inactive languages

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/3864.yml
+++ b/integreat_cms/release_notes/current/unreleased/3864.yml
@@ -1,0 +1,2 @@
+en: Deactivate visibility checkbox for inactive languages
+de: Deaktiviere die Sichtbarkeit-Checkbox für inaktive Sprachen

--- a/integreat_cms/static/src/js/languages/language-tree-node-form.ts
+++ b/integreat_cms/static/src/js/languages/language-tree-node-form.ts
@@ -1,20 +1,24 @@
 window.addEventListener("load", () => {
-    const activeButton = document.getElementById("id_active");
-    if (activeButton) {
-        activeButton.addEventListener("change", (event) => {
-            const activeCheckbox = event.target as HTMLInputElement;
-            const visibleCheckbox = document.getElementById("id_visible") as HTMLInputElement;
-            const warningDiv = document.getElementById("visible-warning") as HTMLDivElement;
-            if (!activeCheckbox.checked) {
-                if (visibleCheckbox.checked) {
-                    warningDiv.classList.toggle("hidden", false);
-                }
-                visibleCheckbox.disabled = true;
-                visibleCheckbox.checked = false;
-            } else {
-                visibleCheckbox.disabled = false;
-                warningDiv.classList.toggle("hidden", true);
-            }
+    const warningDiv = document.getElementById("visible-warning") as HTMLDivElement;
+    const activeCheckbox = document.getElementById("id_active") as HTMLInputElement;
+    const visibleCheckbox = document.getElementById("id_visible") as HTMLInputElement;
+
+    const toggleCheckbox = (languageIsActive: boolean) => {
+        if (languageIsActive) {
+            visibleCheckbox.disabled = false;
+            warningDiv.classList.toggle("hidden", true);
+        } else {
+            warningDiv.classList.toggle("hidden", false);
+            visibleCheckbox.disabled = true;
+            visibleCheckbox.checked = false;
+        }
+    };
+
+    if (warningDiv && activeCheckbox && visibleCheckbox) {
+        toggleCheckbox(activeCheckbox.checked);
+
+        activeCheckbox.addEventListener("change", () => {
+            toggleCheckbox(activeCheckbox.checked);
         });
     }
 });


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the bug that the visibility checkbox is not deactivated when an inactive language node is opened.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Deactivate it when opening an inactive language
- A bit of code refactoring


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- Less confused users


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explain why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this (e.g. specific environment variables and settings to be set, --> 
<!-- and things to pay attention to) -->


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3864 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
