### PR TITLE
pretend unreleased dir not there if without release notes

### DIFF
--- a/tools/make_release_notes.sh
+++ b/tools/make_release_notes.sh
@@ -104,7 +104,7 @@ function format_release_notes_version {
 }
 
 function format_release_notes_year {
-    find "$1/" -maxdepth 1 -type d | sort --version-sort --reverse | while read -r VERSION; do
+    find "$1/" -mindepth 1 -maxdepth 1 -type d | sort --version-sort --reverse | while read -r VERSION; do
         format_release_notes_version "${VERSION}"
     done
 }
@@ -130,7 +130,7 @@ if [[ -n ${ONLY_VERSION} ]]; then
     format_release_notes_version "${RELEASE_NOTES_DIR}/${ONLY_VERSION_PATH}/${ONLY_VERSION}" | sed '$ d' | sed '$ d' >> "${OUTPUT}"
 elif [[ -n ${ALL} ]]; then
     # Append each year's entries
-    find "${RELEASE_NOTES_DIR}/" -maxdepth 1 -type d | sort --reverse | while read -r YEAR; do
+    find "${RELEASE_NOTES_DIR}/" -mindepth 1 -maxdepth 1 -type d | sort --reverse | while read -r YEAR; do
         format_release_notes_year "${YEAR}" >> "${OUTPUT}"
     done
 else
@@ -147,6 +147,10 @@ else
     $empty && note_dirs=("${note_dirs[@]/${RELEASE_NOTES_DIR}'/current/unreleased'}")
     # Only return the latest version by default
     latest_version_dir="$(printf '%s\n' "${note_dirs[@]}" | sort --version-sort | tail -n1)"
+    if [[ -z "${latest_version_dir}" ]]; then
+        echo "No release notes found" > /dev/stderr
+        exit 1
+    fi
     format_release_notes_version "$latest_version_dir" | sed '$ d' | sed '$ d' >> "${OUTPUT}"
 fi
 

--- a/tools/make_release_notes.sh
+++ b/tools/make_release_notes.sh
@@ -97,14 +97,14 @@ function format_release_notes_version {
             fi
         fi
     fi
-    find "$1"/* -maxdepth 0 -type f | sort --version-sort | while read -r ENTRY; do
+    find "$1/" -maxdepth 1 -type f -name '*.yml' | sort --version-sort | while read -r ENTRY; do
         format_release_notes_entry "${ENTRY}"
     done
     echo -e "\n"
 }
 
 function format_release_notes_year {
-    find "$1"/* -maxdepth 0 -type d | sort --version-sort --reverse | while read -r VERSION; do
+    find "$1/" -maxdepth 1 -type d | sort --version-sort --reverse | while read -r VERSION; do
         format_release_notes_version "${VERSION}"
     done
 }
@@ -130,12 +130,24 @@ if [[ -n ${ONLY_VERSION} ]]; then
     format_release_notes_version "${RELEASE_NOTES_DIR}/${ONLY_VERSION_PATH}/${ONLY_VERSION}" | sed '$ d' | sed '$ d' >> "${OUTPUT}"
 elif [[ -n ${ALL} ]]; then
     # Append each year's entries
-    find "${RELEASE_NOTES_DIR}"/* -maxdepth 0 -type d | sort --reverse | while read -r YEAR; do
+    find "${RELEASE_NOTES_DIR}/" -maxdepth 1 -type d | sort --reverse | while read -r YEAR; do
         format_release_notes_year "${YEAR}" >> "${OUTPUT}"
     done
 else
+    mapfile -t note_dirs < <(find "${RELEASE_NOTES_DIR}/" -mindepth 2 -maxdepth 2 -type d)
+    # If there are no release notes in unreleased, pretend it's not there
+    empty=true
+    shopt -s nullglob
+    for _ in "${RELEASE_NOTES_DIR}/current/unreleased"/*.yml; do
+        empty=false
+        break
+    done
+    shopt -u nullglob
+    # Filter out /current/unreleased
+    $empty && note_dirs=("${note_dirs[@]/${RELEASE_NOTES_DIR}'/current/unreleased'}")
     # Only return the latest version by default
-    format_release_notes_version "$(find "${RELEASE_NOTES_DIR}"/* -mindepth 1 -maxdepth 1 -type d | sort --version-sort | tail -n1)" | sed '$ d' | sed '$ d' >> "${OUTPUT}"
+    latest_version_dir="$(printf '%s\n' "${note_dirs[@]}" | sort --version-sort | tail -n1)"
+    format_release_notes_version "$latest_version_dir" | sed '$ d' | sed '$ d' >> "${OUTPUT}"
 fi
 
 if [[ "${OUTPUT}" != "/dev/stdout" ]]; then


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
The pipeline for our [most recent release](https://github.com/digitalfabrik/integreat-cms/pull/4230) failed after the changes introduced by #4205.

This PR contains the necessary changes to `tools/make_release_notes.sh` that should have been included in #4205.

#4205 changed how we handle release notes for developer convenience, specifically how release notes are moved from `current/unreleased/` to `2026/2026.X.X`, now always leaving the `unreleased` directory around. `tools/make_release_notes.sh` previously only picked the "last" release note directory, relying on the directories to always contain release notes, and thus also that the `unreleased` directory doesn't exist on full releases.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Modify arguments to `find` commands to not throw an error for empty directories
- When automatically determining the most recent version to show release notes for, ensure the `unreleased` directly is not included when it does not contain any `*.yml` release notes


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- This PR can be merged directly into `main` without further disrupting the release process. The version bump step on the previous merge commit for the release PR did not complete and the bump commit was not pushed to `main`. Thus the code on `main` currently still specifies the old version (`2026.3.0`) and merging another PR into it won't result in a version like `2026.5.0` or `2026.4.1` but the expected `2026.4.0`.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4246


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
