### PR TITLE
improve log for MT error

### DIFF
--- a/integreat_cms/deepl_api/deepl_api_client.py
+++ b/integreat_cms/deepl_api/deepl_api_client.py
@@ -126,7 +126,12 @@ class DeepLApiClient(MachineTranslationApiClient):
                             "A problem with DeepL API has occurred. Please contact an administrator.",
                         ),
                     )
-                    logger.exception("")
+                    logger.exception(
+                        "Could not translate %r from %r to %r",
+                        ctx.instance,
+                        self.source_language.slug,
+                        self.target_language_key,
+                    )
                     return
 
             self.save_translation(ctx, data)

--- a/integreat_cms/google_translate_api/google_translate_api_client.py
+++ b/integreat_cms/google_translate_api/google_translate_api_client.py
@@ -146,7 +146,12 @@ class GoogleTranslateApiClient(MachineTranslationApiClient):
                             "A problem with Google Translate API has occurred. Please contact an administrator.",
                         ),
                     )
-                    logger.exception("")
+                    logger.exception(
+                        "Could not translate %r from %r to %r",
+                        ctx.instance,
+                        self.source_language.slug,
+                        self.target_language_key,
+                    )
                     return
 
             self.save_translation(ctx, data)


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds detailed information into log to identify which content blocked a MT process

### Proposed changes
<!-- Describe this PR in more detail. -->

- Store information about the content type, id and the source and target language like this:

Could not translate <Page (id: 18, region: augsburg, slug: deutsche-sprache)> from 'en' to 'am'

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be noe 


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
- Set up so the DeepL/Google Translate API client faces an error (for example, by setting an invalid language slug for the source/target language)
- Try MT by DeepL and Google Translate
- See the error in the GUI
- See the log like above example in `integreat-cms.log`

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4236 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
