### PR TITLE
Pupulate id of event and event translation in events endpoint

### DIFF
--- a/integreat_cms/api/v3/events.py
+++ b/integreat_cms/api/v3/events.py
@@ -48,7 +48,7 @@ def transform_event(event: Event, custom_date: date | None = None) -> dict[str, 
         )
 
     return {
-        "id": event.id if not custom_date else None,
+        "id": event.id,
         "start": start_local,
         "start_date": start_local.date(),  # deprecated field in the future
         "start_time": start_local.time(),  # deprecated field in the future
@@ -164,7 +164,6 @@ def transform_event_recurrences(
         return
 
     start_date = event.start_local.date()
-    event_translation.id = None
 
     # Calculate all recurrences of this event
     for recurrence_date in event.recurrence_rule.iter_after(start_date):

--- a/tests/api/expected-outputs/augsburg_ar_events.json
+++ b/tests/api/expected-outputs/augsburg_ar_events.json
@@ -41,7 +41,7 @@
     "location_path": null,
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 1,
       "start": "2030-01-01T13:00:00+01:00",
       "start_date": "2030-01-01",
       "start_time": "13:00:00",
@@ -98,7 +98,7 @@
     "location_path": null,
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 1,
       "start": "2030-01-03T13:00:00+01:00",
       "start_date": "2030-01-03",
       "start_time": "13:00:00",
@@ -155,7 +155,7 @@
     "location_path": null,
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 1,
       "start": "2030-01-15T13:00:00+01:00",
       "start_date": "2030-01-15",
       "start_time": "13:00:00",
@@ -212,7 +212,7 @@
     "location_path": null,
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 1,
       "start": "2030-01-17T13:00:00+01:00",
       "start_date": "2030-01-17",
       "start_time": "13:00:00",
@@ -269,7 +269,7 @@
     "location_path": null,
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 1,
       "start": "2030-01-29T13:00:00+01:00",
       "start_date": "2030-01-29",
       "start_time": "13:00:00",
@@ -326,7 +326,7 @@
     "location_path": null,
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 1,
       "start": "2030-01-31T13:00:00+01:00",
       "start_date": "2030-01-31",
       "start_time": "13:00:00",

--- a/tests/api/expected-outputs/augsburg_de_events.json
+++ b/tests/api/expected-outputs/augsburg_de_events.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": null,
+    "id": 2,
     "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung$2030-01-01/",
     "path": "/augsburg/de/events/test-veranstaltung$2030-01-01/",
     "title": "Test-Veranstaltung mit neuem Titel",
@@ -41,7 +41,7 @@
     "location_path": null,
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 1,
       "start": "2030-01-01T13:00:00+01:00",
       "start_date": "2030-01-01",
       "start_time": "13:00:00",
@@ -57,7 +57,7 @@
     "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
   },
   {
-    "id": null,
+    "id": 2,
     "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung$2030-01-03/",
     "path": "/augsburg/de/events/test-veranstaltung$2030-01-03/",
     "title": "Test-Veranstaltung mit neuem Titel",
@@ -98,7 +98,7 @@
     "location_path": null,
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 1,
       "start": "2030-01-03T13:00:00+01:00",
       "start_date": "2030-01-03",
       "start_time": "13:00:00",
@@ -114,7 +114,7 @@
     "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
   },
   {
-    "id": null,
+    "id": 2,
     "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung$2030-01-15/",
     "path": "/augsburg/de/events/test-veranstaltung$2030-01-15/",
     "title": "Test-Veranstaltung mit neuem Titel",
@@ -155,7 +155,7 @@
     "location_path": null,
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 1,
       "start": "2030-01-15T13:00:00+01:00",
       "start_date": "2030-01-15",
       "start_time": "13:00:00",
@@ -171,7 +171,7 @@
     "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
   },
   {
-    "id": null,
+    "id": 2,
     "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung$2030-01-17/",
     "path": "/augsburg/de/events/test-veranstaltung$2030-01-17/",
     "title": "Test-Veranstaltung mit neuem Titel",
@@ -212,7 +212,7 @@
     "location_path": null,
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 1,
       "start": "2030-01-17T13:00:00+01:00",
       "start_date": "2030-01-17",
       "start_time": "13:00:00",
@@ -228,7 +228,7 @@
     "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
   },
   {
-    "id": null,
+    "id": 2,
     "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung$2030-01-29/",
     "path": "/augsburg/de/events/test-veranstaltung$2030-01-29/",
     "title": "Test-Veranstaltung mit neuem Titel",
@@ -269,7 +269,7 @@
     "location_path": null,
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 1,
       "start": "2030-01-29T13:00:00+01:00",
       "start_date": "2030-01-29",
       "start_time": "13:00:00",
@@ -285,7 +285,7 @@
     "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
   },
   {
-    "id": null,
+    "id": 2,
     "url": "http://localhost:8000/augsburg/de/events/test-veranstaltung$2030-01-31/",
     "path": "/augsburg/de/events/test-veranstaltung$2030-01-31/",
     "title": "Test-Veranstaltung mit neuem Titel",
@@ -326,7 +326,7 @@
     "location_path": null,
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 1,
       "start": "2030-01-31T13:00:00+01:00",
       "start_date": "2030-01-31",
       "start_time": "13:00:00",

--- a/tests/api/expected-outputs/augsburg_en_events.json
+++ b/tests/api/expected-outputs/augsburg_en_events.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": null,
+    "id": 3,
     "url": "http://localhost:8000/augsburg/en/events/test-event$2030-01-01/",
     "path": "/augsburg/en/events/test-event$2030-01-01/",
     "title": "Test-Event",
@@ -41,7 +41,7 @@
     "location_path": null,
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 1,
       "start": "2030-01-01T13:00:00+01:00",
       "start_date": "2030-01-01",
       "start_time": "13:00:00",
@@ -57,7 +57,7 @@
     "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
   },
   {
-    "id": null,
+    "id": 3,
     "url": "http://localhost:8000/augsburg/en/events/test-event$2030-01-03/",
     "path": "/augsburg/en/events/test-event$2030-01-03/",
     "title": "Test-Event",
@@ -98,7 +98,7 @@
     "location_path": null,
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 1,
       "start": "2030-01-03T13:00:00+01:00",
       "start_date": "2030-01-03",
       "start_time": "13:00:00",
@@ -114,7 +114,7 @@
     "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
   },
   {
-    "id": null,
+    "id": 3,
     "url": "http://localhost:8000/augsburg/en/events/test-event$2030-01-15/",
     "path": "/augsburg/en/events/test-event$2030-01-15/",
     "title": "Test-Event",
@@ -155,7 +155,7 @@
     "location_path": null,
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 1,
       "start": "2030-01-15T13:00:00+01:00",
       "start_date": "2030-01-15",
       "start_time": "13:00:00",
@@ -171,7 +171,7 @@
     "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
   },
   {
-    "id": null,
+    "id": 3,
     "url": "http://localhost:8000/augsburg/en/events/test-event$2030-01-17/",
     "path": "/augsburg/en/events/test-event$2030-01-17/",
     "title": "Test-Event",
@@ -212,7 +212,7 @@
     "location_path": null,
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 1,
       "start": "2030-01-17T13:00:00+01:00",
       "start_date": "2030-01-17",
       "start_time": "13:00:00",
@@ -228,7 +228,7 @@
     "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
   },
   {
-    "id": null,
+    "id": 3,
     "url": "http://localhost:8000/augsburg/en/events/test-event$2030-01-29/",
     "path": "/augsburg/en/events/test-event$2030-01-29/",
     "title": "Test-Event",
@@ -269,7 +269,7 @@
     "location_path": null,
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 1,
       "start": "2030-01-29T13:00:00+01:00",
       "start_date": "2030-01-29",
       "start_time": "13:00:00",
@@ -285,7 +285,7 @@
     "recurrence_rule": "DTSTART:20300101T120000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20310101T235959;BYDAY=TU,TH"
   },
   {
-    "id": null,
+    "id": 3,
     "url": "http://localhost:8000/augsburg/en/events/test-event$2030-01-31/",
     "path": "/augsburg/en/events/test-event$2030-01-31/",
     "title": "Test-Event",
@@ -326,7 +326,7 @@
     "location_path": null,
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 1,
       "start": "2030-01-31T13:00:00+01:00",
       "start_date": "2030-01-31",
       "start_time": "13:00:00",

--- a/tests/api/expected-outputs/nurnberg_de_events.json
+++ b/tests/api/expected-outputs/nurnberg_de_events.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": null,
+    "id": 5,
     "url": "http://localhost:8000/nurnberg/de/events/test-veranstaltung$2031-01-01/",
     "path": "/nurnberg/de/events/test-veranstaltung$2031-01-01/",
     "title": "Test-Veranstaltung",
@@ -31,7 +31,7 @@
     "location_path": "/nurnberg/de/locations/test-ort/",
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 2,
       "start": "2031-01-01T15:00:00+01:00",
       "start_date": "2031-01-01",
       "start_time": "15:00:00",
@@ -47,7 +47,7 @@
     "recurrence_rule": "DTSTART:20310101T140000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20320101T235959;BYDAY=WE,FR"
   },
   {
-    "id": null,
+    "id": 5,
     "url": "http://localhost:8000/nurnberg/de/events/test-veranstaltung$2031-01-03/",
     "path": "/nurnberg/de/events/test-veranstaltung$2031-01-03/",
     "title": "Test-Veranstaltung",
@@ -78,7 +78,7 @@
     "location_path": "/nurnberg/de/locations/test-ort/",
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 2,
       "start": "2031-01-03T15:00:00+01:00",
       "start_date": "2031-01-03",
       "start_time": "15:00:00",
@@ -94,7 +94,7 @@
     "recurrence_rule": "DTSTART:20310101T140000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20320101T235959;BYDAY=WE,FR"
   },
   {
-    "id": null,
+    "id": 5,
     "url": "http://localhost:8000/nurnberg/de/events/test-veranstaltung$2031-01-15/",
     "path": "/nurnberg/de/events/test-veranstaltung$2031-01-15/",
     "title": "Test-Veranstaltung",
@@ -125,7 +125,7 @@
     "location_path": "/nurnberg/de/locations/test-ort/",
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 2,
       "start": "2031-01-15T15:00:00+01:00",
       "start_date": "2031-01-15",
       "start_time": "15:00:00",
@@ -141,7 +141,7 @@
     "recurrence_rule": "DTSTART:20310101T140000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20320101T235959;BYDAY=WE,FR"
   },
   {
-    "id": null,
+    "id": 5,
     "url": "http://localhost:8000/nurnberg/de/events/test-veranstaltung$2031-01-17/",
     "path": "/nurnberg/de/events/test-veranstaltung$2031-01-17/",
     "title": "Test-Veranstaltung",
@@ -172,7 +172,7 @@
     "location_path": "/nurnberg/de/locations/test-ort/",
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 2,
       "start": "2031-01-17T15:00:00+01:00",
       "start_date": "2031-01-17",
       "start_time": "15:00:00",
@@ -188,7 +188,7 @@
     "recurrence_rule": "DTSTART:20310101T140000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20320101T235959;BYDAY=WE,FR"
   },
   {
-    "id": null,
+    "id": 5,
     "url": "http://localhost:8000/nurnberg/de/events/test-veranstaltung$2031-01-29/",
     "path": "/nurnberg/de/events/test-veranstaltung$2031-01-29/",
     "title": "Test-Veranstaltung",
@@ -219,7 +219,7 @@
     "location_path": "/nurnberg/de/locations/test-ort/",
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 2,
       "start": "2031-01-29T15:00:00+01:00",
       "start_date": "2031-01-29",
       "start_time": "15:00:00",
@@ -235,7 +235,7 @@
     "recurrence_rule": "DTSTART:20310101T140000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20320101T235959;BYDAY=WE,FR"
   },
   {
-    "id": null,
+    "id": 5,
     "url": "http://localhost:8000/nurnberg/de/events/test-veranstaltung$2031-01-31/",
     "path": "/nurnberg/de/events/test-veranstaltung$2031-01-31/",
     "title": "Test-Veranstaltung",
@@ -266,7 +266,7 @@
     "location_path": "/nurnberg/de/locations/test-ort/",
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 2,
       "start": "2031-01-31T15:00:00+01:00",
       "start_date": "2031-01-31",
       "start_time": "15:00:00",

--- a/tests/api/expected-outputs/nurnberg_en_events.json
+++ b/tests/api/expected-outputs/nurnberg_en_events.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": null,
+    "id": 6,
     "url": "http://localhost:8000/nurnberg/en/events/test-event$2031-01-01/",
     "path": "/nurnberg/en/events/test-event$2031-01-01/",
     "title": "Test-Event",
@@ -31,7 +31,7 @@
     "location_path": "/nurnberg/en/locations/test-location/",
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 2,
       "start": "2031-01-01T15:00:00+01:00",
       "start_date": "2031-01-01",
       "start_time": "15:00:00",
@@ -47,7 +47,7 @@
     "recurrence_rule": "DTSTART:20310101T140000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20320101T235959;BYDAY=WE,FR"
   },
   {
-    "id": null,
+    "id": 6,
     "url": "http://localhost:8000/nurnberg/en/events/test-event$2031-01-03/",
     "path": "/nurnberg/en/events/test-event$2031-01-03/",
     "title": "Test-Event",
@@ -78,7 +78,7 @@
     "location_path": "/nurnberg/en/locations/test-location/",
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 2,
       "start": "2031-01-03T15:00:00+01:00",
       "start_date": "2031-01-03",
       "start_time": "15:00:00",
@@ -94,7 +94,7 @@
     "recurrence_rule": "DTSTART:20310101T140000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20320101T235959;BYDAY=WE,FR"
   },
   {
-    "id": null,
+    "id": 6,
     "url": "http://localhost:8000/nurnberg/en/events/test-event$2031-01-15/",
     "path": "/nurnberg/en/events/test-event$2031-01-15/",
     "title": "Test-Event",
@@ -125,7 +125,7 @@
     "location_path": "/nurnberg/en/locations/test-location/",
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 2,
       "start": "2031-01-15T15:00:00+01:00",
       "start_date": "2031-01-15",
       "start_time": "15:00:00",
@@ -141,7 +141,7 @@
     "recurrence_rule": "DTSTART:20310101T140000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20320101T235959;BYDAY=WE,FR"
   },
   {
-    "id": null,
+    "id": 6,
     "url": "http://localhost:8000/nurnberg/en/events/test-event$2031-01-17/",
     "path": "/nurnberg/en/events/test-event$2031-01-17/",
     "title": "Test-Event",
@@ -172,7 +172,7 @@
     "location_path": "/nurnberg/en/locations/test-location/",
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 2,
       "start": "2031-01-17T15:00:00+01:00",
       "start_date": "2031-01-17",
       "start_time": "15:00:00",
@@ -188,7 +188,7 @@
     "recurrence_rule": "DTSTART:20310101T140000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20320101T235959;BYDAY=WE,FR"
   },
   {
-    "id": null,
+    "id": 6,
     "url": "http://localhost:8000/nurnberg/en/events/test-event$2031-01-29/",
     "path": "/nurnberg/en/events/test-event$2031-01-29/",
     "title": "Test-Event",
@@ -219,7 +219,7 @@
     "location_path": "/nurnberg/en/locations/test-location/",
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 2,
       "start": "2031-01-29T15:00:00+01:00",
       "start_date": "2031-01-29",
       "start_time": "15:00:00",
@@ -235,7 +235,7 @@
     "recurrence_rule": "DTSTART:20310101T140000\nRRULE:FREQ=WEEKLY;INTERVAL=2;UNTIL=20320101T235959;BYDAY=WE,FR"
   },
   {
-    "id": null,
+    "id": 6,
     "url": "http://localhost:8000/nurnberg/en/events/test-event$2031-01-31/",
     "path": "/nurnberg/en/events/test-event$2031-01-31/",
     "title": "Test-Event",
@@ -266,7 +266,7 @@
     "location_path": "/nurnberg/en/locations/test-location/",
     "meeting_url": null,
     "event": {
-      "id": null,
+      "id": 2,
       "start": "2031-01-31T15:00:00+01:00",
       "start_date": "2031-01-31",
       "start_time": "15:00:00",


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR populates `id` fields of the event and event translation in the response of `events/` endpoint.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Do not refresh `event_translation.id` to `None`
- Always return the id of event


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- Let me know if anyone notice any risk with those changes. I checked old PRs related to this topic but didn't find any concrete describtion why the ids weren't delivered. After this PR there will be multiple entries with the same id in the response of endpoint but this is fine and expected as discussed [here](https://chat.tuerantuer.org/digitalfabrik/pl/q5dj1yugjpryjn1sbsf73w41sh)


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
- Call the endpoint `event/` and `event/?combine_recurring=True`
- Compare the result in `develop` and this branch

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4296 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
