### PR TITLE
Add fallback message for failed LLM responses

### DIFF
--- a/integreat_cms/api/v3/chat/utils/chat_bot.py
+++ b/integreat_cms/api/v3/chat/utils/chat_bot.py
@@ -12,6 +12,8 @@ import aiohttp
 from celery import shared_task
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
+from django.utils.translation import gettext
+from django.utils.translation import override as translation_override
 
 from integreat_cms.cms.models import Region, UserChat
 
@@ -108,6 +110,25 @@ async def async_process_user_message(
         return translation, answer
 
 
+def fallback_message(zammad_chat: UserChat) -> None:
+    """
+    Provide an error message to the front end user if the back end failed
+    to generate a response.
+
+    :param zammad_chat: The chat which is currently being processed.
+    """
+    zammad_chat.refresh_from_db()
+    with translation_override(zammad_chat.language.slug):
+        fallback_message = gettext(
+            "Sorry, an error occurred. We were not able to provide an answer. Please try again later."
+        )
+    zammad_chat.save_message(
+        message=fallback_message,
+        internal=False,
+        automatic_message=True,
+    )
+
+
 @shared_task
 def celery_translate_and_answer_question(
     message_timestamp: datetime,
@@ -149,6 +170,7 @@ def celery_translate_and_answer_question(
         logger.exception(
             "Failed to get response from chat back end due to connection error."
         )
+        fallback_message(zammad_chat)
         zammad_chat.processing_answer = False
         return
     zammad_chat.refresh_from_db()
@@ -159,6 +181,7 @@ def celery_translate_and_answer_question(
     if answer:
         if answer["status"] == "error":
             logger.error("Integreat Chat: %s", answer["message"])
+            fallback_message(zammad_chat)
         else:
             zammad_chat.save_message(
                 message=answer["answer"],

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -22,6 +22,14 @@ msgstr ""
 msgid "API"
 msgstr "API"
 
+#: api/v3/chat/utils/chat_bot.py
+msgid ""
+"Sorry, an error occurred. We were not able to provide an answer. Please try "
+"again later."
+msgstr ""
+"Entschuldigung, es ist ein Fehler aufgetreten. Bitte probiere es später "
+"erneut."
+
 #: cms/apps.py
 msgid "CMS"
 msgstr "CMS"


### PR DESCRIPTION
### Short description
Add error message for Ask Integreat users when the LLM fails to generate a response.

### Proposed changes
- Catch error and write fallback message to Zammad.


### Side effects
- Not all app languages are currently supported. Most languages will se an EN message.


### Faithfulness to issue description and design
There are no intended deviations from the issue and design.


### How to test
1. Start generating a message.
2. Restart the chat back end while answer is being processed.
3. Fallback message should be saved to Zammad.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: https://github.com/digitalfabrik/integreat-chat/issues/442


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
