### PR TITLE
Handle chat back end exceptions

### DIFF
--- a/integreat_cms/api/v3/chat/utils/chat_bot.py
+++ b/integreat_cms/api/v3/chat/utils/chat_bot.py
@@ -132,14 +132,25 @@ def celery_translate_and_answer_question(
         return
     zammad_chat.processing_answer = True  # type: ignore[assignment]
     messages = zammad_chat.get_messages(before=message_timestamp, only_user=True)
-    translation, answer = asyncio.run(
-        async_process_user_message(
-            zammad_chat.language.slug,
-            region_slug,
-            region.default_language.slug,
-            messages,
-        ),
-    )
+    try:
+        translation, answer = asyncio.run(
+            async_process_user_message(
+                zammad_chat.language.slug,
+                region_slug,
+                region.default_language.slug,
+                messages,
+            ),
+        )
+    except (
+        aiohttp.client_exceptions.ContentTypeError,
+        aiohttp.client_exceptions.ServerDisconnectedError,
+        aiohttp.client_exceptions.ClientConnectionError,
+    ):
+        logger.exception(
+            "Failed to get response from chat back end due to connection error."
+        )
+        zammad_chat.processing_answer = False
+        return
     zammad_chat.refresh_from_db()
     if translation and translation["translation"] != messages[-1]["content"]:
         zammad_chat.save_message(


### PR DESCRIPTION
### Short description
In some cases the chat back runs into unexpected errors which usually only imply that no answer could be generated for the user. This PR catches the most important ones, logs them, and turns the typing indicator off, so that the user does not expect messages that will never come.

### Proposed changes
- Catch some more often occurring aiohttp errors and turn off typing indicator.

### Side effects
- None.


### Faithfulness to issue description and design
This improves the UX as asked for in https://github.com/digitalfabrik/integreat-chat/issues/362


### How to test
Turn off chat back end and send message. The typing indicator should turn off before the 60s cache expires.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes:  https://github.com/digitalfabrik/integreat-chat/issues/362


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
