### PR TITLE
Management Command for async script to make all slugs unique

### DIFF
--- a/integreat_cms/cms/utils/slug_utils.py
+++ b/integreat_cms/cms/utils/slug_utils.py
@@ -5,17 +5,27 @@ This module contains helpers regarding unique string identifiers without special
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from time import time
+from typing import Final, Literal, TYPE_CHECKING
 
+from celery import shared_task
+from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import ValidationError
+from django.db import transaction
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 
 if TYPE_CHECKING:
-    from typing import Any, Literal, NotRequired, TypeAlias, TypedDict, Unpack
+    from typing import (
+        Any,
+        NotRequired,
+        TypeAlias,
+        TypedDict,
+        Unpack,
+    )
 
-    from django.db.models import Manager
+    from django.db.models import Manager, QuerySet
     from django.forms import ModelForm
     from django.http.request import QueryDict
 
@@ -23,6 +33,9 @@ if TYPE_CHECKING:
     from ..models.abstract_base_model import AbstractBaseModel
     from ..models.abstract_content_model import AbstractContentModel
 
+SlugObject = Literal["page", "event", "poi"]
+DEFAULT_OBJECTS: Final[tuple[SlugObject, ...]] = ("event", "poi", "page")
+ALLOWED_OBJECTS = {"event", "poi", "page"}
 
 logger = logging.getLogger(__name__)
 
@@ -182,3 +195,70 @@ def generate_unique_slug(**kwargs: Unpack[SlugKwargs]) -> str:
 
     logger.debug("unique slug: %r", unique_slug)
     return unique_slug
+
+
+def update_translations(
+    translations: QuerySet, foreign_attr: Literal["page", "event", "poi"], dry_run: bool
+) -> int:
+    logger.info("Updating slugs in %sTranslations", foreign_attr.capitalize())
+    counter = 0
+    with transaction.atomic():
+        for translation in translations:
+            foreign_obj: AbstractContentModel | None = getattr(
+                translation, foreign_attr, None
+            )
+            if foreign_obj is None:
+                continue
+            region = getattr(foreign_obj, "region", None)
+            if not region:
+                continue
+            old_slug = translation.slug
+            translation.slug = generate_unique_slug(
+                slug=translation.slug,
+                manager=type(translation).objects,
+                object_instance=translation,
+                foreign_model=foreign_attr,
+                foreign_object=foreign_obj,
+                region=region,
+                language=translation.language,
+            )
+            if old_slug != translation.slug:
+                counter += 1
+                if not dry_run:
+                    translation.save()
+    return counter
+
+
+@shared_task()
+def make_all_slugs_unique(
+    objects: tuple[SlugObject, ...] = DEFAULT_OBJECTS,
+    dry_run: bool = False,
+) -> None:
+    logger.info("Starting to make all slugs unique ...")
+    start_time = time()
+
+    slug_counter = 0
+
+    for model_name in objects:
+        translation_model = apps.get_model(
+            "cms", f"{model_name.capitalize()}Translation"
+        )
+        translations = translation_model.objects.all()
+        slug_counter += update_translations(translations, model_name, dry_run)
+
+    end_time = time() - start_time
+    if not dry_run:
+        logger.info(
+            "Finished >make_all_slugs_unique< after: %.3fs with %d updated slugs",
+            end_time,
+            slug_counter,
+        )
+    if dry_run:
+        logger.info(
+            "Finished dry run for >make_all_slugs_unique< after: %.3fs. "
+            "In total %d non-unique slugs were identified. "
+            "Keep in mind that during a real run, "
+            "only a subset of the non-unique slugs will be actually changed in order to make them all unique.",
+            end_time,
+            slug_counter,
+        )

--- a/integreat_cms/core/management/commands/make_slugs_unique.py
+++ b/integreat_cms/core/management/commands/make_slugs_unique.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from django.core.management.base import CommandError, CommandParser
+
+from integreat_cms.cms.utils.slug_utils import (
+    ALLOWED_OBJECTS,
+    DEFAULT_OBJECTS,
+    make_all_slugs_unique,
+)
+from integreat_cms.core.management.log_command import LogCommand
+
+logger = logging.getLogger(__name__)
+
+
+class Command(LogCommand):
+    """
+    Management command to generate unique slugs for all translation objects
+    """
+
+    help = "Generates unique slugs for all translation objects"
+
+    def add_arguments(self, parser: CommandParser) -> None:
+        """
+        Define the arguments of this command
+
+        :param parser: The argument parser
+        """
+        parser.add_argument(
+            "--objects",
+            nargs="+",
+            default=DEFAULT_OBJECTS,
+            help="The objects for which the translations slug should be updated ",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Do a dry-run, without commiting to the database",
+        )
+
+    def handle(
+        self,
+        **options: Any,
+    ) -> None:
+        objects = tuple(options["objects"])
+        dry_run = options["dry_run"]
+
+        invalid = [obj for obj in objects if obj not in ALLOWED_OBJECTS]
+        if invalid:
+            raise CommandError(
+                f"Invalid models for make_slugs_unique command: {', '.join(sorted(invalid))}"
+            )
+        make_all_slugs_unique.delay(objects, dry_run)
+
+        logger.info("Queued task make_all_slugs_unique")


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR is based on: #3917 
- a (@shared_task) script that makes sure all ~~latest~~ translations of events, pois and pages have unique slugs (EDIT: I have decided to delete the query for only latest translations, since the database constraint will guarantee it for all)
- a management command that queues the script with celery


### Proposed changes
<!-- Describe this PR in more detail. -->

- the script is optimized for speed compared to the original migration script
- if this command runs fast enough, I will turn it into a migration and add it to #3826 
- I have added no tests for now, as its unsure we will keep the command anyways and because I see no way to create a test state with duplicate slugs with the application level constraints already in place and the database constraints coming up soon


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->

- You will have to manipulate the test-data.json to get duplicate slugs (within one region and language!)
- Or enter the slugs into the database directly (django-admin wont work)
- in the shell you can use the .update method or the bulk_create method as they circumvent the application level constraints that have already been implemented

Then run the command with `tools/integreat-cms-cli make_slugs_unique`


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #
Blocks: #3826 
Relates to #3917 

### Follow Up

- [x] Run command on Test-System after 2026-02-17 `integreat-cms-cli make_slug_unique --dry-run` and check for the celery logs: https://chat.tuerantuer.org/digitalfabrik/pl/gf855khc3bg47jq78kwgo4egqw
- 2026-03-31: 
  - duration dry-run: 489.63871692s    / slugs identified:  1051 identified slugs
  - duration real run: 45.461s   / slugs fixed:   675 updated slugs 
  - !!!BUT!!!   duration second real run: 489.3568178640003s / slugs fixed: 0 updated slugs
  That means the less duplicate slugs we have the longer it takes

- 2026-05-04:
  - the quick duration on first run from 2026-03-31 could not be replicated locally with a production database dump
  - on two different machines: the runs lasted app. 10 to 15 minutes for 939 updated slugs
__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
