### PR TITLE
Fix changing slug if title not changed

### DIFF
--- a/integreat_cms/static/src/js/forms/update-permalink.ts
+++ b/integreat_cms/static/src/js/forms/update-permalink.ts
@@ -23,6 +23,8 @@ window.addEventListener("load", () => {
     /* slug field buffer for restoring input value */
     let currentSlug: string;
     /* slug field to be updated */
+    const titleField = document.querySelector("#id_title") as HTMLInputElement;
+    let oldTitle = titleField.value;
     const slugField = <HTMLInputElement>document.getElementById("id_slug");
     const linkContainer = document.getElementById("link-container");
 
@@ -42,18 +44,26 @@ window.addEventListener("load", () => {
 
     document.querySelectorAll("#id_title").forEach((item) => {
         item.addEventListener("focusout", ({ target }) => {
-            const submissionLock = new SubmissionPrevention(".no-premature-submission");
             const currentTitle = (target as HTMLInputElement).value;
-            const nodeList: NodeListOf<HTMLInputElement> = document.querySelectorAll(
-                '[for="id_title"],[for="id_slug"]'
-            );
-            for (const node of nodeList) {
-                const datasetItem = node.dataset;
-                slugify(datasetItem.slugifyUrl, { title: currentTitle, model_id: datasetItem.modelId })
-                    .then((response) => {
+            if (currentTitle !== oldTitle) {
+                const submissionLock = new SubmissionPrevention(".no-premature-submission");
+                const nodeList: NodeListOf<HTMLInputElement> = document.querySelectorAll("[data-slugify-url]");
+                const requests: Promise<void>[] = [];
+                for (const node of nodeList) {
+                    const datasetItem = node.dataset;
+                    const request = slugify(datasetItem.slugifyUrl, {
+                        title: currentTitle,
+                        model_id: datasetItem.modelId,
+                    }).then((response) => {
                         /* on success write response to both slug field and permalink */
                         slugField.value = response.unique_slug;
                         updatePermalink(response.unique_slug);
+                    });
+                    requests.push(request);
+                }
+                Promise.all(requests)
+                    .then(() => {
+                        oldTitle = currentTitle;
                     })
                     .finally(() => submissionLock.release());
             }


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. --> A small PR to fix unnecessary fetch calls to endpoint `ajax/de/page/slugify/` if the title has not changed


### Proposed changes
<!-- Describe this PR in more detail. -->

- now we keep track of the old title and compare it on the focusout event listener against the current title, if they are the same we do not propegate further


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
- open any page
- open chrome devtools > network tab:

1.) Check behavior if title does not change:
  - click inside the title input field
  - click outside the title input field
  - check inside the network list that /slugify was not called
 
2.) Check behavior if title does change
  - click inside the title input field
  - change the title
  - click outside the title input field
  - check inside the network list that /slugify was called


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3961 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
