### PR TITLE
Fix "do-not-translate" and link are mutally exclusive

### DIFF
--- a/integreat_cms/cms/migrations/0149_alter_contact_opening_hours.py
+++ b/integreat_cms/cms/migrations/0149_alter_contact_opening_hours.py
@@ -5,7 +5,7 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("cms", "0145_userchat_created_timestamp_and_more"),
+        ("cms", "0148_region_machine_translate_pushnotifications"),
     ]
 
     operations = [

--- a/integreat_cms/release_notes/current/unreleased/4017.yml
+++ b/integreat_cms/release_notes/current/unreleased/4017.yml
@@ -1,0 +1,2 @@
+en: Fix the bug that "do-not-translate" and a link are mutally exclusive
+de: Behebe den Fehler, dass "do-not-translate" und eine Verlinkung sich gegenseitig ausschließen

--- a/integreat_cms/static/src/js/forms/tinymce-init.ts
+++ b/integreat_cms/static/src/js/forms/tinymce-init.ts
@@ -54,9 +54,18 @@ const toggleNoTranslate = (editor: Editor) => {
         tinymce.activeEditor.dom.removeClass(tinymce.activeEditor.selection.getNode(), "notranslate");
         tinymce.activeEditor.dom.setAttrib(tinymce.activeEditor.selection.getNode(), "dir", null);
     } else if (editor.selection.getContent().length > 0) {
-        editor.insertContent(
-            `<span class="notranslate" translate="no" dir="ltr">${editor.selection.getContent()}</span>`
+        const selectedText = editor.selection.getContent({ format: "html" });
+        const span = editor.dom.create(
+            "span",
+            {
+                class: "notranslate",
+                translate: "no",
+                dir: "ltr",
+            },
+            selectedText
         );
+
+        editor.selection.setNode(span);
     }
 };
 

--- a/integreat_cms/static/src/js/tinymce-plugins/custom_link_input/plugin.js
+++ b/integreat_cms/static/src/js/tinymce-plugins/custom_link_input/plugin.js
@@ -280,9 +280,23 @@ import { getCsrfToken } from "../../utils/csrf-token";
                     // Either insert a new link or update the existing one
                     const anchor = getAnchor();
                     if (!anchor) {
-                        editor.insertContent(
-                            `<a href=${realUrl}${autoupdate ? ' data-integreat-auto-update="true"' : ""}>${text}</a>`
+                        const selectedNode = editor.selection.getNode();
+                        const selectedNodeText = selectedNode.textContent;
+
+                        let selectedHTML = editor.selection.getContent({ format: "html" });
+                        if (selectedHTML.length === 0) {
+                            selectedHTML = text;
+                        }
+
+                        const link = editor.dom.create(
+                            "a",
+                            {
+                                href: `${realUrl}${autoupdate ? ' data-integreat-auto-update="true"' : ""}`,
+                            },
+                            selectedNodeText === text ? selectedNode : selectedHTML
                         );
+
+                        editor.selection.setNode(link);
                     } else {
                         updateLink(editor, anchor, text, {
                             "href": realUrl,


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the bug that `<a href>` and "do-not-translate" marking are removing the other tag each other.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Manually set the attributes for "do-not-translate" instead of inserting


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- Less irritated users


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4017 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
