### PR TITLE
preserve Link.ignore flag through content version updates

### DIFF
--- a/integreat_cms/cms/apps.py
+++ b/integreat_cms/cms/apps.py
@@ -9,7 +9,9 @@ from django.utils.translation import gettext_lazy as _
 if TYPE_CHECKING:
     from typing import Final
 
+    from django.db.models import Model
     from django.utils.functional import Promise
+    from linkcheck import Linklist
 
 logger = logging.getLogger(__name__)
 
@@ -29,11 +31,57 @@ class CmsConfig(AppConfig):
     verbose_name: Final[Promise] = _("CMS")
 
     def ready(self) -> None:
-        """
-        Monkeypatch the checking of internal URLs
-        """
-        from linkcheck.models import Url
+        from django.core.cache import cache
+        from linkcheck import celery as linkcheck_celery
+        from linkcheck import listeners as linkcheck_listeners
+        from linkcheck import worker_tasks as linkcheck_worker_tasks
+        from linkcheck.models import Link, Url
 
+        from .models.abstract_content_translation import AbstractContentTranslation
         from .utils.internal_link_checker import check_internal
+        from .utils.link_ignore_preservation import cache_key_for, target_key
 
         Url.check_internal = check_internal
+
+        # Reapply ignore=True to Link rows that were stashed by a
+        # preserve_ignored_links context manager at the delete site.
+        upstream = linkcheck_worker_tasks.do_check_instance_links
+
+        def do_check_instance_links_preserving_ignore(
+            sender: type[Model],
+            instance: Model,
+            linklist_cls: type[Linklist],
+            wait: bool = False,
+        ) -> None:
+            cache_key = (
+                cache_key_for(instance)
+                if isinstance(instance, AbstractContentTranslation)
+                else None
+            )
+            stashed = cache.get(cache_key) if cache_key else None
+            upstream(sender, instance, linklist_cls, wait=wait)
+            if stashed:
+                ignored_keys = {tuple(k) for k in stashed}
+                cache.delete(cache_key)
+                to_re_ignore = [
+                    link.pk
+                    for link in Link.objects.filter(
+                        content_type=linklist_cls.content_type(),
+                        object_id=instance.pk,
+                    ).select_related("url")
+                    if target_key(link.url.url) in ignored_keys
+                ]
+                if to_re_ignore:
+                    Link.objects.filter(pk__in=to_re_ignore).update(ignore=True)
+
+        # Patch all three references — listeners and celery imported the
+        # name at module load.
+        linkcheck_worker_tasks.do_check_instance_links = (
+            do_check_instance_links_preserving_ignore
+        )
+        linkcheck_listeners.do_check_instance_links = (
+            do_check_instance_links_preserving_ignore
+        )
+        linkcheck_celery.do_check_instance_links = (
+            do_check_instance_links_preserving_ignore
+        )

--- a/integreat_cms/cms/forms/custom_content_model_form.py
+++ b/integreat_cms/cms/forms/custom_content_model_form.py
@@ -14,6 +14,7 @@ from ..utils.content_translation_utils import (
     update_links_to,
 )
 from ..utils.content_utils import clean_content
+from ..utils.link_ignore_preservation import preserve_ignored_links
 from ..utils.slug_utils import generate_unique_slug_helper
 from .custom_model_form import CustomModelForm
 
@@ -128,26 +129,32 @@ class CustomContentModelForm(CustomModelForm):
         :return: The saved content translation object
         """
 
-        if commit:
-            # Delete now outdated link objects
-            self.instance.links.all().delete()
-
         # If none of the text content fields were changed, treat as minor edit (even if checkbox isn't clicked)
         # so that existing translations in other languages are not incorrectly flagged as outdated
         if {"title", "content"}.isdisjoint(self.changed_data):
             self.logger.debug("Set 'minor_edit=True' since the content did not change")
             self.instance.minor_edit = True
 
-        # Save new version
-        self.instance.version += 1
-        self.instance.pk = None
-
-        # Save CustomModelForm, retrying with a recomputed version on conflict
-        # to handle race conditions from concurrent saves (e.g. bulk MT)
         parent_save = super().save
-        result = save_new_version_with_retry(
-            self.instance, lambda: parent_save(commit=commit)
-        )
+
+        if commit:
+            with preserve_ignored_links(self.instance):
+                # Delete now outdated link objects
+                self.instance.links.all().delete()
+                # Save new version
+                self.instance.version += 1
+                self.instance.pk = None
+                # Save CustomModelForm, retrying with a recomputed version on conflict
+                # to handle race conditions from concurrent saves (e.g. bulk MT)
+                result = save_new_version_with_retry(
+                    self.instance, lambda: parent_save(commit=commit)
+                )
+        else:
+            self.instance.version += 1
+            self.instance.pk = None
+            result = save_new_version_with_retry(
+                self.instance, lambda: parent_save(commit=commit)
+            )
 
         # Update links to this content translation
         # Also update if the status got changed, since title or slug might have changed in a previous draft version

--- a/integreat_cms/cms/models/abstract_content_translation.py
+++ b/integreat_cms/cms/models/abstract_content_translation.py
@@ -646,7 +646,11 @@ class AbstractContentTranslation(AbstractBaseModel):
         )
         new_translation.content = fix_content_link_encoding(new_translation.content)
         if new_translation.content != self.content and commit:
-            with transaction.atomic():
+            # Local import: preserve_ignored_links pulls in internal_link_utils,
+            # which imports from cms.models, which loads this very module.
+            from ..utils.link_ignore_preservation import preserve_ignored_links
+
+            with transaction.atomic(), preserve_ignored_links(self):
                 self.links.all().delete()
                 save_new_version_with_retry(new_translation, new_translation.save)
 

--- a/integreat_cms/cms/utils/content_translation_utils.py
+++ b/integreat_cms/cms/utils/content_translation_utils.py
@@ -16,6 +16,7 @@ from linkcheck.models import Url
 
 from .content_utils import clean_content
 from .internal_link_utils import get_public_translation_for_link
+from .link_ignore_preservation import preserve_ignored_links
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -108,7 +109,10 @@ def update_links_to(
         )
         fixed_content_translation.content = new_content
         try:
-            with transaction.atomic():
+            with (
+                transaction.atomic(),
+                preserve_ignored_links(outdated_content_translation),
+            ):
                 outdated_content_translation.links.all().delete()
                 save_new_version_with_retry(
                     fixed_content_translation, fixed_content_translation.save

--- a/integreat_cms/cms/utils/link_ignore_preservation.py
+++ b/integreat_cms/cms/utils/link_ignore_preservation.py
@@ -1,0 +1,69 @@
+"""
+Carry editor-set ``Link.ignore`` flags across the delete-and-recreate
+cycle that runs on every translation save.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+
+from django.contrib.contenttypes.models import ContentType
+from django.core.cache import cache
+
+from . import internal_link_utils
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from ..models.abstract_content_translation import AbstractContentTranslation
+
+
+_CACHE_TTL = 600
+_CACHE_PREFIX = "linkcheck_pending_ignore"
+
+
+def target_key(url_string: str) -> tuple[str, object]:
+    """
+    Stable identity for a URL's target. Internal URLs that resolve to a
+    content object share a key across slug rewrites; everything else
+    falls back to the URL string.
+    """
+    resolved = internal_link_utils.get_public_translation_for_link(url_string)
+    if resolved is None:
+        return ("ext", url_string)
+    return (type(resolved).__name__, resolved.foreign_object.pk)
+
+
+def cache_key_for(translation: AbstractContentTranslation) -> str:
+    foreign = translation.foreign_object
+    foreign_ct = ContentType.objects.get_for_model(foreign)
+    return f"{_CACHE_PREFIX}:{foreign_ct.id}:{foreign.pk}:{translation.language_id}"
+
+
+@contextmanager
+def preserve_ignored_links(
+    translation: AbstractContentTranslation,
+) -> Iterator[None]:
+    """
+    Snapshot target-keys of ignored Links on ``translation`` so the next
+    ``do_check_instance_links`` for the same (foreign_object, language)
+    can restore the flag on the freshly reconciled Links.
+
+    Wrap the delete-and-save sequence:
+
+        with preserve_ignored_links(self):
+            self.links.all().delete()
+            new_translation.save()
+
+    The follow-up reconciliation may run synchronously or via Celery on
+    transaction commit; the stash is shared via the Django cache so both
+    paths see it.
+    """
+    keys = [
+        target_key(link.url.url)
+        for link in translation.links.filter(ignore=True).select_related("url")
+    ]
+    if keys:
+        cache.set(cache_key_for(translation), keys, timeout=_CACHE_TTL)
+    yield

--- a/integreat_cms/core/management/commands/fix_internal_links.py
+++ b/integreat_cms/core/management/commands/fix_internal_links.py
@@ -15,6 +15,7 @@ from lxml.html import rewrite_links
 
 from ....cms.models import Region
 from ....cms.utils import internal_link_utils
+from ....cms.utils.link_ignore_preservation import preserve_ignored_links
 from ....cms.utils.link_utils import fix_content_link_encoding
 from ....cms.utils.linkcheck_utils import get_link_query
 from ..log_command import LogCommand
@@ -188,8 +189,9 @@ def replace_links_of_translation(
         rules.keys(),
     )
     if commit:
-        translation.links.all().delete()
-        new_translation.save()
+        with preserve_ignored_links(translation):
+            translation.links.all().delete()
+            new_translation.save()
 
 
 def replace_link_helper(rules: dict[str, str], link: str) -> str:

--- a/integreat_cms/core/management/commands/update_link_text.py
+++ b/integreat_cms/core/management/commands/update_link_text.py
@@ -12,6 +12,8 @@ from linkcheck.models import Url
 from lxml.etree import ParserError
 from lxml.html import fromstring, tostring
 
+from ....cms.utils.link_ignore_preservation import preserve_ignored_links
+
 if TYPE_CHECKING:
     from typing import Any
 
@@ -126,8 +128,9 @@ class Command(LogCommand):
                 )
 
                 if new_translation.content != target_content.content:
-                    target_content.links.all().delete()
-                    new_translation.save()
+                    with preserve_ignored_links(target_content):
+                        target_content.links.all().delete()
+                        new_translation.save()
         # Wait until all post-save signals have been processed
         time.sleep(0.1)
         # Wait until all background tasks of linkcheck indexing the new content objects have been processed

--- a/integreat_cms/release_notes/current/unreleased/3859.yml
+++ b/integreat_cms/release_notes/current/unreleased/3859.yml
@@ -1,0 +1,2 @@
+en: Keep links marked as verified when their content gets updated
+de: Behalte als verifiziert markierte Links bei, wenn deren Inhalte aktualisiert werden

--- a/tests/cms/utils/test_internal_link_checker.py
+++ b/tests/cms/utils/test_internal_link_checker.py
@@ -141,3 +141,227 @@ def test_check_internal_skipped(
     """
     url = prepage_url(link, trailing_slash)
     assert check_internal(url) is None, f"URL '{link}' is not skipped"
+
+
+@pytest.mark.django_db
+def test_preserve_ignored_links_across_form_save_cycle(load_test_data: None) -> None:
+    """
+    Mirrors what ``CustomContentModelForm.save`` does on every editor
+    edit: delete the prior version's Link rows, then save the new
+    version. ``preserve_ignored_links`` must carry ``ignore=True`` from
+    the old translation's Link onto the new translation's freshly
+    reconciled Link of the same URL.
+    """
+    from django.contrib.contenttypes.models import ContentType
+    from linkcheck.models import Link
+    from linkcheck.worker_tasks import do_check_instance_links
+
+    from integreat_cms.cms.models import PageTranslation
+    from integreat_cms.cms.utils.link_ignore_preservation import (
+        preserve_ignored_links,
+    )
+
+    embedded_url = "https://this-link-is-not-working.de"
+    translation = (
+        PageTranslation.objects.filter(
+            page__region__slug="augsburg",
+            language__slug="de",
+        )
+        .order_by("-version")
+        .first()
+    )
+    PageTranslation.objects.filter(pk=translation.pk).update(
+        content=f'<a href="{embedded_url}">First text</a>',
+    )
+    translation.refresh_from_db()
+
+    content_type = ContentType.objects.get_for_model(PageTranslation)
+    do_check_instance_links(
+        PageTranslation,
+        translation,
+        PageTranslation._linklist,
+    )
+    Link.objects.filter(
+        content_type=content_type,
+        object_id=translation.pk,
+        url__url=embedded_url,
+    ).update(ignore=True)
+
+    # Production-equivalent form save: snapshot via context manager,
+    # delete the prior version's Links, save a new version with
+    # different link text, then reconcile.
+    new_translation = translation.create_new_version_copy(user=None)
+    new_translation.is_validated = True
+    new_translation.content = f'<a href="{embedded_url}">Second text</a>'
+    with preserve_ignored_links(translation):
+        translation.links.all().delete()
+        new_translation.save()
+        do_check_instance_links(
+            PageTranslation,
+            new_translation,
+            PageTranslation._linklist,
+        )
+
+    surviving_link = Link.objects.get(
+        content_type=content_type,
+        object_id=new_translation.pk,
+        url__url=embedded_url,
+    )
+    assert surviving_link.ignore is True, (
+        "ignore=True should survive the form's delete+save cycle"
+    )
+
+
+@pytest.mark.django_db
+def test_preserve_ignored_links_across_internal_url_rewrite(
+    load_test_data: None,
+) -> None:
+    """
+    When ``clean_content`` rewrites an internal href (e.g. an ancestor
+    slug changed), reconciliation creates a ``Url`` row at the new path
+    distinct from the pre-rewrite row. The whitelist must follow the
+    link's *target*, not its URL string.
+    """
+    from django.contrib.contenttypes.models import ContentType
+    from linkcheck.models import Link
+    from linkcheck.worker_tasks import do_check_instance_links
+
+    from integreat_cms.cms.models import PageTranslation
+    from integreat_cms.cms.utils import internal_link_utils
+    from integreat_cms.cms.utils.link_ignore_preservation import (
+        preserve_ignored_links,
+    )
+
+    old_url = (
+        "https://integreat.app/augsburg/de/legacy-prefix/"
+        "uber-die-app-integreat-augsburg/"
+    )
+    new_url = (
+        "https://integreat.app/augsburg/de/willkommen/uber-die-app-integreat-augsburg/"
+    )
+    target_old = internal_link_utils.get_public_translation_for_link(old_url)
+    target_new = internal_link_utils.get_public_translation_for_link(new_url)
+    assert target_old is not None and target_new is not None
+    assert target_old.foreign_object.pk == target_new.foreign_object.pk
+
+    translation = (
+        PageTranslation.objects.filter(
+            page__region__slug="augsburg",
+            language__slug="de",
+        )
+        .order_by("-version")
+        .first()
+    )
+    PageTranslation.objects.filter(pk=translation.pk).update(
+        content=f'<a href="{old_url}">link</a>',
+    )
+    translation.refresh_from_db()
+
+    content_type = ContentType.objects.get_for_model(PageTranslation)
+    do_check_instance_links(
+        PageTranslation,
+        translation,
+        PageTranslation._linklist,
+    )
+    Link.objects.filter(
+        content_type=content_type,
+        object_id=translation.pk,
+        url__url=old_url,
+    ).update(ignore=True)
+
+    new_translation = translation.create_new_version_copy(user=None)
+    new_translation.is_validated = True
+    new_translation.content = f'<a href="{new_url}">link</a>'
+    with preserve_ignored_links(translation):
+        translation.links.all().delete()
+        new_translation.save()
+        do_check_instance_links(
+            PageTranslation,
+            new_translation,
+            PageTranslation._linklist,
+        )
+
+    surviving_link = Link.objects.get(
+        content_type=content_type,
+        object_id=new_translation.pk,
+        url__url=new_url,
+    )
+    assert surviving_link.ignore is True, (
+        "ignore=True should follow the link's target across a URL rewrite"
+    )
+
+
+@pytest.mark.django_db
+def test_preserve_ignored_links_across_update_links_to(load_test_data: None) -> None:
+    """
+    ``update_links_to`` bumps the version of every translation whose
+    content links to the given translation, deleting and re-creating its
+    Link rows in the process. ``ignore=True`` on the referencing
+    translation's links must survive this cycle.
+    """
+    from django.contrib.contenttypes.models import ContentType
+    from linkcheck.models import Link
+    from linkcheck.worker_tasks import do_check_instance_links
+
+    from integreat_cms.cms.models import PageTranslation
+    from integreat_cms.cms.utils import internal_link_utils
+    from integreat_cms.cms.utils.content_translation_utils import update_links_to
+
+    # An href whose path is outdated but still resolves to the target page,
+    # so that ``clean_content`` rewrites it and ``update_links_to`` saves a
+    # new version of the referencing translation
+    outdated_url = (
+        "https://integreat.app/augsburg/de/legacy-prefix/"
+        "uber-die-app-integreat-augsburg/"
+    )
+    target = internal_link_utils.get_public_translation_for_link(outdated_url)
+    assert target is not None
+
+    referencing = (
+        PageTranslation.objects.filter(
+            page__region__slug="augsburg",
+            language__slug="de",
+            slug="willkommen",
+        )
+        .order_by("-version")
+        .first()
+    )
+    assert referencing.foreign_object != target.foreign_object
+    PageTranslation.objects.filter(pk=referencing.pk).update(
+        content=f'<a href="{outdated_url}">link text</a>',
+    )
+    referencing.refresh_from_db()
+
+    content_type = ContentType.objects.get_for_model(PageTranslation)
+    do_check_instance_links(
+        PageTranslation,
+        referencing,
+        PageTranslation._linklist,
+    )
+    Link.objects.filter(
+        content_type=content_type,
+        object_id=referencing.pk,
+        url__url=outdated_url,
+    ).update(ignore=True)
+
+    update_links_to(target, None)
+
+    new_referencing = referencing.latest_version
+    assert new_referencing.pk != referencing.pk, (
+        "update_links_to should have saved a new version"
+    )
+    assert target.full_url in new_referencing.content
+    do_check_instance_links(
+        PageTranslation,
+        new_referencing,
+        PageTranslation._linklist,
+    )
+
+    surviving_link = Link.objects.get(
+        content_type=content_type,
+        object_id=new_referencing.pk,
+        url__url=target.full_url,
+    )
+    assert surviving_link.ignore is True, (
+        "ignore=True should survive the update_links_to version bump"
+    )


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Broken links can be marked as verified in the link checker dashboard, which sets the `Link.ignore` flag on the model. Thus far, these flags did not survive content updates or management commands like `fix_internal_links`, because the `Link` and `Url` objects in the database are deleted and re-created, thus losing the `ignore=True` information. This PR attempts to carry the `ignore` flag across different versions of the same link.

### Proposed changes
<!-- Describe this PR in more detail. -->
There are several issues that make this not straight forward:
- the `Link` and `Url` objects are created by `linkcheck.worker_tasks:do_check_instance_links`, which is in the `linkcheck` library and not our own codebase
- we manually remove the `Link` objects on a content translation object when a new version is created to prevent accumulating `Link`s in the DB. this happens before the new content translation object is created, and thus before the new `Link` objects exist
- `linkcheck` runs in celery on production, so the process that creates the new `Link` objects is different then the process that deletes the old ones

So this PR 
- adds a context manager `preserve_ignored_links` that snapshots `Link` objects with `ignore=True` that are deleted and writes them to the cache (TTL 10 minutes)
- monkey-patches `do_check_instance_links` to read the cache and transfer the `ignore` flag to the newly created `Link`s

Note that the links are identified by their target, which is the content object they resolve to for internal links and the url for external links. Using the Url row id for reference was not sufficient since the Url rows also get deleted and re-created.
### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- every linkcheck trigger now runs through the new wrapper. worth keeping an eye on performance
- if linkcheck executes after the 10 minute TTL expired (celery worker down, or big queue backlog), the flag won't be transfered


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
XLIFF import path is not covered, thus the `ignore` flags are still lost there


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
- create a page with a broken link
- mark the link as verified in the dashboard
- edit the page and update to create a new version
- see that the broken link remains listed as verified

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3859 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
