### PR TITLE
Disable checkboxes of translation box for archived PNs

### DIFF
--- a/integreat_cms/cms/forms/push_notifications/push_notification_form.py
+++ b/integreat_cms/cms/forms/push_notifications/push_notification_form.py
@@ -73,6 +73,8 @@ class PushNotificationForm(CustomModelForm):
             self.fields["schedule_send"].disabled = True
             self.fields["scheduled_send_date_day"].disabled = True
             self.fields["scheduled_send_date_time"].disabled = True
+        if disabled:
+            self.fields["do_not_translate_title"].disabled = True
 
         self.fields["scheduled_send_date_day"].widget.attrs["min"] = str(
             timezone.now().date(),

--- a/integreat_cms/cms/views/push_notifications/push_notification_form_view.py
+++ b/integreat_cms/cms/views/push_notifications/push_notification_form_view.py
@@ -137,6 +137,8 @@ class PushNotificationFormView(TemplateView):
             request=request,
             language=language,
             instance=push_notification_translation,
+            disabled=details["disable_edit"]
+            or (push_notification and push_notification.archived),
         )
 
         return render(


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR disables the checkboxes of "Implications on translations" for archived PNs

### Proposed changes
<!-- Describe this PR in more detail. -->
- Pass `disabled` to the push notification translation form
- Set `do_not_translate_title` to disabled in the initilisation


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- Should be none


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
- Checkout to `develop`
- Go to a region
- Archive a PN
- Open the PN
- See the check boxes of "Implications on translations" are not disabled
- Checkout to `bug/mt_not_disabled_for_archived_pn`
- Open the same PN
- See the chec boxes are disabled

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4112 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
