### PR TITLE
Fix page path in API response

### DIFF
--- a/integreat_cms/cms/models/pages/page.py
+++ b/integreat_cms/cms/models/pages/page.py
@@ -111,6 +111,10 @@ class PageQuerySet(NS_NodeQuerySet, ContentQuerySet):
                     # Set the relative depth to the relative depth of the parent + 1
                     page._relative_depth = result[page.parent_id].relative_depth + 1
                 else:
+                    if page.parent_id:
+                        page._cached_ancestors = list(
+                            page.get_ancestors().prefetch_public_translations()
+                        )
                     # Set the relative depth to 1
                     page._relative_depth = 1
                 result[page.id] = page


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the bug that slugs of ancestors (higher than parent) are missing in the page pathes in the `children` endpoint response.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Include not only the parent but also higher ancestors into the query `pages` in `children`
- Exclude them but in the loop with `transform_page` so they are not included in the response


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- Should be none
- There is probably a more beautiful/thorough solution. This is but in my opinion less invasive and less risk of breaking something else while the added loop is small. We could adjust `cache_tree_dict` or use `get_ancestors()` instead of `get_cached_ancestors()`, but the `cache_tree` is calling `cache_tree_dict` and being used in several places, and `get_ancestors()` may affect loading time negatively.


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
- Start the CMS in `develop` branch
- Create a page tree with more than 2 levels
<img width="779" height="377" alt="image" src="https://github.com/user-attachments/assets/0d7ed5a9-a2a8-4aa9-858c-1f3493a66c4b" />

- Call the endpoint `children` (example: http://localhost:8000/api/v3/testumgebung/de/children/?depth=3&url=/testumgebung/de/parent/child-1/child-2/child-3)
- See the slugs of the first and second level page (`/root/child-1/` in the example) is missing in the path
<img width="548" height="695" alt="image" src="https://github.com/user-attachments/assets/2d8e5574-e0f1-45a0-96af-2fc91c96459e" />

- Check out to this branch and try the endpoint
- See the slugs of the first and second level appear
<img width="651" height="729" alt="image" src="https://github.com/user-attachments/assets/00aa8fb7-6816-4823-866e-ce42c0866fb8" />



### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4220


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
