### PR TITLE
Fix: raise max page size to match pagination UI

### DIFF
--- a/integreat_cms/cms/views/mixins.py
+++ b/integreat_cms/cms/views/mixins.py
@@ -163,7 +163,7 @@ class PaginationMixin:
 
     request: Any
     default_page_size: int = settings.PER_PAGE or 10
-    max_page_size: int = 100
+    max_page_size: int = 500
 
     def paginate_queryset(self, queryset: QuerySet) -> Page:
         page = self.request.GET.get("page", 1)

--- a/integreat_cms/release_notes/current/unreleased/4140.yml
+++ b/integreat_cms/release_notes/current/unreleased/4140.yml
@@ -1,0 +1,2 @@
+en: Fix pagination allowing up to 500 entries per page as offered in the UI
+de: Paginierung erlaubt nun bis zu 500 Einträge pro Seite wie in der Benutzeroberfläche angeboten


### PR DESCRIPTION
## Summary
- Raises `max_page_size` in `PaginationMixin` from 100 to 500, matching the largest option offered in the pagination template (`pagination.html`)
- Previously, selecting "500" in the page size dropdown was silently clamped to 100

## Test plan
- [ ] Go to a contact list with more than 100 entries
- [ ] Select "500" in the page size dropdown
- [ ] Verify all entries (up to 500) are shown on a single page

Fixes #4140

🤖 Generated with [Claude Code](https://claude.ai/code)