### PR TITLE
Fix existing translations incorrectly marked as outdated after MT into new language

### DIFF
--- a/integreat_cms/cms/forms/machine_translation_form.py
+++ b/integreat_cms/cms/forms/machine_translation_form.py
@@ -148,7 +148,13 @@ class MachineTranslationForm(CustomContentModelForm):
         :param foreign_form_changed: Whether or not the foreign form of this translation form was changed
         :return: The saved content translation object
         """
-        self.instance = super().save(commit, foreign_form_changed)
+        # If no text content changed, mark the source translation as minor edit so that
+        # existing translations in other languages are not incorrectly flagged as outdated
+        if {"title", "content"}.isdisjoint(self.changed_data):
+            self.instance.minor_edit = True
+        self.instance: EventTranslation | PageTranslation | POITranslation = (
+            super().save(commit, foreign_form_changed)
+        )
 
         language_nodes = self.cleaned_data["mt_translations_to_create"].union(
             self.cleaned_data["mt_translations_to_update"],

--- a/integreat_cms/release_notes/current/unreleased/4254.yml
+++ b/integreat_cms/release_notes/current/unreleased/4254.yml
@@ -1,0 +1,2 @@
+en: Fix existing translations incorrectly marked as outdated after machine-translating into a new language
+de: Behebe einen Fehler, bei dem bestehende Übersetzungen nach maschineller Übersetzung in eine neue Sprache fälschlicherweise als veraltet markiert wurden

--- a/integreat_cms/release_notes/current/unreleased/4284.yml
+++ b/integreat_cms/release_notes/current/unreleased/4284.yml
@@ -1,0 +1,2 @@
+en: Fix existing translations incorrectly marked as outdated after saving the default language translation into draft
+de: Behebe einen Fehler, bei dem bestehende Übersetzungen fälschlicherweise als veraltet markiert wurden, nachdem die Seite in der Standard-Sprache als Entwurf gespeichert wurde


### PR DESCRIPTION
Fixes: #4254
Fixes: #4284 

## Summary

- Adds `minor_edit = True` in `MachineTranslationForm.save()` before calling `super().save()` when no text content (`title`/`content`) changed
- Minor-edit versions are excluded from `major_source_translation` lookups, so the outdated timestamp comparison is done against the last content-bearing source version, not the just-created empty save
- `CustomContentModelForm` is deliberately left unchanged to preserve the behaviour from #1864 (editor can mark an outdated translation as up-to-date by saving without content changes)

## Root Cause

See [comment on #4254](https://github.com/digitalfabrik/integreat-cms/issues/4254#issuecomment-4387736177) for the full analysis.

**Why not fix it in `CustomContentModelForm`?**
The condition `{"title", "content"}.isdisjoint(self.changed_data) and foreign_form_changed` was introduced intentionally to fix #1864: without it, an editor opening an outdated translation and saving without content changes would get `minor_edit=True` forced, keeping the translation stuck as outdated forever. The fix therefore targets only `MachineTranslationForm` — the code path triggered when saving a source translation purely to kick off MT for a new language.

## Test plan

- [ ] Open a page that has multiple up-to-date machine-translated languages (e.g. Spanish, Russian)
- [ ] Save the page with MT enabled for one additional new language, without changing any content
- [ ] Verify existing translations still show as up to date (robot icon), not outdated (red icon)
- [ ] Verify the new language was correctly machine-translated
- [ ] Open an outdated translation, save without changing content → should now appear up-to-date (regression test for #1864)
- [ ] Run `tools/test.sh tests/cms/models/ tests/cms/views/pages/`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)