### PR TITLE
Save original language Frag Integreat response

### DIFF
--- a/integreat_cms/api/v3/chat/utils/chat_bot.py
+++ b/integreat_cms/api/v3/chat/utils/chat_bot.py
@@ -191,7 +191,12 @@ def celery_translate_and_answer_question(
             )
             zammad_chat.save_automatic_answers(answer["automatic_answers"])
             zammad_chat.save_message(
-                message=f"Search term: '{answer['rag_message']}'. Used sources:\n<ul>"
+                message=(
+                    f"Original Response: {answer['original_answer']}\n\n"
+                    if "original_answer" in answer
+                    else ""
+                )
+                + f"Search term: '{answer['rag_message']}'. Used sources:\n<ul>"
                 + "\n".join(
                     [
                         f"<li><a href='{source['source']}'>{source['source'].split('/')[-2]}</a>: {source['reason_inclusion']}</li>"


### PR DESCRIPTION
### Short description
Save the original language Frag Integreat response in the Zammad debug message. This allows Zammad users to read the message in German or English.

### Proposed changes
- Render the original_answer field into the Zammad debug message if the field exists in the response.


### Side effects
None 


### Faithfulness to issue description and design
There are no intended deviations from the issue and design.


### How to test
1. Connect a region Frag Integreat to https://zammad-integreat.tuerantuer.org
2. Add a UserChat Item to the database with the Django shell
3. Start a celery_translate_and_answer_questions task and wait for the response

Alternatively, generate a chat response object with curl:
```
curl -s -X POST https://igchat-inference.tuerantuer.org/chatanswers/extract_answer/ -d'{"message":"Wo kann ich Deutsch lernen?","language":"fr","region":"muenchen"}' -H 'Content-Type: application/json'
```

Then run the code snippet with the response:
```
answer = "JSON"
zammad_chat = UserChat.objects.get(zammad_id=zammad_ticket_id, region=region)
zammad_chat.save_message(
    message=f"Search term: '{answer['rag_message']}'. Used sources:\n<ul>"
    message=(
        f"Original Response: {answer['original_answer']}\n\n"
        if "original_answer" in answer
        else ""
    )
    + f"Search term: '{answer['rag_message']}'. Used sources:\n<ul>"
    + "\n".join(
        [
            f"<li><a href='{source['source']}'>{source['source'].split('/')[-2]}</a>: {source['reason_inclusion']}</li>"
            for source in answer["details"]
        ]
    )
    + "</ul>",
    internal=True,
    automatic_message=True,
)
  ```

### Resolved issues
Fixes: https://github.com/digitalfabrik/integreat-chat/issues/451


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
