### PR TITLE
Media Library: Nullify file index before re-render is triggered

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/4384.yml
+++ b/integreat_cms/release_notes/current/unreleased/4384.yml
@@ -1,0 +1,2 @@
+en: Fix media library getting stuck on the loading indicator when a file was selected.
+de: Behebe, dass die Medienbibliothek im Ladeindikator hängen bleibt, wenn eine Datei ausgewählt war.

--- a/integreat_cms/static/src/js/media-management/directory-content-library.tsx
+++ b/integreat_cms/static/src/js/media-management/directory-content-library.tsx
@@ -33,6 +33,7 @@ const DirectoryContentLibrary = (props: LibraryProps) => {
     useEffect(() => {
         const loadDirectory = async () => {
             setLoading(true);
+            setFileIndex(null);
             const urlParams = new URLSearchParams({});
             if (directoryId) {
                 console.debug(`Loading directory with id ${directoryId}...`);
@@ -48,9 +49,6 @@ const DirectoryContentLibrary = (props: LibraryProps) => {
             } finally {
                 setLoading(false);
             }
-
-            // Close the file sidebar
-            setFileIndex(null);
         };
         loadDirectory();
         /* eslint-disable-next-line react-hooks/exhaustive-deps */

--- a/integreat_cms/static/src/js/media-management/filter-result-library.tsx
+++ b/integreat_cms/static/src/js/media-management/filter-result-library.tsx
@@ -29,13 +29,12 @@ const FilterResultLibrary = (props: LibraryProps) => {
         const applyFilter = async () => {
             if (mediaFilter === "unused") {
                 setLoading(true);
+                setFileIndex(null);
                 console.debug("Loading unused media files...");
                 const urlParams = new URLSearchParams({});
                 try {
                     // Load the filtered result
                     await ajaxRequest(filterUnusedMediaFiles, urlParams, setMediaLibraryContent);
-                    // Close the file sidebar
-                    setFileIndex(null);
                 } finally {
                     setLoading(false);
                 }

--- a/integreat_cms/static/src/js/media-management/search-result-library.tsx
+++ b/integreat_cms/static/src/js/media-management/search-result-library.tsx
@@ -28,6 +28,7 @@ const SearchResultLibrary = (props: LibraryProps) => {
     useEffect(() => {
         const applySearch = async () => {
             setLoading(true);
+            setFileIndex(null);
             const urlParams = new URLSearchParams({
                 query: searchQuery,
             });
@@ -36,8 +37,6 @@ const SearchResultLibrary = (props: LibraryProps) => {
             try {
                 // Load the search result
                 await ajaxRequest(getSearchResult, urlParams, setMediaLibraryContent);
-                // Close the file sidebar
-                setFileIndex(null);
             } finally {
                 setLoading(false);
             }


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Set file index to null before re-render is triggered. Otherwise we run into a situation where the sidebar re-render fails on `edit-sidebar.tsx:94` because `file` is null.


### Proposed changes
<!-- Describe this PR in more detail. -->

- nullify the fileIndex right from the start before re-render is triggered


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
- follow the instructions from the original issue for reproduction

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4384 #4271 #4315 possibly #4157 (hard to reproduce locally)


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
