### PR TITLE
fix bumpver for rc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -417,7 +417,7 @@ jobs:
             echo "Current production version: ${CURRENT_VERSION}"
             # Bump version to current alpha version if it is newer
             # Attention: exit(True) in Python means exit(1) which is False in Bash :)
-            if python -c "from bumpver.version import parse_version; exit(parse_version('${CURRENT_VERSION}') > parse_version('${CURRENT_ALPHA_VERSION}'))"; then
+            if python -c "from bumpver.version import parse_version; exit(parse_version('${CURRENT_VERSION}') >= parse_version('${CURRENT_ALPHA_VERSION}'))"; then
               echo "Bump to the currently existing version"
               bumpver update -n --set-version="${CURRENT_ALPHA_VERSION}" --no-commit
             fi
@@ -468,7 +468,7 @@ jobs:
             echo "Current production version: ${CURRENT_VERSION}"
             # Bump version to current release candidate version if it is newer
             # Attention: exit(True) in Python means exit(1) which is False in Bash :)
-            if python -c "from bumpver.version import parse_version; exit(parse_version('${CURRENT_VERSION}') > parse_version('${CURRENT_RC_VERSION}'))"; then
+            if python -c "from bumpver.version import parse_version; exit(parse_version('${CURRENT_VERSION}') >= parse_version('${CURRENT_RC_VERSION}'))"; then
               echo "Bump to the currently existing version"
               bumpver update -n --set-version="${CURRENT_RC_VERSION}" --no-commit
             fi


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Our rc pipeline failed at the bumpver step

Previously, the conditional in the bumpver step was only necessary for alpha builds from develop. On main, the new version was always a jump in the major version, there was nothing to compare. For alpha builds, the conditional is needed for when there just was a release of a new major and the current build was about to be uploaded as the first alpha build after that, i.e. the first alpha build containing the new major release number. But the alpha builds are uploaded to test.pypi.org, where there are only alpha builds, never the major releases. The version in the code never exactly matched the last available version number there.

Our newly introduced rc builds live on the proper pypy.org, as pre-releases among the real ones. Now the last available version can be the same one mentioned in the code, and we did not treat this correctly historically since it didn't matter.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Properly handle the case when the versions are equal: Only exit with a non-zero code when a new major release needs to be set before bumping the rc number


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- 


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
Merge it and see whether the pipeline passes this time



__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
