### PR TITLE
Fix timeout when deleting a language with many translations

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/3997.yml
+++ b/integreat_cms/release_notes/current/unreleased/3997.yml
@@ -1,0 +1,2 @@
+en: Fix timeout when deleting a language with many translations
+de: Behebe Zeitüberschreitung beim Löschen einer Sprache mit vielen Übersetzungen


### PR DESCRIPTION
## Summary

Fixes the Internal Server Error that occurs when deleting a language with many translations.

### Problem
When deleting a language, all translations (pages, events, POIs) with that language get cascade-deleted. For each deletion, the linkcheck library's `pre_delete` signal fires and calls `get_absolute_url()`. With thousands of translations, this causes a timeout before the DELETE query reaches the database.

### Evidence
- `region_actions.py` already uses `disable_listeners()` when deleting regions
- The comment there states: *"Active linkchecking would drastically slow performance"*
- `language_tree_actions.py` was missing this pattern

### Solution
Wrap `language_node.delete()` with `disable_listeners()` - the same pattern already used for region deletion.

## Test plan
- [ ] Delete a language that has many translations in a test region
- [ ] Verify no timeout or Internal Server Error occurs
- [ ] Verify the language and all its translations are properly deleted

Fixes #3997

🤖 Generated with [Claude Code](https://claude.ai/code)