### PR TITLE
Bump CI Python & PSQL versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   pip-install:
     docker:
-      - image: cimg/python:3.11.7
+      - image: cimg/python:3.13.11
     resource_class: small
     steps:
       - checkout
@@ -36,7 +36,7 @@ jobs:
             - integreat_cms.egg-info
   djlint:
     docker:
-      - image: cimg/python:3.11.7
+      - image: cimg/python:3.13.11
     resource_class: small
     steps:
       - checkout
@@ -50,7 +50,7 @@ jobs:
           command: djlint --check --lint integreat_cms
   ruff:
     docker:
-      - image: cimg/python:3.11.7
+      - image: cimg/python:3.13.11
     resource_class: small
     steps:
       - checkout
@@ -66,7 +66,7 @@ jobs:
             ruff format --check
   mypy:
     docker:
-      - image: cimg/python:3.11.7
+      - image: cimg/python:3.13.11
     resource_class: small
     steps:
       - checkout
@@ -77,7 +77,7 @@ jobs:
           command: ./tools/mypy.sh
   check-release-notes:
     docker:
-      - image: cimg/python:3.11.7
+      - image: cimg/python:3.13.11
     resource_class: small
     steps:
       - checkout
@@ -97,7 +97,7 @@ jobs:
           command: ./tools/make_release_notes.sh --format=raw --all
   check-translations:
     docker:
-      - image: cimg/python:3.11.7
+      - image: cimg/python:3.13.11
     resource_class: small
     steps:
       - checkout
@@ -111,7 +111,7 @@ jobs:
           command: ./tools/check_translations.sh
   compile-translations:
     docker:
-      - image: cimg/python:3.11.7
+      - image: cimg/python:3.13.11
     resource_class: small
     steps:
       - checkout
@@ -222,8 +222,8 @@ jobs:
             - integreat_cms/webpack-stats.json
   check-migrations:
     docker:
-      - image: cimg/python:3.11.7
-      - image: cimg/postgres:14.1
+      - image: cimg/python:3.13.11
+      - image: cimg/postgres:17.10
         environment:
           POSTGRES_USER: integreat
           POSTGRES_DB: integreat
@@ -244,8 +244,8 @@ jobs:
           command: integreat-cms-cli makemigrations cms --check --settings=integreat_cms.core.circleci_settings
   test:
     docker:
-      - image: cimg/python:3.11.7
-      - image: cimg/postgres:14.1
+      - image: cimg/python:3.13.11
+      - image: cimg/postgres:17.10
         environment:
           POSTGRES_USER: integreat
           POSTGRES_DB: integreat
@@ -293,7 +293,7 @@ jobs:
           path: integreat-cms.log
   build-package:
     docker:
-      - image: cimg/python:3.11.7
+      - image: cimg/python:3.13.11
     resource_class: small
     steps:
       - checkout
@@ -314,7 +314,7 @@ jobs:
             - dist
   publish-package:
     docker:
-      - image: cimg/python:3.11.7
+      - image: cimg/python:3.13.11
     resource_class: small
     steps:
       - checkout
@@ -328,7 +328,7 @@ jobs:
           command: twine upload --non-interactive ./dist/integreat_cms-*.tar.gz
   build-documentation:
     docker:
-      - image: cimg/python:3.11.7
+      - image: cimg/python:3.13.11
     resource_class: large
     steps:
       - checkout
@@ -346,7 +346,7 @@ jobs:
             - docs/dist
   deploy-documentation:
     docker:
-      - image: cimg/python:3.11.7
+      - image: cimg/python:3.13.11
     resource_class: small
     environment:
       BRANCH: gh-pages
@@ -390,7 +390,7 @@ jobs:
             git push origin $BRANCH
   bump-dev-version:
     docker:
-      - image: cimg/python:3.11.7
+      - image: cimg/python:3.13.11
     resource_class: large
     steps:
       - checkout
@@ -440,7 +440,7 @@ jobs:
             - integreat_cms/_manifest
   bump-rc-version:
     docker:
-      - image: cimg/python:3.11.7
+      - image: cimg/python:3.13.11
     resource_class: large
     steps:
       - checkout
@@ -491,7 +491,7 @@ jobs:
             - integreat_cms/_manifest
   bump-version:
     docker:
-      - image: cimg/python:3.11.7
+      - image: cimg/python:3.13.11
     resource_class: large
     steps:
       - checkout
@@ -567,7 +567,7 @@ jobs:
           command: git checkout develop && git merge main --commit --no-edit && git push
   create-release:
     docker:
-      - image: cimg/python:3.11.7
+      - image: cimg/python:3.13.11
     resource_class: small
     steps:
       - checkout

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,7 +28,7 @@ jobs:
         name: Setup python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.11"
+          python-version: "3.13"
       - if: matrix.language == 'python'
         name: Install dependencies with pip
         run: pip install -e .[dev-pinned,pinned]

--- a/integreat_cms/api/v3/locations.py
+++ b/integreat_cms/api/v3/locations.py
@@ -136,9 +136,7 @@ def transform_poi_translation(
         )
         contact_data.append(
             {
-                "area_of_responsibility": contact.area_of_responsibility
-                if contact.area_of_responsibility
-                else None,
+                "area_of_responsibility": contact.area_of_responsibility or None,
                 "name": contact.name,
                 "email": contact.email,
                 "phone_number": contact.phone_number,

--- a/integreat_cms/api/v3/regions.py
+++ b/integreat_cms/api/v3/regions.py
@@ -45,9 +45,7 @@ def transform_region(region: Region) -> dict[str, Any]:
         "aliases": region.aliases,
         "tunews": region.external_news_enabled,
         "external_news": region.external_news_enabled,
-        "zammad_privacy_policy": region.zammad_privacy_policy
-        if region.zammad_privacy_policy
-        else None,
+        "zammad_privacy_policy": region.zammad_privacy_policy or None,
         "languages": list(map(transform_language, region.visible_languages)),
         "is_chat_enabled": bool(
             region.integreat_chat_enabled

--- a/integreat_cms/cms/forms/regions/region_form.py
+++ b/integreat_cms/cms/forms/regions/region_form.py
@@ -789,8 +789,7 @@ class RegionForm(CustomModelForm):
         """
         return (
             self.cleaned_data["zammad_access_token"]
-            if self.cleaned_data["zammad_access_token"]
-            else self.instance.zammad_access_token
+            or self.instance.zammad_access_token
         )
 
     @staticmethod

--- a/integreat_cms/cms/models/abstract_content_translation.py
+++ b/integreat_cms/cms/models/abstract_content_translation.py
@@ -626,7 +626,9 @@ class AbstractContentTranslation(AbstractBaseModel):
         """
         Function to replace links that are in the translation and match the given keyword `search`
         """
-        from ..utils.content_translation_utils import save_new_version_with_retry
+        from ..utils.content_translation_utils import (
+            save_new_version_with_retry,
+        )
 
         new_translation = self.create_new_version_copy(user)
         logger.debug("Replacing links of %r: %r", new_translation, urls_to_replace)
@@ -688,7 +690,9 @@ class AbstractContentTranslation(AbstractBaseModel):
         and renumber all affected versions to be continuous.
         """
         # Moved here to avoid circular imports
-        from ...core.signals.hix_signals import disable_listeners as disable_hix
+        from ...core.signals.hix_signals import (
+            disable_listeners as disable_hix,
+        )
 
         logger.debug("Cleaning up old autosaves")
 

--- a/integreat_cms/cms/utils/shadow_instance.py
+++ b/integreat_cms/cms/utils/shadow_instance.py
@@ -3,14 +3,12 @@ This module contains utilities to repair or detect inconsistencies in a tree
 """
 
 from collections.abc import Iterable
-from typing import Any, Generic, TypeVar
+from typing import Any, cast
 
 from django.db.models import Model
 
-T = TypeVar("T", bound=Model)
 
-
-class ShadowInstance(Generic[T]):
+class ShadowInstance[T: Model]:
     """
     An object shadowing the attributes of the model instance passed to it on instantiation
     and withholding any attribute changes until explicitly applied,
@@ -84,12 +82,12 @@ class ShadowInstance(Generic[T]):
             for name, value in self._overrides.items()
         }
 
-    def save(self, *args: list, **kwargs: dict) -> None:
+    def save(self, *args: Any, **kwargs: Any) -> None:
         """
         Save the shadowed instance.
         Does nothing if no changes were applied yet (see :meth:`apply_changes`).
         """
-        self._instance.save(*args, **kwargs)
+        cast("Model", self._instance).save(*args, **kwargs)
 
     def reload(self) -> None:
         """
@@ -98,7 +96,10 @@ class ShadowInstance(Generic[T]):
 
         This can be used to incorporate recent changes to the database object after a longer (i.e. user directed) staging period.
         """
-        self._instance = type(self._instance).objects.get(id=self._instance.pk)
+        self._instance = cast(
+            "T",
+            type(self._instance).objects.get(id=self._instance.pk),
+        )
 
     def __getattribute__(self, name: str) -> Any:
         """

--- a/integreat_cms/cms/utils/shortcodes/utils.py
+++ b/integreat_cms/cms/utils/shortcodes/utils.py
@@ -1,13 +1,9 @@
 from collections.abc import Callable
-from typing import ParamSpec, TypeVar
 
 import shortcodes
 
-R = TypeVar("R")
-P = ParamSpec("P")
 
-
-def shortcode(
+def shortcode[**P, R](
     tag: Callable[P, R] | str | None, endtag: str | None = None
 ) -> Callable[[Callable[P, R]], Callable[P, R]] | Callable[P, R]:
     """

--- a/integreat_cms/cms/utils/slug_utils.py
+++ b/integreat_cms/cms/utils/slug_utils.py
@@ -19,7 +19,6 @@ if TYPE_CHECKING:
     from typing import (
         Any,
         NotRequired,
-        TypeAlias,
         TypedDict,
         TypeVar,
         Unpack,
@@ -43,7 +42,7 @@ logger = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
-    ForeignModelType: TypeAlias = Literal[
+    type ForeignModelType = Literal[
         "page",
         "event",
         "poi",
@@ -213,7 +212,7 @@ def is_reserved_slug(slug: str | None, foreign_model: str | None) -> bool:
     return False
 
 
-def exclude_current_object(
+def exclude_current_object[T](
     qs: QuerySet[T],
     object_instance: AbstractBaseModel,
     foreign_model: str | None,

--- a/integreat_cms/cms/utils/tree_mutex.py
+++ b/integreat_cms/cms/utils/tree_mutex.py
@@ -21,13 +21,13 @@ INTERVAL = 0.1
 
 
 #: A dictionary holding separate locks for each classname to be guarded
-_LOCKS = {}
+_LOCKS: dict[str, threading.RLock] = {}
 
 
 @contextmanager
 def monkeypatch_cursor_func(
     using: str = DEFAULT_DB_ALIAS,
-) -> Generator[None, None, None]:
+) -> Generator[None]:
     """
     Get connection for upstream transaction and
     set alternative :meth:`treebeard.models.Node._get_database_cursor` that returns its cursor instead.

--- a/integreat_cms/cms/views/imprint/open_source_licenses_view.py
+++ b/integreat_cms/cms/views/imprint/open_source_licenses_view.py
@@ -39,9 +39,7 @@ class OpenSourceLicensesView(TemplateView):
         packages = data["packages"]
 
         for package in packages:
-            package["versionInfo"] = (
-                package["versionInfo"] if package["versionInfo"] else "N/A"
-            )
+            package["versionInfo"] = package["versionInfo"] or "N/A"
             package["url"] = None
             if "externalRefs" in package:
                 package_managers = [

--- a/integreat_cms/cms/views/pages/page_actions.py
+++ b/integreat_cms/cms/views/pages/page_actions.py
@@ -377,8 +377,7 @@ def upload_xliff(
             # Copy uploaded file from its temporary location into the upload directory
             with open(os.path.join(upload_dir, upload_file.name), "wb+") as file_write:
                 # Using chunks() instead of read() ensures that large files don’t overwhelm your system’s memory
-                for chunk in upload_file.chunks():
-                    file_write.write(chunk)
+                file_write.writelines(upload_file.chunks())
 
             if upload_file.name.endswith(".zip"):
                 # Extract zip archive

--- a/integreat_cms/cms/views/utils/translation_coverage.py
+++ b/integreat_cms/cms/views/utils/translation_coverage.py
@@ -27,8 +27,9 @@ def get_translation_and_word_count(
     # Ignore all pages which do not have a published translation in the default language
     pages = list(
         filter(
-            lambda page: page.get_translation_state(region.default_language.slug)
-            == UP_TO_DATE,
+            lambda page: (
+                page.get_translation_state(region.default_language.slug) == UP_TO_DATE
+            ),
             pages,
         )
     )

--- a/integreat_cms/core/logging_filter.py
+++ b/integreat_cms/core/logging_filter.py
@@ -16,7 +16,9 @@ class DebugRequestFilter(logging.Filter):
         :return: True if the record should be logged, False otherwise
         """
         if settings.REQUEST_DEBUG_USERS:
-            from integreat_cms.core.middleware.debug_request import get_request
+            from integreat_cms.core.middleware.debug_request import (
+                get_request,
+            )
 
             request = get_request()
 

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -134,7 +134,7 @@ API_EVENTS_MAX_TIME_SPAN_DAYS: Final[int] = 31
 
 #: The maximum duration of an event
 MAX_EVENT_DURATION: Final[int] = int(
-    os.environ.get("INTEGREAT_CMS_MAX_EVENT_DURATION", 28),
+    os.environ.get("INTEGREAT_CMS_MAX_EVENT_DURATION", "28"),
 )
 
 #: The company operating this CMS
@@ -196,7 +196,7 @@ DEFAULT_BOUNDING_BOX: Final[BoundingBox] = BoundingBox(
 
 #: The default timeout in seconds for retrieving external APIs etc.
 DEFAULT_REQUEST_TIMEOUT: Final[int] = int(
-    os.environ.get("INTEGREAT_CMS_DEFAULT_REQUEST_TIMEOUT", 10),
+    os.environ.get("INTEGREAT_CMS_DEFAULT_REQUEST_TIMEOUT", "10"),
 )
 
 #: Where release notes are stored
@@ -261,14 +261,14 @@ FCM_HISTORY_DAYS: Final[int] = 28
 #: The interval at which scheduled push notifications are sent out
 #: Must be <= 60 and a divisor of 60
 FCM_SCHEDULE_INTERVAL_MINUTES: Final[int] = int(
-    os.environ.get("INTEGREAT_CMS_FCM_SCHEDULE_INTERVAL_MINUTES", 60),
+    os.environ.get("INTEGREAT_CMS_FCM_SCHEDULE_INTERVAL_MINUTES", "60"),
 )
 if 60 % FCM_SCHEDULE_INTERVAL_MINUTES:
     raise ValueError("Interval must be <= 60 and a divisor of 60")
 
 #: Duration (in hours) that we retain pending push notifications for retry attempts before discarding them
 FCM_NOTIFICATION_RETAIN_TIME_IN_HOURS: Final[int] = int(
-    os.environ.get("INTEGREAT_CMS_NOTIFICATION_RETAIN_TIME_IN_HOURS", 24),
+    os.environ.get("INTEGREAT_CMS_NOTIFICATION_RETAIN_TIME_IN_HOURS", "24"),
 )
 
 ###########
@@ -338,22 +338,22 @@ TEXTLAB_API_CONTENT_TYPES: Final[list[str]] = ["pagetranslation"]
 
 #: How many seconds we should wait between the requests in the bulk management command
 TEXTLAB_API_BULK_WAITING_TIME: Final[float] = float(
-    os.environ.get("INTEGREAT_CMS_TEXTLAB_API_BULK_WAITING_TIME", 0.5),
+    os.environ.get("INTEGREAT_CMS_TEXTLAB_API_BULK_WAITING_TIME", "0.5"),
 )
 
 #: How many seconds we should wait after finishing a region in the bulk management command
 TEXTLAB_API_BULK_COOL_DOWN_PERIOD: Final[float] = float(
-    os.environ.get("INTEGREAT_CMS_TEXTLAB_API_BULK_COOL_DOWN_PERIOD", 60),
+    os.environ.get("INTEGREAT_CMS_TEXTLAB_API_BULK_COOL_DOWN_PERIOD", "60"),
 )
 
 #: Which text type / benchmark id to default to
 TEXTLAB_API_DEFAULT_BENCHMARK_ID: Final[int] = int(
-    os.environ.get("INTEGREAT_CMS_TEXTLAB_API_DEFAULT_BENCHMARK_ID", 420),
+    os.environ.get("INTEGREAT_CMS_TEXTLAB_API_DEFAULT_BENCHMARK_ID", "420"),
 )
 
 #: The minimum HIX score required for machine translation
 HIX_REQUIRED_FOR_MT: Final[float] = float(
-    os.environ.get("INTEGREAT_CMS_HIX_REQUIRED_FOR_MT", 15.0),
+    os.environ.get("INTEGREAT_CMS_HIX_REQUIRED_FOR_MT", "15.0"),
 )
 
 
@@ -884,7 +884,7 @@ EMAIL_HOST_USER: Final[str] = os.environ.get(
 
 #: Port to use for the SMTP server defined in :attr:`~integreat_cms.core.settings.EMAIL_HOST`
 #: (see :setting:`django:EMAIL_PORT`)
-EMAIL_PORT: Final[int] = int(os.environ.get("INTEGREAT_CMS_EMAIL_PORT", 587))
+EMAIL_PORT: Final[int] = int(os.environ.get("INTEGREAT_CMS_EMAIL_PORT", "587"))
 
 #: Whether to use a TLS (secure) connection when talking to the SMTP server.
 #: This is used for explicit TLS connections, generally on port 587.
@@ -980,7 +980,7 @@ DEFAULT_PHONE_NUMBER_COUNTRY_CODE: Final[str] = os.environ.get(
 
 #: A floating point that specifies the percentage of MT budget used as a soft margin
 MT_SOFT_MARGIN_FRACTION: Final[float] = float(
-    os.environ.get("INTEGREAT_CMS_MT_SOFT_MARGIN", 0.01),
+    os.environ.get("INTEGREAT_CMS_MT_SOFT_MARGIN", "0.01"),
 )
 
 
@@ -1058,7 +1058,7 @@ SUMM_AI_API_KEY: str | None = os.environ.get("INTEGREAT_CMS_SUMM_AI_API_KEY")
 SUMM_AI_ENABLED: bool = bool(SUMM_AI_API_KEY)
 
 #: An integer specifying the number of translation credits for simplified translations that can be bought as an add-on
-SUMM_AI_CREDITS: Final[int] = int(os.environ.get("SUMM_AI_CREDITS", 10_000))
+SUMM_AI_CREDITS: Final[int] = int(os.environ.get("SUMM_AI_CREDITS", "10_000"))
 
 #: Whether requests to the SUMM.AI are done with the ``is_test`` flag
 SUMM_AI_TEST_MODE: Final[bool] = strtobool(
@@ -1070,17 +1070,17 @@ SUMM_AI_TIMEOUT: Final[int] = 10
 
 #: The limit for "Too many requests".
 SUMM_AI_MAX_CONCURRENT_REQUESTS = int(
-    os.environ.get("INTEGREAT_CMS_SUMM_AI_MAX_CONCURRENT_REQUESTS", 20),
+    os.environ.get("INTEGREAT_CMS_SUMM_AI_MAX_CONCURRENT_REQUESTS", "20"),
 )
 
 #: Waiting time after "Too many requests" response was sent
 SUMM_AI_RATE_LIMIT_COOLDOWN = float(
-    os.environ.get("INTEGREAT_CMS_SUMM_AI_RATE_LIMIT_COOLDOWN", 30),
+    os.environ.get("INTEGREAT_CMS_SUMM_AI_RATE_LIMIT_COOLDOWN", "30"),
 )
 
 #: Maximum amount of retries before giving up
 #: Retries are reset if translation requests are successful after completing the cooldown
-SUMM_AI_MAX_RETRIES = int(os.environ.get("INTEGREAT_CMS_SUMM_AI_MAX_RETRIES", 5))
+SUMM_AI_MAX_RETRIES = int(os.environ.get("INTEGREAT_CMS_SUMM_AI_MAX_RETRIES", "5"))
 
 #: The language slugs for German
 SUMM_AI_GERMAN_LANGUAGE_SLUG: Final[str] = os.environ.get(
@@ -1190,7 +1190,7 @@ LEGACY_FILE_UPLOAD: Final[bool] = bool(
 
 #: The maximum size of media files in bytes
 MEDIA_MAX_UPLOAD_SIZE: Final[int] = int(
-    os.environ.get("INTEGREAT_CMS_MEDIA_MAX_UPLOAD_SIZE", 3 * 1024 * 1024),
+    os.environ.get("INTEGREAT_CMS_MEDIA_MAX_UPLOAD_SIZE", str(3 * 1024 * 1024)),
 )
 
 
@@ -1359,10 +1359,14 @@ PDF_URL: Final[str] = "/pdf/"
 
 
 #: Slugs of languages for which PDF export should be deactivated
-PDF_DEACTIVATED_LANGUAGES: Final[str | list[str]] = os.environ.get(
-    "INTEGREAT_CMS_PDF_DEACTIVATED_LANGUAGES",
-    [],
-)
+PDF_DEACTIVATED_LANGUAGES: Final[list[str]] = [
+    slug
+    for slug in os.environ.get(
+        "INTEGREAT_CMS_PDF_DEACTIVATED_LANGUAGES",
+        "",
+    ).split(",")
+    if slug
+]
 
 
 #######################
@@ -1447,9 +1451,11 @@ INTEGREAT_CHAT_BACK_END_DOMAIN = os.environ.get(
 )
 
 #: Integreat Chat (app) backend timeout
-INTEGREAT_CHAT_BACK_END_TIMEOUT = os.environ.get(
-    "INTEGREAT_CMS_INTEGREAT_CHAT_BACK_END_TIMEOUT",
-    300,
+INTEGREAT_CHAT_BACK_END_TIMEOUT = int(
+    os.environ.get(
+        "INTEGREAT_CMS_INTEGREAT_CHAT_BACK_END_TIMEOUT",
+        "300",
+    )
 )
 
 #: The e-mail address of the user that the Integreat
@@ -1503,7 +1509,11 @@ CELERY_RESULT_BACKEND = os.environ.get(
 ########################
 
 # Slugs of regions participating in the pilot phase of page based statistics
-PILOT_REGIONS_PAGE_BASED_STATISTICS = os.environ.get(
-    "INTEGREAT_CMS_PILOT_REGIONS_PAGE_BASED_STATISTICS",
-    [""],
-)
+PILOT_REGIONS_PAGE_BASED_STATISTICS: list[str] = [
+    slug
+    for slug in os.environ.get(
+        "INTEGREAT_CMS_PILOT_REGIONS_PAGE_BASED_STATISTICS",
+        "",
+    ).split(",")
+    if slug
+]

--- a/integreat_cms/core/signals/hix_signals.py
+++ b/integreat_cms/core/signals/hix_signals.py
@@ -77,7 +77,7 @@ def unregister_listeners() -> None:
 
 
 @contextmanager
-def enable_listeners() -> Generator[None, None, None]:
+def enable_listeners() -> Generator[None]:
     register_listeners()
     try:
         yield
@@ -86,7 +86,7 @@ def enable_listeners() -> Generator[None, None, None]:
 
 
 @contextmanager
-def disable_listeners() -> Generator[None, None, None]:
+def disable_listeners() -> Generator[None]:
     unregister_listeners()
     try:
         yield

--- a/integreat_cms/gvz_api/utils.py
+++ b/integreat_cms/gvz_api/utils.py
@@ -109,13 +109,13 @@ class GvzApiWrapper:
             ad.CITY_STATE,
         ]:
             result = 10
-        elif division_type in [ad.GOVERNMENTAL_DISTRICT]:
+        elif division_type == ad.GOVERNMENTAL_DISTRICT:
             result = 20
-        elif division_type in [ad.REGION]:
+        elif division_type == ad.REGION:
             result = 30
         elif division_type in [ad.RURAL_DISTRICT, ad.DISTRICT, ad.CITY_AND_DISTRICT]:
             result = 40
-        elif division_type in [ad.COLLECTIVE_MUNICIPALITY]:
+        elif division_type == ad.COLLECTIVE_MUNICIPALITY:
             result = 50
         elif division_type in [
             ad.CITY,

--- a/integreat_cms/summ_ai_api/utils.py
+++ b/integreat_cms/summ_ai_api/utils.py
@@ -10,7 +10,7 @@ import logging
 import time
 from collections import deque
 from html import unescape
-from typing import Generic, TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING
 
 from django.conf import settings
 from django.contrib import messages
@@ -382,10 +382,7 @@ class TranslationHelper:
         return f"<TranslationHelper (translation: {self.german_translation!r})>"
 
 
-T = TypeVar("T")
-
-
-class PatientTaskQueue(deque, Generic[T]):
+class PatientTaskQueue[T](deque):
     """
     A 'patient' task queue which only hands out sleep tasks after a task was reported as failed.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = "Content Management System for the Integreat App"
 version = "2026.5.1"
 authors = [{name = "Tür an Tür – Digitalfabrik gGmbH", email = "tech@integreat-app.de"}]
 readme = "README.md"
-requires-python = ">=3.11,<3.14"
+requires-python = ">=3.13,<3.14"
 keywords = [
     "integreat",
     "cms",
@@ -31,8 +31,6 @@ classifiers = [
     "Natural Language :: German",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Topic :: Internet :: WWW/HTTP :: Dynamic Content :: Content Management System",
     "Topic :: Internet :: WWW/HTTP :: WSGI :: Application",
@@ -413,10 +411,12 @@ disallow_untyped_defs = true
 ignore_missing_imports = true
 warn_redundant_casts = true
 strict_equality = true
+enable_incomplete_feature = ["NewGenericSyntax"]
+python_version = "3.13"
 
 [tool.ruff]
 line-length = 88
-target-version = "py311"
+target-version = "py313"
 
 # [tool.ruff.lint.pydocstyle]
 # waiting for: https://github.com/astral-sh/ruff/issues/6606

--- a/tests/cms/views/dashboard/test_dashboard.py
+++ b/tests/cms/views/dashboard/test_dashboard.py
@@ -153,7 +153,7 @@ def test_number_of_outdated_pages_is_correct(
     load_test_data: None,
     login_role_user: tuple[Client, str],
 ) -> None:
-    client, role = login_role_user
+    client, _role = login_role_user
     expected_number_of_pages = 13
 
     pages = reverse(
@@ -190,7 +190,7 @@ def test_most_outdated_page_is_correct(
     load_test_data: None,
     login_role_user: tuple[Client, str],
 ) -> None:
-    client, role = login_role_user
+    client, _role = login_role_user
     days_since_page_is_outdated = 1602
 
     dashboard = reverse(
@@ -257,7 +257,7 @@ def test_number_of_drafted_pages_is_correct(
     load_test_data: None,
     login_role_user: tuple[Client, str],
 ) -> None:
-    client, role = login_role_user
+    client, _role = login_role_user
     expected_number_of_pages = 1
 
     pages = reverse(
@@ -293,7 +293,7 @@ def test_single_drafted_page_is_correct(
     load_test_data: None,
     login_role_user: tuple[Client, str],
 ) -> None:
-    client, role = login_role_user
+    client, _role = login_role_user
 
     dashboard = reverse(
         "dashboard",

--- a/tests/cms/views/events/test_event_form.py
+++ b/tests/cms/views/events/test_event_form.py
@@ -446,7 +446,7 @@ def test_event_start_date_range_validation(
     Test that event start dates are validated to be within ISO 8601 range (>= 1583)
     """
     client, role = login_role_user
-    start_date, end_date, should_succeed, error_field = parameter
+    start_date, end_date, should_succeed, _error_field = parameter
     settings.LANGUAGE_CODE = "en"
 
     new_event = reverse(

--- a/tests/cms/views/pages/test_page_translations.py
+++ b/tests/cms/views/pages/test_page_translations.py
@@ -17,7 +17,7 @@ def test_cleanup_autosaves(
     load_test_data: None,
     login_role_user: tuple[Client, str],
 ) -> None:
-    client, role = login_role_user
+    client, _role = login_role_user
 
     new_page_url = reverse(
         "new_page",

--- a/tests/cms/views/poi_categories/test_poi_category_form_view.py
+++ b/tests/cms/views/poi_categories/test_poi_category_form_view.py
@@ -107,7 +107,7 @@ def test_create_poi_category_with_missing_translation_was_not_successful(
     load_test_data: None,
     login_role_user: tuple[Client, str],
 ) -> None:
-    client, role = login_role_user
+    client, _role = login_role_user
 
     new_poicategory_url = reverse("new_poicategory")
 

--- a/tests/cms/views/view_config.py
+++ b/tests/cms/views/view_config.py
@@ -31,38 +31,38 @@ from ...conftest import (
 )
 
 if TYPE_CHECKING:
-    from typing import Any, Final, TypeAlias
+    from typing import Any, Final
 
-    ViewNameStr: TypeAlias = str
-    ViewNameGetparams: TypeAlias = str
-    ViewName: TypeAlias = ViewNameStr | tuple[ViewNameStr, ViewNameGetparams]
-    Roles: TypeAlias = list[str]
-    PostDataDict: TypeAlias = dict[str, Any]
-    PostDataJSON: TypeAlias = str
-    PostData: TypeAlias = PostDataDict | PostDataJSON
-    View: TypeAlias = tuple[ViewName, Roles] | tuple[ViewName, Roles, PostData]
-    ViewKwargs: TypeAlias = dict[str, str | int]
-    ViewGroup: TypeAlias = tuple[list[View], ViewKwargs]
-    ViewConfig: TypeAlias = list[ViewGroup]
+    type ViewNameStr = str
+    type ViewNameGetparams = str
+    type ViewName = ViewNameStr | tuple[ViewNameStr, ViewNameGetparams]
+    type Roles = list[str]
+    type PostDataDict = dict[str, Any]
+    type PostDataJSON = str
+    type PostData = PostDataDict | PostDataJSON
+    type View = tuple[ViewName, Roles] | tuple[ViewName, Roles, PostData]
+    type ViewKwargs = dict[str, str | int]
+    type ViewGroup = tuple[list[View], ViewKwargs]
+    type ViewConfig = list[ViewGroup]
 
-    ParametrizedView: TypeAlias = tuple[ViewName, ViewKwargs, PostData, Roles]
-    ParametrizedViewConfig: TypeAlias = list[ParametrizedView]
+    type ParametrizedView = tuple[ViewName, ViewKwargs, PostData, Roles]
+    type ParametrizedViewConfig = list[ParametrizedView]
 
-    RedirectTarget: TypeAlias = str
-    RedirectView: TypeAlias = tuple[ViewNameStr, Roles, RedirectTarget]
-    RedirectViewGroup: TypeAlias = tuple[list[RedirectView], ViewKwargs]
-    RedirectViewConfig: TypeAlias = list[RedirectViewGroup]
+    type RedirectTarget = str
+    type RedirectView = tuple[ViewNameStr, Roles, RedirectTarget]
+    type RedirectViewGroup = tuple[list[RedirectView], ViewKwargs]
+    type RedirectViewConfig = list[RedirectViewGroup]
 
-    ParametrizedRedirectView: TypeAlias = tuple[
+    type ParametrizedRedirectView = tuple[
         ViewName,
         ViewKwargs,
         Roles,
         RedirectTarget,
     ]
-    ParametrizedRedirectViewConfig: TypeAlias = list[ParametrizedRedirectView]
+    type ParametrizedRedirectViewConfig = list[ParametrizedRedirectView]
 
     ParametrizedPublicView = tuple[ViewNameStr, PostDataDict]
-    ParametrizedPublicViewConfig: TypeAlias = list[ParametrizedPublicView]
+    type ParametrizedPublicViewConfig = list[ParametrizedPublicView]
 
 #: This list contains the config for all views
 #: Each element is a tuple which consists of two elements: A list of view configs and the keyword arguments that are

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -142,7 +142,7 @@ def mock_server(httpserver: HTTPServer) -> MockServer:
 
 
 @pytest.fixture(scope="function")
-def mock_firebase_credentials() -> Generator[None, None, None]:
+def mock_firebase_credentials() -> Generator[None]:
     patch_obj = patch.object(
         FirebaseSecurityService,
         "_get_access_token",

--- a/tests/mt_api/mt_api_test.py
+++ b/tests/mt_api/mt_api_test.py
@@ -860,7 +860,7 @@ def test_do_not_translate_title(
     :param caplog: The :fixture:`caplog` fixture
     :param mock_server: The fixture providing the mock http server used for faking the DeepL API server
     """
-    client, role = login_role_user
+    client, _role = login_role_user
 
     region = Region.objects.get(slug=REGION_SLUG)
     test_page = Page.objects.create(
@@ -985,7 +985,7 @@ def test_mt_empty_content(
     - translations are marked as up to date
     - no MT API request is sent
     """
-    client, role = login_role_user
+    client, _role = login_role_user
 
     region = Region.objects.get(slug=REGION_SLUG)
     test_page = Page.objects.create(

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -74,7 +74,7 @@ def assert_message_in_log(message: str, caplog: LogCaptureFixture) -> None:
 
 
 @contextmanager
-def disable_hix_post_save_signal() -> Generator[None, None, None]:
+def disable_hix_post_save_signal() -> Generator[None]:
     pre_save.disconnect(receiver=page_translation_save_handler, sender=PageTranslation)
     try:
         yield None

--- a/tools/_analyze_force_merges.py
+++ b/tools/_analyze_force_merges.py
@@ -132,9 +132,7 @@ def get_merged_prs(session: requests.Session, since: date, until: date) -> list[
         for pr in batch:
             if not pr.get("merged_at"):
                 continue
-            merged_at = datetime.fromisoformat(
-                pr["merged_at"].replace("Z", "+00:00")
-            ).date()
+            merged_at = datetime.fromisoformat(pr["merged_at"]).date()
             if merged_at > until:
                 continue
             if merged_at < since:

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -35,7 +35,7 @@ fi
 
 # Check if requirements are satisfied
 # Define the required python version
-required_python_version="3.11"
+required_python_version="3.13"
 if [[ ! -x "$(command -v python3)" ]]; then
     echo "Python3 is not installed. Please install Python ${required_python_version} or higher manually and run this script again."  | print_error
     exit 1
@@ -45,8 +45,8 @@ python_version=$(${PYTHON} --version | cut -d" " -f2)
 if [[ $(major "$python_version") -lt $(major "$required_python_version") ]] || \
    [[ $(major "$python_version") -eq $(major "$required_python_version") ]] && [[ $(minor "$python_version") -lt $(minor "$required_python_version") ]]; then
     echo "python version ${required_python_version} is required, but version ${python_version} is installed. Please install a recent version manually and run this script again."  | print_error
-    echo -e "If you installed higher python version manually which is not your default python3, please pass the alternative python interpreter (e.g. python3.11) to the script:\n" | print_info
-    echo -e "\t$(dirname "${BASH_SOURCE[0]}")/install.sh --python python3.11\n" | print_bold
+    echo -e "If you installed higher python version manually which is not your default python3, please pass the alternative python interpreter (e.g. python3.13) to the script:\n" | print_info
+    echo -e "\t$(dirname "${BASH_SOURCE[0]}")/install.sh --python python3.13\n" | print_bold
     exit 1
 fi
 # Check if pip is installed


### PR DESCRIPTION
### Short description
After we added Python 3.13 support in https://github.com/digitalfabrik/integreat-cms/pull/3837, we should soon switch to Debian Trixie, as Bookworm is nearing its EOL.
In preparation, we should run all tests on Python 3.13 and also use PostgresSQL 17.10.

### Proposed changes
- Bump CircleCI tests to Python 3.13 and PostgreSQL 17.10
- Bump install tool Python version & PSQL server
- Make the new ruff version happy while trying to keep the changes as minimal as possible

### Side effects
- ~~we will see.~~ None that I can see.


### Faithfulness to issue description and design
N/A

### How to test
The tests test.

### Resolved issues
Fixes: N/A


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
