### PR TITLE
avoid UniqueViolation upon saving a new content translation version

### DIFF
--- a/integreat_cms/cms/forms/custom_content_model_form.py
+++ b/integreat_cms/cms/forms/custom_content_model_form.py
@@ -9,7 +9,10 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.utils.translation import gettext_lazy as _
 
 from ..constants import status
-from ..utils.content_translation_utils import update_links_to
+from ..utils.content_translation_utils import (
+    save_new_version_with_retry,
+    update_links_to,
+)
 from ..utils.content_utils import clean_content
 from ..utils.slug_utils import generate_unique_slug_helper
 from .custom_model_form import CustomModelForm
@@ -139,8 +142,12 @@ class CustomContentModelForm(CustomModelForm):
         self.instance.version += 1
         self.instance.pk = None
 
-        # Save CustomModelForm
-        result = super().save(commit=commit)
+        # Save CustomModelForm, retrying with a recomputed version on conflict
+        # to handle race conditions from concurrent saves (e.g. bulk MT)
+        parent_save = super().save
+        result = save_new_version_with_retry(
+            self.instance, lambda: parent_save(commit=commit)
+        )
 
         # Update links to this content translation
         # Also update if the status got changed, since title or slug might have changed in a previous draft version

--- a/integreat_cms/cms/models/abstract_content_translation.py
+++ b/integreat_cms/cms/models/abstract_content_translation.py
@@ -626,6 +626,8 @@ class AbstractContentTranslation(AbstractBaseModel):
         """
         Function to replace links that are in the translation and match the given keyword `search`
         """
+        from ..utils.content_translation_utils import save_new_version_with_retry
+
         new_translation = self.create_new_version_copy(user)
         logger.debug("Replacing links of %r: %r", new_translation, urls_to_replace)
         new_translation.content = rewrite_links(
@@ -634,8 +636,9 @@ class AbstractContentTranslation(AbstractBaseModel):
         )
         new_translation.content = fix_content_link_encoding(new_translation.content)
         if new_translation.content != self.content and commit:
-            self.links.all().delete()
-            new_translation.save()
+            with transaction.atomic():
+                self.links.all().delete()
+                save_new_version_with_retry(new_translation, new_translation.save)
 
     def __str__(self) -> str:
         """

--- a/integreat_cms/cms/utils/content_translation_utils.py
+++ b/integreat_cms/cms/utils/content_translation_utils.py
@@ -25,6 +25,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+MAX_RETRY = 3  # number of retry attempts when hitting the translation version number race condition
+
 
 def save_new_version_with_retry(
     translation: AbstractContentTranslation,
@@ -48,7 +50,7 @@ def save_new_version_with_retry(
     foreign_field = translation.foreign_field()
     foreign_id = getattr(translation, f"{foreign_field}_id")
 
-    for attempt in range(3):
+    for attempt in range(MAX_RETRY):
         try:
             with transaction.atomic():
                 return save_fn()

--- a/integreat_cms/cms/utils/content_translation_utils.py
+++ b/integreat_cms/cms/utils/content_translation_utils.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 
 import logging
 import operator
-from collections.abc import Callable
 from functools import reduce
 from typing import Any, TYPE_CHECKING
 
@@ -19,6 +18,8 @@ from .content_utils import clean_content
 from .internal_link_utils import get_public_translation_for_link
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
+
     from ..models import User
     from ..models.abstract_content_translation import AbstractContentTranslation
 

--- a/integreat_cms/cms/utils/content_translation_utils.py
+++ b/integreat_cms/cms/utils/content_translation_utils.py
@@ -6,11 +6,13 @@ from __future__ import annotations
 
 import logging
 import operator
+from collections.abc import Callable
 from functools import reduce
-from typing import TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 from django.conf import settings
-from django.db.models import Q
+from django.db import IntegrityError, transaction
+from django.db.models import Max, Q
 from linkcheck.models import Url
 
 from .content_utils import clean_content
@@ -21,6 +23,55 @@ if TYPE_CHECKING:
     from ..models.abstract_content_translation import AbstractContentTranslation
 
 logger = logging.getLogger(__name__)
+
+
+def save_new_version_with_retry(
+    translation: AbstractContentTranslation,
+    save_fn: Callable[[], Any],
+) -> Any:
+    """
+    Call *save_fn* inside a savepoint, retrying with a recomputed version
+    number when a :class:`~django.db.IntegrityError` on the
+    ``unique_version`` constraint is raised (up to 3 attempts).
+
+    This handles race conditions where concurrent requests both try to
+    insert a new version with the same ``(foreign_object, language, version)``
+    tuple.
+
+    :param translation: The content translation whose ``version`` field will
+        be corrected on conflict
+    :param save_fn: A zero-argument callable that persists *translation*
+        (e.g. ``lambda: form.save(commit=True)`` or ``translation.save``)
+    :return: Whatever *save_fn* returns
+    """
+    foreign_field = translation.foreign_field()
+    foreign_id = getattr(translation, f"{foreign_field}_id")
+
+    for attempt in range(3):
+        try:
+            with transaction.atomic():
+                return save_fn()
+        except IntegrityError as e:
+            if "unique_version" not in str(e) or attempt >= 2:
+                raise
+            # Recompute the next version from the database
+            max_version = (
+                (
+                    type(translation)
+                    .objects.filter(
+                        **{foreign_field: foreign_id, "language": translation.language}
+                    )
+                    .aggregate(max_v=Max("version"))["max_v"]
+                )
+                or 0
+            )
+            translation.version = max_version + 1
+            logger.info(
+                "Version conflict on %r, retrying with version %d",
+                translation,
+                translation.version,
+            )
+    return None  # unreachable, but satisfies type checkers
 
 
 def update_links_to(

--- a/integreat_cms/cms/utils/content_translation_utils.py
+++ b/integreat_cms/cms/utils/content_translation_utils.py
@@ -55,7 +55,7 @@ def save_new_version_with_retry(
             with transaction.atomic():
                 return save_fn()
         except IntegrityError as e:
-            if "unique_version" not in str(e) or attempt >= 2:
+            if "unique_version" not in str(e) or attempt >= MAX_RETRY - 1:
                 raise
             # Recompute the next version from the database
             max_version = (

--- a/integreat_cms/cms/utils/content_translation_utils.py
+++ b/integreat_cms/cms/utils/content_translation_utils.py
@@ -107,8 +107,19 @@ def update_links_to(
             outdated_content_translation.create_new_version_copy(user)
         )
         fixed_content_translation.content = new_content
-        outdated_content_translation.links.all().delete()
-        fixed_content_translation.save()
+        try:
+            with transaction.atomic():
+                outdated_content_translation.links.all().delete()
+                save_new_version_with_retry(
+                    fixed_content_translation, fixed_content_translation.save
+                )
+        except IntegrityError:
+            logger.exception(
+                "Could not update links in %r referencing %r",
+                outdated_content_translation,
+                content_translation,
+            )
+            continue
 
         logger.debug(
             "Updated links to %s in %r",

--- a/integreat_cms/cms/utils/linkcheck_utils.py
+++ b/integreat_cms/cms/utils/linkcheck_utils.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import quote
 
 from django.conf import settings
+from django.db import IntegrityError
 from django.db.models import (
     CharField,
     Count,
@@ -382,7 +383,13 @@ def replace_links(
 
     with update_lock:
         for content, urls_to_replace in content_objects.items():
-            content.replace_urls(urls_to_replace, user, commit)
+            try:
+                content.replace_urls(urls_to_replace, user, commit)
+            except IntegrityError:
+                logger.exception(
+                    "Could not replace URLs in %r — skipping this translation",
+                    content,
+                )
 
     # Wait until all post-save signals have been processed
     logger.debug("Waiting for linkcheck listeners to update link database...")

--- a/integreat_cms/cms/views/linkcheck/linkcheck_list_view.py
+++ b/integreat_cms/cms/views/linkcheck/linkcheck_list_view.py
@@ -8,6 +8,7 @@ from urllib.parse import urlencode
 from cacheops import invalidate_model
 from django.conf import settings
 from django.contrib import messages
+from django.db import IntegrityError
 from django.http import Http404
 from django.shortcuts import redirect, reverse
 from django.utils.decorators import method_decorator
@@ -166,11 +167,26 @@ class LinkcheckListView(ListView):
                 )
                 contents = {link.content_object for link in links}
                 # Replace the old urls with the new urls in the content
+                failed_replacements = []
                 for content in contents:
-                    content.replace_urls(
-                        {self.instance.url: new_url},
-                        request.user,
-                        True,
+                    try:
+                        content.replace_urls(
+                            {self.instance.url: new_url},
+                            request.user,
+                            True,
+                        )
+                    except IntegrityError:
+                        logger.exception(
+                            "Could not replace URL in %r — skipping this translation",
+                            content,
+                        )
+                        failed_replacements.append(content)
+                if failed_replacements:
+                    messages.warning(
+                        request,
+                        _(
+                            "{} translation(s) could not be updated due to a database conflict. Please try again."
+                        ).format(len(failed_replacements)),
                     )
 
                 if new_url.startswith("mailto:"):

--- a/integreat_cms/cms/views/utils/publication_status.py
+++ b/integreat_cms/cms/views/utils/publication_status.py
@@ -11,6 +11,7 @@ from django.utils.translation import ngettext, ngettext_lazy
 
 from ...constants import status
 from ...models import Language
+from ...utils.content_translation_utils import save_new_version_with_retry
 from ...utils.stringify_list import iter_to_string
 
 if TYPE_CHECKING:
@@ -51,7 +52,7 @@ def change_publication_status(
                         translation.all_versions.filter(status=status.PUBLIC).update(
                             status=status.DRAFT,
                         )
-                    translation.save()
+                    save_new_version_with_retry(translation, translation.save)
                     successful.append(translation.title)
             else:
                 failed.append(content.best_translation.title)

--- a/integreat_cms/cms/views/utils/publication_status.py
+++ b/integreat_cms/cms/views/utils/publication_status.py
@@ -4,9 +4,11 @@ This file contains the helper function to change the publication status of trans
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from django.contrib import messages
+from django.db import IntegrityError, transaction
 from django.utils.translation import ngettext, ngettext_lazy
 
 from ...constants import status
@@ -17,6 +19,8 @@ from ...utils.stringify_list import iter_to_string
 if TYPE_CHECKING:
     from django.db.models.query import QuerySet
     from django.http import HttpRequest
+
+logger = logging.getLogger(__name__)
 
 
 def change_publication_status(
@@ -37,6 +41,7 @@ def change_publication_status(
     successful = []
     unchanged = []
     failed = []
+    failed_to_save = []
 
     if request.user.is_superuser or request.user.is_staff:
         for content in selected_content:
@@ -44,16 +49,23 @@ def change_publication_status(
                 if translation.status == desired_status:
                     unchanged.append(translation.title)
                 else:
-                    translation.links.all().delete()
-                    translation.status = desired_status
-                    translation.pk = None
-                    translation.version += 1
-                    if desired_status == status.DRAFT:
-                        translation.all_versions.filter(status=status.PUBLIC).update(
-                            status=status.DRAFT,
+                    try:
+                        with transaction.atomic():
+                            translation.links.all().delete()
+                            translation.status = desired_status
+                            translation.pk = None
+                            translation.version += 1
+                            if desired_status == status.DRAFT:
+                                translation.all_versions.filter(
+                                    status=status.PUBLIC,
+                                ).update(status=status.DRAFT)
+                            save_new_version_with_retry(translation, translation.save)
+                        successful.append(translation.title)
+                    except IntegrityError:
+                        logger.exception(
+                            "Could not save new version for %r", translation
                         )
-                    save_new_version_with_retry(translation, translation.save)
-                    successful.append(translation.title)
+                        failed_to_save.append(translation.title)
             else:
                 failed.append(content.best_translation.title)
 
@@ -118,5 +130,23 @@ def change_publication_status(
                 changed_status=changed_status,
                 language=Language.objects.filter(slug=language_slug).first(),
                 object_names=iter_to_string(failed),
+            ),
+        )
+
+    if failed_to_save:
+        messages.error(
+            request,
+            ngettext_lazy(
+                'The publication status of {model_name} {object_names} could not be changed to "{changed_status}" due to a database conflict. Please try again.',
+                'The publication status of the following {model_name} could not be changed to "{changed_status}" due to database conflicts. Please try again: {object_names}',
+                len(failed_to_save),
+            ).format(
+                model_name=ngettext(
+                    model_name,
+                    model_name_plural,
+                    len(failed_to_save),
+                ),
+                changed_status=changed_status,
+                object_names=iter_to_string(failed_to_save),
             ),
         )

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -10314,6 +10314,14 @@ msgid "Links were replaced successfully."
 msgstr "Links wurden erfolgreich ersetzt."
 
 #: cms/views/linkcheck/linkcheck_list_view.py
+msgid ""
+"{} translation(s) could not be updated due to a database conflict. Please "
+"try again."
+msgstr ""
+"{} Übersetzungen konnten aufgrund eines Datenbankfehlers nicht aktualisiert werden. "
+"Bitte erneut versuchen."
+
+#: cms/views/linkcheck/linkcheck_list_view.py
 msgid "Email link was successfully replaced"
 msgstr "E-Mail-Link wurde erfolgreich ersetzt"
 

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -11635,6 +11635,24 @@ msgstr[1] ""
 "\"{changed_status}\" geändert werden, weil es keine Übersetztung in "
 "{language} gibt: {object_names}."
 
+#: cms/views/utils/publication_status.py
+#, python-brace-format
+msgid ""
+"The publication status of {model_name} {object_names} could not be changed "
+"to \"{changed_status}\" due to a database conflict. Please try again."
+msgid_plural ""
+"The publication status of the following {model_name} could not be changed to "
+"\"{changed_status}\" due to database conflicts. Please try again: "
+"{object_names}"
+msgstr[0] ""
+"Der Veröffentlichungsstatus von {model_name} {object_names} konnte aufgrund "
+"eines Datenbankfehlers nicht zu \"{changed_status}\" geändert werden. Bitte "
+"erneut versuchen."
+msgstr[1] ""
+"Der Veröffentlichungsstatus der folgenden {model_name} konnte aufgrund eines "
+"Datenbankfehler nicht zu \"{changed_status}\" geändert werden: "
+"{object_names}. Bitte erneut versuchen."
+
 #: core/apps.py
 msgid "Core"
 msgstr "Core"
@@ -11679,10 +11697,11 @@ msgid_plural ""
 "The following {model_name} could not be translated automatically into "
 "'{target_language}': {object_names}"
 msgstr[0] ""
-"{model_name} {object_names} konnte nicht automatisch nach '{target_language}' übersetzt werden."
+"{model_name} {object_names} konnte nicht automatisch nach "
+"'{target_language}' übersetzt werden."
 msgstr[1] ""
-"Die folgenden {model_name} konnten nicht automatisch nach '{target_language}' übersetzt werden: "
-"{object_names}"
+"Die folgenden {model_name} konnten nicht automatisch nach "
+"'{target_language}' übersetzt werden: {object_names}"
 
 #: core/utils/machine_translation_api_client.py
 #, python-brace-format
@@ -11693,11 +11712,12 @@ msgid_plural ""
 "The following {model_name} were not translated into '{target_language}', "
 "because there were no changes to the source translation: {object_names}"
 msgstr[0] ""
-"{model_name} {object_names} konnte nicht nach '{target_language}' übersetzt werden, weil die Quell-"
-"Übersetzung sich nicht geändert hat."
+"{model_name} {object_names} konnte nicht nach '{target_language}' übersetzt "
+"werden, weil die Quell-Übersetzung sich nicht geändert hat."
 msgstr[1] ""
-"Die folgenden {model_name} konnten nicht nach '{target_language}' übersetzt werden, weil ihre Quell-"
-"Übersetzungen sich nicht geändert haben: {object_names}"
+"Die folgenden {model_name} konnten nicht nach '{target_language}' übersetzt "
+"werden, weil ihre Quell-Übersetzungen sich nicht geändert haben: "
+"{object_names}"
 
 #: core/utils/machine_translation_api_client.py
 #, python-brace-format

--- a/integreat_cms/xliff/utils.py
+++ b/integreat_cms/xliff/utils.py
@@ -29,7 +29,6 @@ from linkcheck import update_lock
 from ..cms.constants import text_directions
 from ..cms.forms import PageTranslationForm
 from ..cms.models import Page, PageTranslation
-from ..cms.utils.content_translation_utils import save_new_version_with_retry
 from ..cms.utils.file_utils import create_zip_archive
 from ..cms.utils.stringify_list import iter_to_string
 from ..cms.utils.translation_utils import gettext_many_lazy as __
@@ -448,19 +447,16 @@ def xliff_import_confirm(
 
                     success = False
                 else:
-                    existing_translation = page_translation.latest_version
+                    # Check if previous version already exists
+                    if existing_translation := page_translation.latest_version:
+                        # Delete link objects of existing translation
+                        existing_translation.links.all().delete()
                     page_translation.machine_translated = machine_translated
                     # Confirm import and write changes to the database
                     try:
-                        # Use encapsulated transaction to allow rollback in case of IntegrityError.
-                        # Link deletion lives inside this block so it rolls back together with the
-                        # save if all retries are exhausted.
+                        # Use encapsulated transaction to allow rollback in case of IntegrityError
                         with transaction.atomic():
-                            if existing_translation:
-                                existing_translation.links.all().delete()
-                            save_new_version_with_retry(
-                                page_translation, page_translation.save
-                            )
+                            page_translation.save()
                     except IntegrityError as e:
                         logger.exception(
                             "%s when importing new version for %r from %r by %r",

--- a/integreat_cms/xliff/utils.py
+++ b/integreat_cms/xliff/utils.py
@@ -29,6 +29,7 @@ from linkcheck import update_lock
 from ..cms.constants import text_directions
 from ..cms.forms import PageTranslationForm
 from ..cms.models import Page, PageTranslation
+from ..cms.utils.content_translation_utils import save_new_version_with_retry
 from ..cms.utils.file_utils import create_zip_archive
 from ..cms.utils.stringify_list import iter_to_string
 from ..cms.utils.translation_utils import gettext_many_lazy as __
@@ -447,16 +448,19 @@ def xliff_import_confirm(
 
                     success = False
                 else:
-                    # Check if previous version already exists
-                    if existing_translation := page_translation.latest_version:
-                        # Delete link objects of existing translation
-                        existing_translation.links.all().delete()
+                    existing_translation = page_translation.latest_version
                     page_translation.machine_translated = machine_translated
                     # Confirm import and write changes to the database
                     try:
-                        # Use encapsulated transaction to allow rollback in case of IntegrityError
+                        # Use encapsulated transaction to allow rollback in case of IntegrityError.
+                        # Link deletion lives inside this block so it rolls back together with the
+                        # save if all retries are exhausted.
                         with transaction.atomic():
-                            page_translation.save()
+                            if existing_translation:
+                                existing_translation.links.all().delete()
+                            save_new_version_with_retry(
+                                page_translation, page_translation.save
+                            )
                     except IntegrityError as e:
                         logger.exception(
                             "%s when importing new version for %r from %r by %r",


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fix server error of concurrent requests saving translations with the same version number, e.g. during bulk MT or rapid consecutive updates

### Proposed changes
<!-- Describe this PR in more detail. -->

- wrap `save()` calls in `save_new_version_with_retry` in `custom_content_model_form` and `publication_status`
- catch `IntegrityError` in wrapper and bump version number based on current database value
- the fix is deliberately not in the model's save() because the XLIFF import relies on IntegrityError propagation to detect conflicting file imports


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are implementation suggestions in a comment on the issue that suggest replacing `self.instance.version += 1` by a database lookup in [custom_content_model_form](https://github.com/digitalfabrik/integreat-cms/blob/15214c62fcc49f6dbf987e5752f0d1b1197fe247/integreat_cms/cms/forms/custom_content_model_form.py#L143). However, this would only partially solve the issue, because concurrent requests could still query the same MAX(version) and trigger the unique violation. The time-of-check-to-time-of-use gap would be smaller (DB query to save vs. request start to save), but the underlying problem remains. Catching the collision and retrying in a loop completely avoids this issue, unless there are so many concurrent requests that the retry attempts get exhausted, which is extremely unlikely under our expected load


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
Since this fixes a race condition, there is no deterministic way to test. Follow the Steps to Reproduce from the issue and see that the error does not occur anymore.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4073 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
