### PR TITLE
Fix inconsistent page accesses

### DIFF
--- a/integreat_cms/cms/models/regions/region.py
+++ b/integreat_cms/cms/models/regions/region.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import uuid
-from datetime import date, datetime, timedelta
+from datetime import date, datetime
 from html import escape
 from typing import TYPE_CHECKING
 
@@ -1087,7 +1087,7 @@ class Region(AbstractBaseModel):
             PageAccesses.objects.filter(
                 page__region=self,
                 page__in=pages,
-                access_date__range=(start_date, end_date + timedelta(days=1)),
+                access_date__range=(start_date, end_date),
                 language__slug__in=language_slugs,
             )
             .values("page__id", "language__slug")

--- a/integreat_cms/static/src/js/pages/toggle-subpages.ts
+++ b/integreat_cms/static/src/js/pages/toggle-subpages.ts
@@ -1,6 +1,7 @@
 /*
  * The functionality to toggle subpages
  */
+import { updatePageAccesses } from "../analytics/statistics-page-accesses";
 import { createIconsAt } from "../utils/create-icons";
 import { restorePageTreeLayout, storeExpandedState } from "./persistent_page_tree";
 
@@ -125,6 +126,9 @@ const expandAllPages = async () => {
 export const toggleSubpages = (event: Event) => {
     event.preventDefault();
     toggleSubpagesForElement((event.target as HTMLElement).closest("span"));
+    if (document.getElementById("statistics-page-access")) {
+        updatePageAccesses();
+    }
 };
 
 /**


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the inconsistencies between page based accesses, total access statistics and matomo itself.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Fix date range error
- Add dynamic recalculation, depending on if a page is in the page tree is expanded by it's children or collapsed. When collapsed, it's children accesses and it's own are added up, otherwise subtracted. When expanded, accesses for a page are consistent with matomo
- Add list of page IDs that are requested from the database as parameter to the backend request
- Add field to the by backend returned dict with the total accesses of page over all languages


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.
The following requirements from the meta issue #1097 are implemented with this fix:
- If a (sub-)tree is collapsed, it will show the sum of all sub pages and its own page access statistics.
- If a tree is expanded, the parent node no longer shows the sum but only its own direct access statistics.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->

It's probably best to test this with a database dump.

To test this locally you need statistics activated:
- Go to the region settings of e.g. Augsburg on the test system and copy the matomo auth token
- Run the cms locally and go to the region settings of Augsburg
- Check the statistics Checkbox and paste the matomo auth token
- Run the fetch page accesses management command: integreat-cms-cli fetch_page_accesses --start-date START_DATE --end--date END_DATE --region-slug augsburg (start and end date can be the same, good pick would be yesterday)
- Wait for about 30 to 40 sec
- Go to the statistics page for Augsburg

When you test look for the following:
- compare if for a page the accesses in total with accesses per language is consistent
- check that total and and accesses per language change accordingly when expanding and collapsing subpages
- compare numbers of expanded pages with matomo directly
- Make sure that the page tree in the page view is still intact

How to access matomo and check statistics there:
- Go to [matomo](https://statistics.integreat-app.de) and login
- Select "Augsburg" and the date you want to check
- Navigate to "Behaviour" and select "Pages"
- Search for a page with the page slug (not ID)
- You will see all pages that contain the slug you searched for with accesses of the selected date
- Keep in mind that we translate page slugs

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4051 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
