### PR TITLE
Remove beta permissions for contact opening hours

### DIFF
--- a/integreat_cms/cms/forms/contacts/contact_form.py
+++ b/integreat_cms/cms/forms/contacts/contact_form.py
@@ -120,10 +120,6 @@ class ContactForm(CustomModelForm):
         :return: The valid opening hours
         """
 
-        # Remove when opening hours become available for all users
-        if not self.request.user.has_perm("cms.test_beta_features"):
-            return None
-
         if self.cleaned_data["use_location_opening_hours"]:
             return None
 

--- a/integreat_cms/cms/templates/_tinymce_config.html
+++ b/integreat_cms/cms/templates/_tinymce_config.html
@@ -81,6 +81,5 @@
      data-content-style="{{ content_style }}"
      data-media-button-translation='{% translate "Media Library" %}'
      data-media-item-translation='{% translate "Media Library..." %}'
-     {% if readonly %}data-readonly="1"{% endif %}
-     {% if perms.cms.test_beta_features %}data-test-beta-features="1"{% endif %}>
+     {% if readonly %}data-readonly="1"{% endif %}>
 </div>

--- a/integreat_cms/cms/templates/contacts/contact_form.html
+++ b/integreat_cms/cms/templates/contacts/contact_form.html
@@ -87,42 +87,40 @@
                                 {{ contact_form.website.label }}
                             </label>
                             {% render_field contact_form.website|add_error_class:"border-red-500" %}
-                            {% if perms.cms.test_beta_features %}
-                                <div class="{% if not contact_form.instance.id %} hidden {% endif %}">
-                                    <p>
-                                        <label for="{{ contact_form.opening_hours.id_for_label }}">
-                                            {{ contact_form.opening_hours.label }}
+                            <div class="{% if not contact_form.instance.id %} hidden {% endif %}">
+                                <p>
+                                    <label for="{{ contact_form.opening_hours.id_for_label }}">
+                                        {{ contact_form.opening_hours.label }}
+                                    </label>
+                                    <div class="flex">
+                                        {% render_field contact_form.use_location_opening_hours class+=" mt-1" %}
+                                        <label class="font-medium text-base my-0"
+                                               for="{{ contact_form.use_location_opening_hours.id_for_label }}">
+                                            {{ contact_form.use_location_opening_hours.label }}
                                         </label>
-                                        <div class="flex">
-                                            {% render_field contact_form.use_location_opening_hours class+=" mt-1" %}
-                                            <label class="font-medium text-base my-0"
-                                                   for="{{ contact_form.use_location_opening_hours.id_for_label }}">
-                                                {{ contact_form.use_location_opening_hours.label }}
-                                            </label>
-                                        </div>
-                                    </p>
-                                    <opening-hours-widget></opening-hours-widget>
-                                    {{ opening_hour_config_data|json_script:"openingHourConfigData" }}
-                                    {{ contact_form.opening_hours.value|json_script:"openingHourInitialData" }}
-                                    {{ contact_form.instance.location.opening_hours|json_script:"openingHourLocationData" }}
-                                    <div class="py-2 px-4">
-                                        {% render_field contact_form.temporarily_closed %}
-                                        <label for="{{ contact_form.temporarily_closed.id_for_label }}">
-                                            {{ contact_form.temporarily_closed.label }}
-                                        </label>
-                                        <div class="help-text">
-                                            {{ contact_form.temporarily_closed.help_text }}
-                                        </div>
-                                        <label for="{{ contact_form.appointment_url.id_for_label }}">
-                                            {{ contact_form.appointment_url.label }}
-                                        </label>
-                                        {% render_field contact_form.appointment_url %}
-                                        <div class="help-text">
-                                            {{ contact_form.appointment_url.help_text }}
-                                        </div>
+                                    </div>
+                                </p>
+                                <opening-hours-widget></opening-hours-widget>
+                                {{ opening_hour_config_data|json_script:"openingHourConfigData" }}
+                                {{ contact_form.opening_hours.value|json_script:"openingHourInitialData" }}
+                                {{ contact_form.instance.location.opening_hours|json_script:"openingHourLocationData" }}
+                                <div class="py-2 px-4">
+                                    {% render_field contact_form.temporarily_closed %}
+                                    <label for="{{ contact_form.temporarily_closed.id_for_label }}">
+                                        {{ contact_form.temporarily_closed.label }}
+                                    </label>
+                                    <div class="help-text">
+                                        {{ contact_form.temporarily_closed.help_text }}
+                                    </div>
+                                    <label for="{{ contact_form.appointment_url.id_for_label }}">
+                                        {{ contact_form.appointment_url.label }}
+                                    </label>
+                                    {% render_field contact_form.appointment_url %}
+                                    <div class="help-text">
+                                        {{ contact_form.appointment_url.help_text }}
                                     </div>
                                 </div>
-                            {% endif %}
+                            </div>
                         </div>
                     </div>
                     {% if contact_form.instance.id %}

--- a/integreat_cms/release_notes/current/unreleased/4133.yml
+++ b/integreat_cms/release_notes/current/unreleased/4133.yml
@@ -1,0 +1,2 @@
+en: Show opening hours for contacts
+de: Zeige Öffnungszeiten für Kontakte an

--- a/integreat_cms/static/src/js/tinymce-plugins/custom_contact_input/plugin.js
+++ b/integreat_cms/static/src/js/tinymce-plugins/custom_contact_input/plugin.js
@@ -4,7 +4,6 @@ import { getCsrfToken } from "../../utils/csrf-token";
 (() => {
     const tinymceConfig = document.getElementById("tinymce-config-options");
     const isContactsEnabled = tinymceConfig.getAttribute("data-contact-module-activated") !== "False";
-    const testBetaFeatures = !!tinymceConfig.getAttribute("data-test-beta-features");
 
     const completionUrl = tinymceConfig.getAttribute("data-contact-ajax-url");
     const noEmptyContactHint = tinymceConfig.getAttribute("data-no-empty-contact-hint");
@@ -164,37 +163,34 @@ import { getCsrfToken } from "../../utils/csrf-token";
                     }
 
                     const availableDetails = tomSelectInstance.options[value].details;
-                    const detailsInBeta = ["opening_hours"];
 
                     for (const [key, value] of Object.entries(availableDetails)) {
-                        if (testBetaFeatures || !detailsInBeta.includes(key)) {
-                            const wrapper = document.createElement("div");
+                        const wrapper = document.createElement("div");
 
-                            const checkbox = document.createElement("input");
-                            checkbox.type = "checkbox";
-                            checkbox.classList = ["details-checkbox"];
-                            checkbox.checked = selectedDetails?.includes(key) || !selectedDetails;
-                            checkbox.value = key;
-                            checkbox.id = key;
-                            checkbox.style.border = "1px solid";
-                            checkbox.style.width = "1em";
-                            checkbox.style.height = "1em";
-                            checkbox.style.margin = "0 5px 0 5px";
-                            checkbox.style.verticalAlign = "middle";
+                        const checkbox = document.createElement("input");
+                        checkbox.type = "checkbox";
+                        checkbox.classList = ["details-checkbox"];
+                        checkbox.checked = selectedDetails?.includes(key) || !selectedDetails;
+                        checkbox.value = key;
+                        checkbox.id = key;
+                        checkbox.style.border = "1px solid";
+                        checkbox.style.width = "1em";
+                        checkbox.style.height = "1em";
+                        checkbox.style.margin = "0 5px 0 5px";
+                        checkbox.style.verticalAlign = "middle";
 
-                            const label = document.createElement("label");
-                            label.htmlFor = key;
-                            label.textContent = value;
-                            label.style.verticalAlign = "middle";
+                        const label = document.createElement("label");
+                        label.htmlFor = key;
+                        label.textContent = value;
+                        label.style.verticalAlign = "middle";
 
-                            wrapper.append(checkbox);
-                            wrapper.append(label);
-                            detailsArea.append(wrapper);
+                        wrapper.append(checkbox);
+                        wrapper.append(label);
+                        detailsArea.append(wrapper);
 
-                            checkbox.addEventListener("click", () => {
-                                setSubmitDisableStatus(true);
-                            });
-                        }
+                        checkbox.addEventListener("click", () => {
+                            setSubmitDisableStatus(true);
+                        });
                     }
                 };
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Remove the beta permissions for the contact opening hours, so that the municipalities can access them


### Proposed changes
<!-- Describe this PR in more detail. -->

- Remove the beta permissions contact_form.py and contact_form.html as well as from the tinymce editor.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->

Login as a user without beta permissions (for example a user, with the role "author") and see that the opening hours are showing both in the contact form, as well as in the content editor (tinymce) of a page




### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4133


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
