### PR TITLE
Add AI traffic interpretation note to statistics page

### DIFF
--- a/integreat_cms/cms/templates/statistics/statistics_overview.html
+++ b/integreat_cms/cms/templates/statistics/statistics_overview.html
@@ -9,6 +9,18 @@
                     {% translate "Statistics" %}
                 </h1>
             </div>
+            <div class="bg-blue-100 border-l-4 border-blue-500 text-blue-700 px-4 py-3 mb-4"
+                 role="note">
+                <p>
+                    {% blocktranslate trimmed %}
+                        Note: These numbers show only part of the impact of your content.
+                        More and more people find information through AI assistants like ChatGPT –
+                        <strong>there, your texts are used without a page visit being counted</strong>.
+                        This can considerably distort page views in the future.
+                        So use these numbers only for rough orientation.
+                    {% endblocktranslate %}
+                </p>
+            </div>
             <div class="pt-4 lg:pt-0 3xl:grid grid-cols-2 3xl:grid-cols-[minmax(0px,_1fr)_400px] 4xl:grid-cols-[minmax(0px,_1fr)_816px] gap-4">
                 <div class="flex flex-col flex-wrap col-span-1 3xl:col-span-1 min-w-0">
                     {% include "statistics/statistics_chart.html" with box_id="statistics_chart" %}

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -9029,6 +9029,20 @@ msgstr "Der Statistik-Server hat aktuell eine hohe Auslastung."
 msgid "Total accesses"
 msgstr "Gesamtzugriffe"
 
+#: cms/templates/statistics/statistics_overview.html
+msgid ""
+"Note: These numbers show only part of the impact of your content. More and "
+"more people find information through AI assistants like ChatGPT – <strong>"
+"there, your texts are used without a page visit being counted</strong>. This "
+"can considerably distort page views in the future. So use these numbers only "
+"for rough orientation."
+msgstr ""
+"Hinweis: Diese Zahlen zeigen nur einen Teil der Wirkung Ihrer Inhalte. Immer "
+"mehr Menschen finden Informationen über KI-Assistenten wie ChatGPT – <strong>"
+"dort werden Ihre Texte genutzt, ohne dass ein Seitenbesuch gezählt wird</"
+"strong>. Das kann die Seitenaufrufe in Zukunft stark verzerren. Nutzen Sie "
+"die Zahlen also nur zur groben Orientierung."
+
 #: cms/templates/statistics/statistics_sidebar.html
 msgid "Adjust shown data"
 msgstr "Angezeigte Daten anpassen"

--- a/integreat_cms/release_notes/current/unreleased/4342.yml
+++ b/integreat_cms/release_notes/current/unreleased/4342.yml
@@ -1,0 +1,2 @@
+en: Add a note to the statistics page that access numbers are increasingly influenced by AI-powered search results
+de: Füge der Statistik-Seite einen Hinweis hinzu, dass Zugriffszahlen zunehmend durch KI-gestützte Suchergebnisse beeinflusst werden


### PR DESCRIPTION
### Short description
Adds a static informational banner to the statistics page explaining that access numbers are increasingly influenced by AI-powered search results and should be read as a supplementary signal.

### Proposed changes

- Add an info banner above the charts in `statistics/statistics_overview.html`, using the existing info-box style of the CMS (blue background, left accent border, cf. `messages.html`)
- Add the German translation of the banner text

### Side effects

- None — the banner is purely informational, not dismissible, and does not change any statistics logic

### Faithfulness to issue description and design
There are no intended deviations from the issue and design.

### How to test

1. Log in to a region with statistics enabled (`statistics_enabled`) as a user with `view_statistics` permission
2. Open *Statistics* — the banner appears between the heading and the charts
3. Switch the interface language to German to verify the translated wording

### Resolved issues

Fixes: #4342


__________________________________________________
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)