### PR TITLE
fix sort by related m2m fields in POI list view

### DIFF
--- a/integreat_cms/cms/templates/pois/poi_list.html
+++ b/integreat_cms/cms/templates/pois/poi_list.html
@@ -76,7 +76,7 @@
                         {% endif %}
                     </th>
                     <th class="whitespace-nowrap text-sm text-left uppercase py-3 pr-2">
-                        {% sort_link title_label "translations__title" %}
+                        {% sort_link title_label "_sort_title" %}
                     </th>
                     {% if backend_language and backend_language != language %}
                         <th class="text-sm text-left uppercase py-3 pr-2">
@@ -98,7 +98,7 @@
                         </div>
                     </th>
                     <th class="whitespace-nowrap text-sm text-left uppercase py-3 pr-2">
-                        {% sort_link publication_status_label "translations__status" %}
+                        {% sort_link publication_status_label "_sort_status" %}
                     </th>
                     <th class="whitespace-nowrap text-sm text-left uppercase py-3 pr-2">
                         {% sort_link street_label "address" %}
@@ -113,7 +113,7 @@
                         {% sort_link country_label "country" %}
                     </th>
                     <th class="whitespace-nowrap text-sm text-left uppercase py-3 pr-2">
-                        {% sort_link category_label "category" %}
+                        {% sort_link category_label "_sort_category_name" %}
                     </th>
                     <th class="text-sm text-right uppercase py-3 pr-4 min">
                         {% translate "Options" %}

--- a/integreat_cms/cms/views/mixins.py
+++ b/integreat_cms/cms/views/mixins.py
@@ -9,7 +9,6 @@ from typing import TYPE_CHECKING
 from django.conf import settings
 from django.contrib.auth.mixins import UserPassesTestMixin
 from django.core.paginator import EmptyPage, PageNotAnInteger, Paginator
-from django.db.models import Min
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.views.generic.base import ContextMixin, TemplateResponseMixin
@@ -249,22 +248,5 @@ class FilterSortMixin:
         if order_by:
             # queryset.order_by([]) would override default ordering and result in an unordered queryset
             # so we only use order_by if "sort" is not empty
-            annotations = {}
-            final_order = []
-            for f in order_by:
-                bare = f.lstrip("-")
-                descending = f.startswith("-")
-                if "__" in bare:
-                    # Sorting by a relational field via JOIN produces duplicate rows.
-                    # Use Min annotation instead, which collapses via GROUP BY.
-                    annotation_name = f"_sort_{bare.replace('__', '_')}"
-                    annotations[annotation_name] = Min(bare)
-                    final_order.append(
-                        f"-{annotation_name}" if descending else annotation_name
-                    )
-                else:
-                    final_order.append(f)
-            if annotations:
-                queryset = queryset.annotate(**annotations)
-            queryset = queryset.order_by(*final_order)
+            queryset = queryset.order_by(*order_by)
         return queryset

--- a/integreat_cms/cms/views/pois/poi_list_view.py
+++ b/integreat_cms/cms/views/pois/poi_list_view.py
@@ -1,25 +1,26 @@
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING
 
 from django.contrib import messages
+from django.db.models import Case, IntegerField, OuterRef, Subquery, Value, When
 from django.shortcuts import redirect, render
 from django.utils.decorators import method_decorator
+from django.utils.translation import get_language
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import TemplateView
 
+from ...constants import status
 from ...decorators import permission_required
-from ...models import POI, POITranslation
+from ...models import POI, POICategoryTranslation, POITranslation
 from ..mixins import FilterSortMixin, MachineTranslationContextMixin, PaginationMixin
 from .poi_context_mixin import POIContextMixin
 
 if TYPE_CHECKING:
     from typing import Any
 
+    from django.db.models.query import QuerySet
     from django.http import HttpRequest, HttpResponse
-
-logger = logging.getLogger(__name__)
 
 
 @method_decorator(permission_required("cms.view_poi"), name="dispatch")
@@ -42,14 +43,52 @@ class POIListView(
     translation_model = POITranslation
     model = POI
     table_fields = [
-        ("translations__title", _("Title")),
-        ("translations__status", _("Publication status")),
+        ("_sort_title", _("Title")),
+        ("_sort_status", _("Publication status")),
         ("address", _("Street")),
         ("postcode", _("Postal Code")),
         ("city", _("City")),
         ("country", _("Country")),
-        ("category", _("Category")),
+        ("_sort_category_name", _("Category")),
     ]
+
+    def get_filtered_sorted_queryset(self, queryset: QuerySet) -> QuerySet:
+        """
+        Annotate sort keys that match what the user actually sees in the list:
+
+        * ``_sort_title`` and ``_sort_status``: latest translation (any version,
+          including auto-saves) in the language slug from the URL — this is the
+          translation rendered by ``poi_list_row.html``.
+        * ``_sort_status`` ranks status values by workflow order (AUTO_SAVE, DRAFT,
+          REVIEW, PUBLIC) instead of by the lexicographic order of
+          the choice keys, which has no relation to the localized labels shown.
+        * ``_sort_category_name``: name of the category in the active backend
+          (UI) language, mirroring how :class:`POICategory.__str__` renders the
+          column.
+        """
+        latest_translation = POITranslation.objects.filter(
+            poi=OuterRef("pk"),
+            language__slug=self.kwargs["language_slug"],
+        ).order_by("-version")
+        ranked_status = latest_translation.annotate(
+            _rank=Case(
+                When(status=status.AUTO_SAVE, then=Value(0)),
+                When(status=status.DRAFT, then=Value(1)),
+                When(status=status.REVIEW, then=Value(2)),
+                When(status=status.PUBLIC, then=Value(3)),
+                output_field=IntegerField(),
+            ),
+        )
+        category_translation = POICategoryTranslation.objects.filter(
+            category=OuterRef("category_id"),
+            language__slug=get_language(),
+        )
+        queryset = queryset.annotate(
+            _sort_title=Subquery(latest_translation.values("title")[:1]),
+            _sort_status=Subquery(ranked_status.values("_rank")[:1]),
+            _sort_category_name=Subquery(category_translation.values("name")[:1]),
+        )
+        return super().get_filtered_sorted_queryset(queryset)
 
     def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
         r"""

--- a/tests/cms/views/poi/test_poi_list_sort.py
+++ b/tests/cms/views/poi/test_poi_list_sort.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import pytest
+from django.test import RequestFactory
+
+from integreat_cms.cms.constants import status
+from integreat_cms.cms.models import Language, POITranslation, Region
+from integreat_cms.cms.views.pois.poi_list_view import POIListView
+
+REGION_SLUG = "augsburg"
+LANGUAGE_SLUG = "de"
+
+# Augsburg POIs visible in the unarchived list (region 1, language de):
+#   pk=4 "Test-Ort"    PUBLIC  — also has en + ar translations
+#   pk=6 "Entwurf-Ort" DRAFT   — also has an en translation
+POI_TEST_ORT = 4
+POI_ENTWURF_ORT = 6
+
+
+def _sorted_poi_ids(sort_param: str) -> list[int]:
+    """Run the list view's sort/filter logic and return the ordered POI ids."""
+    view = POIListView()
+    view.request = RequestFactory().get("/", {"sort": sort_param})
+    view.kwargs = {"language_slug": LANGUAGE_SLUG}
+
+    region = Region.objects.get(slug=REGION_SLUG)
+    queryset = region.pois.filter(archived=False)
+    return list(
+        view.get_filtered_sorted_queryset(queryset).values_list("pk", flat=True),
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "sort_param,expected_order",
+    [
+        ("_sort_title", [POI_ENTWURF_ORT, POI_TEST_ORT]),
+        ("-_sort_title", [POI_TEST_ORT, POI_ENTWURF_ORT]),
+    ],
+)
+def test_poi_list_sort_by_title_does_not_duplicate_translations(
+    load_test_data: None,
+    sort_param: str,
+    expected_order: list[int],
+) -> None:
+    """
+    Sorting through the reverse FK ``translations`` used to JOIN and produce one row
+    per (POI, translation), so a POI with N translations appeared N times. POI 4 has
+    three translations (de/en/ar); the buggy ordering returned [6, 6, 4, 4, 4, 4].
+    The fix annotates a Subquery over the latest translation in the URL language and
+    orders by that — exactly the title rendered by the row template.
+    """
+    assert _sorted_poi_ids(sort_param) == expected_order
+
+
+@pytest.mark.django_db
+def test_poi_list_sort_by_status_uses_workflow_order(load_test_data: None) -> None:
+    """
+    Status sorting must follow the workflow order
+    (DRAFT < REVIEW < PUBLIC < AUTO_SAVE), not the lexicographic order of the choice
+    keys (where AUTO_SAVE < DRAFT < PUBLIC < REVIEW). Promote POI 6's latest DE
+    translation to REVIEW so the two POIs differ on a status pair where workflow and
+    alphabetic orderings disagree (REVIEW < PUBLIC by workflow, PUBLIC < REVIEW
+    alphabetically).
+    """
+    POITranslation.objects.create(
+        poi_id=POI_ENTWURF_ORT,
+        language=Language.objects.get(slug=LANGUAGE_SLUG),
+        title="Entwurf-Ort",
+        slug="entwurf-ort",
+        status=status.REVIEW,
+        version=2,
+        content="",
+    )
+
+    # workflow asc: REVIEW(rank 1) = POI 6 < PUBLIC(rank 2) = POI 4
+    # alphabetic asc would give the opposite: PUBLIC < REVIEW → [4, 6]
+    assert _sorted_poi_ids("_sort_status") == [POI_ENTWURF_ORT, POI_TEST_ORT]


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fix sorting in list views when the sort field is a reverse relation

### Proposed changes
<!-- Describe this PR in more detail. -->
Sorting a queryset is trivial when sorting by a field that is on the model, but not trivial when the field is on a related model, especially when the relation produces multiple rows per parent (a reverse foreign key like POI ↔ POITranslation). The current (generic) approach attempted to handle this in the `FilterSortMixin` by collapsing those rows using `Min`, annotate it to the base queryset and then sort by the annotated field. Unfortunately, this does not yield any useful results for our use cases for 2 reasons:

- The collapsed value picks the lexicographically smallest `translations__status` (or `translations__title`) across all languages and all versions of a POI, not the translation in the language the user has selected in their view
- status is stored as the choice key (AUTO_SAVE, DRAFT, PUBLIC, REVIEW), so even after collapsing the alphabetic order has no relation to the localized labels the user sees

What we want instead is to sort the queryset based on the latest translation in the user-selected language. So with this PR, we

- remove the attempt to handle reverse-relation sort fields generically from the `FilterSortMixin`
- add custom logic to `POIListView` to handle sorting by title, publication status and category name (Note that POICategory has no name column: the property goes through `best_translation.name`. So the category sort uses a Subquery against POICategoryTranslation in the active backend language, matching what is rendered in the row)


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Since no other list views sort by related fields yet, only the `POIListView` is affected by these changes
- The mixin still passes __ sort keys through to plain `order_by`, which is correct for single-row joins (FKs from the listed model). A future view that wants to sort by a reverse-relation field will need to provide its own annotation, otherwise the joined rows will be duplicated, and similar bugs as the ones fixed here may be introduced

### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
- In a region with at least two languages, create POIs whose translations differ between languages — e.g. one POI is Published in DE but Draft in EN
- Go to 'Locations' in EN and sort by Publication Status ascending — verify Draft rows come before Published rows, and that the order reflects the EN status, not the DE one.
- Sort by Title ascending/descending in EN and in DE — verify the ordering matches the titles actually rendered in the row, not the title in the other language.
- Sort by Category ascending — verify it's alphabetical by the category name shown in the row (i.e. by the active backend language's translation), not by category id.
- Verify rows are not duplicated and pagination still works under each sort.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4257 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
