### PR TITLE
Make slug uniqueness validation & constraint case insensitive

### DIFF
--- a/integreat_cms/cms/fixtures/test_data.json
+++ b/integreat_cms/cms/fixtures/test_data.json
@@ -5528,7 +5528,7 @@
     "pk": 89,
     "fields": {
       "title": "ስለ Augsburg መታወቅ ያለበት",
-      "slug": "ስለ-Augsburg-መታወቅ-ያለበት",
+      "slug": "ስለ-augsburg-መታወቅ-ያለበት",
       "status": "PUBLIC",
       "content": "<p>Augsburg የሚገኘው በ Bayern ግዛት ውስጥ እና በመካከለኛው franken አውራጃ ውስጥ ነው፡፡ Augsburg 500,000 አካባቢ ነዋሪዎች ሲኖሩት Bayern ውስጥ ከሙኒክ ቀጥሎ ሁለተኛው ትልቅ ከተማ ነው፡፡ Pegnitz የሚባል ወንዝ ከተማ ውስጥ ይፈሳል፡፡</p>",
       "language": 8,

--- a/integreat_cms/cms/migrations/0154_enforce_case_insensitive_slug_uniqueness.py
+++ b/integreat_cms/cms/migrations/0154_enforce_case_insensitive_slug_uniqueness.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import django.db.models.functions.text
+from django.db import migrations, models
+
+from integreat_cms.cms.utils.slug_utils import make_all_slug_lowercase
+
+if TYPE_CHECKING:
+    from django.apps.registry import Apps
+    from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+
+
+def forwards(_apps: Apps, _schema_editor: BaseDatabaseSchemaEditor) -> None:
+    make_all_slug_lowercase()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("cms", "0153_enforce_slug_uniqueness"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            forwards,
+            migrations.RunPython.noop,
+        ),
+        migrations.AddConstraint(
+            model_name="eventtranslation",
+            constraint=models.CheckConstraint(
+                condition=models.Q(
+                    ("slug", django.db.models.functions.text.Lower("slug"))
+                ),
+                name="eventtranslation_slug_lowercase",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="pagetranslation",
+            constraint=models.CheckConstraint(
+                condition=models.Q(
+                    ("slug", django.db.models.functions.text.Lower("slug"))
+                ),
+                name="pagetranslation_slug_lowercase",
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name="poitranslation",
+            constraint=models.CheckConstraint(
+                condition=models.Q(
+                    ("slug", django.db.models.functions.text.Lower("slug"))
+                ),
+                name="poitranslation_slug_lowercase",
+            ),
+        ),
+    ]

--- a/integreat_cms/cms/models/events/event_translation.py
+++ b/integreat_cms/cms/models/events/event_translation.py
@@ -6,6 +6,7 @@ import pgtrigger
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 from django.db.models import Q
+from django.db.models.functions import Lower
 from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
@@ -195,6 +196,9 @@ class EventTranslation(AbstractContentTranslation):
             models.UniqueConstraint(
                 fields=["event", "language", "version"],
                 name="%(class)s_unique_version",
+            ),
+            models.CheckConstraint(
+                condition=Q(slug=Lower("slug")), name="%(class)s_slug_lowercase"
             ),
         ]
         triggers = [

--- a/integreat_cms/cms/models/pages/page_translation.py
+++ b/integreat_cms/cms/models/pages/page_translation.py
@@ -8,6 +8,8 @@ import pgtrigger
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
+from django.db.models import Q
+from django.db.models.functions import Lower
 from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils.functional import cached_property
@@ -451,6 +453,9 @@ class PageTranslation(AbstractBasePageTranslation):
             models.UniqueConstraint(
                 fields=["page", "language", "version"],
                 name="%(class)s_unique_version",
+            ),
+            models.CheckConstraint(
+                condition=Q(slug=Lower("slug")), name="%(class)s_slug_lowercase"
             ),
         ]
 

--- a/integreat_cms/cms/models/pois/poi_translation.py
+++ b/integreat_cms/cms/models/pois/poi_translation.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 from django.db.models import Q
+from django.db.models.functions import Lower
 from django.urls import reverse
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
@@ -216,6 +217,9 @@ class POITranslation(AbstractContentTranslation):
             models.UniqueConstraint(
                 fields=["poi", "language", "version"],
                 name="%(class)s_unique_version",
+            ),
+            models.CheckConstraint(
+                condition=Q(slug=Lower("slug")), name="%(class)s_slug_lowercase"
             ),
         ]
         triggers = [

--- a/integreat_cms/cms/utils/slug_utils.py
+++ b/integreat_cms/cms/utils/slug_utils.py
@@ -12,7 +12,8 @@ from celery import shared_task
 from django.apps import apps
 from django.conf import settings
 from django.db import transaction
-from django.db.models import Exists, OuterRef
+from django.db.models import Exists, OuterRef, Q
+from django.db.models.functions import Lower
 from django.utils.text import slugify
 
 if TYPE_CHECKING:
@@ -175,12 +176,12 @@ def generate_base_slug(
     Generates the base slug from the given slug or fallback.
     """
     if slug:
-        return slug
+        return slug.lower()
 
     allow_unicode = object_instance._meta.get_field("slug").allow_unicode
     slug = slugify(fallback, allow_unicode=allow_unicode)
 
-    return slug or foreign_model or ""
+    return slug.lower() or (foreign_model or "").lower()
 
 
 def get_prefiltered_queryset(
@@ -319,3 +320,31 @@ def make_all_slugs_unique(
             end_time,
             slug_counter,
         )
+
+
+def make_all_slug_lowercase(objects: tuple[SlugObject, ...] = DEFAULT_OBJECTS) -> None:
+    logger.info("Starting to make all slugs lowercase ...")
+    start_time = time()
+
+    slug_counter = 0
+
+    for model_name in objects:
+        translation_model = apps.get_model(
+            "cms", f"{model_name.capitalize()}Translation"
+        )
+
+        with_upper_case_slug = translation_model.objects.filter(~Q(slug=Lower("slug")))
+
+        slug_counter += update_translations(
+            with_upper_case_slug,
+            model_name,
+            dry_run=False,
+        )
+
+    end_time = time() - start_time
+
+    logger.info(
+        "Finished >make_all_slugs_lowercase< after: %.3fs with %d updated slugs",
+        end_time,
+        slug_counter,
+    )

--- a/integreat_cms/cms/views/events/event_form_view.py
+++ b/integreat_cms/cms/views/events/event_form_view.py
@@ -347,31 +347,41 @@ class EventFormView(
         """
         Shows a message to the user if the slug they provided was not unique and therefore changed.
         """
-        if user_slug and user_slug != event_translation_form.cleaned_data["slug"]:
-            other_translation = EventTranslation.objects.filter(
-                event__region=region,
-                slug=user_slug,
-                language=language,
-            ).first()
-            other_translation_link = other_translation.backend_edit_link
-            message = _(
-                "The slug was changed from '{user_slug}' to '{slug}', "
-                "because '{user_slug}' is already used by <a>{translation}</a> or one of its previous versions.",
-            ).format(
-                user_slug=user_slug,
-                slug=event_translation_form.cleaned_data["slug"],
-                translation=other_translation,
-            )
-            messages.warning(
-                request,
-                translate_link(
-                    message,
-                    attributes={
-                        "href": other_translation_link,
-                        "class": "underline hover:no-underline",
-                    },
-                ),
-            )
+        cleaned_slug = event_translation_form.cleaned_data["slug"]
+        if user_slug and user_slug != cleaned_slug:
+            if user_slug.lower() == cleaned_slug:
+                message = _(
+                    "The slug was changed from '{user_slug}' to '{slug}', because uppercase letters are not allowed."
+                ).format(
+                    user_slug=user_slug,
+                    slug=cleaned_slug,
+                )
+                messages.warning(request, message)
+            else:
+                other_translation = EventTranslation.objects.filter(
+                    event__region=region,
+                    slug=user_slug,
+                    language=language,
+                ).first()
+                other_translation_link = other_translation.backend_edit_link
+                message = _(
+                    "The slug was changed from '{user_slug}' to '{slug}', "
+                    "because '{user_slug}' is already used by <a>{translation}</a> or one of its previous versions.",
+                ).format(
+                    user_slug=user_slug,
+                    slug=cleaned_slug,
+                    translation=other_translation,
+                )
+                messages.warning(
+                    request,
+                    translate_link(
+                        message,
+                        attributes={
+                            "href": other_translation_link,
+                            "class": "underline hover:no-underline",
+                        },
+                    ),
+                )
 
     def add_success_message(
         self,

--- a/integreat_cms/cms/views/pages/page_form_view.py
+++ b/integreat_cms/cms/views/pages/page_form_view.py
@@ -522,52 +522,64 @@ class PageFormView(
         """
         Shows a message to the user if the slug they provided was not unique and therefore changed.
         """
-        if user_slug and user_slug != page_translation_form.cleaned_data["slug"]:
-            other_translation = PageTranslation.objects.filter(
-                page__region=region,
-                slug=user_slug,
-                language=language,
-            ).first()
-            if other_translation:
-                other_translation_link = reverse(
-                    "page_versions",
-                    kwargs={
-                        "page_id": other_translation.page.id,
-                        "language_slug": language.slug,
-                        "region_slug": region.slug,
-                        "selected_version": other_translation.version,
-                    },
-                )
+        cleaned_slug = page_translation_form.cleaned_data["slug"]
+        if user_slug and user_slug != cleaned_slug:
+            if user_slug.lower() == cleaned_slug:
                 message = _(
-                    "The slug was changed from '{user_slug}' to '{slug}', "
-                    "because '{user_slug}' is already used by <a>{translation}</a>.",
+                    "The slug was changed from '{user_slug}' to '{slug}', because uppercase letters are not allowed."
                 ).format(
                     user_slug=user_slug,
-                    slug=page_translation_form.cleaned_data["slug"],
-                    translation=other_translation,
+                    slug=cleaned_slug,
                 )
-                messages.warning(
-                    request,
-                    translate_link(
-                        message,
-                        attributes={
-                            "href": other_translation_link,
-                            "class": "underline hover:no-underline",
-                        },
-                    ),
-                )
+                messages.warning(request, message)
             else:
-                logger.warning(
-                    "Slug was changed from the one the user provided, but we can't find the translation that already used it: %s (cleaned to %s)",
-                    user_slug,
-                    page_translation_form.cleaned_data["slug"],
-                )
-                messages.warning(
-                    _("The slug was changed from '{user_slug}' to '{slug}'.").format(
+                other_translation = PageTranslation.objects.filter(
+                    page__region=region,
+                    slug=user_slug,
+                    language=language,
+                ).first()
+                if other_translation:
+                    other_translation_link = reverse(
+                        "page_versions",
+                        kwargs={
+                            "page_id": other_translation.page.id,
+                            "language_slug": language.slug,
+                            "region_slug": region.slug,
+                            "selected_version": other_translation.version,
+                        },
+                    )
+                    message = _(
+                        "The slug was changed from '{user_slug}' to '{slug}', "
+                        "because '{user_slug}' is already used by <a>{translation}</a>.",
+                    ).format(
                         user_slug=user_slug,
                         slug=page_translation_form.cleaned_data["slug"],
+                        translation=other_translation,
                     )
-                )
+                    messages.warning(
+                        request,
+                        translate_link(
+                            message,
+                            attributes={
+                                "href": other_translation_link,
+                                "class": "underline hover:no-underline",
+                            },
+                        ),
+                    )
+                else:
+                    logger.warning(
+                        "Slug was changed from the one the user provided, but we can't find the translation that already used it: %s (cleaned to %s)",
+                        user_slug,
+                        page_translation_form.cleaned_data["slug"],
+                    )
+                    messages.warning(
+                        _(
+                            "The slug was changed from '{user_slug}' to '{slug}'."
+                        ).format(
+                            user_slug=user_slug,
+                            slug=page_translation_form.cleaned_data["slug"],
+                        )
+                    )
 
     def set_dependent_translations_to_draft(
         self, page: Page, region: Region, language: Language

--- a/integreat_cms/cms/views/pois/poi_form_view.py
+++ b/integreat_cms/cms/views/pois/poi_form_view.py
@@ -304,31 +304,42 @@ class POIFormView(
         """
         Shows a message to the user if the slug they provided was not unique and therefore changed.
         """
-        if user_slug and user_slug != poi_translation_form.cleaned_data["slug"]:
-            other_translation = POITranslation.objects.filter(
-                poi__region=region,
-                slug=user_slug,
-                language=language,
-            ).first()
-            other_translation_link = other_translation.backend_edit_link
-            message = _(
-                "The slug was changed from '{user_slug}' to '{slug}', "
-                "because '{user_slug}' is already used by <a>{translation}</a> or one of its previous versions.",
-            ).format(
-                user_slug=user_slug,
-                slug=poi_translation_form.cleaned_data["slug"],
-                translation=other_translation,
-            )
-            messages.warning(
-                request,
-                translate_link(
-                    message,
-                    attributes={
-                        "href": other_translation_link,
-                        "class": "underline hover:no-underline",
-                    },
-                ),
-            )
+        if user_slug:
+            cleaned_slug = poi_translation_form.cleaned_data["slug"]
+            if user_slug != cleaned_slug:
+                if user_slug.lower() == cleaned_slug:
+                    message_uppercase = _(
+                        "The slug was changed from '{user_slug}' to '{slug}', because uppercase letters are not allowed."
+                    ).format(
+                        user_slug=user_slug,
+                        slug=cleaned_slug,
+                    )
+                    messages.warning(request, message_uppercase)
+                else:
+                    other_translation = POITranslation.objects.filter(
+                        poi__region=region,
+                        slug=user_slug,
+                        language=language,
+                    ).first()
+                    other_translation_link = other_translation.backend_edit_link
+                    message = _(
+                        "The slug was changed from '{user_slug}' to '{slug}', "
+                        "because '{user_slug}' is already used by <a>{translation}</a> or one of its previous versions.",
+                    ).format(
+                        user_slug=user_slug,
+                        slug=cleaned_slug,
+                        translation=other_translation,
+                    )
+                    messages.warning(
+                        request,
+                        translate_link(
+                            message,
+                            attributes={
+                                "href": other_translation_link,
+                                "class": "underline hover:no-underline",
+                            },
+                        ),
+                    )
 
     def get_instances(
         self, language: Language, poi_id: Any

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -10093,6 +10093,16 @@ msgstr ""
 "veröffentlichen, aber Sie können Änderungen vornehmen und diese zur Freigabe "
 "vorlegen."
 
+#: cms/views/events/event_form_view.py cms/views/pages/page_form_view.py
+#: cms/views/pois/poi_form_view.py
+#, python-brace-format
+msgid ""
+"The slug was changed from '{user_slug}' to '{slug}', because uppercase "
+"letters are not allowed."
+msgstr ""
+"Der URL-Parameter wurde von '{user_slug}' zu '{slug}' geändert, da "
+"Großbuchstaben nicht erlaubt sind."
+
 #: cms/views/events/event_form_view.py cms/views/pois/poi_form_view.py
 #, python-brace-format
 msgid ""

--- a/integreat_cms/release_notes/current/unreleased/4321.yml
+++ b/integreat_cms/release_notes/current/unreleased/4321.yml
@@ -1,0 +1,2 @@
+en: Only allow lowercase page links (slugs).
+de: Nur kleingeschriebene Seitenlinks (Slugs) zulassen.

--- a/tests/cms/models/events/test_event_translation.py
+++ b/tests/cms/models/events/test_event_translation.py
@@ -21,6 +21,11 @@ def test_when_creating_even_translations_to_automatically_create_unique_slugs() 
         end=timezone.now() + timedelta(days=2),
         region=region,
     )
+    event3 = Event.objects.create(
+        start=timezone.now(),
+        end=timezone.now() + timedelta(days=2),
+        region=region,
+    )
     language = Language.objects.create(slug="da", primary_country_code="de")
 
     event_translation1 = EventTranslation.objects.create(
@@ -29,8 +34,31 @@ def test_when_creating_even_translations_to_automatically_create_unique_slugs() 
     event_translation2 = EventTranslation.objects.create(
         event=event2, language=language, slug="new-slug"
     )
+    event_translation3 = EventTranslation.objects.create(
+        event=event3, language=language, slug="New-slug"
+    )
 
-    assert event_translation1.slug != event_translation2.slug
+    assert event_translation1.slug != event_translation2.slug != event_translation3.slug
+
+
+@pytest.mark.django_db
+def test_when_creating_even_translations_to_automatically_create_lowercase_slug() -> (
+    None
+):
+    region = Region.objects.create(name="new-region")
+
+    event1 = Event.objects.create(
+        start=timezone.now(),
+        end=timezone.now() + timedelta(days=1),
+        region=region,
+    )
+    language = Language.objects.create(slug="da", primary_country_code="de")
+
+    event_translation1 = EventTranslation.objects.create(
+        event=event1, language=language, slug="New-slug"
+    )
+
+    assert event_translation1.slug == "new-slug"
 
 
 @pytest.mark.order("last")

--- a/tests/cms/models/pages/test_page_translation.py
+++ b/tests/cms/models/pages/test_page_translation.py
@@ -17,6 +17,7 @@ def test_when_creating_page_translations_to_automatically_create_unique_slugs(
 
     page1 = create_page(region=region)
     page2 = create_page(region=region)
+    page3 = create_page(region=region)
     language = Language.objects.create(slug="da", primary_country_code="de")
 
     page_translation1 = PageTranslation.objects.create(
@@ -25,8 +26,27 @@ def test_when_creating_page_translations_to_automatically_create_unique_slugs(
     page_translation2 = PageTranslation.objects.create(
         page=page2, language=language, slug="new-slug"
     )
+    page_translation3 = PageTranslation.objects.create(
+        page=page3, language=language, slug="New-slug"
+    )
 
-    assert page_translation1.slug != page_translation2.slug
+    assert page_translation1.slug != page_translation2.slug != page_translation3.slug
+
+
+@pytest.mark.django_db
+def test_when_creating_page_translations_to_automatically_create_lowercase_slugs(
+    create_page: Callable[..., Page],
+) -> None:
+    region = Region.objects.create(name="new-region")
+
+    page1 = create_page(region=region)
+    language = Language.objects.create(slug="da", primary_country_code="de")
+
+    page_translation1 = PageTranslation.objects.create(
+        page=page1, language=language, slug="New-slug"
+    )
+
+    assert page_translation1.slug == "new-slug"
 
 
 @pytest.mark.django_db

--- a/tests/cms/models/pois/test_poi_translation.py
+++ b/tests/cms/models/pois/test_poi_translation.py
@@ -32,6 +32,16 @@ def test_creating_poi_translations_to_automatically_create_unique_slugs() -> Non
         longitude="10.8879783",
         category=poi_category,
     )
+    poi3 = POI.objects.create(
+        region=region,
+        address="Adress 42",
+        postcode="00000",
+        city="Augsburg",
+        country="Deutschland",
+        latitude="48.3780446",
+        longitude="10.8879783",
+        category=poi_category,
+    )
     language = Language.objects.create(slug="da", primary_country_code="de")
     poi_translation1 = POITranslation.objects.create(
         poi=poi1, language=language, slug="new-slug"
@@ -39,7 +49,36 @@ def test_creating_poi_translations_to_automatically_create_unique_slugs() -> Non
     poi_translation2 = POITranslation.objects.create(
         poi=poi2, language=language, slug="new-slug"
     )
-    assert poi_translation1.slug != poi_translation2.slug
+    poi_translation3 = POITranslation.objects.create(
+        poi=poi3, language=language, slug="New-slug"
+    )
+    assert poi_translation1.slug != poi_translation2.slug != poi_translation3.slug
+
+
+@pytest.mark.django_db
+def test_creating_poi_translations_to_automatically_create_lowercase_slug() -> None:
+    region = Region.objects.create(name="new-region")
+    poi_category = POICategory.objects.create(
+        icon=poicategory.OTHER,
+        color=poicategory.DARK_BLUE,
+    )
+    poi1 = POI.objects.create(
+        region=region,
+        address="Adress 42",
+        postcode="00000",
+        city="Augsburg",
+        country="Deutschland",
+        latitude="48.3780446",
+        longitude="10.8879783",
+        category=poi_category,
+    )
+
+    language = Language.objects.create(slug="da", primary_country_code="de")
+    poi_translation1 = POITranslation.objects.create(
+        poi=poi1, language=language, slug="New-slug"
+    )
+
+    assert poi_translation1.slug == "new-slug"
 
 
 @pytest.mark.order("last")


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
So far the app and database levels for slug uniqueness have been treating slugs as case sensitive, but they need to by case insensitive, because the app treats url with case insenstive identical slugs as the same. 


### Proposed changes
<!-- Describe this PR in more detail. -->

- data migration, that lowers all slugs and makes sure they are unique
  - on prod data dump it: 
  ```
  Jun 02 12:48:41 INFO integreat_cms.cms.utils.slug_utils - Finished >make_all_slugs_lowercase< after: 311.830s with 369 updated slugs
  ```
- check constraint on translation models
- ~~adjust database trigger to ensure case insensitive slug uniqueness~~ not necessary if we have the check constraints
- adjust `generate_unique_slug()` to generate only lowercase slugs


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
- try creating uppercase slugs in GUI for page, poi, events -> should not be possible
- try creating uppercase non-unique slugs in GUI -> should not be possibel
- in the shell update a translation with an uppercase slug -> should give IntegrityError


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4269


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
