### PR TITLE
Improve Frag Integreat message processing

### DIFF
--- a/integreat_cms/api/v3/chat/user_chat.py
+++ b/integreat_cms/api/v3/chat/user_chat.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 import requests
 from django.conf import settings
+from django.core.cache import cache
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404
 from django.utils.dateparse import parse_datetime
@@ -102,9 +103,9 @@ def process_chat_payload(
         )
         user_chat.language = language
         user_chat.save()
-        user_chat.processing_answer = True  # type: ignore[assignment]
         if response is not None:
             if user_chat.automatic_answers:
+                user_chat.processing_answer = True  # type: ignore[assignment]
                 celery_translate_and_answer_question.apply_async(
                     args=[
                         parse_datetime(response["updated_at"]),
@@ -186,15 +187,37 @@ def is_app_user_message(webhook_message: dict) -> bool:
 @json_response
 def zammad_webhook(request: HttpRequest) -> JsonResponse:
     """
-    Receive webhooks from Zammad to update the latest article translation
+    Receive webhooks from Zammad to update the latest article translation.
+
+    Optional feature: if a Zammad has an object attribute "device_id" for tickets,
+    we can use this to directly fetch the corresponding chat from our database.
+    This allows multiple regions to use the same Zammad server. As not all Zammad
+    servers have this configured, we still need to support the old method were we
+    fetch the UserChat object identified by the region token and Zammad ticket id.
     """
-    region = get_object_or_404(
+    token_region = get_object_or_404(
         Region,
         zammad_webhook_token=request.GET.get("token", None),
     )
+    webhook_message = json.loads(request.body)
+
+    if (
+        "device_id" in webhook_message["ticket"]
+        and webhook_message["ticket"]["device_id"]
+    ):
+        zammad_chat = get_object_or_404(
+            UserChat, device_id=webhook_message["ticket"]["device_id"]
+        )
+    else:  # legacy support
+        zammad_chat = get_object_or_404(
+            UserChat, zammad_id=webhook_message["ticket"]["id"], region=token_region
+        )
+
+    region = zammad_chat.region
+
     if not region.integreat_chat_enabled:
         return JsonResponse({"status": "Integreat Chat disabled"})
-    webhook_message = json.loads(request.body)
+
     message_text = webhook_message["article"]["body"]
 
     actions = []
@@ -213,7 +236,8 @@ def zammad_webhook(request: HttpRequest) -> JsonResponse:
     elif is_app_user_message(webhook_message):
         actions.append("question translation and answering already tasked")
     else:
-        actions.append("answer translation queued")
+        actions.append("human answer translation queued")
+        cache.delete(f"{zammad_chat.region.slug}_{zammad_chat.device_id}")
         celery_translate_answer.apply_async(
             args=[message_text, region.slug, webhook_message["ticket"]["id"]],
         )

--- a/integreat_cms/cms/utils/zammad.py
+++ b/integreat_cms/cms/utils/zammad.py
@@ -262,15 +262,10 @@ class ZammadAPI:
 
         :return: generate automatic answers or not
         """
-        cache_key = f"chat_automatic_anwers_{self.device_id}"
-        response = cache.get(cache_key)
-        if response is None:
-            response = self.zammad_request(
-                "GET",
-                f"/api/v1/tickets/{self.zammad_id}",
-            ).json()["automatic_answers"]
-            cache.set(cache_key, response, 120)
-        return response
+        return self.zammad_request(
+            "GET",
+            f"/api/v1/tickets/{self.zammad_id}",
+        ).json()["automatic_answers"]
 
     def save_automatic_answers(self, value: bool) -> bool:
         """
@@ -279,7 +274,6 @@ class ZammadAPI:
         :param value: True if user agrees, false if not
         :return: success
         """
-        cache.delete(f"chat_automatic_anwers_{self.device_id}")
         try:
             response = self.zammad_request(
                 "PUT",
@@ -297,14 +291,17 @@ class ZammadAPI:
         :param title: Ticket title
         :return: Zammad ticket ID
         """
+        payload = {
+            "title": title,
+            "group": settings.INTEGREAT_CHAT_TICKET_GROUP,
+            "customer": self.get_zammad_user_mail(),
+        }
+        if settings.MULTI_REGION_ZAMMAD:
+            payload["device_id"] = self.device_id
         return self.zammad_request(
             "POST",
             "/api/v1/tickets",
-            {
-                "title": title,
-                "group": settings.INTEGREAT_CHAT_TICKET_GROUP,
-                "customer": self.get_zammad_user_mail(),
-            },
+            payload,
         ).json()["id"]
 
     @property

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -1460,6 +1460,13 @@ INTEGREAT_CHAT_CMS_USER_MAIL = os.environ.get(
     "tech+integreat-cms@tuerantuer.org",
 )
 
+#: Whether a single Zammad instance is shared by multiple regions. If enabled,
+#: the ``device_id`` attribute is set on Zammad tickets so that incoming webhooks
+#: can be mapped to the correct chat regardless of the region.
+MULTI_REGION_ZAMMAD: Final[bool] = bool(
+    strtobool(os.environ.get("INTEGREAT_CMS_MULTI_REGION_ZAMMAD", "False")),
+)
+
 ##########
 # CELERY #
 ##########


### PR DESCRIPTION
### Short description
Improve Frag Integreat message processing by removing unnecessary cache and flushing cache in case of human responses. This also adds support for a single Zammad that can be used across all regions of the CMS.

### Proposed changes

* The automatic chat answers attribute was cached and therefore changing the value in Zammad did not immediately take effect. As it is only accessed when a user posts a message, we can directly read it from Zammad and avoid any Cache problems.
* The generating answer flag should only be true if we actually generate and answer.
* Add support for single Zammad for all regions by supporting a device_id attribute in Zammad tickets.
* Set the device_id attribute when multi region Zammad setting is true.
* Flush message cache when a new human message webhook triggers

### Side effects
- There should be none. The removed cache is negligible.

### Faithfulness to issue description and design
There are no intended deviations from the issue and design.


### How to test
Due to the difficulty of setting up the full stack, I would recommend to temporarily replace the files on the test server:
```
cd /opt/integreat-cms
cp ./.venv/lib/python3.13/site-packages/integreat_cms/api/v3/chat/user_chat.py ./.venv/lib/python3.13/site-packages/integreat_cms/api/v3/chat/user_chat.py.bak
cp ./.venv/lib/python3.13/site-packages/integreat_cms/cms/utils/zammad.py ./.venv/lib/python3.13/site-packages/integreat_cms/cms/utils/zammad.py.bak
wget https://github.com/digitalfabrik/integreat-cms/blob/fix/chat-cache-issues/integreat_cms/cms/utils/zammad.py -O ./.venv/lib/python3.13/site-packages/integreat_cms/cms/utils/zammad.py
wget https://github.com/digitalfabrik/integreat-cms/blob/fix/chat-cache-issues/integreat_cms/api/v3/chat/user_chat.py -O ./.venv/lib/python3.13/site-packages/integreat_cms/api/v3/chat/user_chat.py
systemctl restart apache2.service
```

Test chat on https://beta.integreat.app/testumgebung/de, then undo changes:

```
mv ./.venv/lib/python3.13/site-packages/integreat_cms/api/v3/chat/user_chat.py.bak ./.venv/lib/python3.13/site-packages/integreat_cms/api/v3/chat/user_chat.py
cp ./.venv/lib/python3.13/site-packages/integreat_cms/cms/utils/zammad.py.bak ./.venv/lib/python3.13/site-packages/integreat_cms/cms/utils/zammad.py
systemctl restart apache2.service
```


### Resolved issues
Fixes: https://github.com/digitalfabrik/integreat-chat/issues/480
Fixes: reported problem were changed "automatic_answers" does not take effect immediately


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
