### PR TITLE
Limit contact card URL length in TinyMCE

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/3791.yml
+++ b/integreat_cms/release_notes/current/unreleased/3791.yml
@@ -1,0 +1,2 @@
+en: Long URLs in contact cards are now truncated with ellipsis
+de: Lange URLs in Kontaktkarten werden jetzt mit Auslassungspunkten abgeschnitten

--- a/integreat_cms/static/src/css/contact_card.css
+++ b/integreat_cms/static/src/css/contact_card.css
@@ -1,4 +1,13 @@
 .contact-card {
+    a[href] {
+        display: inline-block;
+        max-width: 70ch;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        vertical-align: bottom;
+    }
+
     display: inline-block;
     box-sizing: border-box;
     padding: 1rem;


### PR DESCRIPTION
### Short description
Limit the length of a URL in a contact card in TinyMCE (for example page form).

<img width="1330" height="397" alt="image" src="https://github.com/user-attachments/assets/2d7655c3-9cba-4e1e-b881-793a9b45c134" />

### Proposed changes
- Limit the length to 70 chars with CSS with `overflow: hidden` to hide characters beyond the max length.


### Side effects
- Full URLs are now longer visible in the page form. This can deviate from the Integreat app, which needs to introduce this change independently.


### Faithfulness to issue description and design
There are no intended deviations from the issue and design.


### How to test
1. Run the CMS in dev mode
2. [Edit the URL of a contact](http://localhost:8000/augsburg/pois/de/6/edit/) and make it longer than 70 cars.
3. Insert the contact into a [page of your choice](http://localhost:8000/augsburg/pages/de/21/edit/).


### Resolved issues
Fixes: #3791


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
