### PR TITLE
Exclude draft pages from page statistics

### DIFF
--- a/integreat_cms/cms/views/statistics/statistics_view.py
+++ b/integreat_cms/cms/views/statistics/statistics_view.py
@@ -12,7 +12,7 @@ from django.utils.decorators import method_decorator
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import TemplateView
 
-from integreat_cms.cms.constants import language_color
+from integreat_cms.cms.constants import language_color, status
 
 from ...decorators import permission_required
 from ...forms import StatisticsFilterForm
@@ -66,9 +66,12 @@ class AnalyticsView(TemplateView):
 
         # Cache tree structure to reduce database queries
         pages = (
-            page_queryset.prefetch_major_translations()
+            page_queryset.prefetch_translations(
+                to_attr="prefetched_not_draft_translations",
+                status__in=[status.PUBLIC],
+            )
             .prefetch_related("mirroring_pages")
-            .cache_tree(archived=False)
+            .cache_tree(archived=False, language_slug=default_language.slug)
         )
 
         show_page_based_statistics = (


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR excludes pages in draft from the page based statistics view.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Only fetch translations that aren't in Draft in the views
- Only include pages that are published in the default language of the region


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
To test this you need statistics activated:
- Go to the region settings of e.g. Augsburg on the test system and copy the matomo auth token
- Run the cms locally and go to the region settings of Augsburg
- Check the statistics Checkbox and paste the matomo auth token
- Run the fetch page accesses management command: integreat-cms-cli fetch_page_accesses --start-date START_DATE --end--date END_DATE --region-slug augsburg (start and end date can be the same, good pick would be yesterday)
- Wait for about 30 to 40 sec

- Go to the pages page and see pages that are not published in the page tree
- Go to the statistics page for Augsburg and see no pages in the page tree that are not published

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4037 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
