### PR TITLE
Transfer poi name to primary contact only if contact name is not given

### DIFF
--- a/integreat_cms/cms/views/pois/poi_form_view.py
+++ b/integreat_cms/cms/views/pois/poi_form_view.py
@@ -251,7 +251,8 @@ class POIFormView(
                 contact.website = website
                 contact.phone_number = phone_number
                 contact.email = email
-                contact.name = poi.default_translation.title
+                if not contact.name and language == region.default_language:
+                    contact.name = poi_translation_form.instance.title
                 contact.save()
             elif contact is not None:
                 contact.delete()

--- a/integreat_cms/release_notes/current/unreleased/4016.yml
+++ b/integreat_cms/release_notes/current/unreleased/4016.yml
@@ -1,0 +1,2 @@
+en: Transfer name of POI to primary contact only if no contact name is given
+de: Übertrage den Namen des POIs nur dann an den Primärkontakt, wenn kein Kontaktname angegeben ist.


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR limits automatic transfer of POI name to its primary contact only for cases when there is no name given for the primary contact.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Check if any name is given for the primary contact


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Happy users keeping contact names they want


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


`contact.name = poi.default_translation.title` is changed to `contact.name = poi_translation_form.instance.title`, as it was obsered that the name of the second latest translation was transfered, not the latest translation which is freshly created. It is probably a cache problem, or due to [this problem](https://chat.tuerantuer.org/digitalfabrik/pl/t8p4mtmmqbny7f5yof31c5f74c). Anyway I stoped going deeply into it, we can use also `poi_translation_form.instance.title`.

### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
Update a POI, check name transfer works as expected for the primary contact of the POI (no transfer is the primary contact already has a name, transfer occurs when no name is given for the contact)

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4016 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
