### PR TITLE
Add Fallback for PushNotification in `machine_translation_api_client.py`

### DIFF
--- a/integreat_cms/core/utils/machine_translation_api_client.py
+++ b/integreat_cms/core/utils/machine_translation_api_client.py
@@ -337,13 +337,26 @@ class MachineTranslationApiClient(ABC):
                 self.target_language.slug,
             )
             try:
-                ctx.translatable_attributes = (
-                    content_object.get_translatable_attributes(
-                        self.translatable_fields,
-                        self.source_language.slug,
-                        self.target_language.slug,
+                if hasattr(content_object, "get_translatable_attributes"):
+                    ctx.translatable_attributes = (
+                        content_object.get_translatable_attributes(
+                            self.translatable_fields,
+                            self.source_language.slug,
+                            self.target_language.slug,
+                        )
                     )
-                )
+                else:
+                    # push_notifications do not have the get_translatable_attributes logic, so we need to provide a fallback
+                    skip_title = getattr(
+                        content_object, "do_not_translate_title", False
+                    )
+                    ctx.translatable_attributes = [
+                        (attr, getattr(ctx.source_translation, attr))
+                        for attr in self.translatable_fields
+                        if ctx.source_translation
+                        and getattr(ctx.source_translation, attr, None)
+                        and not (attr == "title" and skip_title)
+                    ]
 
                 ctx.word_count = word_count(
                     ctx.translatable_attributes,


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This adds a fallback for `ctx.translatable_attributes` for PushNotifications, that don't have the method `get_translatable_attributes` 


### Proposed changes
<!-- Describe this PR in more detail. -->

- add fallback `ctx.translatable_attributes` if  method `get_trasnlatable_attributes` is not there


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
- for push-notifications the mechanism of only translating changed fields (introduced in  #4173) does not work (since we have no versioning on the translation), so we default back to translating all fields regardless if they have chagned or not


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->

- follow the instructions on #4216 for reproducing


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4216 

### Note
This PR is a release blocker, since the bug would be only be introduced with the next release and machine translations for push notifications not working would be too big a regression


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
