### PR TITLE
Remove obsolete code path

### DIFF
--- a/integreat_cms/cms/views/events/event_form_view.py
+++ b/integreat_cms/cms/views/events/event_form_view.py
@@ -413,14 +413,6 @@ class EventFormView(
                 language__in=languages,
             ).update(status=status.DRAFT)
 
-        elif (
-            event_translation_form.instance.status == status.PUBLIC
-            and event_translation_form.instance.minor_edit
-        ):
-            event_translation_form.instance.event.translations.filter(
-                language=language,
-            ).update(status=status.PUBLIC)
-
     def is_qualified_for_save(
         self,
         request: HttpRequest,

--- a/integreat_cms/cms/views/pois/poi_form_view.py
+++ b/integreat_cms/cms/views/pois/poi_form_view.py
@@ -446,13 +446,6 @@ class POIFormView(
             poi_translation_form.instance.poi.translations.filter(
                 language__in=languages,
             ).update(status=status.DRAFT)
-        elif (
-            poi_translation_form.instance.status == status.PUBLIC
-            and poi_translation_form.instance.minor_edit
-        ):
-            poi_translation_form.instance.poi.translations.filter(
-                language=language,
-            ).update(status=status.PUBLIC)
 
     def warn_if_coordinates_too_far(
         self, request: HttpRequest, poi_form: POIForm


### PR DESCRIPTION
### Short description
We have some logic in the codebase that is no longer relevant:

> If event/poi translation is updated to public and the “minor edit” checkbox is NOT set, we do not update all previous versions to public.
> But if event/poi translation is updated to public and the “minor edit” checkbox IS set, we update all previous versions to public.

This logic was added in 2022 to fix the bug https://github.com/digitalfabrik/integreat-cms/issues/1788

Since a lot has changed since 2022, this code path is no longer needed. The bug can no longer be reproduced.

### Proposed changes
Remove the update of all previous versions to PUBLIC when a minor edit is published.

### Side effects
I believe there are none.

### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
Check that the original bug is not reproduced: https://github.com/digitalfabrik/integreat-cms/issues/1788


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4317


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
