### PR TITLE
Fix slug being overwritten when editing page title

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/3961.yml
+++ b/integreat_cms/release_notes/current/unreleased/3961.yml
@@ -1,0 +1,2 @@
+en: Fix slug being overwritten when editing page title
+de: Behebe das Überschreiben des Slugs beim Bearbeiten des Seitentitels

--- a/integreat_cms/static/src/js/forms/update-permalink.ts
+++ b/integreat_cms/static/src/js/forms/update-permalink.ts
@@ -41,13 +41,20 @@ window.addEventListener("load", () => {
     };
 
     document.querySelectorAll("#id_title").forEach((item) => {
+        /* Store original title to detect actual changes */
+        let originalTitle: string;
+
+        item.addEventListener("focusin", ({ target }) => {
+            originalTitle = (target as HTMLInputElement).value;
+        });
+
         item.addEventListener("focusout", ({ target }) => {
-            // Only auto-generate slug if the field is empty
-            if (slugField?.value) {
+            const currentTitle = (target as HTMLInputElement).value;
+            // Only update slug if the title actually changed
+            if (currentTitle === originalTitle) {
                 return;
             }
             const submissionLock = new SubmissionPrevention(".no-premature-submission");
-            const currentTitle = (target as HTMLInputElement).value;
             const nodeList: NodeListOf<HTMLInputElement> = document.querySelectorAll(
                 '[for="id_title"],[for="id_slug"]'
             );

--- a/integreat_cms/static/src/js/forms/update-permalink.ts
+++ b/integreat_cms/static/src/js/forms/update-permalink.ts
@@ -42,6 +42,10 @@ window.addEventListener("load", () => {
 
     document.querySelectorAll("#id_title").forEach((item) => {
         item.addEventListener("focusout", ({ target }) => {
+            // Only auto-generate slug if the field is empty
+            if (slugField?.value) {
+                return;
+            }
             const submissionLock = new SubmissionPrevention(".no-premature-submission");
             const currentTitle = (target as HTMLInputElement).value;
             const nodeList: NodeListOf<HTMLInputElement> = document.querySelectorAll(


### PR DESCRIPTION
## Summary
- Only auto-generate the slug from the title if the slug field is empty
- Prevents manually set slugs from being overwritten when editing the title

Fixed as discussed in #3961. Slug will only be adjusted/created when the field is empty. If the title changes it will not be affected.

## Test plan
- [ ] Edit an existing page with a custom slug, change the title, verify slug is NOT overwritten
- [ ] Create a new page, enter a title, verify slug IS auto-generated
- [ ] Works for pages, events, and POIs

Fixes #3961

🤖 Generated with [Claude Code](https://claude.ai/code)