### PR TITLE
Fix machine translation when page content is cleared

### DIFF
--- a/integreat_cms/cms/models/abstract_content_model.py
+++ b/integreat_cms/cms/models/abstract_content_model.py
@@ -544,17 +544,20 @@ class AbstractContentModel(AbstractBaseModel):
         result = []
 
         for attr in attrs:
+            # When no old source translation exists, only include attributes with a value
             value = getattr(source_translation, attr, None)
-            if not value:
+            if not value and not old_source_translation:
                 continue
             if self.do_not_translate_title and attr == "title":
                 continue
+            # When an old source translation exists, only include changed attributes
             if old_source_translation and not source_translation.attr_differs_from(
                 attr, old_source_translation
             ):
                 continue
 
-            result.append((attr, value))
+            # Use an empty string if value was cleared
+            result.append((attr, value or ""))
 
         return result
 

--- a/integreat_cms/core/utils/machine_translation_api_client.py
+++ b/integreat_cms/core/utils/machine_translation_api_client.py
@@ -213,7 +213,7 @@ class MachineTranslationApiClient(ABC):
         filtered_context = []
 
         for ctx in context:
-            if ctx.word_count > 0:
+            if bool(ctx.translatable_attributes):
                 filtered_context.append(ctx)
             else:
                 self.failed_because_no_changes_made.append(

--- a/integreat_cms/deepl_api/deepl_api_client.py
+++ b/integreat_cms/deepl_api/deepl_api_client.py
@@ -102,6 +102,9 @@ class DeepLApiClient(MachineTranslationApiClient):
                 )
 
             for attr, attr_val in ctx.translatable_attributes:
+                if not attr_val:
+                    data[attr] = ""
+                    continue
                 try:
                     # data has to be unescaped for DeepL to recognize Umlaute
                     glossary = deepl_config.get_glossary(

--- a/integreat_cms/google_translate_api/google_translate_api_client.py
+++ b/integreat_cms/google_translate_api/google_translate_api_client.py
@@ -111,6 +111,9 @@ class GoogleTranslateApiClient(MachineTranslationApiClient):
                     }
                 )
             for attr, attr_val in ctx.translatable_attributes:
+                if not attr_val:
+                    data[attr] = ""
+                    continue
                 try:
                     # data has to be unescaped to recognize Umlaute
                     if settings.GOOGLE_TRANSLATE_VERSION == "Advanced":

--- a/integreat_cms/release_notes/current/unreleased/4277.yml
+++ b/integreat_cms/release_notes/current/unreleased/4277.yml
@@ -1,0 +1,2 @@
+en: Fix machine translation when page content is cleared
+de: Behebe maschinelle Übersetzung bei gelöschtem Seiteninhalt

--- a/tests/mt_api/mt_api_test.py
+++ b/tests/mt_api/mt_api_test.py
@@ -838,12 +838,16 @@ do_not_translate_title = [True, False]
 
 @pytest.mark.django_db
 @pytest.mark.parametrize("do_not_translate_title", do_not_translate_title)
+@pytest.mark.parametrize(
+    "login_role_user",
+    [*PRIV_STAFF_ROLES, MANAGEMENT, EDITOR],
+    indirect=True,
+)
 def test_do_not_translate_title(
     load_test_data: None,
     login_role_user: tuple[Client, str],
     do_not_translate_title: bool,
     settings: SettingsWrapper,
-    caplog: LogCaptureFixture,
     mock_server: MockServer,
 ) -> None:
     """
@@ -858,104 +862,232 @@ def test_do_not_translate_title(
     """
     client, role = login_role_user
 
-    if role in [*PRIV_STAFF_ROLES, MANAGEMENT, EDITOR]:
-        region = Region.objects.get(slug=REGION_SLUG)
-        test_page = Page.objects.create(
-            region=region,
-            do_not_translate_title=do_not_translate_title,
-            lft=1,
-            rgt=2,
-            tree_id=14,
-            depth=1,
+    region = Region.objects.get(slug=REGION_SLUG)
+    test_page = Page.objects.create(
+        region=region,
+        do_not_translate_title=do_not_translate_title,
+        lft=1,
+        rgt=2,
+        tree_id=14,
+        depth=1,
+    )
+    PageTranslation.objects.create(
+        page=test_page,
+        title="xxxx",
+        slug="xxxx",
+        language=Language.objects.get(slug="de"),
+        content="",
+    )
+
+    mt_setup(["de"], ["en-gb", "en-us"], ["en"], ["ar"], settings, mock_server)
+
+    with patch.object(
+        GoogleTranslateApiClient,
+        "__init__",
+        setup_fake_google_translate_api,
+    ):
+        edit_page_de = reverse(
+            "edit_page",
+            kwargs={
+                "region_slug": REGION_SLUG,
+                "language_slug": "de",
+                "page_id": test_page.id,
+            },
         )
-        de_translation = PageTranslation.objects.create(
-            page=test_page,
-            title="xxxx",
-            slug="xxxx",
-            language=Language.objects.get(slug="de"),
-            content="",
+        client.post(
+            edit_page_de,
+            data={
+                "title": "Neuer Titel",
+                "content": "Neuer Inhalt",
+                "mirrored_page_region": "",
+                "automatic_translation": "on",
+                "mt_translations_to_create": region.language_tree_nodes.get(
+                    language__slug="en"
+                ).id,
+                "status": status.PUBLIC,
+                "_position": "right",
+                "do_not_translate_title": do_not_translate_title,
+            },
         )
 
-        mt_setup(["de"], ["en-gb", "en-us"], ["en"], ["ar"], settings, mock_server)
+        de_translation = PageTranslation.objects.filter(
+            page=test_page, language__slug="de"
+        ).first()
+        en_translation = PageTranslation.objects.filter(
+            page=test_page, language__slug="en"
+        ).first()
 
-        with patch.object(
-            GoogleTranslateApiClient,
-            "__init__",
-            setup_fake_google_translate_api,
-        ):
-            edit_page_de = reverse(
-                "edit_page",
-                kwargs={
-                    "region_slug": REGION_SLUG,
-                    "language_slug": "de",
-                    "page_id": test_page.id,
-                },
-            )
-            client.post(
-                edit_page_de,
-                data={
-                    "title": "Neuer Titel",
-                    "content": "Neuer Inhalt",
-                    "mirrored_page_region": "",
-                    "automatic_translation": "on",
-                    "mt_translations_to_create": Language.objects.get(slug="en").id,
-                    "status": status.PUBLIC,
-                    "_position": "right",
-                    "do_not_translate_title": do_not_translate_title,
-                },
-            )
+        assert de_translation
+        assert en_translation
 
-            de_translation = PageTranslation.objects.filter(
-                page=test_page, language__slug="de"
-            ).first()
-            en_translation = PageTranslation.objects.filter(
-                page=test_page, language__slug="en"
-            ).first()
+        if do_not_translate_title:
+            assert en_translation.title == de_translation.title
+        else:
+            assert en_translation.title == "This is your translation from DeepL"
 
-            assert de_translation
-            assert en_translation
+        edit_page_en = reverse(
+            "edit_page",
+            kwargs={
+                "region_slug": REGION_SLUG,
+                "language_slug": "en",
+                "page_id": test_page.id,
+            },
+        )
+        client.post(
+            edit_page_en,
+            data={
+                "title": "Titel in English",
+                "content": "New content",
+                "mirrored_page_region": "",
+                "automatic_translation": "on",
+                "mt_translations_to_create": region.language_tree_nodes.get(
+                    language__slug="ar"
+                ).id,
+                "status": status.PUBLIC,
+                "_position": "right",
+                "do_not_translate_title": do_not_translate_title,
+            },
+        )
 
-            if do_not_translate_title:
-                assert en_translation.title == de_translation.title
-            else:
-                assert en_translation.title == "This is your translation from DeepL"
+        en_translation = PageTranslation.objects.filter(
+            page=test_page, language__slug="en"
+        ).first()
+        ar_translation = PageTranslation.objects.filter(
+            page=test_page, language__slug="ar"
+        ).first()
 
-            edit_page_en = reverse(
-                "edit_page",
-                kwargs={
-                    "region_slug": REGION_SLUG,
-                    "language_slug": "en",
-                    "page_id": test_page.id,
-                },
-            )
-            client.post(
-                edit_page_en,
-                data={
-                    "title": "Titel in English",
-                    "content": "New content",
-                    "mirrored_page_region": "",
-                    "automatic_translation": "on",
-                    "mt_translations_to_create": Language.objects.get(slug="ar").id,
-                    "status": status.PUBLIC,
-                    "_position": "right",
-                    "do_not_translate_title": do_not_translate_title,
-                },
+        assert en_translation
+        assert ar_translation
+
+        if do_not_translate_title:
+            assert ar_translation.title == en_translation.title
+        else:
+            assert (
+                ar_translation.title == "This is your translation from Google Translate"
             )
 
-            en_translation = PageTranslation.objects.filter(
-                page=test_page, language__slug="en"
-            ).first()
-            ar_translation = PageTranslation.objects.filter(
-                page=test_page, language__slug="ar"
-            ).first()
 
-            assert en_translation
-            assert ar_translation
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "login_role_user",
+    [*PRIV_STAFF_ROLES, MANAGEMENT, EDITOR],
+    indirect=True,
+)
+def test_mt_empty_content(
+    load_test_data: None,
+    login_role_user: tuple[Client, str],
+    settings: SettingsWrapper,
+    mock_server: MockServer,
+) -> None:
+    """
+    When a page is saved with empty content and MT update enabled:
+    - target translations are cleared
+    - translations are marked as up to date
+    - no MT API request is sent
+    """
+    client, role = login_role_user
 
-            if do_not_translate_title:
-                assert ar_translation.title == en_translation.title
-            else:
-                assert (
-                    ar_translation.title
-                    == "This is your translation from Google Translate"
-                )
+    region = Region.objects.get(slug=REGION_SLUG)
+    test_page = Page.objects.create(
+        region=region,
+        lft=1,
+        rgt=2,
+        tree_id=14,
+        depth=1,
+    )
+    PageTranslation.objects.create(
+        page=test_page,
+        title="Titel",
+        slug="titel",
+        language=Language.objects.get(slug="de"),
+        content="Inhalt",
+    )
+    PageTranslation.objects.create(
+        page=test_page,
+        title="Titel",
+        slug="titel",
+        language=Language.objects.get(slug="en"),
+        content="Content",
+    )
+    PageTranslation.objects.create(
+        page=test_page,
+        title="العنوان",
+        slug="العنوان",
+        language=Language.objects.get(slug="ar"),
+        content="المحتوى",
+    )
+
+    mt_setup(["de"], ["en-gb", "en-us"], ["en"], ["ar"], settings, mock_server)
+
+    with patch.object(
+        GoogleTranslateApiClient,
+        "__init__",
+        setup_fake_google_translate_api,
+    ):
+        edit_page_de = reverse(
+            "edit_page",
+            kwargs={
+                "region_slug": REGION_SLUG,
+                "language_slug": "de",
+                "page_id": test_page.id,
+            },
+        )
+        client.post(
+            edit_page_de,
+            data={
+                "title": "Titel",
+                "content": "",
+                "mirrored_page_region": "",
+                "automatic_translation": "on",
+                "mt_translations_to_update": region.language_tree_nodes.get(
+                    language__slug="en"
+                ).id,
+                "status": status.PUBLIC,
+                "_position": "right",
+            },
+        )
+
+        en_translation = PageTranslation.objects.filter(
+            page=test_page, language__slug="en"
+        ).first()
+
+        assert en_translation
+        assert en_translation.title == "Titel"
+        assert en_translation.content == ""
+        assert en_translation.machine_translated is True
+        assert en_translation.is_up_to_date is True
+        assert mock_server.requests_counter == 0
+
+        edit_page_en = reverse(
+            "edit_page",
+            kwargs={
+                "region_slug": REGION_SLUG,
+                "language_slug": "en",
+                "page_id": test_page.id,
+            },
+        )
+        client.post(
+            edit_page_en,
+            data={
+                "title": "Titel",
+                "content": "",
+                "mirrored_page_region": "",
+                "automatic_translation": "on",
+                "mt_translations_to_update": region.language_tree_nodes.get(
+                    language__slug="ar"
+                ).id,
+                "status": status.PUBLIC,
+                "_position": "right",
+            },
+        )
+
+        ar_translation = PageTranslation.objects.filter(
+            page=test_page, language__slug="ar"
+        ).first()
+
+        assert ar_translation
+        assert ar_translation.title == "العنوان"
+        assert ar_translation.content == ""
+        assert ar_translation.machine_translated is True
+        assert ar_translation.is_up_to_date is True
+        assert mock_server.requests_counter == 0


### PR DESCRIPTION
### Short description
When a page’s content field is cleared (e.g. turning a content page into a heading-only parent page), triggering machine translation incorrectly reports "no changes to the source translation" and does not update target translations. As a result, target translations contain stale content while the source translation is empty.

**Suggested fix**: target translations are now also updated - cleared, marked with the machine-translated icon, and set to up to date.


### Proposed changes
- In `get_translatable_attributes`: when a field is now empty but was non-empty in `old_source_translation`, add it as `(attr, "")` to signal the deletion.
- In `filter_unchanged_translations`: change the condition from `word_count > 0` to `bool(translatable_attributes)` so a cleared field still counts as a change.
- In the API clients (DeepL, Google Translate): skip calling the external API for empty values but write `data[attr] = ""` so the target translation's field is cleared on save.
- Add new test


### Side effects
no?


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
- Create a page with non-empty content, enable `Automatic translation` and `Create new translations` checkboxes, click "Publish".
- Clear the content of the source translation, enable `Automatic translation` and `Update existing translations` checkboxes, click "Publish".
- Verify that the target translation is updated: content is empty and the translation is marked as up to date.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4277


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
