### PR TITLE
Uninstall eslint-config-airbnb

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -36,7 +36,13 @@ module.exports = {
         "vitest.config.ts",
     ],
 
-    extends: ["airbnb", "airbnb/hooks", "eslint-config-preact", "plugin:import/typescript"],
+    extends: [
+        "plugin:react/recommended",
+        "plugin:jsx-a11y/recommended",
+        "plugin:import/recommended",
+        "plugin:import/typescript",
+        "eslint-config-preact",
+    ],
     parser: "@typescript-eslint/parser",
     parserOptions: {
         ecmaVersion: 6,
@@ -81,6 +87,7 @@ module.exports = {
         "import/extensions": "off",
         "import/no-extraneous-dependencies": "off",
         "import/prefer-default-export": "off",
+        "import/no-named-as-default": "off",
         "indent": "off",
         "lines-between-class-members": "off",
         "react/jsx-filename-extension": "off",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -87,7 +87,6 @@ module.exports = {
         "import/extensions": "off",
         "import/no-extraneous-dependencies": "off",
         "import/prefer-default-export": "off",
-        "import/no-named-as-default": "off",
         "indent": "off",
         "lines-between-class-members": "off",
         "react/jsx-filename-extension": "off",
@@ -119,6 +118,149 @@ module.exports = {
         "react-hooks/exhaustive-deps": "error",
         "vars-on-top": "error",
         "no-console": ["error", { allow: ["debug", "warn", "error"] }],
+
+        // re-enabled from airbnb
+        "import/first": ["error"],
+        "import/order": [
+            "error",
+            {
+                groups: [["builtin", "external", "internal"]],
+                distinctGroup: true,
+                sortTypesGroup: false,
+                named: false,
+                warnOnUnassignedImports: false,
+            },
+        ],
+        "import/newline-after-import": ["error"],
+        "camelcase": [
+            "error",
+            {
+                properties: "never",
+                ignoreDestructuring: false,
+                ignoreImports: false,
+                ignoreGlobals: false,
+            },
+        ],
+        "no-nested-ternary": ["error"],
+        "no-await-in-loop": ["error"],
+        "consistent-return": ["error"],
+        "dot-notation": [
+            "error",
+            {
+                allowKeywords: true,
+                allowPattern: "",
+            },
+        ],
+        "eqeqeq": [
+            "error",
+            "always",
+            {
+                null: "ignore",
+            },
+        ],
+        "guard-for-in": ["error"],
+        "no-alert": ["warn"],
+        "no-eval": ["error"],
+        "no-implied-eval": ["error"],
+        "no-loop-func": ["error"],
+        "no-new-func": ["error"],
+        "no-param-reassign": [
+            "error",
+            {
+                props: true,
+                ignorePropertyModificationsFor: [
+                    "acc",
+                    "accumulator",
+                    "e",
+                    "ctx",
+                    "context",
+                    "req",
+                    "request",
+                    "res",
+                    "response",
+                    "$scope",
+                    "staticContext",
+                ],
+            },
+        ],
+        "no-return-assign": ["error", "always"],
+        "no-self-compare": ["error"],
+        "no-sequences": ["error"],
+        "no-throw-literal": ["error"],
+
+        "no-underscore-dangle": [
+            "error",
+            {
+                allow: ["__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"],
+                allowAfterThis: false,
+                allowAfterSuper: false,
+                enforceInMethodNames: true,
+                allowAfterThisConstructor: false,
+                allowFunctionParams: true,
+                enforceInClassFields: false,
+                allowInArrayDestructuring: true,
+                allowInObjectDestructuring: true,
+            },
+        ],
+        "react/jsx-pascal-case": [
+            "error",
+            {
+                allowAllCaps: true,
+                ignore: [],
+            },
+        ],
+        "react/no-array-index-key": ["error"],
+        "react/button-has-type": [
+            "error",
+            {
+                button: true,
+                submit: true,
+                reset: false,
+            },
+        ],
+        "react/no-unstable-nested-components": ["error"],
+        "react/no-invalid-html-attribute": ["error"],
+        "import/no-named-as-default": ["error"],
+        "arrow-body-style": [
+            "error",
+            "as-needed",
+            {
+                requireReturnForObjectLiteral: false,
+            },
+        ],
+        "no-bitwise": ["error"],
+        "no-continue": ["error"],
+        "one-var": ["error", "never"],
+        "spaced-comment": [
+            "error",
+            "always",
+            {
+                line: {
+                    exceptions: ["-", "+"],
+                    markers: ["=", "!", "/"],
+                },
+                block: {
+                    exceptions: ["-", "+"],
+                    markers: ["=", "!", ":", "::"],
+                    balanced: true,
+                },
+            },
+        ],
+        "no-promise-executor-return": ["error"],
+        "no-template-curly-in-string": ["error"],
+        "no-unreachable-loop": [
+            "error",
+            {
+                ignore: [],
+            },
+        ],
+        "no-extend-native": ["error"],
+        "no-lone-blocks": ["error"],
+        "no-new": ["error"],
+        "no-script-url": ["error"],
+        "no-useless-return": ["error"],
+        "no-void": ["error"],
+        "yoda": ["error"],
     },
     overrides: [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,6 @@
         "dropzone": "^6.0.0-beta.2",
         "element-closest": "^3.0.2",
         "eslint": "^8.57.1",
-        "eslint-config-airbnb": "^19.0.4",
         "eslint-config-preact": "^1.5.0",
         "eslint-import-resolver-typescript": "^4.4.4",
         "eslint-plugin-import": "^2.32.0",
@@ -7706,13 +7705,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/confusing-browser-globals": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz",
-      "integrity": "sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -9092,48 +9084,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint-config-airbnb": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-19.0.4.tgz",
-      "integrity": "sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "eslint-config-airbnb-base": "^15.0.0",
-        "object.assign": "^4.1.2",
-        "object.entries": "^1.1.5"
-      },
-      "engines": {
-        "node": "^10.12.0 || ^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "peerDependencies": {
-        "eslint": "^7.32.0 || ^8.2.0",
-        "eslint-plugin-import": "^2.25.3",
-        "eslint-plugin-jsx-a11y": "^6.5.1",
-        "eslint-plugin-react": "^7.28.0",
-        "eslint-plugin-react-hooks": "^4.3.0"
-      }
-    },
-    "node_modules/eslint-config-airbnb-base": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz",
-      "integrity": "sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "confusing-browser-globals": "^1.0.10",
-        "object.assign": "^4.1.2",
-        "object.entries": "^1.1.5",
-        "semver": "^6.3.0"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      },
-      "peerDependencies": {
-        "eslint": "^7.32.0 || ^8.2.0",
-        "eslint-plugin-import": "^2.25.2"
       }
     },
     "node_modules/eslint-config-preact": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "dropzone": "^6.0.0-beta.2",
     "element-closest": "^3.0.2",
     "eslint": "^8.57.1",
-    "eslint-config-airbnb": "^19.0.4",
     "eslint-config-preact": "^1.5.0",
     "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import": "^2.32.0",


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Uninstalls the `eslint-config-airbnb` npm package. 
We NEED to get rid of it, because it blocks our eslint upgrade (see: #3539)
We CAN get rid of it, because the rules it pulls come all from plugins that we have already installed itself


### Proposed changes
<!-- Describe this PR in more detail. -->

- delete the dependency from package.json (and package-lock.json)
- adjust the extends array to use the necessary plugins directly
- add one unwanted rules for which we otherwise would get a warning


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- tools/install.sh needs to be run to uninstally the package


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
- run tools/code_style.sh and see that there are no eslint errors or warnings


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4305


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
