### PR TITLE
add sortable table headers in POI list view

### DIFF
--- a/integreat_cms/cms/templates/pois/poi_list.html
+++ b/integreat_cms/cms/templates/pois/poi_list.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load rules %}
 {% load static %}
+{% load sort_tags %}
 {% load content_filters %}
 {% block content %}
     {% get_current_language as LANGUAGE_CODE %}
@@ -62,14 +63,20 @@
         </form>
         <table class="w-full mt-4 rounded border border-gray-200 shadow bg-white">
             <thead>
+                {% translate "Publication status" as publication_status_label %}
+                {% translate "Street" as street_label %}
+                {% translate "Postal Code" as postcode_label %}
+                {% translate "City" as city_label %}
+                {% translate "Country" as country_label %}
+                {% translate "Category" as category_label %}
                 <tr class="border-b border-gray-200">
                     <th class="py-3 pl-4 pr-2 min">
                         {% if perms.cms.change_poi %}
                             <input form="bulk-action-form" type="checkbox" id="bulk-select-all" />
                         {% endif %}
                     </th>
-                    <th class="text-sm text-left uppercase py-3 pr-2">
-                        {% translate "Title in" %} {{ language.translated_name }}
+                    <th class="whitespace-nowrap text-sm text-left uppercase py-3 pr-2">
+                        {% sort_link title_label "translations__title" %}
                     </th>
                     {% if backend_language and backend_language != language %}
                         <th class="text-sm text-left uppercase py-3 pr-2">
@@ -90,23 +97,23 @@
                             {% endspaceless %}
                         </div>
                     </th>
-                    <th class="text-sm text-left uppercase py-3 pr-2">
-                        {% translate "Publication status" %}
+                    <th class="whitespace-nowrap text-sm text-left uppercase py-3 pr-2">
+                        {% sort_link publication_status_label "translations__status" %}
                     </th>
-                    <th class="text-sm text-left uppercase py-3 pr-2">
-                        {% translate "Street" %}
+                    <th class="whitespace-nowrap text-sm text-left uppercase py-3 pr-2">
+                        {% sort_link street_label "address" %}
                     </th>
-                    <th class="text-sm text-left uppercase py-3 pr-2">
-                        {% translate "Postal Code" %}
+                    <th class="whitespace-nowrap text-sm text-left uppercase py-3 pr-2">
+                        {% sort_link postcode_label "postcode" %}
                     </th>
-                    <th class="text-sm text-left uppercase py-3 pr-2">
-                        {% translate "City" %}
+                    <th class="whitespace-nowrap text-sm text-left uppercase py-3 pr-2">
+                        {% sort_link city_label "city" %}
                     </th>
-                    <th class="text-sm text-left uppercase py-3 pr-2">
-                        {% translate "Country" %}
+                    <th class="whitespace-nowrap text-sm text-left uppercase py-3 pr-2">
+                        {% sort_link country_label "country" %}
                     </th>
-                    <th class="text-sm text-left uppercase py-3 pr-2">
-                        {% translate "Category" %}
+                    <th class="whitespace-nowrap text-sm text-left uppercase py-3 pr-2">
+                        {% sort_link category_label "category" %}
                     </th>
                     <th class="text-sm text-right uppercase py-3 pr-4 min">
                         {% translate "Options" %}

--- a/integreat_cms/cms/templatetags/sort_tags.py
+++ b/integreat_cms/cms/templatetags/sort_tags.py
@@ -1,5 +1,6 @@
 from django import template
 from django.template.context import RequestContext
+from django.utils.html import escape
 from django.utils.http import urlencode
 from django.utils.safestring import mark_safe
 
@@ -21,17 +22,17 @@ def sort_link(context: RequestContext, label: str, field: str) -> str:
 
     if field == current:
         params["sort"] = f"-{field}"
-        arrow = " ▼"
+        arrow = "<span style='color: #9E9E9E;'>↑</span>↓︎"
     elif f"-{field}" == current:
         params.pop("sort", None)
-        arrow = " ▲"
+        arrow = "↑<span style='color: #9E9E9E;'>↓︎</span>"
     else:
         params["sort"] = field
-        arrow = ""
+        arrow = "<span style='color: #9E9E9E;'>↑↓︎</span>"
 
     url = f"?{urlencode(params, doseq=True)}"
 
-    return mark_safe(f'<a href="{url}" class="hover:underline">{label}{arrow}</a>')
+    return mark_safe(f'<a href="{url}">{escape(label)}{arrow}</a>')
 
 
 @register.inclusion_tag("_sortable_table_header.html", takes_context=True)

--- a/integreat_cms/cms/views/mixins.py
+++ b/integreat_cms/cms/views/mixins.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from django.conf import settings
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
+from django.db.models import Min
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.views.generic.base import ContextMixin, TemplateResponseMixin
@@ -248,5 +249,22 @@ class FilterSortMixin:
         if order_by:
             # queryset.order_by([]) would override default ordering and result in an unordered queryset
             # so we only use order_by if "sort" is not empty
-            return queryset.order_by(*order_by)
+            annotations = {}
+            final_order = []
+            for f in order_by:
+                bare = f.lstrip("-")
+                descending = f.startswith("-")
+                if "__" in bare:
+                    # Sorting by a relational field via JOIN produces duplicate rows.
+                    # Use Min annotation instead, which collapses via GROUP BY.
+                    annotation_name = f"_sort_{bare.replace('__', '_')}"
+                    annotations[annotation_name] = Min(bare)
+                    final_order.append(
+                        f"-{annotation_name}" if descending else annotation_name
+                    )
+                else:
+                    final_order.append(f)
+            if annotations:
+                queryset = queryset.annotate(**annotations)
+            queryset = queryset.order_by(*final_order)
         return queryset

--- a/integreat_cms/cms/views/pois/poi_list_view.py
+++ b/integreat_cms/cms/views/pois/poi_list_view.py
@@ -41,6 +41,15 @@ class POIListView(
     #: The translation model of this list view (used to determine whether machine translations are permitted)
     translation_model = POITranslation
     model = POI
+    table_fields = [
+        ("translations__title", _("Title")),
+        ("translations__status", _("Publication status")),
+        ("address", _("Street")),
+        ("postcode", _("Postal Code")),
+        ("city", _("City")),
+        ("country", _("Country")),
+        ("category", _("Category")),
+    ]
 
     def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         r"""
@@ -105,5 +114,6 @@ class POIListView(
                 "source_language": region.get_source_language(language.slug),
                 "content_type": "locations",
                 "is_archive": self.archived,
+                "title_label": "{} {}".format(_("Title in"), language.translated_name),
             },
         )

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -27,6 +27,7 @@ msgid "CMS"
 msgstr "CMS"
 
 #: cms/constants/administrative_division.py cms/templates/pois/poi_list.html
+#: cms/views/pois/poi_list_view.py
 msgid "City"
 msgstr "Stadt"
 
@@ -1941,7 +1942,7 @@ msgstr "{} hier eingeben"
 #: cms/templates/content_versions.html cms/templates/events/event_form.html
 #: cms/templates/events/event_list.html cms/templates/pages/page_form.html
 #: cms/templates/pages/pages_page_tree.html cms/templates/pois/poi_form.html
-#: cms/templates/pois/poi_list.html
+#: cms/templates/pois/poi_list.html cms/views/pois/poi_list_view.py
 msgid "Publication status"
 msgstr "Veröffentlichungsstatus"
 
@@ -2092,6 +2093,7 @@ msgstr "Alle Kategorien"
 #: cms/templates/feedback/admin_feedback_list.html
 #: cms/templates/feedback/region_feedback_list.html
 #: cms/templates/pois/poi_list.html cms/views/feedback/feedback_resource.py
+#: cms/views/pois/poi_list_view.py
 msgid "Category"
 msgstr "Kategorie"
 
@@ -3685,7 +3687,7 @@ msgstr "Ob die Seite explizit archiviert ist oder nicht"
 #: cms/templates/events/event_form.html cms/templates/events/event_list.html
 #: cms/templates/pages/_generic_page_tree_header.html
 #: cms/templates/pages/page_form.html cms/templates/pois/poi_form.html
-#: cms/templates/pois/poi_list.html
+#: cms/templates/pois/poi_list.html cms/views/pois/poi_list_view.py
 msgid "Title in"
 msgstr "Titel auf"
 
@@ -7670,6 +7672,7 @@ msgstr "Keine Änderungen vorgenommen."
 
 #: cms/templates/pages/_page_xliff_import_diff.html
 #: cms/templates/push_notifications/push_notification_list.html
+#: cms/views/pois/poi_list_view.py
 msgid "Title"
 msgstr "Titel"
 
@@ -8301,15 +8304,15 @@ msgid ""
 msgstr ""
 "Sie können Orte nur in der Standard-Sprache (%(default_language)s) anlegen."
 
-#: cms/templates/pois/poi_list.html
+#: cms/templates/pois/poi_list.html cms/views/pois/poi_list_view.py
 msgid "Street"
 msgstr "Straße"
 
-#: cms/templates/pois/poi_list.html
+#: cms/templates/pois/poi_list.html cms/views/pois/poi_list_view.py
 msgid "Postal Code"
 msgstr "Postleitzahl"
 
-#: cms/templates/pois/poi_list.html
+#: cms/templates/pois/poi_list.html cms/views/pois/poi_list_view.py
 msgid "Country"
 msgstr "Land"
 

--- a/integreat_cms/release_notes/current/unreleased/1936.yml
+++ b/integreat_cms/release_notes/current/unreleased/1936.yml
@@ -1,0 +1,2 @@
+en: Add sortable table headers to Locations list view.
+de: Füge Sortierfunktion zur „Orte“ Listenansicht hinzu.


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Add sort function to POI list view

### Proposed changes
<!-- Describe this PR in more detail. -->

- allow sorting by Title, Street, Postal Code, Country and Category
- because the list view features the 'Publication status', the standard `render_table_header` helper function could not be used. instead, the `sort_link` tag is used directly in the sortable table headers


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Because the table header cannot be rendered directly from the `table_fields` property, it needs to be ensured that every change in the table headers in the template is also reflected in the `table_fields`


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
- go to POI list view
- check the sorting works for Title, Street, Postal Code, Country and Category

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1936 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
