### PR TITLE
Increase Celery log level

### DIFF
--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -794,7 +794,7 @@ LOGGING: dict[str, Any] = {
         },
         "celery": {
             "handlers": ["console-service", "logfile"],
-            "level": "INFO" if DEPS_LOG_LEVEL == "DEBUG" else DEPS_LOG_LEVEL,
+            "level": "INFO" if DEPS_LOG_LEVEL == "WARN" else DEPS_LOG_LEVEL,
         },
         "deepl": {
             "handlers": ["console", "logfile"],


### PR DESCRIPTION
### Short description
We want to increase (not decrease) the Celery log level. Celery logs the starting and ending of tasks in the INFO level. We want to have those messages in our journal to know if jobs are being executed.


### Proposed changes
- Set the Celery log level to INFO while all other dependency log levels are WARN.


### Side effects 


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
