### PR TITLE
Exclude archived and certain hidden regions from live content selection

### DIFF
--- a/integreat_cms/cms/forms/pages/page_form.py
+++ b/integreat_cms/cms/forms/pages/page_form.py
@@ -4,8 +4,11 @@ import logging
 from typing import TYPE_CHECKING
 
 from django import forms
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.db.models import Q
+
+from integreat_cms.cms.constants import region_status
 
 if TYPE_CHECKING:
     from typing import Any
@@ -45,8 +48,15 @@ class PageForm(CustomModelForm, CustomTreeNodeForm):
         label=_("Editors"),
         help_text=_("These users can edit and publish this page."),
     )
+    region_qs = Region.objects.exclude(
+        Q(status=region_status.ARCHIVED)
+        | Q(
+            slug__in=settings.EXCLUDED_HIDDEN_MIRRORED_REGIONS,
+            status=region_status.HIDDEN,
+        )
+    )
     mirrored_page_region = forms.ModelChoiceField(
-        queryset=Region.objects.all(),
+        queryset=region_qs,
         required=False,
         label=_("Source region for live content"),
     )

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -1507,3 +1507,13 @@ PILOT_REGIONS_PAGE_BASED_STATISTICS = os.environ.get(
     "INTEGREAT_CMS_PILOT_REGIONS_PAGE_BASED_STATISTICS",
     [""],
 )
+
+################
+# Live Content #
+################
+
+# Hidden Regions that should not be mirrored (archived regions are hidden by default)
+EXCLUDED_HIDDEN_MIRRORED_REGIONS = os.environ.get(
+    "INTEGREAT_CMS_EXCLUDED_HIDDEN_MIRRORED_REGIONS",
+    "",
+).split(",")

--- a/integreat_cms/release_notes/current/unreleased/4299.yml
+++ b/integreat_cms/release_notes/current/unreleased/4299.yml
@@ -1,0 +1,2 @@
+en: Exclude archived and certain hidden regions fro live content selection.
+de: Archivierte und bestimmte verborgene Regionen bei der Auswahl von Live-Inhalten ausschließen.


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Archived regions and certain hidden regions are not to be shown in the selection options for live content in the pages form


### Proposed changes
<!-- Describe this PR in more detail. -->

- add filter to region queryset
- import excluded hidden region list as environment var
- https://git.tuerantuer.org/DF/salt/pulls/729


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- the environment env for integreat and malte need to be set on the server (both testsystem and prod system)


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
- localhost: 
  - set env var `export INTEGREAT_CMS_EXCLUDED_HIDDEN_MIRRORED_REGIONS=hallo,augsburg`
  - go to a page and see in the dropdown for live content selection that no archived regions nor "Hallo Aschaffenburg" is shown (but augsburg is, because it is not hidden)
- Testsystem: See that neither archived regions nor regions in the lists are shown in the dropdown:
  - Integreat: deutschlandvorlage,testumgebung-e2e,hallo,musterstadt,testumgebung,testumgebung-frag-integreat,testumgebung-reg,viersen_backup
  - Malte: testumgebung,testumgebung-reg 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3998


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
