### PR TITLE
Chat: store search term in debug message

### DIFF
--- a/integreat_cms/api/v3/chat/utils/chat_bot.py
+++ b/integreat_cms/api/v3/chat/utils/chat_bot.py
@@ -168,7 +168,7 @@ def celery_translate_and_answer_question(
             )
             zammad_chat.save_automatic_answers(answer["automatic_answers"])
             zammad_chat.save_message(
-                message="Used Sources\n<ul>"
+                message=f"Search term: '{answer['rag_message']}'. Used sources:\n<ul>"
                 + "\n".join(
                     [
                         f"<li><a href='{source['source']}'>{source['source'].split('/')[-2]}</a>: {source['reason_inclusion']}</li>"


### PR DESCRIPTION
### Short description
Store the search term in the RAG info message in Zammad.


### Proposed changes
- Add the search term used by the chat back end to the internal Zammad note.


### Side effects
- N/A


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
1. Start a chat on https://integreat.app/testumgebung-frag-integreat/en
2. Look into the chat on https://zammad-ig-testumgebung-frag-integreat.tuerantuer.org/


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fix: https://github.com/digitalfabrik/integreat-chat/issues/439


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
