### PR TITLE
Fix URL replacement for percent-encoded URLs

### DIFF
--- a/integreat_cms/cms/models/abstract_content_translation.py
+++ b/integreat_cms/cms/models/abstract_content_translation.py
@@ -4,6 +4,7 @@ import logging
 from copy import deepcopy
 from html import escape
 from typing import TYPE_CHECKING
+from urllib.parse import unquote
 
 from django.conf import settings
 from django.db import models, transaction
@@ -617,9 +618,22 @@ class AbstractContentTranslation(AbstractBaseModel):
         """
         new_translation = self.create_new_version_copy(user)
         logger.debug("Replacing links of %r: %r", new_translation, urls_to_replace)
+
+        # Build a normalized lookup: map decoded URLs to their replacements too
+        # so that percent-encoded URLs in HTML match against decoded dict keys
+        normalized: dict[str, str] = {}
+        for old_url, new_url in urls_to_replace.items():
+            normalized[old_url] = new_url
+            normalized[unquote(old_url)] = new_url
+
+        def resolve_url(content_url: str) -> str:
+            return normalized.get(
+                content_url, normalized.get(unquote(content_url), content_url)
+            )
+
         new_translation.content = rewrite_links(
             new_translation.content,
-            lambda content_url: urls_to_replace.get(content_url, content_url),
+            resolve_url,
         )
         new_translation.content = fix_content_link_encoding(new_translation.content)
         if new_translation.content != self.content and commit:

--- a/integreat_cms/release_notes/current/unreleased/4129.yml
+++ b/integreat_cms/release_notes/current/unreleased/4129.yml
@@ -1,0 +1,2 @@
+en: Fix URL replacement not working for percent-encoded URLs
+de: URL-Ersetzung für prozent-kodierte URLs repariert

--- a/tests/cms/views/link_replace/test_link_actions.py
+++ b/tests/cms/views/link_replace/test_link_actions.py
@@ -90,9 +90,7 @@ def test_url_replace(
         )
 
         assert Link.objects.filter(url__url=OLD_URL).count() == after
-        """
         assert Link.objects.filter(url__url=NEW_URL).count() == before - after
-        """
 
     elif role == ANONYMOUS:
         assert response.status_code == 302
@@ -184,12 +182,10 @@ def test_search_and_replace_links(
         )
 
         assert Link.objects.filter(url__url=SEARCH_REPLACE_TARGET_URL).count() == after
-        """
         assert (
-           Link.objects.filter(url__url=TARGET_URL_AFTER_REPLACE).count()
-           == before - after
+            Link.objects.filter(url__url=TARGET_URL_AFTER_REPLACE).count()
+            == before - after
         )
-        """
 
     elif role == ANONYMOUS:
         assert response.status_code == 302


### PR DESCRIPTION
## Summary
- Fixes #4129: The linkchecker's "Replace URL" button silently fails for URLs containing non-ASCII characters (e.g., Cyrillic) due to an encoding mismatch between lxml's `rewrite_links()` callback and the linkcheck `Url.url` dict keys
- Normalizes URL encoding in `replace_urls()` by building a lookup dict that maps both raw and `unquote()`-decoded URLs to their replacements
- Re-enables previously commented-out test assertions that verify replacement results

## Test plan
- [ ] Run `tools/test.sh tests/cms/views/link_replace/test_link_actions.py` to verify existing and re-enabled assertions pass
- [ ] Manually test replacing a URL containing non-ASCII characters (e.g., Cyrillic) via the linkchecker's pencil icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)