### PR TITLE
Prevent PNs from being sent without user using Send button

### DIFF
--- a/integreat_cms/core/management/commands/send_push_notifications.py
+++ b/integreat_cms/core/management/commands/send_push_notifications.py
@@ -61,19 +61,10 @@ class Command(LogCommand):
             scheduled_send_date__gte=timezone.now() - timedelta(hours=retain_time),
         )
 
-        failed_push_notifications = PushNotification.objects.filter(
-            archived=False,
-            sent_date__isnull=True,
-            scheduled_send_date__isnull=True,
-            created_date__gte=timezone.now() - timedelta(hours=retain_time),
-        )
-
-        pending_push_notifications = list(failed_push_notifications) + list(
-            scheduled_push_notifications,
-        )
-
-        if total := len(pending_push_notifications):
-            for counter, push_notification in enumerate(pending_push_notifications, 1):
+        if total := len(scheduled_push_notifications):
+            for counter, push_notification in enumerate(
+                scheduled_push_notifications, 1
+            ):
                 self.send_push_notification(counter, total, push_notification)
             logger.success(  # type: ignore[attr-defined]
                 "✔ All %d scheduled push notifications have been processed.",

--- a/tests/core/management/commands/test_send_push_notifications.py
+++ b/tests/core/management/commands/test_send_push_notifications.py
@@ -196,7 +196,7 @@ class TestSendPushNotification:
 
         LanguageTreeNode.add_root(language=german_language, region=region)
 
-        push_notification = PushNotification.objects.create(
+        immediate_push_notification = PushNotification.objects.create(
             channel="default",
             sent_date=None,
             mode="ONLY_AVAILABLE",
@@ -205,12 +205,31 @@ class TestSendPushNotification:
         PushNotificationTranslation.objects.create(
             title="Test Push Notification",
             text="Test Push Notification",
-            push_notification=push_notification,
+            push_notification=immediate_push_notification,
             language=german_language,
         )
 
-        push_notification.regions.add(region)
-        push_notification.save()
+        immediate_push_notification.regions.add(region)
+        immediate_push_notification.save()
+
+        scheduled_push_notification = PushNotification.objects.create(
+            channel="default",
+            sent_date=None,
+            scheduled_send_date=datetime.now() - timedelta(hours=1),
+            mode="ONLY_AVAILABLE",
+        )
+
+        PushNotificationTranslation.objects.create(
+            title="Test Push Notification",
+            text="Test Push Notification",
+            push_notification=scheduled_push_notification,
+            language=german_language,
+        )
+
+        scheduled_push_notification.regions.add(region)
+        scheduled_push_notification.save()
+
+        assert region.push_notifications.count() == 2
 
         call_command("send_push_notifications")
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the bug that PNs which was only saved and not yet "sent" was sent by the management command cron job.

### Proposed changes
<!-- Describe this PR in more detail. -->
~~- Add a flag whether user clicked "Send" button (set `ready_to_be_sent` to `True`).~~
~~- Check for `ready_to_be_sent = True` when the management command is collecting failed (one-time) PNs~~
~~- Do not care `ready_to_be_sent`, as scheduled PNs are to be considered as "ready" (agreed [here](https://chat.tuerantuer.org/digitalfabrik/pl/shp1f7aji7ntzxxrs83qfoj8yy) )~~

- Make management command check only scheduled PNs

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- I hope none......


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.

### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
- Create a PN (X)
- Save (click "Save" button)
- Create another PN (Y)
- Save (click "Save") and send (Click "Send")
- `./tools/integreat-cms-cli shell` and set `sent_date` of Y to `None`
- `./tools/integreat-cms-cli send_push_notifications`
- See only Y is sent, X is not sent

Use "Testumgebung" or a region which does not exist in the prod system 

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4080


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
