### PR TITLE
Bugfix: Update translation state to up to date when an outdated translation is published without changes

### DIFF
--- a/integreat_cms/cms/models/abstract_content_translation.py
+++ b/integreat_cms/cms/models/abstract_content_translation.py
@@ -393,6 +393,15 @@ class AbstractContentTranslation(AbstractBaseModel):
         return self.foreign_object.get_translation(self.language.slug)
 
     @cached_property
+    def latest_public_or_draft_version(self) -> AbstractContentTranslation | None:
+        """
+        This property is a link to the most recent public or draft version of this translation.
+
+        :return: The latest public or draft revision of the translation
+        """
+        return self.foreign_object.get_public_or_draft_translation(self.language.slug)
+
+    @cached_property
     def public_version(self) -> AbstractContentTranslation | None:
         """
         This property is a link to the most recent public version of this translation.
@@ -488,7 +497,11 @@ class AbstractContentTranslation(AbstractBaseModel):
             # If the source translation is already outdated, this translation is as well
             or source_translation.translation_state == translation_status.OUTDATED
             # If the translation was edited before the last major change in the source language, it is outdated
-            or translation.last_updated <= source_translation.last_updated
+            or (
+                self.latest_public_or_draft_version
+                and self.latest_public_or_draft_version.last_updated
+                <= source_translation.last_updated
+            )
         ):
             return translation_status.OUTDATED
         if translation.machine_translated:

--- a/integreat_cms/cms/models/abstract_content_translation.py
+++ b/integreat_cms/cms/models/abstract_content_translation.py
@@ -490,6 +490,8 @@ class AbstractContentTranslation(AbstractBaseModel):
         if not self.source_language:
             # If the language of this translation is the root of this region's language tree, it is always "up to date"
             return translation_status.UP_TO_DATE
+
+        latest_translation = self.latest_public_or_draft_version or translation
         if (
             # If the source language does not have a major public version, the translation is considered "outdated",
             # because the content is not in sync with its source translation
@@ -497,11 +499,7 @@ class AbstractContentTranslation(AbstractBaseModel):
             # If the source translation is already outdated, this translation is as well
             or source_translation.translation_state == translation_status.OUTDATED
             # If the translation was edited before the last major change in the source language, it is outdated
-            or (
-                self.latest_public_or_draft_version
-                and self.latest_public_or_draft_version.last_updated
-                <= source_translation.last_updated
-            )
+            or latest_translation.last_updated <= source_translation.last_updated
         ):
             return translation_status.OUTDATED
         if translation.machine_translated:

--- a/integreat_cms/release_notes/current/unreleased/4385.yml
+++ b/integreat_cms/release_notes/current/unreleased/4385.yml
@@ -1,0 +1,2 @@
+en: Update translation state to up to date when an outdated translation is published without changes
+de: Setze den Übersetzungsstatus auf Aktuell, wenn eine veraltete Übersetzung ohne Änderungen veröffentlicht wird


### PR DESCRIPTION
### Short description
When evaluating `translation_state`, we use the latest major version of a translation.
When a translation is saved without content changes, it is marked as a "minor edit". 
This leads to inconsistent behavior: 
Publishing an outdated translation without changes does not update it to "up to date".


### Proposed changes
- Adjust `translation_state` property implementation: determine whether a translation is outdated using the latest public or draft version instead of the latest major version.


### Side effects
Previously, the translation state was evaluated against the latest major version. This logic has been in place for many years.
Changing this behavior may affect other parts of the system, although I have not identified any issues so far.
Careful testing is required.


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
- Follow the reproduction steps described in the issue.
- Think of any other scenarios where the `translation_state` can be used & properly displayed.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4385


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
