### PR TITLE
Increase PDF link text truncation limit from 50 to 80 characters

### DIFF
--- a/integreat_cms/cms/templates/pages/page_pdf.html
+++ b/integreat_cms/cms/templates/pages/page_pdf.html
@@ -113,11 +113,11 @@
                 <h1 class="level-{{ page.depth|add:"-1" }}">{{ page_translation.title }}</h1>
                 <div class="content">
                     {% if page.mirrored_page_first %}
-                        {{ page_translation.mirrored_translation_text|pdf_strip_fontstyles|pdf_truncate_links:50|safe }}
+                        {{ page_translation.mirrored_translation_text|pdf_strip_fontstyles|pdf_truncate_links:80|safe }}
                     {% endif %}
-                    {{ page_translation.content|pdf_strip_fontstyles|pdf_truncate_links:50|safe }}
+                    {{ page_translation.content|pdf_strip_fontstyles|pdf_truncate_links:80|safe }}
                     {% if not page.mirrored_page_first %}
-                        {{ page_translation.mirrored_translation_text|pdf_strip_fontstyles|pdf_truncate_links:50|safe }}
+                        {{ page_translation.mirrored_translation_text|pdf_strip_fontstyles|pdf_truncate_links:80|safe }}
                     {% endif %}
                 </div>
                 {% for close in info.close %}

--- a/integreat_cms/release_notes/current/unreleased/4275.yml
+++ b/integreat_cms/release_notes/current/unreleased/4275.yml
@@ -1,0 +1,2 @@
+en: Increase PDF link text truncation limit from 50 to 80 characters to reduce premature truncation of long URLs
+de: Erhöht die Kürzungsgrenze für Linktexte in PDFs von 50 auf 80 Zeichen, um vorzeitiges Abschneiden langer URLs zu reduzieren


### PR DESCRIPTION
## Summary

- Raises the per-token link text truncation limit in generated PDFs from 50 to 80 characters
- The previous value of 50 was chosen arbitrarily; on A4 with standard margins at the PDF font size (~large), approximately 80–90 characters fit per line, making 80 a more appropriate threshold
- The truncation workaround remains necessary since xhtml2pdf has no support for `word-break` or `overflow-wrap` CSS properties

Closes #4275

## Test plan
- [ ] Generate a PDF for a page that contains a link (raw url) between 51 and 80 characters — verify it is no longer truncated
- [ ] Generate a PDF for a page that contains a link (raw url) over 80 characters — verify it is still truncated (no line overflow)
- [ ] Generate a PDF for a page that contains a link with anchor text longer than 80 characters - verify that the text is not truncated
- [ ] Run existing PDF tests: `tools/test.sh tests/pdf/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)