### PR TITLE
Fix import poi from csv bug

### DIFF
--- a/integreat_cms/core/management/commands/import_pois_from_csv.py
+++ b/integreat_cms/core/management/commands/import_pois_from_csv.py
@@ -225,10 +225,10 @@ class Command(LogCommand):
                         poi["category"],
                         region.default_language,
                     ).id,
-                    "website": poi["website"],
+                    "primary_website": poi["website"],
                     "appointment_url": poi["appointment_url"],
-                    "email": poi["email"],
-                    "phone_number": poi["phone_number"],
+                    "primary_email": poi["email"],
+                    "primary_phone_number": poi["phone_number"],
                     "barrier_free": strtobool(poi["barrier_free"]),
                 }
                 poi_form = POIForm(


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
With the changes to contacts in the poi_form.py (differentiating between primary_* and * contact fields) the mapping of field names in the `import_pois_from_csv.py` command has gone stale and needed to be updated


### Proposed changes
<!-- Describe this PR in more detail. -->

- map `website, phone_number, email` to `primary_website, primary_phone_number, primary_email`


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
Follow the instructions for reproducing inside the bug report. Make sure that your csv data contains the right data formatting for the specific fields, e.g. latitude needs to be a decimal number


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4272 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
