### PR TITLE
Allow updating news after scheduled push notification was sent

### DIFF
--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -2291,11 +2291,6 @@ msgid "Cannot be unspecified"
 msgstr "Kann nicht leer gelassen werden"
 
 #: cms/forms/push_notifications/push_notification_form.py
-#: cms/views/push_notifications/push_notification_form_view.py
-msgid "News \"{}\" was already sent on {}"
-msgstr "Nachricht \"{}\" wurde bereits gesendet am {}"
-
-#: cms/forms/push_notifications/push_notification_form.py
 msgid "The scheduled send date cannot be in the past"
 msgstr ""
 "Der geplante Zeitpunkt zum Senden kann nicht in der Vergangenheit liegen"
@@ -11197,6 +11192,10 @@ msgid "News \"{}\" cannot be sent, because it is archived"
 msgstr "Nachricht \"{}\" kann nicht gesendet werden, weil sie archiviert ist."
 
 #: cms/views/push_notifications/push_notification_form_view.py
+msgid "News \"{}\" was already sent on {}"
+msgstr "Nachricht \"{}\" wurde bereits gesendet am {}"
+
+#: cms/views/push_notifications/push_notification_form_view.py
 msgid "News \"{}\" requires a translation in \"{}\" for \"{}\""
 msgstr ""
 "Nachricht \"{}\" hat keine Übersetzung für die Sprache \"{}\" für \"{}\""
@@ -12385,15 +12384,15 @@ msgstr ""
 #~ "Übersetzungen. Bitte haben Sie noch ein wenig Geduld."
 
 #~ msgid ""
-#~ "Your pages currently have <b>"
-#~ "%(number_of_missing_or_outdated_translations)s pages </b>that have an "
+#~ "Your pages currently have "
+#~ "<b>%(number_of_missing_or_outdated_translations)s pages </b>that have an "
 #~ "outdated or no translation. In order for the users to benefit from your "
 #~ "content you should translate them or have them translated."
 #~ msgstr ""
-#~ "Ihre Inhalten haben aktuell <b>"
-#~ "%(number_of_missing_or_outdated_translations)s Seiten </b> mit fehlender "
-#~ "oder veralteter Übersetzung. Damit die Nutzer:innen von Ihren Inhalten "
-#~ "profitieren können, sollten Sie diese übersetzen (lassen)."
+#~ "Ihre Inhalten haben aktuell "
+#~ "<b>%(number_of_missing_or_outdated_translations)s Seiten </b> mit "
+#~ "fehlender oder veralteter Übersetzung. Damit die Nutzer:innen von Ihren "
+#~ "Inhalten profitieren können, sollten Sie diese übersetzen (lassen)."
 
 #~ msgid "View location"
 #~ msgstr "Ort ansehen"

--- a/integreat_cms/release_notes/current/unreleased/3373.yml
+++ b/integreat_cms/release_notes/current/unreleased/3373.yml
@@ -1,0 +1,2 @@
+en: Allow updating news content after scheduled push notification was sent
+de: Ermögliche das Aktualisieren von News-Inhalten, nachdem eine geplante Push-Benachrichtigung gesendet wurde


### PR DESCRIPTION
## Summary
- Fix for issue where news objects became uneditable after a scheduled push notification was sent
- The push notification itself (already sent to devices) remains unchanged
- Only the news content displayed in the app can now be updated

## Root Cause
When updating an already-sent scheduled notification, the disabled `schedule_send` field still returned `True` from its initial value. The validation saw this and blocked the entire form submission, even though the user was just updating content.

## Solution
Added a check to skip the "already sent" validation when the `schedule_send` field is disabled, since:
- The user can't change a disabled field anyway
- They're just updating the news content
- Re-sending is still prevented (scheduling fields stay disabled)

## Test plan
- [ ] Create a news with a scheduled push notification (set to current time)
- [ ] Wait for the notification to be sent
- [ ] Try to edit the news content
- [ ] Verify the update succeeds and content is changed in the app

Fixes #3373

🤖 Generated with [Claude Code](https://claude.com/claude-code)