### PR TITLE
Add previous slugs to the page related API responses

### DIFF
--- a/integreat_cms/api/v3/pages.py
+++ b/integreat_cms/api/v3/pages.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 import logging
+from collections import defaultdict
 from typing import TYPE_CHECKING
 
 from django.conf import settings
@@ -19,7 +20,7 @@ from django.utils.text import slugify
 from django.views.decorators.csrf import csrf_exempt
 
 from ...cms.forms import PageTranslationForm
-from ...cms.models import Page
+from ...cms.models import Page, PageTranslation
 from ...cms.utils.shortcodes import expand_shortcodes
 from ..decorators import json_response, matomo_tracking
 from .offers import transform_offer
@@ -29,13 +30,16 @@ if TYPE_CHECKING:
 
     from django.http import HttpRequest
 
-    from ...cms.models import Page, PageTranslation
+    from ...cms.models.pages.page import PageQuerySet
 
 logger = logging.getLogger(__name__)
 
 
 def transform_page(
-    page_translation: PageTranslation, context: dict[str, Any] | None = None
+    page_translation: PageTranslation,
+    page: Page | None = None,
+    context: dict[str, Any] | None = None,
+    slug_history: list[str] | None = None,
 ) -> dict[str, Any]:
     """
     Function to create a dict from a single page_translation Object.
@@ -51,10 +55,13 @@ def transform_page(
         "path": None,
     }
 
-    parent_page = page_translation.page.cached_parent
+    if page is None:
+        page = page_translation.page
+    parent_page = page.cached_parent
+    language = page_translation.language
     if parent_page and not parent_page.explicitly_archived:
         if parent_public_translation := parent_page.get_public_translation(
-            page_translation.language.slug,
+            language.slug,
         ):
             parent_absolute_url = parent_public_translation.get_absolute_url()
             parent = {
@@ -63,21 +70,21 @@ def transform_page(
                 "path": parent_absolute_url,
             }
             # use left edge indicator of mptt model for ordering of child pages
-            order = page_translation.page.lft
+            order = page.lft
         else:
             logger.info(
                 "The parent %r of %r does not have a public translation in %r",
                 parent_page,
-                page_translation.page,
-                page_translation.language,
+                page,
+                language,
             )
             raise Http404("No Page matches the given url or id.")
     else:
         parent = fallback_parent
         # use tree id of mptt model for ordering of root pages
-        order = page_translation.page.tree_id
+        order = page.tree_id
 
-    organization = page_translation.page.organization
+    organization = page.organization
     absolute_url = page_translation.get_absolute_url()
     return {
         "id": page_translation.id,
@@ -93,9 +100,7 @@ def transform_page(
         "parent": parent,
         "order": order,
         "available_languages": page_translation.available_languages_dict,
-        "thumbnail": (
-            page_translation.page.icon.url if page_translation.page.icon else None
-        ),
+        "thumbnail": (page.icon.url if page.icon else None),
         "organization": (
             {
                 "id": organization.id,
@@ -109,9 +114,17 @@ def transform_page(
         ),
         "hash": None,
         "embedded_offers": [
-            transform_offer(offer, page_translation.page.region)
-            for offer in page_translation.page.embedded_offers.all()
+            transform_offer(offer, page.region) for offer in page.embedded_offers.all()
         ],
+        "slug_history": list(slug_history)
+        if slug_history is not None
+        else list(
+            dict.fromkeys(
+                page_translation.all_versions.order_by("version").values_list(
+                    "slug", flat=True
+                )
+            )
+        ),
     }
 
 
@@ -135,24 +148,30 @@ def pages(
     result = []
     # The preliminary filter for explicitly_archived=False is not strictly required, but reduces the number of entries
     # requested from the database
-    for page in (
+    pages = (
         region.pages.select_related("organization__icon")
         .prefetch_related(
             "embedded_offers",
         )
         .filter(explicitly_archived=False)
         .cache_tree(archived=False, language_slug=language_slug)
-    ):
+    )
+
+    slug_history: defaultdict[int, list[str]] = get_slug_history(pages, language_slug)
+
+    for page in pages:
         if page_translation := page.get_public_translation(language_slug):
             result.append(
                 transform_page(
                     page_translation,
+                    page,
                     context={
                         "region_slug": region_slug,
                         "language_slug": language_slug,
                         "content_object": page_translation,
                         "request": request,
                     },
+                    slug_history=slug_history.get(page.id, []),
                 )
             )
     return JsonResponse(
@@ -246,12 +265,20 @@ def single_page(
         return JsonResponse(
             transform_page(
                 page_translation,
+                page,
                 context={
                     "region_slug": region_slug,
                     "language_slug": language_slug,
                     "content_object": page_translation,
                     "request": request,
                 },
+                slug_history=list(
+                    dict.fromkeys(
+                        page_translation.all_versions.order_by("version").values_list(
+                            "slug", flat=True
+                        )
+                    )
+                ),
             ),
             safe=False,
         )
@@ -318,15 +345,20 @@ def children(
             should_prefetch_nonpublic_translations=False,
         )
     )
+
+    slug_history: defaultdict[int, list[str]] = get_slug_history(pages, language_slug)
+
     result = [
         transform_page(
             page_translation,
+            page,
             context={
                 "region_slug": region_slug,
                 "language_slug": language_slug,
                 "content_object": page_translation,
                 "request": request,
             },
+            slug_history=slug_history.get(page.id, []),
         )
         for page in pages.values()
         if root_page is None or page.id != root_page.parent_id
@@ -380,6 +412,11 @@ def get_public_ancestor_translations(
     result = []
     cached_ancestors = current_page.get_cached_ancestors()
     prefetch_related_objects(cached_ancestors, "organization")
+
+    slug_history: defaultdict[int, list[str]] = get_slug_history(
+        cached_ancestors, language_slug
+    )
+
     for ancestor in cached_ancestors:
         public_translation = ancestor.get_public_translation(language_slug)
         if not public_translation or ancestor.explicitly_archived:
@@ -387,10 +424,12 @@ def get_public_ancestor_translations(
         result.append(
             transform_page(
                 public_translation,
+                ancestor,
                 context={
                     "language_slug": language_slug,
                     "content_object": public_translation,
                 },
+                slug_history=slug_history.get(ancestor.id, []),
             )
         )
     return result
@@ -447,3 +486,27 @@ def push_page_translation_content(
         return JsonResponse({"status": "success"})
     logger.error("Push Content: failed to validate page translation.")
     return JsonResponse({"status": "error"}, status=405)
+
+
+def get_slug_history(
+    pages: PageQuerySet | list[Page], language_slug: str
+) -> defaultdict[int, list[str]]:
+    """
+    :param page: ID of requested page
+    :param language_slug: Code to identify the desired language
+
+    :return: dict with page id and slugs of all versions of the page translation
+    """
+    page_translations = (
+        PageTranslation.objects.filter(page_id__in=pages, language__slug=language_slug)
+        .order_by("version")
+        .values("page_id", "slug")
+    )
+
+    slug_history: defaultdict[int, list[str]] = defaultdict(list)
+    for row in page_translations:
+        slug = row["slug"]
+        if slug not in slug_history[row["page_id"]]:
+            slug_history[row["page_id"]].append(slug)
+
+    return slug_history

--- a/tests/api/api_config.py
+++ b/tests/api/api_config.py
@@ -51,14 +51,14 @@ API_ENDPOINTS: Final[list[tuple[str, str, str, int, int]]] = [
         "/augsburg/de/wp-json/extensions/v3/pages/",
         "tests/api/expected-outputs/augsburg_de_pages.json",
         200,
-        6,
+        7,
     ),
     (
         "/api/v3/augsburg/ar/pages/",
         "/augsburg/ar/wp-json/extensions/v3/pages/",
         "tests/api/expected-outputs/augsburg_ar_pages.json",
         200,
-        6,
+        7,
     ),
     (
         "/api/v3/augsburg/non-existing/pages/",
@@ -121,14 +121,14 @@ API_ENDPOINTS: Final[list[tuple[str, str, str, int, int]]] = [
         "/augsburg/de/wp-json/extensions/v3/children/",
         "tests/api/expected-outputs/augsburg_de_children.json",
         200,
-        5,
+        6,
     ),
     (
         "/api/v3/augsburg/de/children/?depth=3&url=/augsburg/de/behörden-und-beratung/behörden/",
         "/augsburg/de/wp-json/extensions/v3/children/?depth=3&url=/augsburg/de/behörden-und-beratung/behörden/",
         "tests/api/expected-outputs/augsburg_de_children_archived_descendants.json",
         200,
-        13,
+        15,
     ),
     (
         "/augsburg/de/wp-json/extensions/v3/page/?url=/augsburg/de/behörden-und-beratung/behörden/archiviertes-amt/",
@@ -142,7 +142,7 @@ API_ENDPOINTS: Final[list[tuple[str, str, str, int, int]]] = [
         "/augsburg/de/wp-json/extensions/v3/children/?depth=2",
         "tests/api/expected-outputs/augsburg_de_children_depth_2.json",
         200,
-        5,
+        6,
     ),
     (
         "/api/v3/augsburg/de/events/",
@@ -184,7 +184,7 @@ API_ENDPOINTS: Final[list[tuple[str, str, str, int, int]]] = [
         "/augsburg/de/wp-json/extensions/v3/page/?id=1",
         "tests/api/expected-outputs/augsburg_de_page_1.json",
         200,
-        5,
+        6,
     ),
     (
         "/api/v3/augsburg/de/imprint/",

--- a/tests/api/expected-outputs/augsburg_ar_pages.json
+++ b/tests/api/expected-outputs/augsburg_ar_pages.json
@@ -34,7 +34,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["معلومات-الوصول"]
   },
   {
     "id": 17,
@@ -66,7 +67,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["الحياة-في-أوجسبرج"]
   },
   {
     "id": 15,
@@ -109,7 +111,8 @@
       "website": "https://integreat-app.de/"
     },
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["نبذة-حول-تطبيق-إنتجريت-أوجسبورج"]
   },
   {
     "id": 14,
@@ -142,7 +145,8 @@
       "website": "https://integreat-app.de/"
     },
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["مرحبا-بكم-في-مدينة-أوجسبورج"]
   },
   {
     "id": 43,
@@ -179,7 +183,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["المصالح-الحكومية-والاستشارة"]
   },
   {
     "id": 46,
@@ -216,7 +221,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["المصالح-الحكومية"]
   },
   {
     "id": 38,
@@ -261,7 +267,8 @@
         "post": { "form-id": "example", "zammad-url": "https://zammad.example.com" }
       }
     ],
-    "hash": null
+    "hash": null,
+    "slug_history": ["دائرة-شؤون-الأجانب"]
   },
   {
     "id": 41,
@@ -298,7 +305,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["مكتب-الصحة"]
   },
   {
     "id": 50,
@@ -335,7 +343,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["اللغة-الألمانية"]
   },
   {
     "id": 54,
@@ -372,7 +381,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["تعلم-اللغة-الألمانية-بنفسك"]
   },
   {
     "id": 58,
@@ -404,7 +414,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["دورات-تعليم-اللغة"]
   },
   {
     "id": 69,
@@ -441,7 +452,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["عروض-تعلم-أخرى-للغة"]
   },
   {
     "id": 71,
@@ -473,7 +485,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["الترجمة-الشفهية-والتحريرية"]
   },
   {
     "id": 64,
@@ -518,6 +531,7 @@
         "thumbnail": "https://cms.integreat-app.de/wp-content/uploads/extra-thumbnails/ihk-lehrstellenboerse.png"
       }
     ],
-    "hash": null
+    "hash": null,
+    "slug_history": ["الحياة-اليومية"]
   }
 ]

--- a/tests/api/expected-outputs/augsburg_de_children.json
+++ b/tests/api/expected-outputs/augsburg_de_children.json
@@ -34,7 +34,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["willkommen"]
   },
   {
     "id": 34,
@@ -71,7 +72,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["behörden-und-beratung"]
   },
   {
     "id": 49,
@@ -108,7 +110,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["deutsche-sprache"]
   },
   {
     "id": 61,
@@ -153,7 +156,8 @@
         "thumbnail": "https://cms.integreat-app.de/wp-content/uploads/extra-thumbnails/ihk-lehrstellenboerse.png"
       }
     ],
-    "hash": null
+    "hash": null,
+    "slug_history": ["alltag"]
   },
   {
     "id": 83,
@@ -174,7 +178,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["test-hidden-language"]
   },
   {
     "id": 94,
@@ -201,7 +206,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["test-links"]
   },
   {
     "id": 98,
@@ -228,7 +234,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["jetzt-google-translate-ist-da"]
   },
   {
     "id": 101,
@@ -249,7 +256,8 @@
     "thumbnail": null,
     "organization": null,
     "hash": null,
-    "embedded_offers": []
+    "embedded_offers": [],
+    "slug_history": ["wichtige-kontakte"]
   },
   {
     "id": 102,
@@ -276,7 +284,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["im-übersetzungsprozess"]
   },
   {
     "id": 103,
@@ -303,6 +312,7 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["auch-im-übersetzungsprozess"]
   }
 ]

--- a/tests/api/expected-outputs/augsburg_de_children_archived_descendants.json
+++ b/tests/api/expected-outputs/augsburg_de_children_archived_descendants.json
@@ -34,7 +34,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["behörden"]
   },
   {
     "id": 36,
@@ -79,7 +80,8 @@
         "post": { "form-id": "example", "zammad-url": "https://zammad.example.com" }
       }
     ],
-    "hash": null
+    "hash": null,
+    "slug_history": ["ausländerbehörde"]
   },
   {
     "id": 39,
@@ -116,6 +118,7 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["gesundheitsamt"]
   }
 ]

--- a/tests/api/expected-outputs/augsburg_de_children_depth_2.json
+++ b/tests/api/expected-outputs/augsburg_de_children_depth_2.json
@@ -34,7 +34,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["willkommen"]
   },
   {
     "id": 4,
@@ -66,7 +67,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["wissenswertes-uber-augsburg"]
   },
   {
     "id": 3,
@@ -109,7 +111,8 @@
       "website": "https://integreat-app.de/"
     },
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["uber-die-app-integreat-augsburg"]
   },
   {
     "id": 2,
@@ -142,7 +145,8 @@
       "website": "https://integreat-app.de/"
     },
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["willkommen-in-augsburg"]
   },
   {
     "id": 5,
@@ -174,7 +178,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["stadtplan"]
   },
   {
     "id": 6,
@@ -195,7 +200,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["kontakt-zu-app-team-augsburg"]
   },
   {
     "id": 34,
@@ -232,7 +238,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["behörden-und-beratung"]
   },
   {
     "id": 35,
@@ -269,7 +276,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["behörden"]
   },
   {
     "id": 49,
@@ -306,7 +314,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["deutsche-sprache"]
   },
   {
     "id": 53,
@@ -343,7 +352,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["deutsch-selber-lernen"]
   },
   {
     "id": 57,
@@ -375,7 +385,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["sprachkurse"]
   },
   {
     "id": 66,
@@ -412,7 +423,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["sprachlernangebote", "sonstige-sprachlernangebote"]
   },
   {
     "id": 70,
@@ -444,7 +456,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["dolmetschen-und-übersetzen"]
   },
   {
     "id": 61,
@@ -489,7 +502,8 @@
         "thumbnail": "https://cms.integreat-app.de/wp-content/uploads/extra-thumbnails/ihk-lehrstellenboerse.png"
       }
     ],
-    "hash": null
+    "hash": null,
+    "slug_history": ["alltag"]
   },
   {
     "id": 83,
@@ -510,7 +524,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["test-hidden-language"]
   },
   {
     "id": 94,
@@ -537,7 +552,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["test-links"]
   },
   {
     "id": 98,
@@ -564,7 +580,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["jetzt-google-translate-ist-da"]
   },
   {
     "id": 101,
@@ -585,7 +602,8 @@
     "thumbnail": null,
     "organization": null,
     "hash": null,
-    "embedded_offers": []
+    "embedded_offers": [],
+    "slug_history": ["wichtige-kontakte"]
   },
   {
     "id": 102,
@@ -612,7 +630,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["im-übersetzungsprozess"]
   },
   {
     "id": 103,
@@ -639,6 +658,7 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["auch-im-übersetzungsprozess"]
   }
 ]

--- a/tests/api/expected-outputs/augsburg_de_page_1.json
+++ b/tests/api/expected-outputs/augsburg_de_page_1.json
@@ -33,5 +33,6 @@
   "thumbnail": null,
   "organization": null,
   "embedded_offers": [],
-  "hash": null
+  "hash": null,
+  "slug_history": ["willkommen"]
 }

--- a/tests/api/expected-outputs/augsburg_de_pages.json
+++ b/tests/api/expected-outputs/augsburg_de_pages.json
@@ -34,7 +34,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["willkommen"]
   },
   {
     "id": 4,
@@ -66,7 +67,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["wissenswertes-uber-augsburg"]
   },
   {
     "id": 3,
@@ -109,7 +111,8 @@
       "website": "https://integreat-app.de/"
     },
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["uber-die-app-integreat-augsburg"]
   },
   {
     "id": 2,
@@ -142,7 +145,8 @@
       "website": "https://integreat-app.de/"
     },
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["willkommen-in-augsburg"]
   },
   {
     "id": 5,
@@ -174,7 +178,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["stadtplan"]
   },
   {
     "id": 6,
@@ -195,7 +200,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["kontakt-zu-app-team-augsburg"]
   },
   {
     "id": 34,
@@ -232,7 +238,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["behörden-und-beratung"]
   },
   {
     "id": 35,
@@ -269,7 +276,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["behörden"]
   },
   {
     "id": 36,
@@ -317,7 +325,8 @@
         }
       }
     ],
-    "hash": null
+    "hash": null,
+    "slug_history": ["ausländerbehörde"]
   },
   {
     "id": 39,
@@ -354,7 +363,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["gesundheitsamt"]
   },
   {
     "id": 49,
@@ -391,7 +401,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["deutsche-sprache"]
   },
   {
     "id": 53,
@@ -428,7 +439,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["deutsch-selber-lernen"]
   },
   {
     "id": 57,
@@ -460,7 +472,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["sprachkurse"]
   },
   {
     "id": 66,
@@ -497,7 +510,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["sprachlernangebote", "sonstige-sprachlernangebote"]
   },
   {
     "id": 70,
@@ -529,7 +543,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["dolmetschen-und-übersetzen"]
   },
   {
     "id": 61,
@@ -574,7 +589,8 @@
         "thumbnail": "https://cms.integreat-app.de/wp-content/uploads/extra-thumbnails/ihk-lehrstellenboerse.png"
       }
     ],
-    "hash": null
+    "hash": null,
+    "slug_history": ["alltag"]
   },
   {
     "id": 83,
@@ -595,7 +611,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["test-hidden-language"]
   },
   {
     "id": 94,
@@ -622,7 +639,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["test-links"]
   },
   {
     "id": 98,
@@ -649,7 +667,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["jetzt-google-translate-ist-da"]
   },
   {
     "id": 101,
@@ -670,7 +689,8 @@
     "thumbnail": null,
     "organization": null,
     "hash": null,
-    "embedded_offers": []
+    "embedded_offers": [],
+    "slug_history": ["wichtige-kontakte"]
   },
   {
     "id": 102,
@@ -697,7 +717,8 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["im-übersetzungsprozess"]
   },
   {
     "id": 103,
@@ -724,6 +745,7 @@
     "thumbnail": null,
     "organization": null,
     "embedded_offers": [],
-    "hash": null
+    "hash": null,
+    "slug_history": ["auch-im-übersetzungsprozess"]
   }
 ]


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds previous slugs to page entries in the API responses.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Collect slugs of all versions of a requested page by `get_translation_slug`
- Remove duplicates and the same slugs with the given translation version
- Return the result as a part of each page entry by `transform_page`


- Publication status of each version is not checked. Let me know if it harms.

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- The number of performed queries grows up dramatically. I'm afraid this worsens response time 👀 


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
- Select or create a page which has 1. only one version, 2. several versions with different slugs 3. several version with the same slug in all or some versions
- Call `children/`, `pages/`, `parents`, `page` endpoints
- See the field `previous_slugs` is filled as expected

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #1587 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
