### PR TITLE
Fix generate_unique_slug() without Form

### DIFF
--- a/integreat_cms/cms/models/abstract_content_model.py
+++ b/integreat_cms/cms/models/abstract_content_model.py
@@ -207,6 +207,7 @@ class AbstractContentModel(AbstractBaseModel):
                 "foreign_model": self._meta.model_name,
                 "region": self.region,
                 "language": translation.language,
+                "fallback": self.created_date.isoformat(),
             }
             translation.slug = generate_unique_slug(**kwargs)
             translation.currently_in_translation = False

--- a/integreat_cms/cms/models/events/event_translation.py
+++ b/integreat_cms/cms/models/events/event_translation.py
@@ -167,7 +167,7 @@ class EventTranslation(AbstractContentTranslation):
                 "foreign_model": "event",
                 "region": self.event.region,
                 "language": self.language,
-                "fallback": "title",
+                "fallback": self.title,
             }
             self.slug = generate_unique_slug(**kwargs)
 

--- a/integreat_cms/cms/models/pages/page_translation.py
+++ b/integreat_cms/cms/models/pages/page_translation.py
@@ -423,7 +423,7 @@ class PageTranslation(AbstractBasePageTranslation):
                 "foreign_model": "page",
                 "region": self.page.region,
                 "language": self.language,
-                "fallback": "title",
+                "fallback": self.title,
             }
             self.slug = generate_unique_slug(**kwargs)
 

--- a/integreat_cms/cms/models/pois/poi_translation.py
+++ b/integreat_cms/cms/models/pois/poi_translation.py
@@ -188,7 +188,7 @@ class POITranslation(AbstractContentTranslation):
                 "foreign_model": "poi",
                 "region": self.poi.region,
                 "language": self.language,
-                "fallback": "title",
+                "fallback": self.title,
             }
             self.slug = generate_unique_slug(**kwargs)
 

--- a/integreat_cms/cms/utils/slug_utils.py
+++ b/integreat_cms/cms/utils/slug_utils.py
@@ -11,11 +11,9 @@ from typing import Final, Literal, TYPE_CHECKING
 from celery import shared_task
 from django.apps import apps
 from django.conf import settings
-from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db.models import Exists, OuterRef
 from django.utils.text import slugify
-from django.utils.translation import gettext_lazy as _
 
 if TYPE_CHECKING:
     from typing import (
@@ -29,7 +27,6 @@ if TYPE_CHECKING:
 
     from django.db.models import Manager, QuerySet
     from django.forms import ModelForm
-    from django.http.request import QueryDict
 
     from ..models import Language, Region
     from ..models.abstract_base_model import AbstractBaseModel
@@ -60,8 +57,7 @@ if TYPE_CHECKING:
         A custom type for keyword arguments to :func:`generate_unique_slug`
         """
 
-        cleaned_data: NotRequired[QueryDict]
-        fallback: NotRequired[Literal["name", "title"]]
+        fallback: NotRequired[str]
         foreign_model: ForeignModelType
         foreign_object: NotRequired[AbstractContentModel]
         language: NotRequired[Language]
@@ -82,25 +78,22 @@ def generate_unique_slug_helper(
     :param form_object: The form which contains the slug field
     :param foreign_model: If the form instance has a foreign key to another model (e.g. because it is a translation of
                           a content-object), this parameter contains the model of the foreign related object.
-    :raises ~django.core.exceptions.ValidationError: When no slug is given and there is also no field which can be used
-                                                     as fallback (either ``title`` or ``name``).
 
     :return: An unique slug identifier
     """
     kwargs: SlugKwargs = {
         "slug": form_object.cleaned_data["slug"],
-        "cleaned_data": form_object.cleaned_data,
         "manager": form_object.Meta.model.objects,
         "object_instance": form_object.instance,
         "foreign_model": foreign_model,
-        "fallback": "name",
+        "fallback": form_object.cleaned_data.get("name"),
     }
     if foreign_model in ALLOWED_OBJECTS:
         kwargs.update(
             {
                 "region": form_object.instance.foreign_object.region,
                 "language": form_object.instance.language,
-                "fallback": "title",
+                "fallback": form_object.cleaned_data.get("title"),
             },
         )
     return generate_unique_slug(**kwargs)
@@ -110,7 +103,7 @@ def generate_unique_slug(**kwargs: Unpack[SlugKwargs]) -> str:
     r"""
     This function can be used in :mod:`~integreat_cms.cms.forms` to clean slug fields. It will make sure the slug field contains a
     unique identifier per region and language. It can also be used for region slugs (``foreign_model`` is ``None`` in
-    this case). If the slug field is empty, it creates a fallback value from either the ``title`` or the ``name`` field.
+    this case). If the slug field is empty, it assumes the fallback value, if given.
     In case the slug exists already, it appends a counter which is increased until the slug is unique.
 
     Example usages:
@@ -121,8 +114,6 @@ def generate_unique_slug(**kwargs: Unpack[SlugKwargs]) -> str:
     * :func:`~integreat_cms.cms.forms.pois.poi_translation_form.POITranslationForm.clean_slug`
 
     :param \**kwargs: The supplied keyword arguments
-    :raises ~django.core.exceptions.ValidationError: When no slug is given and there is also no field which can be used
-                                                     as fallback (either ``title`` or ``name``).
 
     :return: An unique slug identifier
     """
@@ -130,8 +121,7 @@ def generate_unique_slug(**kwargs: Unpack[SlugKwargs]) -> str:
     foreign_model: str | None = kwargs.get("foreign_model")
     foreign_object: AbstractContentModel | None = kwargs.get("foreign_object")
     object_instance: AbstractBaseModel = kwargs["object_instance"]
-    fallback: Literal["name", "title", ""] = kwargs.get("fallback", "")
-    cleaned_data: dict[str, Any] = kwargs.get("cleaned_data", {})
+    fallback: str = kwargs.get("fallback", "")
     region: Region | None = kwargs.get("region")
     language: Language | None = kwargs.get("language")
     manager: Any = kwargs["manager"]
@@ -141,9 +131,7 @@ def generate_unique_slug(**kwargs: Unpack[SlugKwargs]) -> str:
         logger.debug("%r, %r", region, language)
     logger.debug("slug: %r", slug)
 
-    base_slug = generate_base_slug(
-        slug, fallback, cleaned_data, object_instance, foreign_model
-    )
+    base_slug = generate_base_slug(slug, fallback, object_instance, foreign_model)
     pre_filtered_objects = get_prefiltered_queryset(
         manager,
         foreign_model,
@@ -180,24 +168,17 @@ def generate_unique_slug(**kwargs: Unpack[SlugKwargs]) -> str:
 def generate_base_slug(
     slug: str,
     fallback: str,
-    cleaned_data: dict[str, Any],
     object_instance: AbstractBaseModel,
     foreign_model: str | None,
 ) -> str:
     """
-    Generates the base slug either from the given slug or from the fallback field.
+    Generates the base slug from the given slug or fallback.
     """
     if slug:
         return slug
 
-    if fallback not in cleaned_data:
-        raise ValidationError(
-            _("Cannot generate slug from {}.").format(_(fallback)),
-            code="invalid",
-        )
-
     allow_unicode = object_instance._meta.get_field("slug").allow_unicode
-    slug = slugify(cleaned_data[fallback], allow_unicode=allow_unicode)
+    slug = slugify(fallback, allow_unicode=allow_unicode)
 
     return slug or foreign_model or ""
 
@@ -283,6 +264,7 @@ def update_translations(
                 foreign_object=foreign_obj,
                 region=region,
                 language=translation.language,
+                fallback=translation.title,  # function is already restricted to handle only objects with title
             )
             if old_slug != translation.slug:
                 counter += 1

--- a/integreat_cms/cms/views/utils/slugify_ajax.py
+++ b/integreat_cms/cms/views/utils/slugify_ajax.py
@@ -71,6 +71,7 @@ def slugify_ajax(
         "foreign_model": model_type,
         "region": request.region,
         "language": language,
+        "fallback": object_instance.title,  # function is already restricted to handle only objects with title
     }
     unique_slug = generate_unique_slug(**kwargs)
     return JsonResponse({"unique_slug": unique_slug})

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -9508,10 +9508,6 @@ msgstr "PDF-Datei konnte nicht erfolgreich erzeugt werden."
 msgid "MISSING LINK"
 msgstr "FEHLENDER LINK"
 
-#: cms/utils/slug_utils.py
-msgid "Cannot generate slug from {}."
-msgstr "Slug kann nicht aus dem {} abgeleitet werden."
-
 #: cms/utils/stringify_list.py
 msgid "and 1 other"
 msgstr "und 1 weitere"
@@ -11964,6 +11960,9 @@ msgid "This page belongs to another region ({})."
 msgstr ""
 "Diese Seite konnte nicht importiert werden, da sie zu einer anderen Region "
 "gehört ({})."
+
+#~ msgid "Cannot generate slug from fallback."
+#~ msgstr "Slug kann nicht aus dem Fallback abgeleitet werden."
 
 #~ msgid ""
 #~ "Any manager with access to only some of the selected regions can view but "

--- a/tests/cms/utils/test_slug_utils.py
+++ b/tests/cms/utils/test_slug_utils.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pytest
-from django.core.exceptions import ValidationError
 
 from integreat_cms.cms.models import PageTranslation, Region
 from integreat_cms.cms.utils.slug_utils import generate_unique_slug
@@ -20,16 +19,14 @@ def test_generate_unique_slug_fallback(
     load_test_data: None,
 ) -> None:
     """
-    Test whether the :meth:`~integreat_cms.cms.utils.slug_utils.generate_unique_slug_helper` function correctly uses the fallback property
-    when no slug is provided
+    Test whether the :func:`~integreat_cms.cms.utils.slug_utils.generate_unique_slug` function correctly uses the fallback when no slug is provided
     """
     region = Region.objects.get(slug="augsburg")
     kwargs: SlugKwargs = {
-        "cleaned_data": {"name": "unique_slug_fallback"},
         "manager": Region.objects,
         "object_instance": region,
         "foreign_model": "region",
-        "fallback": "name",
+        "fallback": "unique_slug_fallback",
     }
     assert generate_unique_slug(**kwargs) == "unique_slug_fallback", (
         "Name is not used as fallback when slug is missing"
@@ -42,17 +39,15 @@ def test_generate_unique_slug_reserved_region_slug(
     load_test_data: None,
 ) -> None:
     """
-    Test whether the :meth:`~integreat_cms.cms.utils.slug_utils.generate_unique_slug_helper` function returns the correct unique slug
-    when the new region slug is a reserved slug
+    Test whether the :func:`~integreat_cms.cms.utils.slug_utils.generate_unique_slug` function returns the correct unique slug when the new region slug is a reserved slug
     """
     region = Region.objects.get(slug="augsburg")
     kwargs: SlugKwargs = {
         "slug": "landing",
-        "cleaned_data": {},
         "manager": Region.objects,
         "object_instance": region,
         "foreign_model": "region",
-        "fallback": "name",
+        "fallback": "Augsburg",
     }
     assert generate_unique_slug(**kwargs) == "landing-2", (
         "Reserved region slug is not prevented"
@@ -65,13 +60,11 @@ def test_generate_unique_slug_reserved_page_slug(
     load_test_data: None,
 ) -> None:
     """
-    Test whether the :meth:`~integreat_cms.cms.utils.slug_utils.generate_unique_slug_helper` function  function returns the correct unique slug
-    when the new page slug is a reserved slug
+    Test whether the :func:`~integreat_cms.cms.utils.slug_utils.generate_unique_slug` function  function returns the correct unique slug when the new page slug is a reserved slug
     """
     page = PageTranslation.objects.filter(page__region__slug="augsburg").first()
     kwargs: SlugKwargs = {
         "slug": "disclaimer",
-        "cleaned_data": {},
         "manager": PageTranslation.objects,
         "language": page.language,
         "object_instance": page,
@@ -80,19 +73,3 @@ def test_generate_unique_slug_reserved_page_slug(
     assert generate_unique_slug(**kwargs) == "disclaimer-2", (
         "Reserved imprint slug is not prevented for pages"
     )
-
-
-def test_generate_unique_slug_no_fallback() -> None:
-    """
-    Test whether the :meth:`~integreat_cms.cms.utils.slug_utils.generate_unique_slug_helper` throws a :class:`django.core.exceptions.ValidationError`,
-    while the fallback property does not exist
-    """
-    kwargs: SlugKwargs = {
-        "cleaned_data": {},
-        "manager": [],
-        "object_instance": Region(),
-        "foreign_model": "region",
-        "fallback": "name",
-    }
-    with pytest.raises(ValidationError):
-        generate_unique_slug(**kwargs)


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
`test_duplicate_pages` currently always fails with `django.core.exceptions.ValidationError: ['Slug kann nicht aus dem Titel abgeleitet werden.']`. It seems that `generate_unique_slug()` is built with forms in mind, but also called directly from `PageTranslation.clean()`, where `kwargs["cleaned_data"]` is not supplied and thus regarded `{}`, meaning that the title is not where `generate_unique_slug()` looks for a fallback.

### Proposed changes
<!-- Describe this PR in more detail. -->

- In `PageTranslation.clean()`, gather the current attributes of the object into a dict to pass in as `cleaned_data`


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- This might be a source of confusion later, the alternative is to consider a refactoring of `generate_unique_slug()` to not name it `cleaned_data` and not imply the involvement of a form.
- There might be differences in the way a form produces `cleaned_data` and how the naive gathering of attributes via `._meta.fields` works. Fields may be missing, produce extra entries and unexpected values. It currently works for slugs but expecting this to be generalizable to any attribute is a dangerous assumption.


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
Run `test_duplicate_pages`

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4149


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
