### PR TITLE
add get_safe_page helper method for ModelListView

### DIFF
--- a/integreat_cms/cms/views/list_views.py
+++ b/integreat_cms/cms/views/list_views.py
@@ -11,7 +11,11 @@ from django.conf import settings
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.views.generic.list import ListView
 
-from .mixins import ModelConfirmationContextMixin, ModelTemplateResponseMixin
+from .mixins import (
+    get_safe_page,
+    ModelConfirmationContextMixin,
+    ModelTemplateResponseMixin,
+)
 
 if TYPE_CHECKING:
     from typing import Any
@@ -89,6 +93,19 @@ class ModelListView(
         :return: The permissions that are required for views inheriting from this Mixin
         """
         return (f"cms.view_{self.model._meta.model_name}",)
+
+    def paginate_queryset(self, queryset: QuerySet, page_size: int) -> tuple:
+        """
+        Gracefully handle out-of-range page numbers instead of returning a 404.
+        This prevents errors when changing the page size from a page that doesn't
+        exist with the new size.
+        """
+        paginator = self.get_paginator(queryset, page_size)
+        page = self.kwargs.get(self.page_kwarg) or self.request.GET.get(
+            self.page_kwarg, 1
+        )
+        page_obj = get_safe_page(paginator, page)
+        return paginator, page_obj, page_obj.object_list, page_obj.has_other_pages()
 
     def get_queryset(self) -> QuerySet:
         """

--- a/integreat_cms/cms/views/mixins.py
+++ b/integreat_cms/cms/views/mixins.py
@@ -148,6 +148,24 @@ class MachineTranslationContextMixin(ContextMixin):
         return context
 
 
+def get_safe_page(paginator: Paginator, page: int | str) -> Page:
+    """
+    Resolve a page number against a paginator, falling back gracefully on errors.
+    Returns the first page if the page number is not an integer,
+    or the last page if the page number exceeds the total number of pages.
+
+    :param paginator: The paginator instance
+    :param page: The requested page number
+    :return: The resolved page
+    """
+    try:
+        return paginator.page(page)
+    except PageNotAnInteger:
+        return paginator.page(1)
+    except EmptyPage:
+        return paginator.page(paginator.num_pages)
+
+
 class PaginationMixin:
     """
     Mixin to add pagination to a view.
@@ -174,14 +192,7 @@ class PaginationMixin:
             size = self.default_page_size
 
         paginator = Paginator(queryset, size)
-        try:
-            page_obj = paginator.page(page)
-        except PageNotAnInteger:
-            page_obj = paginator.page(1)
-        except EmptyPage:
-            page_obj = paginator.page(paginator.num_pages)
-
-        return page_obj
+        return get_safe_page(paginator, page)
 
 
 class FilterSortMixin:

--- a/integreat_cms/release_notes/current/unreleased/3249.yml
+++ b/integreat_cms/release_notes/current/unreleased/3249.yml
@@ -1,0 +1,2 @@
+en: Display the last valid page instead of an error when the page does not exist due to a change in page size.
+de: Zeige die letzte gültige Seite anstelle einer Fehlermeldung an, wenn die Seite aufgrund einer geänderten Anzahl Einträge pro Seite nicht existiert.


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Changing the page size in a list view can result in a 404 exception if the page does not exist with the new entries per page setting. `PaginationMixin` (introduced in #3963 ) handles this gracefully, but our existing `ModelListViews` don't use `PaginationMixin`. This PR introduces a shared helper method to handle `EmptyPage` exceptions in all list views.

### Proposed changes
<!-- Describe this PR in more detail. -->

- add `get_safe_page` helper method and use it in `PaginationMixin` and `ModelListView`


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
Ensure that no 404 occurs on any list view when changing the page size

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3249 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
