### PR TITLE
Fix width of statistics box

### DIFF
--- a/integreat_cms/cms/templates/_collapsible_box.html
+++ b/integreat_cms/cms/templates/_collapsible_box.html
@@ -1,5 +1,5 @@
 {# Set collapsed=True when including this template to show the box collapsed in the beginning #}
-<div class="rounded {% if 2_cols %} 2xl:col-span-2 {% endif %} shadow-2xl border border-blue-500 bg-white mb-4">
+<div class="max-w-full rounded {% if 2_cols %} 2xl:col-span-2 {% endif %} shadow-2xl border border-blue-500 bg-white mb-4">
     <div {% if box_id %}id="{{ box_id }}"{% endif %}
          class="collapsible cursor-pointer rounded p-4 bg-water-500 text-black font-bold flex justify-between"
          {% if collapsed %}data-collapsed{% endif %}>

--- a/integreat_cms/cms/templates/statistics/statistics_chart.html
+++ b/integreat_cms/cms/templates/statistics/statistics_chart.html
@@ -9,7 +9,7 @@
     {% translate "Total accesses" %}
 {% endblock collapsible_box_title %}
 {% block collapsible_box_content %}
-    <div class="lg:col-span-2 2xl:row-span-2 2xl:col-span-3 bg-white">
+    <div class="flex-wrap lg:col-span-2 2xl:row-span-2 2xl:col-span-3 bg-white">
         <div class="p-5 bg-white text-center">
             <div id="chart-network-error" class="text-red-500 px-4 hidden">
                 <i icon-name="alert-triangle"></i> {% translate "A network error has occurred." %} {% translate "Please try again later." %}
@@ -23,7 +23,7 @@
             <div id="chart-loading" class="px-4 hidden">
                 <i icon-name="loader" class="animate-spin"></i> {% translate "Loading..." %}
             </div>
-            <div class="chart-container w-[52vw] h-[60vh]">
+            <div class="chart-container flex-wrap w-full h-[60vh]">
                 <canvas id="statistics"
                         data-statistics-url="{% url 'statistics_visits_per_language' region_slug=request.region.slug %}"></canvas>
             </div>

--- a/integreat_cms/cms/templates/statistics/statistics_overview.html
+++ b/integreat_cms/cms/templates/statistics/statistics_overview.html
@@ -10,7 +10,7 @@
                 </h1>
             </div>
             <div class="pt-4 lg:pt-0 3xl:grid grid-cols-2 3xl:grid-cols-[minmax(0px,_1fr)_400px] 4xl:grid-cols-[minmax(0px,_1fr)_816px] gap-4">
-                <div class="flex flex-col flex-wrap col-span-1 3xl:col-span-1">
+                <div class="flex flex-col flex-wrap col-span-1 3xl:col-span-1 min-w-0">
                     {% include "statistics/statistics_chart.html" with box_id="statistics_chart" %}
                     {% if show_page_based_statistics %}
                         {% include "statistics/statistics_viewed_pages.html" with box_id="statistics_viewed_pages" %}


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the bug that the graph of "Total Accesses" does not use the full width of the box.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Remove `w-[52vw]`
- Control by the (outer) box


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- I hope no negative side effects



- Two more unpleasant behaviours are fixed together:

"Total accesses" and "Page views" extends over the boundary in a small screen/when the screen is made narrower.
<img width="1003" height="653" alt="Screenshot 2025-12-18 165009" src="https://github.com/user-attachments/assets/b3b6fbe4-fc13-4fec-8ed0-83948a24469b" />




The left and right columns are overwrapping when changing the size of screen 

<img width="1668" height="777" alt="Screenshot 2025-12-18 180514" src="https://github.com/user-attachments/assets/aabdb5e3-fc59-4b18-9b65-281f3df6d112" />



### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3609 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
