### PR TITLE
Fix user role permission updates being delayed up to 1 hour

### DIFF
--- a/integreat_cms/cms/forms/users/user_form.py
+++ b/integreat_cms/cms/forms/users/user_form.py
@@ -3,8 +3,10 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from cacheops import invalidate_model
 from django import forms
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
 from django.contrib.auth.password_validation import (
     password_validators_help_texts,
     validate_password,
@@ -149,9 +151,11 @@ class UserForm(CustomModelForm):
             else self.cleaned_data["role"]
         )
 
+        groups_changed = False
         for removed_group in user.groups.exclude(id=role.id):
             # Remove unselected roles
             removed_group.user_set.remove(user)
+            groups_changed = True
             logger.info(
                 "%r was removed from %r",
                 removed_group.role,
@@ -160,7 +164,17 @@ class UserForm(CustomModelForm):
         if role.group not in user.groups.all():
             # Assign the selected role
             role.group.user_set.add(user)
+            groups_changed = True
             logger.info("%r was assigned to %r", role, user)
+
+        if groups_changed:
+            # cacheops does not invalidate the Django auth backend's
+            # group-permission lookup when the User.groups M2M changes via
+            # the auto-generated `cms_user_groups` through table, so the
+            # old permissions linger until CACHEOPS_DEFAULTS["timeout"]
+            # expires (see #4303). Invalidating the Permission model clears
+            # the relevant cached queries.
+            invalidate_model(Permission)
 
         return user
 

--- a/integreat_cms/release_notes/current/unreleased/4303.yml
+++ b/integreat_cms/release_notes/current/unreleased/4303.yml
@@ -1,0 +1,2 @@
+en: Fix user role changes taking up to an hour to apply because cached permission lookups were not invalidated
+de: Behebt, dass Rollenänderungen von Benutzer*innen bis zu einer Stunde brauchten, weil gecachte Berechtigungen nicht invalidiert wurden


### PR DESCRIPTION
### Short description
When the role of a user is changed, the new permissions only take effect after up to one hour. The menu reflects the new role immediately, but `request.user.has_perm(...)` keeps returning the previous role's permissions until the cacheops cache entry expires.

Root cause: cacheops caches the query Django's `ModelBackend.get_group_permissions()` runs for a user (`Permission.objects.filter(group__user=...)`), but the `m2m_changed` signal fired by `Group.user_set.add()` / `Group.user_set.remove()` does not invalidate this specific cache entry. The entry then lives until `CACHEOPS_DEFAULTS["timeout"]` (= 3600 s) elapses — matching the reported "after 60 minutes it is correct".

### Proposed changes
- In `UserForm.save()`: after the M2M operations that change `user.groups`, explicitly call `invalidate_model(Permission)` (only when groups actually changed)
- Add release note `4303.yml`

### Side effects
- Each role change now also drops cached `Permission` querysets; `Permission` rarely changes and re-population is cheap, so this is negligible
- `RegionUserForm` inherits the same `save()` and benefits automatically

### Faithfulness to issue description and design
There are no intended deviations from the issue description.

### How to test
Reproduced locally against Postgres + Redis with cacheops:

1. Pick a user with role A. Call `mb.get_group_permissions(User.objects.get(pk=user.pk))` (primes the cache).
2. Change the user's role to B via `UserForm.save()`.
3. Call `mb.get_group_permissions(User.objects.get(pk=user.pk))` again — should now return role B's permissions instead of role A's.

Manual UI test:

- [ ] Take an account with broad permissions (e.g. Verwalterin) and an account with narrow permissions (e.g. Beobachterin)
- [ ] Log in as the narrow-permission account; verify menu / available actions
- [ ] Log out, log in as the managing account, change the first account's role to the broader one, save
- [ ] Log back in as the first account (or refresh) — the new menu / permissions should be active **immediately**, not after an hour
- [ ] Repeat in the opposite direction (broad → narrow)

### Resolved issues
Fixes: #4303

__________________________________________________
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)