### PR TITLE
Increase upload limit for media library to 4MB

### DIFF
--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -1190,7 +1190,7 @@ LEGACY_FILE_UPLOAD: Final[bool] = bool(
 
 #: The maximum size of media files in bytes
 MEDIA_MAX_UPLOAD_SIZE: Final[int] = int(
-    os.environ.get("INTEGREAT_CMS_MEDIA_MAX_UPLOAD_SIZE", 3 * 1024 * 1024),
+    os.environ.get("INTEGREAT_CMS_MEDIA_MAX_UPLOAD_SIZE", 4 * 1024 * 1024),
 )
 
 

--- a/integreat_cms/release_notes/current/unreleased/4281.yml
+++ b/integreat_cms/release_notes/current/unreleased/4281.yml
@@ -1,0 +1,2 @@
+en: Increase upload limit for media library to 4MB
+de: Erhöhe Upload-Limit für die Mediathek auf 4 MB


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR changes the upload limit of media library to 4 MB from 3MB

### Proposed changes
<!-- Describe this PR in more detail. -->
- Change the environment variable


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- Should be none


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
- Prepare three PDF files, each with <=3MB, >3MB & <=4MB, and >4MB
- Check out to the branch of this PR
- See <=3MB and >3MB & <4MB can be uploaded but >4MB not

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4281 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
