### PR TITLE
Use HTTPS for default Nominatim API URL

### DIFF
--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -303,7 +303,7 @@ NOMINATIM_API_ENABLED: Final[bool] = bool(
 #: This is used to automatically derive coordinates from addresses.
 NOMINATIM_API_URL: Final[str] = os.environ.get(
     "INTEGREAT_CMS_NOMINATIM_API_URL",
-    "http://nominatim.maps.tuerantuer.org/nominatim/",
+    "https://nominatim.maps.tuerantuer.org/nominatim/",
 )
 
 

--- a/integreat_cms/release_notes/current/unreleased/4359.yml
+++ b/integreat_cms/release_notes/current/unreleased/4359.yml
@@ -1,0 +1,2 @@
+en: Use HTTPS instead of HTTP for the default Nominatim API URL
+de: Verwende HTTPS statt HTTP für die Standard-URL der Nominatim-API


### PR DESCRIPTION
### Short description

The default `NOMINATIM_API_URL` used `http://`, so by default geocoding requests went out over plain HTTP. The server only redirects to HTTPS afterwards (`301`), meaning the request URL (including the queried address) was transmitted in cleartext on the first hop. The endpoint is fully available over TLS (valid Let's Encrypt cert, TLS 1.2/1.3), so this just switches the default scheme to `https://`.

Closes #4359

### Proposed changes

- Change default `NOMINATIM_API_URL` scheme from `http://` to `https://` in `integreat_cms/core/settings.py`

### Side effects

- None expected. Installations overriding the URL via `INTEGREAT_CMS_NOMINATIM_API_URL` are unaffected.

### Testing

```
$ curl -so /dev/null -w '%{http_code}\n' https://nominatim.maps.tuerantuer.org/nominatim/status
200
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)