### PR TITLE
fix releases without release notes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -527,7 +527,17 @@ jobs:
             OLD_DIR="integreat_cms/release_notes/current/unreleased"
             NEW_DIR="integreat_cms/release_notes/$(echo "${CURRENT_VERSION}" | cut -c1-4)/${CURRENT_VERSION}"
             mkdir -p "${NEW_DIR}"
-            git mv "${OLD_DIR}"/* "${NEW_DIR}"/
+            # If there are no release notes in unreleased, there is nothing to move
+            empty=true
+            shopt -s nullglob
+            for _ in "${RELEASE_NOTES_DIR}/current/unreleased"/*.yml; do
+                empty=false
+                break
+            done
+            shopt -u nullglob
+            # Don't try to move if empty, the pipeline step will fail
+            # because the first argument for git mv expands to nothing
+            $empty || git mv "${OLD_DIR}"/* "${NEW_DIR}"/
             git commit --amend --no-edit
       - run:
           name: Generate SBOM

--- a/integreat_cms/release_notes/current/unreleased/4220.yml
+++ b/integreat_cms/release_notes/current/unreleased/4220.yml
@@ -1,0 +1,2 @@
+en: Fix broken redirect for third level pages
+de: Fehlerhafte Weiterleitung für Seiten der dritten Ebene behoben


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
After #4247, there is still a bug in the bump version CI step for the case a release is created without any release notes. This is essentially the same bug, but in the CI step definition:

When moving the release notes *(now the individual files, not the whole `current/unreleased/` directory)* as part of the release pipeline step, the move command fails when there are no release notes, as `"$1"/*.yml` expands to nothing.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Check whether there are any release notes to move first. If not, don't attempt to move anything
- Use this opportunity to add a release note for #4245, making the fix not technically necessary, but a release without any release notes is indeed weird


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- It is funny / We are lucky that we noticed this right away by trying to release another fix without adding any release note for the release. Not that I expect this would have been a hugely time consuming investigation if it ever came up at a later point


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4246


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
