### PR TITLE
Limit length of log entries

### DIFF
--- a/integreat_cms/core/logging_formatter.py
+++ b/integreat_cms/core/logging_formatter.py
@@ -71,4 +71,7 @@ class RequestFormatter(logging.Formatter):
                 else:
                     # If the string consists of one single line, just append it to the end
                     message += f"?{query}"
+        if len(message) > 4096:
+            hint_truncated = f"  [truncated from {len(message)} characters]"
+            return message[: 4096 - len(hint_truncated)] + hint_truncated
         return message

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -687,6 +687,7 @@ LOGGING: dict[str, Any] = {
             "style": "{",
         },
         "syslog": {
+            "()": RequestFormatter,
             "format": "INTEGREAT CMS - {levelname}: {message}",
             "style": "{",
         },


### PR DESCRIPTION
### Short description
We sometimes have log entries with multiple megabytes of base64 encoded images. This breaks reading logs.


### Proposed changes
Limit log messages to 4096 characters.


### Side effects
- may cut messages.


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->


### Resolved issues



__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
