### PR TITLE
Fix time period update

### DIFF
--- a/integreat_cms/static/src/js/analytics/statistics-page-accesses.ts
+++ b/integreat_cms/static/src/js/analytics/statistics-page-accesses.ts
@@ -141,6 +141,7 @@ const updateDOM = (data: AjaxResponse, visibleDatasetSlugs: string[]) => {
 export const updatePageAccesses = async (): Promise<void> => {
     const pageAccessesLoading = document.getElementById("page-accesses-loading");
     pageAccessesLoading.classList.remove("hidden");
+    setDates();
 
     const data = await getData();
 
@@ -160,7 +161,6 @@ export const updatePageAccesses = async (): Promise<void> => {
         updateDOM(data, visibleDatasetSlugs);
     }
     pageAccessesLoading.classList.add("hidden");
-    setDates();
 };
 
 export const setPageAccessesEventListeners = () => {


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes that the time period of the page accesses table is updated after the page accesses are loaded or isn't updated at all sometimes. This seems only to be happening when large time periods are loaded, since this is buggy at the moment.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Move update of time period to before data is getting loaded


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
Not really testable locally, only with a database dump but that seems overkill for a oneline change.
For Julian:
- Go to statistics
- Select large time period
- See that the timeframe got updated, despite running into the loading bug (#4040 #4025)

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4041


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
