### PR TITLE
Fix matomo query

### DIFF
--- a/integreat_cms/cms/templates/statistics/statistics_viewed_pages_node.html
+++ b/integreat_cms/cms/templates/statistics/statistics_viewed_pages_node.html
@@ -6,7 +6,7 @@
 <tr id="page-{{ page.id }}"
     data-drop-id="{{ page.id }}"
     data-drop-position="last-child"
-    class="page-row drop drop-on border-t border-b border-solid border-gray-200 hover:bg-gray-100 level-{{ page.relative_depth }} {% if parent_id %}hidden parent-page-{{ parent_id }}{% endif %}">
+    class="page-row drop drop-on border-t border-b border-solid border-gray-200 hover:bg-gray-100 level-{{ page.relative_depth }} {% if parent_id %}hidden parent-page-{{ parent_id }}{% else %}root-page{% endif %}">
     {% include "pages/_generic_page_tree_node.html" %}
     <td class="flex items-stretch accesses px-2"
         data-no-data="{% translate "This page has no accesses in the selected time span" %}">

--- a/integreat_cms/cms/views/statistics/statistics_actions.py
+++ b/integreat_cms/cms/views/statistics/statistics_actions.py
@@ -11,7 +11,6 @@ from datetime import date, timedelta
 from typing import TYPE_CHECKING
 
 from celery import shared_task
-from django.db.models import OuterRef
 from django.http import JsonResponse
 from django.views.decorators.http import require_POST
 
@@ -129,6 +128,7 @@ def get_visits_per_language_ajax(
 
 
 @require_POST
+@permission_required("cms.view_statistics")
 # pylint: disable=unused-argument
 def get_page_accesses_ajax(request: HttpRequest, region_slug: str) -> JsonResponse:
     """
@@ -141,7 +141,8 @@ def get_page_accesses_ajax(request: HttpRequest, region_slug: str) -> JsonRespon
     region = request.region
     data = request.POST
     language_slugs = data.getlist("language_slugs")
-    page_ids = data.getlist("page_ids")
+
+    page_ids = list(map(int, data.getlist("page_ids")))
 
     if not region.statistics_enabled:
         logger.error("Statistics are not enabled for this region.")
@@ -158,7 +159,10 @@ def get_page_accesses_ajax(request: HttpRequest, region_slug: str) -> JsonRespon
             status=400,
         )
 
-    region_pages = Page.objects.filter(region=region, id__in=page_ids)
+    if page_ids:
+        region_pages = Page.objects.filter(region=region, id__in=page_ids)
+    else:
+        region_pages = Page.objects.filter(region=region)
 
     page_access_sums = region.get_page_access_count_by_language(
         pages=region_pages,
@@ -195,15 +199,8 @@ def fetch_page_accesses(
     times_tried = times_tried + 1
 
     # Query PageTranslation and the related Page and Language objects directly from the database to avoid calling data from the cache, due to celery starting with an empty cache
-    subquery = (
-        PageTranslation.objects.filter(
-            page_id=OuterRef("page_id"), language=OuterRef("language")
-        )
-        .order_by("-version")
-        .values("pk")[:1]
-    )
     prefetched_translations = PageTranslation.objects.filter(
-        page__in=pages, pk__in=subquery
+        page__in=pages
     ).select_related("page", "language")
 
     try:
@@ -215,6 +212,7 @@ def fetch_page_accesses(
             pages=pages,
             prefetched_translations=prefetched_translations,
         )
+        logger.info("Finished fetching page accesses for %s", region)
     except MatomoException:
         if times_tried < MAX_ATTEMPTS:
             logger.exception(

--- a/integreat_cms/matomo_api/matomo_api_client.py
+++ b/integreat_cms/matomo_api/matomo_api_client.py
@@ -5,7 +5,7 @@ import logging
 import re
 from datetime import date, datetime
 from typing import TYPE_CHECKING
-from urllib.parse import urlencode
+from urllib.parse import quote_plus, urlencode
 
 import aiohttp
 import requests
@@ -610,18 +610,26 @@ class MatomoApiClient:
                 language = language_map.get(lang_slug)
                 if not language:
                     continue
-                page_query.update(
-                    {"segment": f"pageUrl=@/children/?depth=2&url={full_slug}"}
-                )
+                enc_slug = quote_plus(full_slug)
+                page_query.update({
+                    "segment": f"pageUrl=${enc_slug};pageUrl=@/children/?depth=2&url=/{region_slug}/{lang_slug}"
+                })
                 url_param = {f"urls[{i}]": urlencode(page_query)}
                 i += 1
                 page_params.update(url_param)
+                if (
+                    full_slug
+                    == "augsburg-und-sein-besonderes-wasser-ein-unesco-weltkulturerbe"
+                ):
+                    print(url_param)
             result = self.fetch(**page_params)
             for lang_slug, accesses_list in zip(langs, result, strict=False):
                 language = language_map.get(lang_slug)
                 if not language:
                     continue
                 for accesses_date, accesses in accesses_list.items():  # type: ignore [attr-defined]
+                    if page_id == 50774:
+                        print(accesses)
                     if accesses == 0:
                         continue
                     access = PageAccesses(

--- a/integreat_cms/matomo_api/matomo_api_client.py
+++ b/integreat_cms/matomo_api/matomo_api_client.py
@@ -578,13 +578,11 @@ class MatomoApiClient:
         :param pages: List with prefetch pages of the region
         :param prefetched_translations: List with prefetched page translations
         """
-        total_query = {
-            "method": "API.getBulkRequest",
-        }
         query_params = {
-            "method": "VisitsSummary.getActions",
+            "method": "Actions.getPageUrls",
             "date": f"{start_date},{end_date}",
             "expanded": "1",
+            "flat": "1",
             "filter_limit": "-1",
             "format_metrics": "1",
             "idSite": self.matomo_id,
@@ -592,45 +590,57 @@ class MatomoApiClient:
         }
         logger.debug("Fetching visits for %rlanguages.", languages)
         translation_slugs = get_translation_slug(
-            region_slug=region_slug, prefetched_translations=prefetched_translations
+            prefetched_translations=prefetched_translations
         )
 
-        # retrieve and save accesses per page and language with the corresponding url slugs
-        page_map = {page.id: page for page in pages}
-        language_map = {lang.slug: lang for lang in languages}
-        accesses_objects = []
-        for page_id, langs in translation_slugs.items():
-            page = page_map.get(page_id)
-            if not page:
-                continue
-            page_params = total_query
-            page_query = query_params
-            i = 0
-            for lang_slug, full_slug in langs.items():
-                language = language_map.get(lang_slug)
-                if not language:
-                    continue
-                page_query.update(
-                    {"segment": f"pageUrl=@/children/?depth=2&url={full_slug}"}
-                )
-                url_param = {f"urls[{i}]": urlencode(page_query)}
-                i += 1
-                page_params.update(url_param)
-            result = self.fetch(**page_params)
-            for lang_slug, accesses_list in zip(langs, result, strict=False):
-                language = language_map.get(lang_slug)
-                if not language:
-                    continue
-                for accesses_date, accesses in accesses_list.items():  # type: ignore [attr-defined]
-                    if accesses == 0:
+        # retrieve and save page accesses per language with the corresponding page translation slugs
+        accesses_objects: list[PageAccesses] = []
+        for language in languages:
+            lang_slug = language.slug
+            matomo_query_params = query_params
+            matomo_query_params.update(
+                {
+                    "segment": f"pageUrl=@/children/?depth=2&url=/{region_slug}/{lang_slug}",
+                }
+            )
+            result = self.fetch(**matomo_query_params)
+            for accesses_date in list(result.keys()):
+                all_page_accesses = result[accesses_date]
+                for page in pages:
+                    page_accesses_object_already_exists = False
+
+                    page_translation_slugs = translation_slugs.get(page.id)
+                    if not page_translation_slugs:
                         continue
-                    access = PageAccesses(
-                        access_date=datetime.strptime(accesses_date, "%Y-%m-%d").date(),
-                        language=language,
-                        page=page,
-                        accesses=accesses,
+
+                    page_language_translation_slugs = page_translation_slugs.get(
+                        lang_slug
                     )
-                    accesses_objects.append(access)
+                    if not page_language_translation_slugs:
+                        continue
+
+                    for page_accesses in all_page_accesses:
+                        page_accesses_slug = page_accesses["label"].split("/")[-1]
+                        if (
+                            page_accesses_slug
+                            in page_language_translation_slugs.values()
+                        ):
+                            accesses = page_accesses["nb_visits"]
+                            if accesses == 0:
+                                continue
+                            if page_accesses_object_already_exists:
+                                accesses_objects[-1].accesses += accesses
+                            else:
+                                access_object = PageAccesses(
+                                    access_date=datetime.strptime(
+                                        accesses_date, "%Y-%m-%d"
+                                    ).date(),
+                                    language=language,
+                                    page=page,
+                                    accesses=accesses,
+                                )
+                                accesses_objects.append(access_object)
+                                page_accesses_object_already_exists = True
         PageAccesses.objects.bulk_create(
             accesses_objects,
             update_conflicts=True,

--- a/integreat_cms/matomo_api/utils.py
+++ b/integreat_cms/matomo_api/utils.py
@@ -27,16 +27,6 @@ def get_translation_slug(
         page_id = page_translation.page.id
         language_slug = page_translation.language.slug
         absolute_url = page_translation.slug
-        translations_lookup = {
-            (t.page.id, t.language.slug): t for t in prefetched_translations
-        }
-        absolute_url = build_infix_recursively(
-            absolute_url=absolute_url,
-            language_slug=language_slug,
-            current_page_translation=page_translation,
-            translations_lookup=translations_lookup,
-        )
-        absolute_url = "/" + region_slug + "/" + language_slug + "/" + absolute_url
         translation_slugs[page_id][language_slug] = absolute_url
 
     return dict(translation_slugs)

--- a/integreat_cms/matomo_api/utils.py
+++ b/integreat_cms/matomo_api/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections import defaultdict
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ..cms.models.pages.page_translation import PageTranslation
@@ -11,63 +11,24 @@ logger = logging.getLogger(__name__)
 
 
 def get_translation_slug(
-    region_slug: str,
     prefetched_translations: list[PageTranslation],
-) -> dict[int, dict[str, str]]:
+) -> defaultdict[int, defaultdict[str, dict[int, str]]]:
     """
-    Produce mapping of page ids and language slugs to the absolute url of the corresponding translation.
-    In detail, we need to construct a slug in the foreign language, for example /en/lebensmittel-und-einkaufen needs to become /en/groceries-and-shopping.
+    Produce mapping of page ids and language slugs to all slug versions of the corresponding page translation objects.
 
-    :param region_slug: Slug of the region we want the absolute url of
-    :param prefetched_translations: List of prefetched Pagetranslations that we want the absolute urls of
-    :return: A dictionary of page ids, language slugs and the absolute url of the corresponding translation.
+    :param prefetched_translations: List of prefetched Pagetranslations that we want the mapping for
+    :return: A dictionary of page ids, language slugs and all slug versions of the corresponding translation.
     """
-    translation_slugs: defaultdict[int, dict[str, str]] = defaultdict(dict)
+    translation_slugs: defaultdict[int, defaultdict[str, dict[int, str]]] = defaultdict(
+        lambda: defaultdict(dict)
+    )
     for page_translation in prefetched_translations:
         page_id = page_translation.page.id
         language_slug = page_translation.language.slug
-        absolute_url = page_translation.slug
-        translations_lookup = {
-            (t.page.id, t.language.slug): t for t in prefetched_translations
-        }
-        absolute_url = build_infix_recursively(
-            absolute_url=absolute_url,
-            language_slug=language_slug,
-            current_page_translation=page_translation,
-            translations_lookup=translations_lookup,
+        translation_version = page_translation.version
+        translation_slug = page_translation.slug
+        translation_slugs[page_id][language_slug][translation_version] = (
+            translation_slug
         )
-        absolute_url = "/" + region_slug + "/" + language_slug + "/" + absolute_url
-        translation_slugs[page_id][language_slug] = absolute_url
 
-    return dict(translation_slugs)
-
-
-def build_infix_recursively(
-    absolute_url: str,
-    language_slug: str,
-    current_page_translation: PageTranslation,
-    translations_lookup: dict[tuple[Any, str], PageTranslation],
-) -> str:
-    """
-    Build infix of the absolute url of a PageTranslation object from the prefetched PageTranslations recursively. This is a workaround to avoid calling the cache, which is needed when page accesses are fetched with celery.
-
-    :param absolut_url: absolute url build at hte point of calling
-    :param language_slug: Language slug of the current page translation
-    :param current_page_translation: Page translation for that we want the parent slug of
-    :param prefetched_translations: List with prefetched page translations we select from
-    :return: A string containing the url build until the point of calling. At the end of the recursion it returns the absolute url of the page translation from the first call
-    """
-    if current_page_translation.page.parent:
-        parent = current_page_translation.page.parent
-        page_translation = translations_lookup.get((parent.id, language_slug))
-        if page_translation:
-            parent_translation_slug = page_translation.slug
-            absolute_url = parent_translation_slug + "/" + absolute_url
-            current_page_translation = page_translation
-            return build_infix_recursively(
-                absolute_url=absolute_url,
-                language_slug=language_slug,
-                current_page_translation=current_page_translation,
-                translations_lookup=translations_lookup,
-            )
-    return absolute_url
+    return translation_slugs

--- a/integreat_cms/static/src/js/analytics/statistics-page-accesses.ts
+++ b/integreat_cms/static/src/js/analytics/statistics-page-accesses.ts
@@ -1,9 +1,10 @@
-type AccessesPerLanguage = {
-    [lang: string]: number;
+/* Category as returned by get_page_accesses_ajax in statistics_actions.py is either a language slug or "total_accesses" */
+type AccessesPerLanguageAndInTotal = {
+    [category: string]: number;
 };
 
 type AjaxResponse = {
-    [id: string]: AccessesPerLanguage;
+    [id: string]: AccessesPerLanguageAndInTotal;
 };
 
 let statisticsForm: HTMLFormElement;
@@ -45,7 +46,7 @@ const resetTotalAccessesField = (accessFields: HTMLCollectionOf<Element>, isEmpt
 const updateAllAccessesField = (accessesField: Element, allAccesses: number) => {
     const allAccessesField = accessesField;
     if (allAccesses === 0) {
-        allAccessesField.textContent = `${allAccessesField.getAttribute("data-translation-no-accesses")}`;
+        allAccessesField.textContent = allAccessesField.getAttribute("data-translation-no-accesses");
     } else if (allAccesses === 1) {
         allAccessesField.textContent = `${allAccesses} ${allAccessesField.getAttribute("data-translation-singular")}`;
     } else {
@@ -64,28 +65,13 @@ const setDates = () => {
     document.getElementById("date-range-end").innerHTML = new Date(unformattedEndDate).toLocaleDateString();
 };
 
-const getVisiblePageIDs = (): string[] => {
-    const pageNodes = document.querySelectorAll(`.page-row`);
-    const visiblePageIDs: string[] = [];
-    pageNodes.forEach((page) => {
-        if (!page.classList.contains("hidden")) {
-            const pageId: string = page.id.split("-")[1];
-            visiblePageIDs.push(pageId);
-        }
-    });
-    return visiblePageIDs;
-};
-
 const getData = async (visibleDatasetSlugs: string[], requestID: number): Promise<[AjaxResponse, number]> => {
     if (!statisticsForm) {
         return [{} as AjaxResponse, requestID];
     }
 
-    const visiblePageIDs = getVisiblePageIDs();
-
     const formData = new FormData(statisticsForm);
     visibleDatasetSlugs.forEach((slug) => formData.append("language_slugs", slug));
-    visiblePageIDs.forEach((pageID) => formData.append("page_ids", pageID));
 
     const parameters: RequestInit = {
         method: "POST",
@@ -115,48 +101,72 @@ const getCheckedSlugs = (): string[] => {
     return visibleDatasetSlugs;
 };
 
-const updateDOM = (data: AjaxResponse, visibleDatasetSlugs: string[]) => {
-    const pageNodes = document.querySelectorAll(`.page-row`);
-    pageNodes.forEach((parentField) => {
-        const pageId: string = parentField.id.split("-")[1];
-        const accesses: AccessesPerLanguage = data[pageId];
-        const accessField = parentField.querySelector(".accesses");
-        const allAccessesField = parentField.querySelector(".total-accesses");
-        const accessFieldChildElements = accessField.querySelectorAll(`.accesses span`);
-        const collapseSpan: HTMLSpanElement = parentField.querySelector(".toggle-subpages");
-        let expanded: boolean = false;
+const updateNode = (
+    parentField: Element,
+    visibleDatasetSlugs: string[],
+    accesses: AccessesPerLanguageAndInTotal,
+    allAccesses: number
+) => {
+    const accessField = parentField.querySelector(".accesses");
+    const allAccessesField = parentField.querySelector(".total-accesses");
+    const accessFieldChildElements = accessField.querySelectorAll(`.accesses span`);
 
-        if (collapseSpan) {
-            const icon = collapseSpan.querySelector("svg");
-            expanded = icon.classList.contains("lucide-chevron-down");
-        }
+    accessFieldChildElements.forEach((accessFieldSpan) => {
+        const languageSlug = accessFieldSpan.getAttribute("data-language-slug");
+        const accessesOverTime =
+            visibleDatasetSlugs.includes(languageSlug) && accesses && accesses[languageSlug]
+                ? accesses[languageSlug]
+                : 0;
+        setAccessBarPerLanguage(accessField, languageSlug, accessesOverTime, allAccesses);
+    });
 
-        let allAccesses: number = accesses ? accesses.total_accesses : 0;
+    updateAllAccessesField(allAccessesField, allAccesses);
+};
 
-        if (expanded) {
-            const childrenIds: number[] = JSON.parse(collapseSpan.getAttribute("data-page-children"));
-            childrenIds.forEach((childId) => {
-                const childAllAccesses = data[childId] ? data[childId].total_accesses : 0;
-                allAccesses -= childAllAccesses;
+const updateDOMRecursivly = (
+    data: AjaxResponse,
+    visibleDatasetSlugs: string[],
+    parentField: Element
+): [AccessesPerLanguageAndInTotal, number] => {
+    const pageId: string = parentField.id.split("-")[1];
+    const accesses: AccessesPerLanguageAndInTotal = data[pageId] ? { ...data[pageId] } : {};
+    const returnAccesses: AccessesPerLanguageAndInTotal = data[pageId] ? { ...data[pageId] } : {};
+    const collapseSpan: HTMLSpanElement = parentField.querySelector(".toggle-subpages");
+    const allAccesses: number = accesses.total_accesses ? accesses.total_accesses : 0;
+    let returnAllAccesses: number = allAccesses;
+    let expanded: boolean = false;
 
+    if (collapseSpan) {
+        const icon = collapseSpan.querySelector("svg");
+        expanded = icon.classList.contains("lucide-chevron-down");
+        const childrenIds: number[] = JSON.parse(collapseSpan.getAttribute("data-page-children"));
+
+        childrenIds.forEach((childId) => {
+            const page = document.getElementById(`page-${childId}`);
+            const [childAccesses, childAllAccesses] = updateDOMRecursivly(data, visibleDatasetSlugs, page);
+            returnAllAccesses += childAllAccesses;
+
+            if (returnAccesses) {
                 visibleDatasetSlugs.forEach((slug) => {
-                    if (accesses && accesses[slug]) {
-                        const childAccesses = data[childId] && data[childId][slug] ? data[childId][slug] : 0;
-                        accesses[slug] -= childAccesses;
-                    }
+                    const updateChildAccesses = childAccesses && childAccesses[slug] ? childAccesses[slug] : 0;
+                    returnAccesses[slug] = (returnAccesses[slug] ? returnAccesses[slug] : 0) + updateChildAccesses;
                 });
-            });
-        }
-        accessFieldChildElements.forEach((accessFieldSpan) => {
-            const languageSlug = accessFieldSpan.getAttribute("data-language-slug");
-            const accessesOverTime =
-                visibleDatasetSlugs.includes(languageSlug) && accesses && accesses[languageSlug]
-                    ? accesses[languageSlug]
-                    : 0;
-            setAccessBarPerLanguage(accessField, languageSlug, accessesOverTime, allAccesses);
+            }
         });
+    }
 
-        updateAllAccessesField(allAccessesField, allAccesses);
+    if (expanded) {
+        updateNode(parentField, visibleDatasetSlugs, accesses, allAccesses);
+    } else {
+        updateNode(parentField, visibleDatasetSlugs, returnAccesses, returnAllAccesses);
+    }
+    return [returnAccesses, returnAllAccesses];
+};
+
+const updateDOM = (data: AjaxResponse, visibleDatasetSlugs: string[]) => {
+    const rootPageNodes = document.querySelectorAll(`.root-page`);
+    rootPageNodes.forEach((parentField) => {
+        updateDOMRecursivly(data, visibleDatasetSlugs, parentField);
     });
 };
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the Query we send to matomo every night to update the page accesses in our database.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Change query to matomo to query for the accesses of all pages listed per page instead of bulk requests with all full page urls
- Change `get_translation_slug()` to get a lookup table with page_id, language_slug and all versions of pagetranslation slugs of a page. This enables accounting for historic data when slugs change over time.
- Adapt `staistics-page-accesses.ts` into updating the DOM for the pages recursively to accomandate for the changed way page accesses are saved (parent pages only save their own accesses without their childrens accesses)


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- all currently saved page accesses will be invalid when this is merged. Untill this PR we saved the accesses of parent pages stacked with the accesses of their child pages. With this PR only the accesses of a page itself are saved for a page. What to do with the old data will be part of #3750 


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
Validate Page Accesses:
- on localhost: enable statistics for Augsburg (go to region overview of Augsburg, select "enable statistics and enter Matomo authentification token)
- Run `integreat-cms-cli fetch_page_accesses --start-date 2026-04-27 --end-date 2026-04-27 --region-slug augsburg --sync True`
- Navigate to `Statistics` in Augsburg
- Select `27-04-2026` as time range and languages you want to look at
- Look at `Willkommen` and it's subpages (these exist in our test data and in production)
- Open https://statistics.integreat-app.de/, select Augsburg and 27-04-2026, then anvigate to `Entry pages`
- Expand rows until you see the language slugs, expand the language slug you want to look at
- Then Expand children and `?depth=2&url=`, from here you can look at the pages that are relevant for the page based statistics
- Try to find `Willkommen` and look at it's accesses and compare them with the CMS

Be aware that some third level pages exist double in Matomo

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4160 
Fixes: #4161 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
