### PR TITLE
Fix uncaught type error when loading bigger timeframes

### DIFF
--- a/integreat_cms/cms/models/regions/region.py
+++ b/integreat_cms/cms/models/regions/region.py
@@ -1066,14 +1066,14 @@ class Region(AbstractBaseModel):
         pages: list[Page],
         start_date: date,
         end_date: date,
-        languages: list[Language],
+        language_slugs: list[str],
     ) -> dict:
         """
         Get the sum of page accesses per page and language of this region during the specified time range
         :param pages: List of requested pages
         :param start_date: Earliest date
         :param end_date: Latest date
-        :param languages: List of requested languages
+        :param language_slugs: List of slugs for the requested languages
 
         :return: Sum of page accesses per page and language
         """
@@ -1082,7 +1082,7 @@ class Region(AbstractBaseModel):
                 page__region=self,
                 page__in=pages,
                 access_date__range=(start_date, end_date + timedelta(days=1)),
-                language__in=languages,
+                language__slug__in=language_slugs,
             )
             .values("page__id", "language__slug")
             .annotate(total_accesses=Sum("accesses"))

--- a/integreat_cms/cms/templates/statistics/_statistics_legend_item.html
+++ b/integreat_cms/cms/templates/statistics/_statistics_legend_item.html
@@ -4,7 +4,7 @@
        {% if not language %} checked="" {% endif %}
        data-chart-item="{{ name }}"
        id="{{ name|slugify }}"
-       data-language-slug="{{ language.slug }}" />
+       {% if language %} data-language-slug="{{ language.slug }}" {% endif %} />
 <div class="h-5 w-5 rounded-full" style="background-color: {{ color }}">
 </div>
 {% if language %}

--- a/integreat_cms/cms/views/statistics/statistics_actions.py
+++ b/integreat_cms/cms/views/statistics/statistics_actions.py
@@ -139,6 +139,8 @@ def get_page_accesses_ajax(request: HttpRequest, region_slug: str) -> JsonRespon
     :return: A JSON with all API-Hits of the requested time period
     """
     region = request.region
+    data = request.POST
+    language_slugs = data.getlist("language_slugs")
 
     if not region.statistics_enabled:
         logger.error("Statistics are not enabled for this region.")
@@ -146,7 +148,7 @@ def get_page_accesses_ajax(request: HttpRequest, region_slug: str) -> JsonRespon
             {"error": "Statistics are not enabled for this region."}, status=500
         )
 
-    statistics_form = StatisticsFilterForm(data=request.POST)
+    statistics_form = StatisticsFilterForm(data=data)
 
     if not statistics_form.is_valid():
         logger.error(statistics_form.errors)
@@ -156,12 +158,12 @@ def get_page_accesses_ajax(request: HttpRequest, region_slug: str) -> JsonRespon
         )
 
     region_pages = Page.objects.filter(region=region)
-    languages = region.languages
+
     page_access_sums = region.get_page_access_count_by_language(
         pages=region_pages,
         start_date=statistics_form.cleaned_data["start_date"],
         end_date=statistics_form.cleaned_data["end_date"],
-        languages=languages,
+        language_slugs=language_slugs,
     )
 
     page_accesses_dict: dict[str, dict[str, int]] = defaultdict(dict)

--- a/integreat_cms/static/src/js/analytics/statistics-page-accesses.ts
+++ b/integreat_cms/static/src/js/analytics/statistics-page-accesses.ts
@@ -1,5 +1,3 @@
-import { Chart } from "chart.js";
-
 type AccessesPerLanguage = {
     [lang: string]: number;
 };
@@ -7,8 +5,6 @@ type AccessesPerLanguage = {
 type AjaxResponse = {
     [id: string]: AccessesPerLanguage;
 };
-
-let chart: Chart | null = null;
 
 let statisticsForm: HTMLFormElement;
 let pageAccessesURL: string;
@@ -56,14 +52,17 @@ const setDates = () => {
     document.getElementById("date-range-end").innerHTML = new Date(unformattedEndDate).toLocaleDateString();
 };
 
-const getData = async (): Promise<AjaxResponse> => {
+const getData = async (visibleDatasetSlugs: string[]): Promise<AjaxResponse> => {
     if (!statisticsForm) {
         return {} as AjaxResponse;
     }
 
+    const formData = new FormData(statisticsForm);
+    visibleDatasetSlugs.forEach((slug) => formData.append("language_slugs", slug));
+
     const parameters: RequestInit = {
         method: "POST",
-        body: new FormData(statisticsForm),
+        body: formData,
     };
 
     const response = await fetch(pageAccessesURL, parameters);
@@ -76,49 +75,31 @@ const getData = async (): Promise<AjaxResponse> => {
     return data;
 };
 
-const getAllSlugsFromData = (data: AjaxResponse): Set<string> => {
-    const languageSlugs: Set<string> = new Set();
+const getCheckedSlugs = (): string[] => {
+    const visibleDatasetSlugs: string[] = [];
+    const languageCheckboxes: NodeListOf<HTMLInputElement> = document.querySelectorAll("[data-language-slug]");
 
-    Object.keys(data).forEach((pageId) => {
-        Object.keys(data[pageId]).forEach((languageSlug) => {
-            languageSlugs.add(languageSlug);
-        });
+    languageCheckboxes.forEach((checkbox: HTMLInputElement) => {
+        if (checkbox.checked) {
+            const slug = checkbox.getAttribute("data-language-slug");
+            visibleDatasetSlugs.push(slug);
+        }
     });
-    return languageSlugs;
+    return visibleDatasetSlugs;
 };
-
-const createLanguageDatasetLookup = (chart: Chart, slugSet: Set<string>): Map<number, string> => {
-    const indexToSlug = new Map<number, string>();
-
-    slugSet.forEach((languageSlug) => {
-        const fullLabel = document
-            .querySelector(`#chart-legend [data-language-slug="${languageSlug}"]`)
-            .getAttribute("data-chart-item");
-        const datasetIndex = chart.data.datasets.findIndex((dataset) => dataset.label === fullLabel);
-        indexToSlug.set(datasetIndex, languageSlug);
-    });
-
-    return indexToSlug;
-};
-
-const getVisibleSlugs = (chart: Chart, indexToSlug: Map<number, string>) =>
-    chart.data.datasets
-        .map((dataset, index) => index)
-        .filter((index) => chart.isDatasetVisible(index))
-        .map((index) => indexToSlug.get(index))
-        .filter((slug) => slug);
 
 const updateDOM = (data: AjaxResponse, visibleDatasetSlugs: string[]) => {
-    Object.entries(data).forEach((values) => {
-        const pageId: string = values[0];
-        const accesses: AccessesPerLanguage = values[1];
-        const parentField = document.getElementById(`page-${pageId}`);
+    const pageNodes = document.querySelectorAll(`.page-row`);
+    pageNodes.forEach((parentField) => {
+        const pageId: string = parentField.id.split("-")[1];
+        const accesses: AccessesPerLanguage = data[pageId];
         const accessField = parentField.querySelector(".accesses");
         const allAccessesField = parentField.querySelector(".total-accesses");
+        const accessFieldChildElements = accessField.querySelectorAll(`.accesses span`);
 
         let allAccesses: number = 0;
-        visibleDatasetSlugs.forEach((languageSlug) => {
-            if (accesses[languageSlug]) {
+        visibleDatasetSlugs?.forEach((languageSlug) => {
+            if (accesses && accesses[languageSlug]) {
                 allAccesses += accesses[languageSlug];
             }
         });
@@ -129,9 +110,12 @@ const updateDOM = (data: AjaxResponse, visibleDatasetSlugs: string[]) => {
         } else {
             allAccessesField.textContent = `${String(allAccesses)} ${allAccessesField.getAttribute("data-translation-plural")}`;
         }
-        Object.entries(accesses).forEach((accessesForLanguage) => {
-            const languageSlug = accessesForLanguage[0];
-            const accessesOverTime = visibleDatasetSlugs.includes(languageSlug) ? accessesForLanguage[1] : 0;
+        accessFieldChildElements.forEach((child) => {
+            const languageSlug = child.getAttribute("data-language-slug");
+            const accessesOverTime =
+                visibleDatasetSlugs.includes(languageSlug) && accesses && accesses[languageSlug]
+                    ? accesses[languageSlug]
+                    : 0;
             setAccessBarPerLanguage(accessField, languageSlug, accessesOverTime, allAccesses);
         });
     });
@@ -142,8 +126,9 @@ export const updatePageAccesses = async (): Promise<void> => {
     const pageAccessesLoading = document.getElementById("page-accesses-loading");
     pageAccessesLoading.classList.remove("hidden");
     setDates();
+    const visibleDatasetSlugs = getCheckedSlugs();
 
-    const data = await getData();
+    const data = await getData(visibleDatasetSlugs);
 
     const isEmpty = Object.keys(data).length === 0;
     const accessFields = document.getElementsByClassName("accesses");
@@ -152,12 +137,6 @@ export const updatePageAccesses = async (): Promise<void> => {
     resetTotalAccessesField(accessFields, isEmpty);
 
     if (!isEmpty) {
-        const accessedSlugs = getAllSlugsFromData(data);
-
-        const indexToAccessedSlugs = createLanguageDatasetLookup(chart, accessedSlugs);
-
-        const visibleDatasetSlugs: string[] = getVisibleSlugs(chart, indexToAccessedSlugs);
-
         updateDOM(data, visibleDatasetSlugs);
     }
     pageAccessesLoading.classList.add("hidden");
@@ -168,7 +147,6 @@ export const setPageAccessesEventListeners = () => {
     pageAccessesForm = document.getElementById("statistics-page-access") as HTMLFormElement;
     if (pageAccessesForm && statisticsForm) {
         pageAccessesURL = pageAccessesForm.getAttribute("data-page-accesses-url");
-        chart = Chart.getChart("statistics");
         updatePageAccesses();
         statisticsForm.addEventListener("submit", async (event: Event) => {
             // Prevent form submit


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fixes the the typescript error when loading bigger timeframes for page access statistics. Also includes small refactor to only request data for languages that are actually selected from the backend. And finally it get get rid of the dependency of the page acces statistics from the total accesses chart. They are now completly independent of each other. Both only depend on the language legend.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Refactor request to backend to accomandate a list of selected languages
- Changes to backend to be able to querry with list of language slugs and only non archived pages
- Change `updateDOM` to looping through page tree instead of returned data to ensure all nodes are updated right
- Get list of selected language slugs from language legend
- Get rid of every mention of chart in `statistics-page-accesses.ts`


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
To reproduce the original error and see if its fixed you actually need a database dump. But you can test if everything works as it should without a database dump:
To test everything works fine without loading a data dump you need statistics to be activated. 
- Go to the region settings of e.g. Augsburg on the test system and copy the matomo auth token
- Run the cms locally and go to the region settings of Augsburg
- Check the statistics Checkbox and paste the matomo auth token
- Run the fetch page accesses management command: `integreat-cms-cli fetch_page_accesses --start-date START_DATE --end-date END_DATE --region-slug augsburg` (start and end date can be the same, good pick would be yesterday)
- Wait for about 30 to 40 sec
- Go to the statistics page for Augsburg
- See that everything works fine and no uncaught type error gets thrown for page accesses

For Julian:
Uncaught Type Error for pages accesses should be gone now when selecting bigger timeframes like couple of months. Loading animation should also stop.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4025 
Fixes: #4036 
Fixes: #4040 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
