### PR TITLE
Prevent selected POI from being cleared when contact creation fails

### DIFF
--- a/integreat_cms/cms/views/contacts/contact_form_view.py
+++ b/integreat_cms/cms/views/contacts/contact_form_view.py
@@ -161,6 +161,12 @@ class ContactFormView(TemplateView, ContactContextMixin):
             additional_instance_attributes={"region": region},
         )
 
+        selected_poi_id = int(request.POST.get("location"))
+        # request.POST.get("location") == -1 if no POI is selected
+        selected_poi = (
+            POI.objects.get(id=selected_poi_id) if selected_poi_id > 0 else None
+        )
+
         if not contact_form.is_valid():
             contact_form.add_error_messages(request)
         else:
@@ -210,7 +216,7 @@ class ContactFormView(TemplateView, ContactContextMixin):
             {
                 **self.get_context_data(**kwargs),
                 "contact_form": contact_form,
-                "poi": contact_instance.location if contact_instance else None,
+                "poi": contact_instance.location if contact_instance else selected_poi,
                 "referring_pages": None,
                 "referring_locations": None,
                 "referring_events": None,

--- a/integreat_cms/release_notes/current/unreleased/4089.yml
+++ b/integreat_cms/release_notes/current/unreleased/4089.yml
@@ -1,0 +1,2 @@
+en: Prevent selected location from being cleared when contact creation fails
+de: Verhindere, dass ein ausgewählter Ort gelöscht wird, wenn die Erstellung eines Kontakts fehlschlägt

--- a/tests/cms/views/contacts/test_contact_form.py
+++ b/tests/cms/views/contacts/test_contact_form.py
@@ -22,6 +22,8 @@ from tests.utils import assert_message_in_log
 REGION_SLUG = "augsburg"
 # Use the location with id=6, as it is used by the contacts of Augsburg and has already a primary contact.
 POI_ID = 6
+# The default value handed as POI ID if no POI is selected
+DUMMY_POI_ID = -1
 
 
 @pytest.mark.django_db
@@ -171,6 +173,7 @@ def test_no_contact_without_poi(
     response = client.post(
         new_contact,
         data={
+            "location": DUMMY_POI_ID,
             "area_of_responsibility": "Title",
             "name": "Name",
             "email": "mail@mail.integreat",
@@ -181,10 +184,10 @@ def test_no_contact_without_poi(
 
     if role in (*PRIV_STAFF_ROLES, MANAGEMENT, EDITOR, AUTHOR):
         assert_message_in_log(
-            "ERROR    Location: This field is required.",
+            "ERROR    Location: Location cannot be empty.",
             caplog,
         )
-        assert "Location: This field is required." in response.content.decode("utf-8")
+        assert "Location: Location cannot be empty." in response.content.decode("utf-8")
 
     elif role == ANONYMOUS:
         assert response.status_code == 302


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the bug that the POI user has selected gets cleared when contact creation fails

### Proposed changes
<!-- Describe this PR in more detail. -->
- Store which POI was selected
- Hand it over to the ajax POI form so the POI is shown after redirect


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- Shold be none


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4089 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
