### PR TITLE
Re-introduce link to the sent PN in the form

### DIFF
--- a/integreat_cms/cms/templates/push_notifications/push_notification_form.html
+++ b/integreat_cms/cms/templates/push_notifications/push_notification_form.html
@@ -101,6 +101,17 @@
                                    {% if push_notification_form.instance.id %}data-model-id="{{ push_notification_form.instance.id }}"{% endif %}>
                                 {{ push_notification_translation_form.title.label }}
                             </label>
+                            {% if push_notification_form.instance.sent_date and push_notification_translation_form.instance.id %}
+                                <div class="text-right py-2">
+                                    <span class="text-lg font-bold">{% translate "Link" %}:</span>
+                                    <a href="{{ WEBAPP_URL }}{{ push_notification_translation_form.instance.get_absolute_url }}"
+                                       class="text-blue-500 hover:underline"
+                                       target="_blank"
+                                       rel="noopener noreferrer">
+                                        {{ WEBAPP_URL }}{{ push_notification_translation_form.instance.get_absolute_url }}
+                                    </a>
+                                </div>
+                            {% endif %}
                         </div>
                         {% render_field push_notification_translation_form.title|add_error_class:"border-red-500" class+="mb-2" %}
                         <label for="{{ push_notification_translation_form.text.id_for_label }}">

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -4980,6 +4980,7 @@ msgid "Location"
 msgstr "Ort"
 
 #: cms/templates/_tinymce_config.html
+#: cms/templates/push_notifications/push_notification_form.html
 msgid "Link"
 msgstr "Link"
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR re-introduces the link to the app page of the push notification into the push notification form.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Revive the code


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- Should be none


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
- Checkout to `develop`
- Go to Augsburg, go to "News"
- Open "Test DE" (the only sent message in the default local data)
- See there is no link in any language
- Open another PN (not sent), see no link
- Checkout to `bug/sent_pn_missing_link`
- Go to "Test DE", see a link in German and English (but not in Farsi, for example)
- Go to another PN (not sent), see no link in any language

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4110 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
