### PR TITLE
CI: Release notes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -683,6 +683,10 @@ workflows:
             - pip-install
       - build-package:
           name: build-rc-package
+          filters:
+            branches:
+              only:
+                - /rc\/\d{4}\.\d{1,2}\.\d{1,2}.*/
           requires:
             - webpack
             - compile-translations

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -525,9 +525,9 @@ jobs:
           command: |
             # Move "unreleased" entries to new version directory
             OLD_DIR="integreat_cms/release_notes/current/unreleased"
-            NEW_DIR="integreat_cms/release_notes/$(echo "${CURRENT_VERSION}" | cut -c1-4)"
+            NEW_DIR="integreat_cms/release_notes/$(echo "${CURRENT_VERSION}" | cut -c1-4)/${CURRENT_VERSION}"
             mkdir -p "${NEW_DIR}"
-            git mv "${OLD_DIR}" "${NEW_DIR}/${CURRENT_VERSION}"
+            git mv "${OLD_DIR}"/* "${NEW_DIR}"/
             git commit --amend --no-edit
       - run:
           name: Generate SBOM

--- a/integreat_cms/cms/templates/release_notes/release_notes.html
+++ b/integreat_cms/cms/templates/release_notes/release_notes.html
@@ -9,9 +9,11 @@
         {% for year, versions in release_notes.items %}
             {% for version, notes in versions.items %}
                 {% if version == "unreleased" %}
-                    <h2 class="text-xl mb-2">
-                        <span class="italic">{% translate "Unreleased" %}</span>
-                    </h2>
+                    {% if notes %}
+                        <h2 class="text-xl mb-2">
+                            <span class="italic">{% translate "Unreleased" %}</span>
+                        </h2>
+                    {% endif %}
                 {% else %}
                     <h2 class="text-2xl mb-2">
                         <a href="https://github.com/digitalfabrik/integreat-cms/releases/tag/{{ version }}"

--- a/integreat_cms/cms/views/release_notes/release_notes_context_mixin.py
+++ b/integreat_cms/cms/views/release_notes/release_notes_context_mixin.py
@@ -77,4 +77,5 @@ class ReleaseNotesContextMixin(ContextMixin):
                     stack.enter_context(open(note, encoding="UTF-8")),
                 )[get_language_from_request(self.request)]
                 for note in natsorted(version.iterdir())
+                if note.suffix in (".yml", ".yaml")
             }


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Prevent merge conflics after releases caused by moving release notes.

*(Also only run the build-rc-package step on `rc/` branches, [which I apparently missed](https://app.circleci.com/pipelines/github/digitalfabrik/integreat-cms/17379/workflows/1d05a94b-4652-40d7-8a25-c9770f34aefc) in #4193)*

### Proposed changes
<!-- Describe this PR in more detail. -->

- When moving release notes, don't make git think of it as a rename operation
    - Move the files explicitly instead of the directory
    - Keep the unreleased directory by leaving a `.gitkeep` there
- Fix loading release notes to only read yaml files *(and not fail trying to interpret `.gitkeep` as yaml)*
- Don't show the *Unreleased* headline if there are no release notes *(previously it wasn't shown because the directory didn't exist)*
- *Fix the CI configuration to only run the *build-rc-package* step on `rc/` branches*


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- If I messed something up, the next release will need manual intervention


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
The *build-rc-package* fix was included because it was simpler than opening another issue plus PR for this


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
We will see at the next release

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4204


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
