### PR TITLE
Add an endpoint for single news post

### DIFF
--- a/docs/src/api-docs.rst
+++ b/docs/src/api-docs.rst
@@ -705,6 +705,78 @@ RESPONSE
    }
 
 
+News
+====
+
+Get all news posts from all available sources
+
+REQUEST
+~~~~~~~
+
+.. code:: http
+
+   GET /api/v3/{region_slug}/{language_slug}/news/ HTTP/2
+
+Response
+~~~~~~~~
+
+.. code:: javascript
+
+   [
+      {
+         "id": String,                          // The id of the news
+         "title": String,                       // The title of the news
+         "content": String,                     // The content of the news
+         "last_updated": String,                // Date of last update
+         "display_date": String,                // Date of publication or last update, of which later
+         "channel": String | null,              // The channel of the push notification, null for external news
+         "available_languages": [               // The available languages of the push notification
+               "<language_slug>": {
+                  "id": String | null,          // The id of the translation
+               },
+               ...
+            ],
+         "source": String,                      // The source of the news ('local', 'tuNews' or 'amalNews')
+         "externalUrl": String,                 // The link to the news
+      }
+   ]
+
+
+Single News
+===========
+
+Get a single news
+
+REQUEST
+~~~~~~~
+
+.. code:: http
+
+   GET /api/v3/{region_slug}/{language_slug}/news/{news_id}/ HTTP/2
+
+Response
+~~~~~~~~
+
+.. code:: javascript
+
+   {
+      "id": String,                          // The id of the news
+      "title": String,                       // The title of the news
+      "content": String,                     // The content of the news
+      "last_updated": String,                // Date of last update
+      "display_date": String,                // Date of publication or last update, of which later
+      "channel": String | null,              // The channel of the push notification, null for external news
+      "available_languages": [           // The available languages of the push notification
+            "<language_slug>": {
+               "id": String | null,           // The id of the translation
+            },
+            ...
+         ],
+      "source": String,                      // The source of the news ('local', 'tuNews' or 'amalNews')
+      "externalUrl": String,                 // The link to the news
+   }
+
+
 Imprint / Disclaimer
 ====================
 

--- a/integreat_cms/api/urls.py
+++ b/integreat_cms/api/urls.py
@@ -28,7 +28,7 @@ from .v3.imprint import imprint
 from .v3.languages import languages
 from .v3.location_categories import location_categories
 from .v3.locations import locations
-from .v3.news import news, sent_push_notifications
+from .v3.news import news, sent_push_notifications, single_news
 from .v3.offers import offers
 from .v3.pages import (
     children,
@@ -76,6 +76,7 @@ content_api_urlpatterns: list[URLPattern] = [
         news,
         name="news",
     ),
+    path("news/<slug:news_id>/", single_news, name="single_news"),
     path("imprint/", imprint, name="imprint"),
     path("disclaimer/", imprint, name="imprint"),
     path("offers/", offers, name="offers"),
@@ -209,7 +210,7 @@ social_media_api_urlpatterns = [
                     name="social_region_event_page",
                 ),
                 path(
-                    "news/<slug:news_type>/<slug:slug>/",
+                    "news/<slug:news_type>/<slug:news_raw_id>/",
                     news_social_media_headers,
                     name="social_region_local_news_page",
                 ),

--- a/integreat_cms/api/v3/news.py
+++ b/integreat_cms/api/v3/news.py
@@ -9,7 +9,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from django.core.paginator import Paginator
-from django.http import JsonResponse
+from django.http import Http404, JsonResponse
 
 from integreat_cms.cms.views.mixins import get_safe_page
 
@@ -37,7 +37,9 @@ def sent_push_notifications(
     :return: JSON object according to APIv3 push notifications definition
     """
     channel = request.GET.get("channel", "all")
-    result = registry.PUSHNEWS.collect_news_items(region_slug, language_slug, channel)
+    result = registry.PUSHNEWS.collect_news_items_for_fcm(
+        region_slug, language_slug, channel
+    )
     return JsonResponse(result, safe=False)
 
 
@@ -82,3 +84,42 @@ def news(
     page = get_safe_page(paginator, page_num)
 
     return JsonResponse(list(page.object_list), safe=False)
+
+
+@json_response
+def single_news(
+    request: HttpRequest,
+    region_slug: str,
+    language_slug: str,
+    news_id: str,
+) -> JsonResponse:
+    """
+    Function to collect and return an news item which matched the given news id.
+
+    :param request: Django request
+    :param region_slug: slug of a region
+    :param language_slug: language slug
+    :param news_id: id of the requested news item
+    :return: JSON single NewsItem
+    """
+    region = request.region
+    language = region.get_language_or_404(language_slug, only_active=True)
+
+    parts = news_id.rsplit("-", 1)
+    if len(parts) != 2 or not parts[1].isdigit():
+        raise Http404("Invalid news id.")
+    news_type, raw_id = parts
+
+    news_manager = next(
+        (
+            news_manager
+            for news_manager in registry.CHOICES
+            if news_manager.name == news_type
+        ),
+        None,
+    )
+
+    if not news_manager:
+        raise Http404("No matching news source was found.")
+
+    return news_manager.get_single_news(request, region, language, raw_id)

--- a/integreat_cms/api/v3/social_media_headers.py
+++ b/integreat_cms/api/v3/social_media_headers.py
@@ -247,8 +247,8 @@ def news_social_media_headers(
     request: HttpRequest,
     region_slug: str,
     language_slug: str,
-    slug: str,
     news_type: str,
+    news_raw_id: str,
 ) -> HttpResponse:
     """
     Tries rendering the social media headers for a news page in a specified region and language.
@@ -270,7 +270,7 @@ def news_social_media_headers(
     if not news_manager:
         raise Http404("Invalid news type is given.")
 
-    return news_manager.social_media_headers(request, region, language, slug)
+    return news_manager.social_media_headers(request, region, language, news_raw_id)
 
 
 @partial_html_response

--- a/integreat_cms/news_managers/abstract_news_manager.py
+++ b/integreat_cms/news_managers/abstract_news_manager.py
@@ -6,22 +6,21 @@ from typing import TYPE_CHECKING, TypedDict
 if TYPE_CHECKING:
     from datetime import datetime
 
-    from django.http import HttpRequest, HttpResponse
+    from django.http import HttpRequest, HttpResponse, JsonResponse
 
     from ..cms.models import Language, Region
 
 
 class NewsItem(TypedDict):
-    id: int
+    id: str
     title: str
-    message: str
-    timestamp: datetime
+    content: str
     last_updated: datetime
     display_date: datetime
     channel: str | None
     available_languages: dict | None
     source: str
-    link: str | None
+    externalUrl: str
 
 
 class AbstractNewsManager(ABC):
@@ -53,10 +52,23 @@ class AbstractNewsManager(ABC):
         request: HttpRequest,
         region: Region,
         language: Language,
-        slug: str,
+        news_raw_id: str,
     ) -> HttpResponse:
         """
         Tries rendering the social media headers for a news page in a specified region and language
         To be implemented in the inheriting model
+        """
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_single_news(
+        self,
+        request: HttpRequest,
+        region: Region,
+        language: Language,
+        news_id: str,
+    ) -> JsonResponse:
+        """
+        Returns a news item that is imported from the source and matches the id
         """
         raise NotImplementedError

--- a/integreat_cms/news_managers/pushnews_manager.py
+++ b/integreat_cms/news_managers/pushnews_manager.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 from django.conf import settings
 from django.db.models import F
 from django.db.models.functions import Greatest
-from django.http import Http404
+from django.http import Http404, JsonResponse
 from django.utils import timezone
 
 from ..cms.models import PushNotificationTranslation
@@ -17,35 +17,12 @@ from ..cms.utils.social_media_utils import (
 from .abstract_news_manager import AbstractNewsManager, NewsItem
 
 if TYPE_CHECKING:
+    from typing import Any
+
     from django.db.models.query import QuerySet
     from django.http import HttpRequest, HttpResponse
 
     from ..cms.models import Language, Region
-
-
-def _transform_notification(pnt: PushNotificationTranslation) -> NewsItem:
-    """
-    Function to create a JSON from a single push notification translation Object.
-
-    :param pnt: A push notification translation
-    :return: data necessary for API
-    """
-    available_languages_dict = {
-        translation.language.slug: {"id": translation.id}
-        for translation in pnt.push_notification.translations.all()
-    }
-    return {
-        "id": pnt.pk,
-        "title": pnt.get_title(),
-        "message": pnt.get_text(),
-        "timestamp": pnt.last_updated,  # deprecated field in the future
-        "last_updated": timezone.localtime(pnt.last_updated),
-        "display_date": pnt.display_date,
-        "channel": pnt.push_notification.channel,
-        "available_languages": available_languages_dict,
-        "source": "local",
-        "link": None,
-    }
 
 
 def _query_sent_translations(
@@ -86,17 +63,17 @@ class PushnewsManager(AbstractNewsManager):
         self, region_slug: str, language_slug: str, channel: str
     ) -> list[NewsItem]:
         """
-        Returns push notification news
+        Returns push notification news for common news endpoint
         """
         query_result = _query_sent_translations(region_slug, language_slug, channel)
-        return list(map(_transform_notification, query_result))
+        return list(map(self.transform_notification, query_result))
 
     def social_media_headers(
         self,
         request: HttpRequest,
         region: Region,
         language: Language,
-        slug: str,
+        news_raw_id: str,
     ) -> HttpResponse:
         """
         Tries rendering the social media headers for a news page in a specified region and language
@@ -104,7 +81,7 @@ class PushnewsManager(AbstractNewsManager):
         if not (
             pn_translation := PushNotificationTranslation.objects.filter(
                 language__slug=language.slug,
-                push_notification__id=slug,
+                push_notification__id=news_raw_id,
                 push_notification__regions=region,
             ).first()
         ):
@@ -119,3 +96,95 @@ class PushnewsManager(AbstractNewsManager):
             excerpt=get_excerpt(pn_translation.get_text()),
             url=f"{settings.WEBAPP_URL}{pn_translation.get_absolute_url()}",
         )
+
+    def get_single_news(
+        self,
+        request: HttpRequest,
+        region: Region,
+        language: Language,
+        news_id: str,
+    ) -> JsonResponse:
+        """
+        Returns a push notification that matches the id
+        """
+        if not (
+            pn_translation := PushNotificationTranslation.objects.filter(
+                language__slug=language.slug,
+                id=news_id,
+                push_notification__regions=region,
+            )
+            .filter(push_notification__archived=False)
+            .filter(
+                push_notification__sent_date__gte=timezone.now()
+                - timezone.timedelta(days=settings.FCM_HISTORY_DAYS),
+            )
+            .annotate(
+                display_date=Greatest(
+                    F("last_updated"), F("push_notification__sent_date")
+                )
+            )
+            .first()
+        ):
+            raise Http404(
+                "Push Notification not found in this region with this language."
+            )
+
+        return JsonResponse(self.transform_notification(pn_translation), safe=False)
+
+    def collect_news_items_for_fcm(
+        self, region_slug: str, language_slug: str, channel: str
+    ) -> list[dict[str, Any]]:
+        """
+        Returns push notification news for `fcm` endpoint
+        """
+        query_result = _query_sent_translations(region_slug, language_slug, channel)
+        return list(map(self.transform_notification_for_fcm, query_result))
+
+    def transform_notification(self, pnt: PushNotificationTranslation) -> NewsItem:
+        """
+        Function to create a JSON from a single push notification translation Object.
+
+        :param pnt: A push notification translation
+        :return: data necessary for API
+        """
+        available_languages_dict = {
+            translation.language.slug: {"id": f"{self.name}-{translation.id}"}
+            for translation in pnt.push_notification.translations.all()
+        }
+        return {
+            "id": f"{self.name}-{pnt.pk!s}",
+            "title": pnt.get_title(),
+            "content": pnt.get_text(),
+            "last_updated": timezone.localtime(pnt.last_updated),
+            "display_date": pnt.display_date,
+            "channel": pnt.push_notification.channel,
+            "available_languages": available_languages_dict,
+            "source": "local",
+            "externalUrl": f"{settings.WEBAPP_URL}{pnt.get_absolute_url()}",
+        }
+
+    def transform_notification_for_fcm(
+        self, pnt: PushNotificationTranslation
+    ) -> dict[str, Any]:
+        """
+        Function to create a JSON from a single push notification translation Object for `fcm` endpoint
+
+        The endpoint `fcm/` requires timestamp and id in int.
+
+        :param pnt: A push notification translation
+        :return: data necessary for API
+        """
+        available_languages_dict = {
+            translation.language.slug: {"id": translation.id}
+            for translation in pnt.push_notification.translations.all()
+        }
+        return {
+            "id": pnt.pk,
+            "title": pnt.get_title(),
+            "message": pnt.get_text(),
+            "timestamp": pnt.last_updated,  # deprecated field in the future
+            "last_updated": timezone.localtime(pnt.last_updated),
+            "display_date": pnt.display_date,
+            "channel": pnt.push_notification.channel,
+            "available_languages": available_languages_dict,
+        }

--- a/integreat_cms/news_managers/tunews_manager.py
+++ b/integreat_cms/news_managers/tunews_manager.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, TypedDict
 
 import requests
 from django.core.cache import cache
-from django.http import Http404
+from django.http import Http404, JsonResponse
 from lxml import etree
 
 from ..cms.models import Language, Region
@@ -57,25 +57,6 @@ def clean_html(html_string: str) -> str:
     return etree.tostring(main, pretty_print=True).decode("utf-8")
 
 
-def _transform_post(post: _TunewsPost) -> NewsItem:
-    """
-    Transforms a post of Tü News so it can be used by the news endpoint directly
-    """
-    date = datetime.fromisoformat(post["date"] + "+00:00")
-    return {
-        "id": post["id"],
-        "title": post["title"]["rendered"],
-        "message": clean_html(post["content"]["rendered"]),
-        "timestamp": date,  # deprecated field in the future
-        "last_updated": date,
-        "display_date": date,
-        "channel": None,
-        "available_languages": None,
-        "source": "tuNews",
-        "link": post["link"],
-    }
-
-
 class TunewsManager(AbstractNewsManager):
     name = "tuNews"
 
@@ -111,7 +92,7 @@ class TunewsManager(AbstractNewsManager):
                     try:
                         if not post["acf"]["integreat"]:
                             continue
-                        news.append(_transform_post(post))
+                        news.append(self.transform_post(post))
                     except (KeyError, TypeError, ValueError):
                         logger.exception(
                             "Malformed Tü News post (id=%s); skipped.",
@@ -147,22 +128,67 @@ class TunewsManager(AbstractNewsManager):
         request: HttpRequest,
         region: Region,
         language: Language,
-        slug: str,
+        news_raw_id: str,
     ) -> HttpResponse:
         """
         Tries rendering the social media headers for a news page in a specified region and language
         """
-        if not region.external_news_enabled:
-            raise Http404("External news are not enabled in this region.")
-        posts = cache.get(f"tunews:{language.slug}", [])
-        post = next((post for post in posts if str(post["id"]) == slug), None)
-        if not post:
-            raise Http404("Tü news post not found in this region with this news ID.")
+        post = self.find_post(region, language, news_raw_id)
 
         return render_social_media_headers(
             request=request,
             title=post["title"],
             language_code=language.bcp47_tag,
-            excerpt=post["message"],
-            url=post["link"],
+            excerpt=post["content"],
+            url=post["externalUrl"],
         )
+
+    def get_single_news(
+        self,
+        request: HttpRequest,
+        region: Region,
+        language: Language,
+        news_id: str,
+    ) -> JsonResponse:
+        """
+        Returns a Tü News post that matches the id
+        """
+        post = self.find_post(region, language, news_id)
+        return JsonResponse(post, safe=False)
+
+    def find_post(
+        self,
+        region: Region,
+        language: Language,
+        news_raw_id: str,
+    ) -> NewsItem:
+        """
+        Find and return a news item which matches the given ID
+        """
+        if not region.external_news_enabled:
+            raise Http404("External news are not enabled in this region.")
+        posts = cache.get(f"tunews:{language.slug}", [])
+        post = next(
+            (post for post in posts if post["id"] == f"{self.name}-{news_raw_id}"), None
+        )
+
+        if not post:
+            raise Http404("Tü news post not found in this region with this news ID.")
+        return post
+
+    def transform_post(self, post: _TunewsPost) -> NewsItem:
+        """
+        Transforms a post of Tü News so it can be used by the news endpoint directly
+        """
+        date = datetime.fromisoformat(post["date"] + "+00:00")
+        return {
+            "id": f"{self.name}-{post['id']!s}",
+            "title": post["title"]["rendered"],
+            "content": clean_html(post["content"]["rendered"]),
+            "last_updated": date,
+            "display_date": date,
+            "channel": None,
+            "available_languages": None,
+            "source": "tuNews",
+            "externalUrl": post["link"],
+        }

--- a/tests/api/test_news_endpoint.py
+++ b/tests/api/test_news_endpoint.py
@@ -68,28 +68,31 @@ def test_news_endpoint(load_test_data: None, clean_news_cache: None) -> None:
     tunews_time = now + timedelta(hours=2)
     pn_low_time = now + timedelta(hours=1)
 
-    tunews_id = 42
+    tunews_id = "tuNews-42"
     cache.set(
         f"tunews:{language_slug}",
         [
             {
                 "id": tunews_id,
                 "title": "Tü News Post",
-                "message": "Tü News",
-                "timestamp": tunews_time,
+                "content": "Tü News",
                 "last_updated": tunews_time,
                 "display_date": tunews_time,
                 "channel": None,
                 "available_languages": None,
                 "source": "tuNews",
-                "link": "https://dummy.com",
+                "externalUrl": "https://dummy.com",
             }
         ],
         timeout=None,
     )
 
-    pn_high_id = _create_push_notification(region_slug, language_slug, pn_high_time)
-    pn_low_id = _create_push_notification(region_slug, language_slug, pn_low_time)
+    pn_high_id = (
+        f"local-{_create_push_notification(region_slug, language_slug, pn_high_time)}"
+    )
+    pn_low_id = (
+        f"local-{_create_push_notification(region_slug, language_slug, pn_low_time)}"
+    )
 
     result = client.get(url).json()
     top_ids = [item["id"] for item in result[:3]]
@@ -119,9 +122,7 @@ def test_news_endpoint_pagination(load_test_data: None, clean_news_cache: None) 
     now = datetime.now(tz=UTC)
     # Create 3 push notifications with descending timestamps
     ids = [
-        _create_push_notification(
-            region_slug, language_slug, now + timedelta(hours=3 - i)
-        )
+        f"local-{_create_push_notification(region_slug, language_slug, now + timedelta(hours=3 - i))}"
         for i in range(3)
     ]
 
@@ -168,26 +169,25 @@ def test_news_endpoint_source_filter(
     client = Client()
 
     now = datetime.now(tz=UTC)
-    tunews_id = 99
+    tunews_id = "tuNews-99"
     cache.set(
         f"tunews:{language_slug}",
         [
             {
                 "id": tunews_id,
                 "title": "Tü News Post",
-                "message": "Tü News",
-                "timestamp": now,
+                "content": "Tü News",
                 "last_updated": now,
                 "display_date": now,
                 "channel": None,
                 "available_languages": None,
                 "source": "tuNews",
-                "link": "https://dummy.com",
+                "externalUrl": "https://dummy.com",
             }
         ],
         timeout=None,
     )
-    pn_id = _create_push_notification(region_slug, language_slug, now)
+    pn_id = f"local-{_create_push_notification(region_slug, language_slug, now)}"
 
     # Filter by local — only push notifications
     local_result = client.get(url, {"source": "local"}).json()
@@ -206,3 +206,103 @@ def test_news_endpoint_source_filter(
     assert {item["source"] for item in both_result} == {"local", "tuNews"}
     assert any(item["id"] == pn_id for item in both_result)
     assert any(item["id"] == tunews_id for item in both_result)
+
+
+@pytest.mark.django_db
+def test_single_news_endpoint(load_test_data: None, clean_news_cache: None) -> None:
+    """
+    The single news endpoint returns one news that matches the given id.
+
+    :param load_test_data: The fixture providing the test data (see :meth:`~tests.conftest.load_test_data`)
+    :param clean_news_cache: Fixture that wipes external news-source cache entries
+    """
+    region_slug = "augsburg"
+    language_slug = "de"
+
+    client = Client()
+
+    now = datetime.now(tz=UTC)
+
+    tunews_id_1 = "tuNews-1"
+    tunews_id_2 = "tuNews-2"
+    tunews_id_non_existing = "tuNews-42"
+    cache.set(
+        f"tunews:{language_slug}",
+        [
+            {
+                "id": tunews_id_1,
+                "title": "Tü News Post",
+                "content": "Tü News",
+                "last_updated": now,
+                "display_date": now,
+                "channel": None,
+                "available_languages": None,
+                "source": "tuNews",
+                "externalUrl": "https://dummy.com",
+            },
+            {
+                "id": tunews_id_2,
+                "title": "Tü News Post",
+                "content": "Tü News",
+                "last_updated": now,
+                "display_date": now,
+                "channel": None,
+                "available_languages": None,
+                "source": "tuNews",
+                "externalUrl": "https://dummy.com",
+            },
+        ],
+        timeout=None,
+    )
+
+    pn_id_1 = f"local-{_create_push_notification(region_slug, language_slug, now)}"
+    _create_push_notification(region_slug, language_slug, now)
+    pn_id_non_existing = "local-0"
+
+    url = reverse(
+        "api:single_news",
+        kwargs={
+            "region_slug": region_slug,
+            "language_slug": language_slug,
+            "news_id": tunews_id_1,
+        },
+    )
+    tunews_result = client.get(url).json()
+    assert tunews_result["id"] == tunews_id_1
+
+    url = reverse(
+        "api:single_news",
+        kwargs={
+            "region_slug": region_slug,
+            "language_slug": language_slug,
+            "news_id": pn_id_1,
+        },
+    )
+    local_result = client.get(url).json()
+    assert local_result["id"] == pn_id_1
+
+    url = reverse(
+        "api:single_news",
+        kwargs={
+            "region_slug": region_slug,
+            "language_slug": language_slug,
+            "news_id": tunews_id_non_existing,
+        },
+    )
+    tunews_result_non_existing = client.get(url).json()
+    assert tunews_result_non_existing == {
+        "error": "Tü news post not found in this region with this news ID."
+    }
+
+    url = reverse(
+        "api:single_news",
+        kwargs={
+            "region_slug": region_slug,
+            "language_slug": language_slug,
+            "news_id": pn_id_non_existing,
+        },
+    )
+    local_result_non_existing = client.get(url).json()
+    assert local_result_non_existing == {
+        "error": "Push Notification not found in this region with this language."
+    }

--- a/tests/news_managers/test_tunews_manager.py
+++ b/tests/news_managers/test_tunews_manager.py
@@ -47,16 +47,15 @@ valid_news = {
 }
 expected_result = [
     {
-        "id": 4,
+        "id": "tuNews-4",
         "title": "Gültige Nachricht",
-        "message": "<main>Eine interessante Tatsache</main>\n",
-        "timestamp": datetime(2026, 4, 29, 16, 58, 38, tzinfo=UTC),
+        "content": "<main>Eine interessante Tatsache</main>\n",
         "last_updated": datetime(2026, 4, 29, 16, 58, 38, tzinfo=UTC),
         "display_date": datetime(2026, 4, 29, 16, 58, 38, tzinfo=UTC),
         "channel": None,
         "available_languages": None,
         "source": "tuNews",
-        "link": "https://tuenews.de/news-post-4/",
+        "externalUrl": "https://tuenews.de/news-post-4/",
     }
 ]
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR makes `id` of news items unique and adds a new entpoint which return a single news object.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add a prefix `tuNews-` for news posts from Tü News at import (`name` of each news manager as prefix)
- Return push news with prefix `local-`
- Add a new entpoint `news/<news_id>` which return exact one news item that matches the id 
- Add a test for the new endpoint
- Update API documentation

**updates**
- Two separate transform functions `transform_notification_for_fcm` and `transform_notification` not to break the existing `fcm/` endpoint

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
@steffenkleinle 
- Is it okay to add a prefix `local-` to push news? Does it break anything on the app?
The common endpoint `news` will return push news with `"id": "local-123"` instead of `"id": 123` and `news/<news_id>/` endpoit is expected to ask for a push news like `news/local-123/`

I splitted unique id and the endpoint into two separate issues but noticed it makes sense to implement both together to check it actually works 😅 


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
- Run the command `import_external_news` to see prefix `tuNews-` is added
- Hit the new endpoint `news/<news_id>` to see the correct news item is returned

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4339 
Fixes: #4340 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
