### PR TITLE
Fix error message color

### DIFF
--- a/integreat_cms/core/utils/machine_translation_api_client.py
+++ b/integreat_cms/core/utils/machine_translation_api_client.py
@@ -384,7 +384,7 @@ class MachineTranslationApiClient(ABC):
         if not self.failed_translations:
             return
 
-        messages.success(
+        messages.error(
             self.request,
             ngettext_lazy(
                 "{model_name} {object_names} could not be translated automatically.",


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the color of error message in MT process.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Change to `messages.error()` from `messages.success()` in `alert_failed_translations`


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- This is a code shared by push notification and other contents (page, event, poi). That means this change will be applied to other contents too. But the behaviour is correct for all of them. (The bug was not PN specific)


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
- Switch to `develop` branch
- Go to "News", click "Create News"
- Copy & Paste from https://integreat-test.tuerantuer.org/testumgebung/push-notifications/de/2576/edit/
- Select a mode
- Check "Automatic translation" and select languages (other than Amharic, English, Arabic, Utrainian)
- See "... could not be translated automatically." in green
- Switch to `bug/error_message_pn_mt`
- Do the same
- See "... could not be translated automatically." in red

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4111 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
