### PR TITLE
Fix management command for unique slugs

### DIFF
--- a/docs/src/management-commands.rst
+++ b/docs/src/management-commands.rst
@@ -298,6 +298,23 @@ Source path                                                                     
 * ``--region REGION``: The region slug whose media library to upload the files to
 * ``--global``: Upload the files to the global library
 
+``make_slugs_unique``
+~~~~~~~~~~~~~~~~~~~~~~
+
+Iterates over all translations of pages, events and pois(locations) in the database and if it finds a duplicate slug somewhere, 
+it changes it so that in the end all slugs are unique per language and region. This command is needed because we currently do not 
+guarantee slug uniqueness on the database level, and therefore duplicate slugs are possible. 
+Once the database constraint will have been implemented, this command should be executed 
+once and should not be needed afterwards in the future:
+
+    integreat-cms-cli make_slugs_unique [--dryrun] [--objects OBJECT_NAMES]
+
+**Input options:**
+
+* ``--dry-run``: Runs the Iteration without commiting the changes to the DB
+* ``--objects OBJECT_NAMES``: A list of names of content models this should be applied to e.g. `--objects page poi`
+
+
 Create new commands
 -------------------
 

--- a/integreat_cms/cms/utils/slug_utils.py
+++ b/integreat_cms/cms/utils/slug_utils.py
@@ -13,6 +13,7 @@ from django.apps import apps
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import transaction
+from django.db.models import Exists, OuterRef
 from django.utils.text import slugify
 from django.utils.translation import gettext_lazy as _
 
@@ -304,8 +305,21 @@ def make_all_slugs_unique(
         translation_model = apps.get_model(
             "cms", f"{model_name.capitalize()}Translation"
         )
-        translations = translation_model.objects.all()
-        slug_counter += update_translations(translations, model_name, dry_run)
+
+        other_with_same_slug = translation_model.objects.filter(
+            slug=OuterRef("slug"),
+            language=OuterRef("language"),
+            **{f"{model_name}__region": OuterRef(f"{model_name}__region")},
+        ).exclude(**{f"{model_name}": OuterRef(model_name)})
+        not_unique = translation_model.objects.filter(
+            Exists(other_with_same_slug)
+        ).select_related(model_name, f"{model_name}__region", "language")
+
+        slug_counter += update_translations(
+            not_unique,
+            model_name,
+            dry_run,
+        )
 
     end_time = time() - start_time
     if not dry_run:


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

A new management command that fixes corrupted data rows of page-, poi- and eventtranslations, where slugs within the same region and same language (but for different contentobject) are not unique. 


### Proposed changes
<!-- Describe this PR in more detail. -->

- a management command that defers the execution to celery, to make all slugs for events, pois und pages unique


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->




### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
- this command does not guarantee uniqueness on the database level yet, but a PR with that will follow. This PR will also include a data migration that will basically execute the command as a data migration


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->

on django development server:
- create a translation with duplicate slug throguh shell using the create method (save yields to modellevel constraints already)
- run server (to start up celery)
- in the terminal run `tools/integreat-cms-cli make_slugs_unique -- dry-run`
- see that the task is queued and finished after some time 
- in the terminal run `tools/integreat-cms-cli make_slugs_unique`
- see that duplicate slugs get fixed and persisted to the database


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4156


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
