### PR TITLE
Devcontainer: Fix missing yarn gpg key

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/vscode/devcontainers/python:3.11-bookworm
 
-RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor > /usr/share/keyrings/yarn-archive-keyring.gpg
+RUN rm -f /etc/apt/sources.list.d/yarn.list
 RUN apt-get update && \
     apt-get install -y nodejs npm && \
     npm install -g n && \


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This fixes missing public gpg key for yarn when building the docker image in the devcontainer. I used the solution as mentioned in the comment section of [this](https://github.com/Azure/static-web-apps-cli/issues/982) bug report. This came up while I tried to rebuild my devcontainer in VS code.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Curl for public gpg key for yarn and store it so that apt finds it


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none. I'm not entirely shure if this is something that is going to be solved externally or if this is a good long term fix for us here


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
Build the devcontainer in VS Code


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: # n.a.


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
