### PR TITLE
Add Frag Integreat per language statistics

### DIFF
--- a/integreat_cms/cms/templates/dashboard/_public_chat_stats.html
+++ b/integreat_cms/cms/templates/dashboard/_public_chat_stats.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load static %}
 {% load parse_struct_time %}
+{% load content_filters %}
 {% block collapsible_box_icon %}
     trending-up
 {% endblock collapsible_box_icon %}
@@ -9,22 +10,72 @@
     {% translate "Frag Integreat Statistics" %}
 {% endblock collapsible_box_title %}
 {% block collapsible_box_content %}
-    <ul>
-        <li>
-            {% translate "Chats in last 6 hours" %}: {{ chats_last_6h }} <a class="font-bold text-blue-500 underline"
-    href="{{ request.region.zammad_url }}"><i class="ml-2" icon-name="external-link"></i>{% translate "Open Chat Support System (Zammad)" %}</a>
-        </li>
-        <li>
-            {% translate "Chats in last 30 days" %}: {{ chats_last_30_days }}, {% translate "Used budget in last 30 days" %}: {{ chats_last_30_days_budget }}
-        </li>
-        <li>
-            {% translate "Chats in previous 30 days" %}: {{ chats_previous_30_days }}, {% translate "Used budget in previous 30 days" %}: {{ chats_previous_30_days_budget }}
-        </li>
-        <li>
-            {% translate "Total chats" %}: {{ chats_total }}, {% translate "Total used budget" %}: {{ chats_total_budget }}
-        </li>
-    </ul>
-    <p>
+    <div class="flex flex-wrap gap-4 mb-6">
+        <div class="flex-1 min-w-[150px] flex flex-col">
+            <p class="text-xs text-gray-600">
+                {% translate "Chats in last 6 hours" %}
+            </p>
+            <p class="text-lg font-bold">
+                {{ chats_last_6h }}
+            </p>
+            <p class="text-lg font-bold">
+                {% translate "Budget:" %} {{ chats_last_6h_budget }}
+            </p>
+        </div>
+        <div class="flex-1 min-w-[150px]">
+            <p class="text-xs text-gray-600">
+                {% translate "Last 30 days" %}
+            </p>
+            <p class="text-lg font-bold">
+                {{ chats_last_30_days }}
+            </p>
+            <p class="text-xs text-gray-600">
+                {% translate "Budget:" %} {{ chats_last_30_days_budget }}
+            </p>
+        </div>
+        <div class="flex-1 min-w-[150px]">
+            <p class="text-xs text-gray-600">
+                {% translate "Previous 30 days" %}
+            </p>
+            <p class="text-lg font-bold">
+                {{ chats_previous_30_days }}
+            </p>
+            <p class="text-xs text-gray-600">
+                {% translate "Budget:" %} {{ chats_previous_30_days_budget }}
+            </p>
+        </div>
+        <div class="flex-1 min-w-[150px]">
+            <p class="text-xs text-gray-600">
+                {% translate "Total chats" %}
+            </p>
+            <p class="text-lg font-bold">
+                {{ chats_total }}
+            </p>
+            <p class="text-xs text-gray-600">
+                {% translate "Budget:" %} {{ chats_total_budget }}
+            </p>
+        </div>
+    </div>
+    <div class="flex flex-wrap gap-2 {% if chats_by_language %}mb-4{% endif %}">
+        <p class="w-full text-sm font-medium mb-1">
+            {% translate "Chats by language:" %}
+        </p>
+        {% for entry in chats_by_language %}
+            <span class="px-3 py-1 bg-gray-100 rounded text-sm">
+                {{ entry.language__english_name|translate_language_name }}: {{ entry.count }}
+            </span>
+        {% empty %}
+            <span class="px-3 py-1 text-gray-500">
+                {% translate "No data available" %}
+            </span>
+        {% endfor %}
+    </div>
+    <p class="text-xs text-gray-600">
         <strong>{% translate "Note:" %}</strong> {% blocktranslate %}1 word = {{ budget_weight }} budget points.{% endblocktranslate %}
+        <a href="{{ request.region.zammad_url }}"
+           class="text-blue-500 underline text-sm mt-1 inline-flex items-center">
+            <i icon-name="external-link" class="w-3 h-3 ml-1"></i>
+            {% translate "Open Chat Support System (Zammad)" %}
+        </a>
     </p>
 {% endblock collapsible_box_content %}

--- a/integreat_cms/cms/templates/dashboard/_public_chat_stats.html
+++ b/integreat_cms/cms/templates/dashboard/_public_chat_stats.html
@@ -18,7 +18,7 @@
             <p class="text-lg font-bold">
                 {{ chats_last_6h }}
             </p>
-            <p class="text-lg font-bold">
+            <p class="text-lg">
                 {% translate "Budget:" %} {{ chats_last_6h_budget }}
             </p>
         </div>

--- a/integreat_cms/cms/templatetags/content_filters.py
+++ b/integreat_cms/cms/templatetags/content_filters.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING
 
 from django import template
 from django.urls import reverse
+from django.utils.translation import gettext
 from django.utils.translation import gettext_lazy as _
 
 from ..constants import translation_status, weekdays
@@ -218,6 +219,17 @@ def get_int_list(data: QueryDict, list_name: str) -> list[int]:
     :return: The int value list
     """
     return [int(item) for item in data.getlist(list_name)]
+
+
+@register.filter
+def translate_language_name(english_name: str) -> str:
+    """
+    This filter translates an English language name to the current backend language.
+
+    :param english_name: The English name of a language
+    :return: The translated name of the language
+    """
+    return gettext(english_name)
 
 
 @register.filter

--- a/integreat_cms/cms/views/dashboard/dashboard_view.py
+++ b/integreat_cms/cms/views/dashboard/dashboard_view.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
-from django.db.models import Sum
+from django.db.models import Count, Sum
 from django.http import JsonResponse
 from django.urls import reverse
 from django.utils import translation
@@ -170,12 +170,22 @@ class DashboardView(TemplateView, ChatContextMixin):
             last_message_timestamp__lte=now - timedelta(days=30),
             last_message_timestamp__gt=now - timedelta(days=60),
         )
+        chats_by_language = (
+            UserChat.objects.filter(region=self.request.region)
+            .values("language__english_name")
+            .annotate(count=Count("id"))
+            .order_by("-count")
+        )
 
         return {
             "budget_weight": settings.INTEGREAT_CHAT_BUDGET_WEIGHT,
             "chats_total": total_chats.count(),
-            "chats_last_6h": chats_last_6h.count(),
             "chats_total_budget": total_chats.aggregate(
+                sum=Sum("total_words_generated")
+            )["sum"]
+            or 0,
+            "chats_last_6h": chats_last_6h.count(),
+            "chats_last_6h_budget": chats_last_6h.aggregate(
                 sum=Sum("total_words_generated")
             )["sum"]
             or 0,
@@ -189,6 +199,7 @@ class DashboardView(TemplateView, ChatContextMixin):
                 sum=Sum("total_words_generated")
             )["sum"]
             or 0,
+            "chats_by_language": chats_by_language,
         }
 
     @staticmethod

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -2030,7 +2030,8 @@ msgid ""
 "The start date of the event does not match the selected weekdays for weekly "
 "recurrence"
 msgstr ""
-"Das Startdatum der Veranstaltung stimmt nicht mit den ausgewählten Wochentagen für die wöchentliche Wiederholung überein"
+"Das Startdatum der Veranstaltung stimmt nicht mit den ausgewählten "
+"Wochentagen für die wöchentliche Wiederholung überein"
 
 #: cms/forms/events/recurrence_rule_form.py
 msgid "No weekday for monthly recurrence selected"
@@ -2041,7 +2042,8 @@ msgid ""
 "The start date of the event does not match the selected weekday for monthly "
 "recurrence"
 msgstr ""
-"Das Startdatum der Veranstaltung stimmt nicht mit dem ausgewählten Wochentag für die monatliche Wiederholung überein"
+"Das Startdatum der Veranstaltung stimmt nicht mit dem ausgewählten Wochentag "
+"für die monatliche Wiederholung überein"
 
 #: cms/forms/events/recurrence_rule_form.py
 msgid "No week for monthly recurrence selected"
@@ -2052,7 +2054,8 @@ msgid ""
 "The start date of the event does not match the selected week for monthly "
 "recurrence"
 msgstr ""
-"Das Startdatum der Veranstaltung stimmt nicht mit der ausgewählten Woche für die monatliche Wiederholung überein"
+"Das Startdatum der Veranstaltung stimmt nicht mit der ausgewählten Woche für "
+"die monatliche Wiederholung überein"
 
 #: cms/forms/events/recurrence_rule_form.py
 msgid "The recurrence end date has to be after the event's start date"
@@ -5914,32 +5917,28 @@ msgid "Chats in last 6 hours"
 msgstr "Unterhaltungen in Letzten 6 Stunden"
 
 #: cms/templates/dashboard/_public_chat_stats.html
-msgid "Open Chat Support System (Zammad)"
-msgstr "Chat-Support-System (Zammad) öffnen"
+msgid "Budget:"
+msgstr "Budget:"
 
 #: cms/templates/dashboard/_public_chat_stats.html
-msgid "Chats in last 30 days"
-msgstr "Unterhaltungen in den letzten 30 Tagen"
+msgid "Last 30 days"
+msgstr "Letzte 30 Tage"
 
 #: cms/templates/dashboard/_public_chat_stats.html
-msgid "Used budget in last 30 days"
-msgstr "Genutztes Budget in den letzten 30 Tagen"
-
-#: cms/templates/dashboard/_public_chat_stats.html
-msgid "Chats in previous 30 days"
-msgstr "Unterhaltungen in den vorherigen 30 Tagen"
-
-#: cms/templates/dashboard/_public_chat_stats.html
-msgid "Used budget in previous 30 days"
-msgstr "Genutztes Budget in den vorherigen 30 Tagen"
+msgid "Previous 30 days"
+msgstr "Vorherige 30 Tage"
 
 #: cms/templates/dashboard/_public_chat_stats.html
 msgid "Total chats"
 msgstr "Gesamtzahl Unterhaltungen"
 
 #: cms/templates/dashboard/_public_chat_stats.html
-msgid "Total used budget"
-msgstr "Insgesamt verbrauchtes Budget"
+msgid "Chats by language:"
+msgstr "Chats nach Sprache:"
+
+#: cms/templates/dashboard/_public_chat_stats.html
+msgid "No data available"
+msgstr "Keine Daten vorhanden"
 
 #: cms/templates/dashboard/_public_chat_stats.html
 msgid "Note:"
@@ -5949,6 +5948,10 @@ msgstr "Hinweis:"
 #, python-format
 msgid "1 word = %(budget_weight)s budget points."
 msgstr "1 Wort = %(budget_weight)s Budgetpunkte."
+
+#: cms/templates/dashboard/_public_chat_stats.html
+msgid "Open Chat Support System (Zammad)"
+msgstr "Chat-Support-System (Zammad) öffnen"
 
 #: cms/templates/dashboard/_todo_dashboard_row.html
 msgid "in total"
@@ -8843,7 +8846,7 @@ msgstr "Meine Sprachauswahl"
 
 #: cms/templates/settings/user_settings.html
 msgid "Choose language:"
-msgstr "Sprache auswählen"
+msgstr "Sprache auswählen:"
 
 #: cms/templates/settings/user_settings.html
 msgid "This setting only affects this device."
@@ -10331,8 +10334,8 @@ msgid ""
 "{} translation(s) could not be updated due to a database conflict. Please "
 "try again."
 msgstr ""
-"{} Übersetzungen konnten aufgrund eines Datenbankfehlers nicht aktualisiert werden. "
-"Bitte erneut versuchen."
+"{} Übersetzungen konnten aufgrund eines Datenbankfehlers nicht aktualisiert "
+"werden. Bitte erneut versuchen."
 
 #: cms/views/linkcheck/linkcheck_list_view.py
 msgid "Email link was successfully replaced"


### PR DESCRIPTION
### Short description
Add per language number of chats to the Frag Integreat dashboard widget.

<img width="887" height="246" alt="image" src="https://github.com/user-attachments/assets/600c5db0-5e93-4ba7-a93e-12ef9572c72d" />


### Proposed changes
- Add another DB query that counts chats per language.
- Format statistics as table.


### Side effects
- More stuff in the dashboard.


### Faithfulness to issue description and design
There are no intended deviations from the issue and design.


### How to test
Go to the dashboard of any region with activated Frag Integreat chat.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4184 
Fixes: https://github.com/digitalfabrik/integreat-chat/issues/425


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
