### PR TITLE
Validate recurring event start date against recurrence rule

### DIFF
--- a/integreat_cms/cms/forms/events/recurrence_rule_form.py
+++ b/integreat_cms/cms/forms/events/recurrence_rule_form.py
@@ -84,16 +84,29 @@ class RecurrenceRuleForm(CustomModelForm):
                     _('Recurrence "daily" is not allowed anymore'), code="invalid"
                 ),
             )
-        elif cleaned_data.get("frequency") == frequency.WEEKLY and not cleaned_data.get(
-            "weekdays_for_weekly",
-        ):
-            self.add_error(
-                "weekdays_for_weekly",
-                forms.ValidationError(
-                    _("No weekdays for weekly recurrence selected"),
-                    code="required",
-                ),
-            )
+        elif cleaned_data.get("frequency") == frequency.WEEKLY:
+            if not cleaned_data.get("weekdays_for_weekly"):
+                self.add_error(
+                    "weekdays_for_weekly",
+                    forms.ValidationError(
+                        _("No weekdays for weekly recurrence selected"),
+                        code="required",
+                    ),
+                )
+            elif (
+                self.event_start_date
+                and self.event_start_date.weekday()
+                not in cleaned_data["weekdays_for_weekly"]
+            ):
+                self.add_error(
+                    "weekdays_for_weekly",
+                    forms.ValidationError(
+                        _(
+                            "The start date of the event does not match the selected weekdays for weekly recurrence"
+                        ),
+                        code="invalid",
+                    ),
+                )
         elif cleaned_data.get("frequency") == frequency.MONTHLY:
             if cleaned_data.get("weekday_for_monthly") is None:
                 self.add_error(
@@ -101,6 +114,20 @@ class RecurrenceRuleForm(CustomModelForm):
                     forms.ValidationError(
                         _("No weekday for monthly recurrence selected"),
                         code="required",
+                    ),
+                )
+            elif (
+                self.event_start_date
+                and self.event_start_date.weekday()
+                != cleaned_data["weekday_for_monthly"]
+            ):
+                self.add_error(
+                    "weekday_for_monthly",
+                    forms.ValidationError(
+                        _(
+                            "The start date of the event does not match the selected weekday for monthly recurrence"
+                        ),
+                        code="invalid",
                     ),
                 )
             if not cleaned_data.get("week_for_monthly"):
@@ -111,6 +138,31 @@ class RecurrenceRuleForm(CustomModelForm):
                         code="required",
                     ),
                 )
+            elif (
+                self.event_start_date
+                and "weekday_for_monthly" not in self.errors
+                and cleaned_data.get("weekday_for_monthly") is not None
+            ):
+                temp_rule = RecurrenceRule(
+                    frequency=frequency.MONTHLY,
+                    interval=cleaned_data.get("interval", 1),
+                    weekdays_for_weekly=[],
+                    weekday_for_monthly=cleaned_data["weekday_for_monthly"],
+                    week_for_monthly=cleaned_data["week_for_monthly"],
+                )
+                first_occurrence = next(
+                    iter(temp_rule.iter_after(self.event_start_date)), None
+                )
+                if first_occurrence != self.event_start_date:
+                    self.add_error(
+                        "week_for_monthly",
+                        forms.ValidationError(
+                            _(
+                                "The start date of the event does not match the selected week for monthly recurrence"
+                            ),
+                            code="invalid",
+                        ),
+                    )
 
         if (
             cleaned_data.get("recurrence_end_date")

--- a/integreat_cms/cms/utils/external_calendar_utils.py
+++ b/integreat_cms/cms/utils/external_calendar_utils.py
@@ -500,7 +500,8 @@ def import_event(
     recurrence_rule_form = RecurrenceRuleForm(
         data=recurrence_rule_form_data,
         instance=previously_imported_recurrence_rule,
-        event_start_date=event_form.cleaned_data.get("start_date"),
+        # Don't validate start date for imports: RFC 5545 allows DTSTART to not
+        # fall on one of the RRULE days.
     )
     if recurrence_rule_form_data and not recurrence_rule_form.is_valid():
         logger.error(

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -2029,12 +2029,33 @@ msgid "No weekdays for weekly recurrence selected"
 msgstr "Keine Wochentage für die wöchentliche Wiederholung eingegeben"
 
 #: cms/forms/events/recurrence_rule_form.py
+msgid ""
+"The start date of the event does not match the selected weekdays for weekly "
+"recurrence"
+msgstr ""
+"Das Startdatum der Veranstaltung stimmt nicht mit den ausgewählten Wochentagen für die wöchentliche Wiederholung überein"
+
+#: cms/forms/events/recurrence_rule_form.py
 msgid "No weekday for monthly recurrence selected"
 msgstr "Kein Wochentag für die monatliche Wiederholung eingegeben"
 
 #: cms/forms/events/recurrence_rule_form.py
+msgid ""
+"The start date of the event does not match the selected weekday for monthly "
+"recurrence"
+msgstr ""
+"Das Startdatum der Veranstaltung stimmt nicht mit dem ausgewählten Wochentag für die monatliche Wiederholung überein"
+
+#: cms/forms/events/recurrence_rule_form.py
 msgid "No week for monthly recurrence selected"
 msgstr "Keine Woche für die monatliche Wiederholung eingegeben"
+
+#: cms/forms/events/recurrence_rule_form.py
+msgid ""
+"The start date of the event does not match the selected week for monthly "
+"recurrence"
+msgstr ""
+"Das Startdatum der Veranstaltung stimmt nicht mit der ausgewählten Woche für die monatliche Wiederholung überein"
 
 #: cms/forms/events/recurrence_rule_form.py
 msgid "The recurrence end date has to be after the event's start date"

--- a/integreat_cms/release_notes/current/unreleased/1967.yml
+++ b/integreat_cms/release_notes/current/unreleased/1967.yml
@@ -1,0 +1,2 @@
+en: Validate that the start date of recurring events matches the recurrence rule
+de: Validiere, dass das Startdatum wiederkehrender Veranstaltungen zur Wiederholungsregel passt


### PR DESCRIPTION
## Summary
- Validates that the event start date matches the selected recurrence rule when creating/editing recurring events
- For **weekly** recurrence: the start date's weekday must be among the selected weekdays
- For **monthly** recurrence: the start date must match both the selected weekday **and** the selected week of the month (e.g. a start date on the 3rd Tuesday is rejected for a rule saying "1st Tuesday")

The monthly week-of-month check reuses the existing `iter_after()` logic via a temporary `RecurrenceRule` instance, which correctly handles the "last week of month" edge case.

Closes #1967

## Test plan
- [ ] Create a weekly recurring event where the start date's weekday is **not** in the selected weekdays → should show validation error
- [ ] Create a weekly recurring event where the start date's weekday **is** in the selected weekdays → should save normally
- [ ] Create a monthly recurring event where the start date's weekday does **not** match → should show validation error on weekday field
- [ ] Create a monthly recurring event where the weekday matches but the week does **not** (e.g. start on 3rd Tuesday, rule says 1st Tuesday) → should show validation error on week field
- [ ] Create a monthly recurring event where both weekday and week match → should save normally
- [ ] Edit an existing recurring event and verify validation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)