### PR TITLE
Fix expected Chat Zammad return code

### DIFF
--- a/integreat_cms/cms/utils/zammad.py
+++ b/integreat_cms/cms/utils/zammad.py
@@ -216,7 +216,7 @@ class ZammadAPI:
             )
         except ValueError:
             return None
-        if response.status_code < 200 or response.status_code > 299:
+        if response.ok:
             return None
         return response.json()
 


### PR DESCRIPTION
### Short description
Zammad returns a status code 201 when saving new articles. We should allow all 2xx status codes.


### Proposed changes
- Accept all 2xx status codes.


### Side effects
- There might be some unexpected edge cases with other 2xx status codes than 201.


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: chat answer generation does not start


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
