### PR TITLE
Refactor `get` in `page_form_view`

### DIFF
--- a/integreat_cms/cms/views/pages/page_form_view.py
+++ b/integreat_cms/cms/views/pages/page_form_view.py
@@ -80,7 +80,6 @@ class PageFormView(
             only_active=True,
         )
 
-        # Get page and translation objects if they exist
         page = (
             region.pages.filter(id=kwargs.get("page_id"))
             .prefetch_translations()
@@ -89,102 +88,24 @@ class PageFormView(
         )
         page_translation = page.get_translation(language.slug) if page else None
 
-        disabled = False
-        if page:
-            # Make form disabled if page is archived
-            if page.explicitly_archived:
-                disabled = True
-                messages.warning(
-                    request,
-                    _("You cannot edit this page because it is archived."),
-                )
-            elif page.implicitly_archived:
-                disabled = True
-                messages.warning(
-                    request,
-                    _(
-                        "You cannot edit this page, because one of its parent pages is archived and therefore, this page is archived as well.",
-                    ),
-                )
-            # If the page is not public, check whether we need additional messages to prevent confusion
-            if page_translation and page_translation.status != status.PUBLIC:
-                # Indicate autosaves and changes pending review
-                if page_translation.status in [status.AUTO_SAVE, status.REVIEW]:
-                    revision_url = reverse(
-                        "page_versions",
-                        kwargs={
-                            "region_slug": region.slug,
-                            "language_slug": language.slug,
-                            "page_id": page.id,
-                        },
-                    )
-                    if page_translation.status == status.AUTO_SAVE:
-                        status_message = _("The last changes were saved automatically.")
-                        action = _("discard")
-                    else:
-                        status_message = _("The latest changes are pending approval.")
-                        action = _("reject")
-                    # If the user has the permission to reject/discard, show another message
-                    if request.user.has_perm("cms.publish_page_object", page):
-                        message = __(
-                            status_message,
-                            _(
-                                "You can {action} these changes in the <a>version overview</a>.",
-                            ).format(action=action),
-                        )
-                        status_message = translate_link(
-                            message,
-                            attributes={
-                                "href": revision_url,
-                                "class": "underline hover:no-underline",
-                            },
-                        )
-                    messages.warning(request, status_message)
-                # Show information if a public translation exists even if the latest version is not public
-                if public_translation := page.get_public_translation(language.slug):
-                    if page_translation.status == status.DRAFT:
-                        messages.warning(
-                            request,
-                            _("The latest changes have only been saved as a draft."),
-                        )
-                    revision_url = reverse(
-                        "page_versions",
-                        kwargs={
-                            "region_slug": region.slug,
-                            "language_slug": language.slug,
-                            "page_id": page.id,
-                            "selected_version": public_translation.version,
-                        },
-                    )
-                    message = _(
-                        "Currently, <a>version {}</a> of this page is displayed in the app.",
-                    ).format(public_translation.version)
-                    messages.info(
-                        request,
-                        translate_link(
-                            message,
-                            attributes={
-                                "href": revision_url,
-                                "class": "underline hover:no-underline",
-                            },
-                        ),
-                    )
+        if page and page_translation and page_translation.status != status.PUBLIC:
+            self.check_autosave_or_pending_review(
+                request,
+                page=page,
+                page_translation=page_translation,
+                region=region,
+                language=language,
+            )
 
-        # Make form disabled if user has no permission to edit the page
-        if not request.user.has_perm("cms.change_page_object", page):
-            disabled = True
-            messages.warning(
+            # Show information if a public translation exists even if the latest version is not public
+            self.handle_public_version_not_latest(
                 request,
-                _("You don't have the permission to edit this page."),
+                page=page,
+                page_translation=page_translation,
+                language=language,
             )
-        # Show warning if user has no permission to publish the page
-        elif not request.user.has_perm("cms.publish_page_object", page):
-            messages.warning(
-                request,
-                _(
-                    "You don't have the permission to publish this page, but you can propose changes and submit them for review instead.",
-                ),
-            )
+
+        disabled = self.check_is_disabled(request, page)
 
         page_form = PageForm(
             instance=page,
@@ -456,6 +377,150 @@ class PageFormView(
             and not page_instance.archived
         )
         return context
+
+    def is_initially_disabled(self, request: HttpRequest, page: Page) -> bool:
+        """
+        Disable forms and show a warning message if the page is archived.
+
+        :param self: Description
+        :param request: Description
+        :type request: HttpRequest
+        :param page: Description
+        :type page: Page
+        """
+        if page and page.explicitly_archived:
+            messages.warning(
+                request,
+                _("You cannot edit this page because it is archived."),
+            )
+            return True
+        if page and page.implicitly_archived:
+            messages.warning(
+                request,
+                _(
+                    "You cannot edit this page, because one of its parent pages is archived and therefore, this page is archived as well.",
+                ),
+            )
+            return True
+        return False
+
+    def has_insufficient_permissions(self, request: HttpRequest, page: Page) -> bool:
+        """
+        Handle permission warnings and determine whether forms should be disabled.
+        """
+        if not request.user.has_perm("cms.change_page_object", page):
+            messages.warning(
+                request,
+                _("You don't have the permission to edit this page."),
+            )
+            return True
+
+        if not request.user.has_perm("cms.publish_page_object", page):
+            messages.warning(
+                request,
+                _(
+                    "You don't have the permission to publish this page, "
+                    "but you can propose changes and submit them for review instead."
+                ),
+            )
+            return True
+        return False
+
+    def check_is_disabled(self, request: HttpRequest, page: Page) -> bool:
+        """
+        Checks whether the forms should be disabled and shows appropriate warning messages.
+        """
+        return self.is_initially_disabled(
+            request, page
+        ) or self.has_insufficient_permissions(request, page)
+
+    def handle_public_version_not_latest(
+        self,
+        request: HttpRequest,
+        *,
+        page: Page,
+        page_translation: PageTranslation,
+        language: Language,
+    ) -> None:
+        """
+        This informs the user that the currently published version is not the latest version.
+        """
+        public_translation = page.get_public_translation(language.slug)
+
+        if public_translation is None:
+            return
+
+        if page_translation.status == status.DRAFT:
+            messages.warning(
+                request,
+                _("The latest changes have only been saved as a draft."),
+            )
+        revision_url = reverse(
+            "page_versions",
+            kwargs={
+                "region_slug": page.region.slug,
+                "language_slug": language.slug,
+                "page_id": page.id,
+                "selected_version": public_translation.version,
+            },
+        )
+        message = _(
+            "Currently, <a>version {}</a> of this page is displayed in the app.",
+        ).format(public_translation.version)
+        messages.info(
+            request,
+            translate_link(
+                message,
+                attributes={
+                    "href": revision_url,
+                    "class": "underline hover:no-underline",
+                },
+            ),
+        )
+
+    def check_autosave_or_pending_review(
+        self,
+        request: HttpRequest,
+        *,
+        page: Page,
+        page_translation: PageTranslation,
+        region: Region,
+        language: Language,
+    ) -> None:
+        """
+        This informs the user that there is an autosaved version or a version pending review.
+        """
+        if page_translation.status in [status.AUTO_SAVE, status.REVIEW]:
+            revision_url = reverse(
+                "page_versions",
+                kwargs={
+                    "region_slug": region.slug,
+                    "language_slug": language.slug,
+                    "page_id": page.id,
+                },
+            )
+            if page_translation.status == status.AUTO_SAVE:
+                status_message = _("The last changes were saved automatically.")
+                action = _("discard")
+            else:
+                status_message = _("The latest changes are pending approval.")
+                action = _("reject")
+            # If the user has the permission to reject/discard, show another message
+            if request.user.has_perm("cms.publish_page_object", page):
+                message = __(
+                    status_message,
+                    _(
+                        "You can {action} these changes in the <a>version overview</a>.",
+                    ).format(action=action),
+                )
+                status_message = translate_link(
+                    message,
+                    attributes={
+                        "href": revision_url,
+                        "class": "underline hover:no-underline",
+                    },
+                )
+            messages.warning(request, status_message)
 
     def report_conflicting_slug(
         self,

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -10817,6 +10817,14 @@ msgid "All translations of this page will also be deleted."
 msgstr "Alle Übersetzungen dieser Seite werden gelöscht."
 
 #: cms/views/pages/page_form_view.py
+msgid ""
+"The \"minor edit\" option was disabled because the first version can never "
+"be a minor edit."
+msgstr ""
+"Die \"geringfügige Änderung\"-Option wurde deaktiviert, da die erste Version "
+"niemals eine geringfügige Änderung sein kann."
+
+#: cms/views/pages/page_form_view.py
 msgid "You cannot edit this page because it is archived."
 msgstr "Sie können diese Seite nicht bearbeiten, weil sie archiviert ist."
 
@@ -10827,6 +10835,26 @@ msgid ""
 msgstr ""
 "Sie können diese Seite nicht bearbeiten, weil eine ihrer übergeordneten "
 "Seiten archiviert ist, und sie dadurch ebenfalls archiviert ist."
+
+#: cms/views/pages/page_form_view.py cms/views/pages/page_sbs_view.py
+msgid "You don't have the permission to edit this page."
+msgstr "Sie haben nicht die nötige Berechtigung, um diese Seite zu bearbeiten."
+
+#: cms/views/pages/page_form_view.py
+msgid ""
+"You don't have the permission to publish this page, but you can propose "
+"changes and submit them for review instead."
+msgstr ""
+"Sie haben nicht die nötige Berechtigung, um diese Seite zu veröffentlichen, "
+"aber Sie können Änderungen vornehmen und diese zur Freigabe vorlegen."
+
+#: cms/views/pages/page_form_view.py
+msgid "The latest changes have only been saved as a draft."
+msgstr "Die letzten Änderungen wurden nur als Entwurf gespeichert."
+
+#: cms/views/pages/page_form_view.py
+msgid "Currently, <a>version {}</a> of this page is displayed in the app."
+msgstr "Aktuell wird <a>Version {}</a> dieser Seite in der App angezeigt."
 
 #: cms/views/pages/page_form_view.py
 msgid "The last changes were saved automatically."
@@ -10848,34 +10876,6 @@ msgstr "ablehnen"
 #, python-brace-format
 msgid "You can {action} these changes in the <a>version overview</a>."
 msgstr "Sie können diese Änderungen in der <a>Versionsübersicht</a> {action}."
-
-#: cms/views/pages/page_form_view.py
-msgid "The latest changes have only been saved as a draft."
-msgstr "Die letzten Änderungen wurden nur als Entwurf gespeichert."
-
-#: cms/views/pages/page_form_view.py
-msgid "Currently, <a>version {}</a> of this page is displayed in the app."
-msgstr "Aktuell wird <a>Version {}</a> dieser Seite in der App angezeigt."
-
-#: cms/views/pages/page_form_view.py cms/views/pages/page_sbs_view.py
-msgid "You don't have the permission to edit this page."
-msgstr "Sie haben nicht die nötige Berechtigung, um diese Seite zu bearbeiten."
-
-#: cms/views/pages/page_form_view.py
-msgid ""
-"You don't have the permission to publish this page, but you can propose "
-"changes and submit them for review instead."
-msgstr ""
-"Sie haben nicht die nötige Berechtigung, um diese Seite zu veröffentlichen, "
-"aber Sie können Änderungen vornehmen und diese zur Freigabe vorlegen."
-
-#: cms/views/pages/page_form_view.py
-msgid ""
-"The \"minor edit\" option was disabled because the first version can never "
-"be a minor edit."
-msgstr ""
-"Die \"geringfügige Änderung\"-Option wurde deaktiviert, da die erste Version "
-"niemals eine geringfügige Änderung sein kann."
 
 #: cms/views/pages/page_form_view.py
 #, python-brace-format


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
After refactoring the `post` method of the the `page_form_view`, I decided to also refactor the `get` method.
Similarly to the [previous PR](https://github.com/digitalfabrik/integreat-cms/pull/4045), I also used the [cyclomatic complexity](https://en.wikipedia.org/wiki/Cyclomatic_complexity) as a metric to track progress. This time I was able to reduce the CC by half (from 18 (=C) to 9 (=B)).

### Proposed changes
<!-- Describe this PR in more detail. -->

- Refactor `get` method in `page_form_view`


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- I'm not entirely happy with the method yet, but think it's a good step forward. Let me know if there is still something left in the method that you think should be refactored
- I'm not 100% sure if I really caught every test case, so thorough testing is very welcome


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: /


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
