### PR TITLE
Fix 404 when changing entries-per-page from a non-first page

### DIFF
--- a/integreat_cms/cms/templates/pagination.html
+++ b/integreat_cms/cms/templates/pagination.html
@@ -5,6 +5,7 @@
 <!-- in general there are links for the 2 previous and next pages -->
 <!-- plus additional links to start, end, immediate next and immediate previous -->
 {% with num_pages=chunk.paginator.num_pages chunk_size=request.GET.size url=request.get_full_path %}
+    {% add_queries url 'page' 1 as base_url %}
     <div class="pagination">
         <div>
             <label for="chunk-size">
@@ -13,23 +14,23 @@
                 <option value="">
                     {% translate "Number of entries per page" %}
                 </option>
-                <option value="{% add_queries url 'size' 10 %}"
+                <option value="{% add_queries base_url 'size' 10 %}"
                         {% if chunk_size == "10" %}selected{% endif %}>
                     10
                 </option>
-                <option value="{% add_queries url 'size' 20 %}"
+                <option value="{% add_queries base_url 'size' 20 %}"
                         {% if chunk_size == "20" %}selected{% endif %}>
                     20
                 </option>
-                <option value="{% add_queries url 'size' 50 %}"
+                <option value="{% add_queries base_url 'size' 50 %}"
                         {% if chunk_size == "50" %}selected{% endif %}>
                     50
                 </option>
-                <option value="{% add_queries url 'size' 100 %}"
+                <option value="{% add_queries base_url 'size' 100 %}"
                         {% if chunk_size == "100" %}selected{% endif %}>
                     100
                 </option>
-                <option value="{% add_queries url 'size' 500 %}"
+                <option value="{% add_queries base_url 'size' 500 %}"
                         {% if chunk_size == "500" %}selected{% endif %}>
                     500
                 </option>

--- a/integreat_cms/release_notes/current/unreleased/3249.yml
+++ b/integreat_cms/release_notes/current/unreleased/3249.yml
@@ -1,0 +1,2 @@
+en: Fix pagination size selector resetting to page 1 to avoid 404 errors
+de: Behebe, dass der Seitengrößen-Selektor auf Seite 1 zurücksetzt, um 404-Fehler zu vermeiden


### PR DESCRIPTION
Closes #3249

## Summary

When a user is on page 2+ of a paginated list and changes the entries-per-page size, the URL keeps `page=2` while the new page size may result in fewer total pages — causing a 404.

**Fix**: Pre-compute a `base_url` with `page=1` reset before building the size option URLs, so changing the page size always navigates to page 1.

## Test Plan

- [ ] Go to Languages (or any paginated list), navigate to page 2
- [ ] Change the entries-per-page selector to 50, 100, or 500
- [ ] Verify it navigates to page 1 with the correct size instead of a 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)