### PR TITLE
Prevent reset button activation on Enter key press in search

### DIFF
--- a/integreat_cms/cms/templates/_search_input.html
+++ b/integreat_cms/cms/templates/_search_input.html
@@ -21,7 +21,8 @@
         </ul>
     </div>
     {% if search_query %}
-        <button id="search-reset-btn"
+        <button type="button"
+                id="search-reset-btn"
                 title="{% translate "Reset search" %}"
                 class="bg-gray-200 hover:bg-gray-300 text-gray-800 py-2 px-3">
             <i icon-name="x" class="w-5"></i>

--- a/integreat_cms/release_notes/current/unreleased/4187.yml
+++ b/integreat_cms/release_notes/current/unreleased/4187.yml
@@ -1,0 +1,2 @@
+en: Fix enter key resets search query
+de: Fix Enter-Taste setzt Suchanfrage zurück


### PR DESCRIPTION
### Short description
Fixes the search bar resetting to empty when pressing Enter after modifying the search input a second time.


### Proposed changes

The bug occurs when the user searches, then edits the query and searches again(by pressing Enter), the search resets to empty instead of filtering the table with the new value.
- Handle Enter before the suggestions.length === 0 check in search-query.ts so it is always intercepted.
- Add event.preventDefault() to the Enter keydown handler in search-query.ts to prevent the native Enter event from carrying over to the newly loaded page and activating the reset button
- Move the search-submit-btn click outside the suggestion check so Enter always submits regardless of whether a suggestion is highlighted


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->

- Go to any list view (e.g. Regions)
- Type a search query and press Enter — table filters correctly
- Edit the query and press Enter again — table filters with the new value instead of resetting
- Should behave as a normal search bar over any number of iterations

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4187 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
