### PR TITLE
Change chatbot typing indicator

### DIFF
--- a/integreat_cms/api/v3/chat/user_chat.py
+++ b/integreat_cms/api/v3/chat/user_chat.py
@@ -102,6 +102,7 @@ def process_chat_payload(
         )
         user_chat.language = language
         user_chat.save()
+        user_chat.processing_answer = True  # type: ignore[assignment]
         if response is not None:
             if user_chat.automatic_answers:
                 celery_translate_and_answer_question.apply_async(

--- a/integreat_cms/api/v3/chat/utils/chat_bot.py
+++ b/integreat_cms/api/v3/chat/utils/chat_bot.py
@@ -130,7 +130,7 @@ def celery_translate_and_answer_question(
             "Could not find the given chat: %s %s", zammad_ticket_id, region
         )
         return
-    zammad_chat.processing_answer = True
+    zammad_chat.processing_answer = True  # type: ignore[assignment]
     messages = zammad_chat.get_messages(before=message_timestamp, only_user=True)
     translation, answer = asyncio.run(
         async_process_user_message(
@@ -145,7 +145,6 @@ def celery_translate_and_answer_question(
         zammad_chat.save_message(
             message=translation["translation"], internal=True, automatic_message=True
         )
-    zammad_chat.processing_answer = False
     if answer:
         if answer["status"] == "error":
             logger.error("Integreat Chat: %s", answer["message"])
@@ -169,6 +168,7 @@ def celery_translate_and_answer_question(
                 internal=True,
                 automatic_message=True,
             )
+    zammad_chat.processing_answer = False
 
 
 async def async_process_translate(

--- a/integreat_cms/cms/utils/zammad.py
+++ b/integreat_cms/cms/utils/zammad.py
@@ -321,4 +321,4 @@ class ZammadAPI:
         Set the processing indicator in the cache. This value is stored
         in the cache and does not require the object to be saved.
         """
-        cache.set(f"generating_answer_{self.device_id}", processing, 120)
+        cache.set(f"generating_answer_{self.device_id}", processing, 60)

--- a/tests/api/test_api_chat.py
+++ b/tests/api/test_api_chat.py
@@ -152,6 +152,7 @@ def test_api_chat_first_chat(
     save_message.assert_called_once()
     assert response.status_code == 200
     assert UserChat.objects.current_chat("never_seen_before").zammad_id == 111
+    assert UserChat.objects.current_chat("never_seen_before").processing_answer
 
 
 @pytest.mark.django_db
@@ -258,10 +259,12 @@ def test_api_chat_send_message(
     response = client.post(url, data={"message": "test message"})
 
     assert response.status_code == 200
+    assert response.json()["chatbot_typing"]
     assert (
         UserChat.objects.current_chat(default_kwargs["device_id"]).zammad_id
         == previous_chat
     )
+    assert UserChat.objects.current_chat(default_kwargs["device_id"]).processing_answer
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
* Reduce typing indicator timeout to 60s as answers usually arrive after 20s
* Set processing to true as soon as POST arrives
* Set processing to false _after_ the answer has been saved to Zammad
* Test that processing_answer/chatbot_typing is set

Detailed discussion: https://chat.tuerantuer.org/digitalfabrik/pl/dmeogtj7w3nc7jwjum3bgej79c

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
