### PR TITLE
Fix #3774: Change geocoding error to orange warning

### DIFF
--- a/integreat_cms/cms/templates/pois/poi_form_sidebar/position_box.html
+++ b/integreat_cms/cms/templates/pois/poi_form_sidebar/position_box.html
@@ -15,7 +15,7 @@
             {% translate "Address" %}
         </label>
         <div id="nominatim-error"
-             class="bg-red-100 border-l-4 border-red-500 text-red-700 px-4 py-3 my-2 hidden"
+             class="bg-orange-100 border-l-4 border-orange-500 text-orange-700 px-4 py-3 my-2 hidden"
              role="alert">
         </div>
         <label for="{{ poi_form.address.id_for_label }}" class="secondary">

--- a/integreat_cms/cms/views/pois/poi_actions.py
+++ b/integreat_cms/cms/views/pois/poi_actions.py
@@ -234,7 +234,7 @@ def auto_complete_address(
     )
 
     if not result:
-        raise Http404(_("Address could not be found"))
+        raise Http404(_("Coordinates could not be found"))
 
     address = result.raw.get("address", {})
     return JsonResponse(
@@ -278,7 +278,7 @@ def get_address_from_coordinates(
     )
 
     if not result:
-        raise Http404(_("Address could not be found"))
+        raise Http404(_("Coordinates could not be found"))
 
     address = result.raw.get("address", {})
 

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -11039,8 +11039,8 @@ msgid "Location service is disabled"
 msgstr "Ortung ist deaktiviert"
 
 #: cms/views/pois/poi_actions.py
-msgid "Address could not be found"
-msgstr "Adresse konnte nicht gefunden werden"
+msgid "Coordinates could not be found"
+msgstr "Koordinaten wurden nicht gefunden."
 
 #: cms/views/pois/poi_context_mixin.py
 msgid "Please confirm that you really want to archive this location"

--- a/integreat_cms/release_notes/current/unreleased/3774.yml
+++ b/integreat_cms/release_notes/current/unreleased/3774.yml
@@ -1,0 +1,2 @@
+en: Change geocoding failure message from red error to orange warning
+de: Fehlermeldung bei fehlgeschlagener Geocodierung von rotem Fehler zu orangener Warnung ändern


### PR DESCRIPTION
## Summary
- Change the geocoding failure message styling from red (error) to orange (warning), since saving is still possible when coordinates can't be found
- Update message text from "Address could not be found" to "Coordinates could not be found" which better describes the actual issue
- Update German translation accordingly

Closes #3774

## Test plan
- [ ] Create a new POI with a postbox address (e.g. "Postfach 1234") and verify the warning appears in orange
- [ ] Verify the message text reads "Coordinates could not be found" (or "Koordinaten wurden nicht gefunden." in German)
- [ ] Verify saving still works as expected
- [ ] Verify that when "show on map" is checked and coordinates are missing, the form validation error still correctly blocks saving

🤖 Generated with [Claude Code](https://claude.com/claude-code)