### PR TITLE
Bugfix: Fix region scope for render_contact_card

### DIFF
--- a/integreat_cms/cms/forms/custom_content_model_form.py
+++ b/integreat_cms/cms/forms/custom_content_model_form.py
@@ -103,7 +103,15 @@ class CustomContentModelForm(CustomModelForm):
         :return: The valid content
         """
         content = self.cleaned_data["content"]
-        return clean_content(content, language_slug=self.instance.language.slug)
+        try:
+            region_id = self.instance.foreign_object.region_id
+        except ObjectDoesNotExist:
+            region_id = None
+        return clean_content(
+            content,
+            language_slug=self.instance.language.slug,
+            region_id=region_id,
+        )
 
     def clean_slug(self) -> str:
         """

--- a/integreat_cms/cms/utils/content_translation_utils.py
+++ b/integreat_cms/cms/utils/content_translation_utils.py
@@ -99,6 +99,7 @@ def update_links_to(
         new_content = clean_content(
             outdated_content_translation.content,
             outdated_content_translation.language.slug,
+            outdated_content_translation.foreign_object.region_id,
         )
         if new_content == outdated_content_translation.content:
             continue

--- a/integreat_cms/cms/utils/content_utils.py
+++ b/integreat_cms/cms/utils/content_utils.py
@@ -20,7 +20,9 @@ logger = logging.getLogger(__name__)
 _xss_cleaner = Cleaner(scripts=True, javascript=True, safe_attrs_only=False)
 
 
-def clean_content(content: str, language_slug: str) -> str:
+def clean_content(
+    content: str, language_slug: str, region_id: int | None = None
+) -> str:
     """
     This is the super function to clean content
 
@@ -40,7 +42,7 @@ def clean_content(content: str, language_slug: str) -> str:
     fix_alt_texts(content)
     fix_notranslate(content)
     hide_anchor_tag_around_image(content)
-    update_contacts(content)
+    update_contacts(content, region_id)
 
     content_str = tostring(content, encoding="unicode", with_tail=False)
     return fix_content_link_encoding(content_str)
@@ -149,7 +151,9 @@ def update_internal_links(link: HtmlElement, language_slug: str) -> None:
 
 
 def render_contact_card(
-    contact_id: int | str | None, wanted_details: Iterable[str]
+    contact_id: int | str | None,
+    wanted_details: Iterable[str],
+    region_id: int | None = None,
 ) -> HtmlElement:
     """
     Produces a rendered html element for the contact.
@@ -162,19 +166,32 @@ def render_contact_card(
     """
     template = loader.get_template("contacts/contact_card.html")
     try:
+        if region_id is None:
+            contact = Contact.objects.get(pk=contact_id)
+        else:
+            contact = Contact.objects.get(pk=contact_id, location__region_id=region_id)
+
         context = {
-            "contact": Contact.objects.get(pk=contact_id),
+            "contact": contact,
             "wanted": wanted_details,
         }
     except Contact.DoesNotExist:
-        logger.warning("Contact with id=%r does not exist!", contact_id)
-        # Provide a "dummy contact"
-        # This is super hacky and barely renders a card,
-        # but makes it obvious to the user that there should be a contact here, but there was an error
+        if region_id is not None and Contact.objects.filter(pk=contact_id).exists():
+            message = _(
+                "This contact belongs to a different region and cannot be displayed."
+            )
+            logger.warning(
+                "Contact with id=%r belongs to a different region",
+                contact_id,
+            )
+        else:
+            message = _("Oops! Error displaying contact data")
+            logger.warning("Contact with id=%r does not exist!", contact_id)
         context = {
             "contact": {
-                "name": _("Oops! Error displaying contact data"),
+                "name": message,
                 "absolute_url": f"/{None}/contact/{contact_id}/",
+                "pk": contact_id,
             },
             "wanted": ["name"],
         }
@@ -191,7 +208,7 @@ def render_contact_card(
         return Element("pre", raw_element)
 
 
-def update_contacts(content: HtmlElement) -> None:
+def update_contacts(content: HtmlElement, region_id: int | None = None) -> None:
     """
     Inject rendered contact html for given ID
 
@@ -210,7 +227,7 @@ def update_contacts(content: HtmlElement) -> None:
             wanted_details = []
 
         contact_card_new = (
-            render_contact_card(contact_id, wanted_details)
+            render_contact_card(contact_id, wanted_details, region_id)
             if any(detail for detail in wanted_details)
             else fromstring("<div><p></p></div>")
         )

--- a/integreat_cms/cms/utils/external_calendar_utils.py
+++ b/integreat_cms/cms/utils/external_calendar_utils.py
@@ -59,6 +59,7 @@ class IcalEventData:
         language_slug: str,
         external_calendar: ExternalCalendar,
         logger: logging.Logger,
+        region_id: int | None = None,
     ) -> Self:
         """
         Reads an ical event and constructs an instance of this class from it
@@ -84,6 +85,7 @@ class IcalEventData:
         content = clean_content(
             content=raw_description.replace("\n", "<br>"),
             language_slug=language_slug,
+            region_id=region_id,
         )
         start = event.decoded("DTSTART")
         end = event.decoded(
@@ -438,10 +440,7 @@ def import_event(
 
     try:
         event_data = IcalEventData.from_ical_event(
-            event,
-            language.slug,
-            calendar,
-            logger,
+            event, language.slug, calendar, logger, calendar.region.id
         )
     except ValueError as e:
         logger.exception("Could not import event: %r due to error", event)

--- a/integreat_cms/core/signals/contact_signals.py
+++ b/integreat_cms/core/signals/contact_signals.py
@@ -33,5 +33,7 @@ def contact_save_handler(instance: Contact, **kwargs: Any) -> None:
         if getattr(referrer.foreign_object, "archived", False):
             continue
         logger.debug("Updating %r, since it references %r.", referrer, instance)
-        referrer.content = clean_content(referrer.content, referrer.language.slug)
+        referrer.content = clean_content(
+            referrer.content, referrer.language.slug, referrer.foreign_object.region_id
+        )
         referrer.save(update_fields=["content"])

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -9420,6 +9420,13 @@ msgstr ""
 "Sprachen erfordert."
 
 #: cms/utils/content_utils.py
+msgid ""
+"This contact belongs to a different region and cannot be displayed."
+msgstr ""
+"Dieser Kontakt gehört zu einer anderen Region und kann nicht angezeigt werden. "
+
+
+#: cms/utils/content_utils.py
 msgid "Oops! Error displaying contact data"
 msgstr "Ups! Fehler beim Anzeigen der Kontaktdaten"
 

--- a/tests/cms/utils/test_content_utils.py
+++ b/tests/cms/utils/test_content_utils.py
@@ -1,7 +1,9 @@
 import pytest
 from django.test.client import Client
+from django.utils import translation
+from lxml.html import tostring
 
-from integreat_cms.cms.utils.content_utils import clean_content
+from integreat_cms.cms.utils.content_utils import clean_content, render_contact_card
 from tests.conftest import EDITOR, MANAGEMENT, PRIV_STAFF_ROLES
 
 
@@ -16,7 +18,7 @@ def test_clean_content(
     login_role_user: tuple[Client, str],
 ) -> None:
     raw_content = '<h1>Das ist eine H1</h1><pre>Das ist vordefinierter Text</pre><code>Das ist vordefinierter Code</code><a href="https://www.integreat-app.de"></a><a href="http://localhost:8000/augsburg/pages/de/5" class="link-external"></a>'
-    cleaned_content = clean_content(raw_content, "de")
+    cleaned_content = clean_content(raw_content, "de", 1)
 
     # Test convert_heading works
     assert "<h1>Das ist eine H1</h1>" not in cleaned_content
@@ -48,3 +50,26 @@ def test_clean_content_strips_script_tag() -> None:
 def test_clean_content_strips_event_handler() -> None:
     result = clean_content("<p><a onclick='alert(1)'>click me</a></p>", "de")
     assert "onclick" not in result
+
+
+@pytest.mark.django_db
+def test_render_contact_card_same_region(load_test_data: None) -> None:
+    """
+    Test that render_contact_card renders the contact card when region matches
+    """
+    # Contact 3 belongs to region 1 (augsburg)
+    result = tostring(render_contact_card(3, ["name"], region_id=1), encoding="unicode")
+    assert "Mariana Musterfrau" in result
+
+
+@pytest.mark.django_db
+def test_render_contact_card_cross_region(load_test_data: None) -> None:
+    """
+    Test that render_contact_card returns None when the contact belongs to a different region
+    """
+    # Contact 3 belongs to region 1 (augsburg), not region 8 (berlin)
+    message = "This contact belongs to a different region and cannot be displayed."
+    with translation.override("en"):
+        assert message in tostring(
+            render_contact_card(3, ["name"], region_id=8)
+        ).decode("utf-8")

--- a/tests/cms/utils/test_external_calendar_utils.py
+++ b/tests/cms/utils/test_external_calendar_utils.py
@@ -50,7 +50,7 @@ def test_import_fails(calendar_data: tuple[str, str]) -> None:
 
     for event in ical.walk("VEVENT"):
         with pytest.raises(ValueError, match=error_msg):
-            data = IcalEventData.from_ical_event(event, "de", mock_calendar, logger)
+            data = IcalEventData.from_ical_event(event, "de", mock_calendar, logger, 1)
             print(data)
 
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This fixes the security issue (IDOR) bug that it is possible for an editor from Region A to include contact cards from Region B into their pages.


### Proposed changes
<!-- Describe this PR in more detail. -->

- region scope the function `render_contact_card`
- tests


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
- follow the steps for reproduction on the original bug issue

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4370


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
