### PR TITLE
feat: enable browser spellcheck in TinyMCE editor

### DIFF
--- a/integreat_cms/static/src/js/forms/tinymce-init.ts
+++ b/integreat_cms/static/src/js/forms/tinymce-init.ts
@@ -83,6 +83,7 @@ window.addEventListener("load", () => {
             license_key: "gpl",
             promotion: false,
             deprecation_warnings: false,
+            browser_spellcheck: true,
             menubar: "edit view insert format icon",
             menu: {
                 edit: {


### PR DESCRIPTION
## Description

Enable the browser's native spell checking in the TinyMCE rich text editor by setting `browser_spellcheck: true` in the editor initialization configuration.

This is a minimal one-line change that activates the browser's built-in spellcheck feature for all TinyMCE editor instances, allowing authors to see spelling errors highlighted as they type.

## Motivation

Municipalities have been requesting spell-checking functionality in the editor. While TinyMCE offers a proprietary commercial spellcheck plugin, the browser's native implementation provides excellent coverage with zero cost and minimal implementation effort.

## Changes

- Added `browser_spellcheck: true` to the TinyMCE configuration in `integreat_cms/static/src/js/forms/tinymce-init.ts`

## Testing

- Open any page/event editor that uses TinyMCE
- Type text with intentional spelling errors
- Verify that misspelled words are underlined by the browser's spellchecker
- Right-click to see correction suggestions

Fixes #4151

---

> **AI Disclosure:** This contribution was authored with assistance from an AI coding assistant (Claude). The implementation, testing approach, and PR description were generated with AI support. All code changes have been validated against the project's conventions.

Co-Authored-By: AI Assistant (Claude) <ai-assistant@contributor-bot.dev>