### PR TITLE
Fix redirect after push notification send/schedule fail

### DIFF
--- a/integreat_cms/core/docker_settings.py
+++ b/integreat_cms/core/docker_settings.py
@@ -24,3 +24,4 @@ DATABASES = {
         "PORT": "5433",
     },
 }
+FCM_ENABLED = True


### PR DESCRIPTION
### Short description
This fixes the redirect after sending or scheduling a push notification failed (after it had succesfully been created)


### Proposed changes
<!-- Describe this PR in more detail. -->

- If the scheduling or sending fails we now redirect to the edit version of the form, so that the fields of the new instance (that failed to send or schedule) are available inside the template


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
Make sure that the form for 
     - creating a new push notification still works 
     - the form for an existing pn still works
     - the redirect and form still works if pn was scheduled or sent
     - the redirect and from works now if pn was created but not sent (follow the steps to reproduce from the original issue)
     


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3926


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
