### PR TITLE
Fix preview button on filtered pages

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/4170.yml
+++ b/integreat_cms/release_notes/current/unreleased/4170.yml
@@ -1,0 +1,2 @@
+en: Fix preview button not working for filtered and searched pages
+de: Die Schaltfläche "Vorschau" funktioniert nicht für gefilterte und gesuchte Seiten

--- a/integreat_cms/static/src/js/pages/page-preview.ts
+++ b/integreat_cms/static/src/js/pages/page-preview.ts
@@ -69,3 +69,10 @@ export const addPreviewWindowListeners = (callback: (overlay: HTMLElement, btn: 
         });
     }
 };
+
+// Fallback for filtered views where fetch-subpages.ts never runs.
+window.addEventListener("load", () => {
+    if (!document.querySelector("[data-delay-event-handlers]")) {
+        addPreviewWindowListeners(openPreviewWindowInPageTree);
+    }
+});


### PR DESCRIPTION
### Short description
Fixes the preview button not working for pages after filtering the pages, or after a search

### Proposed changes
The bug appears because addPreviewWindowListeners was only called inside the lazy subpage loading path in `fetch-subpages.ts`, which only runs when `data-delay-event-handlers` is present on the table. When filters or search are active, data-delay-event-handlers is absent, so the preview listeners were never attached.
- The proposed change is to add a load handler to `page-preview.ts `that attaches the preview listeners when `data-delay-event-handlers` is absent 


### Side effects

- None 


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
- Select Pages of a specific region
- Click on 'Show Filters' and apply any filters
- Check if preview page appears on all pages
- Secondly, filter pages using search and check preview button
- The preview should work for both cases (filter/search) in archived pages as well

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4170 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
