### PR TITLE
fix: add overflow-hidden to collapsible box wrapper to clip overflowing content

### DIFF
--- a/integreat_cms/cms/templates/_collapsible_box.html
+++ b/integreat_cms/cms/templates/_collapsible_box.html
@@ -1,5 +1,5 @@
 {# Set collapsed=True when including this template to show the box collapsed in the beginning #}
-<div class="max-w-full rounded {% if 2_cols %} 2xl:col-span-2 {% endif %} shadow-2xl border border-blue-500 bg-white mb-4">
+<div class="max-w-full rounded {% if 2_cols %} 2xl:col-span-2 {% endif %} shadow-2xl border border-blue-500 bg-white mb-4 overflow-hidden">
     <div {% if box_id %}id="{{ box_id }}"{% endif %}
          class="collapsible cursor-pointer rounded p-4 bg-water-500 text-black font-bold flex justify-between"
          {% if collapsed %}data-collapsed{% endif %}>

--- a/integreat_cms/cms/templates/_collapsible_box.html
+++ b/integreat_cms/cms/templates/_collapsible_box.html
@@ -1,5 +1,5 @@
 {# Set collapsed=True when including this template to show the box collapsed in the beginning #}
-<div class="max-w-full rounded {% if 2_cols %} 2xl:col-span-2 {% endif %} shadow-2xl border border-blue-500 bg-white mb-4 overflow-hidden">
+<div class="max-w-full rounded {% if 2_cols %} 2xl:col-span-2 {% endif %} shadow-2xl border border-blue-500 bg-white mb-4">
     <div {% if box_id %}id="{{ box_id }}"{% endif %}
          class="collapsible cursor-pointer rounded p-4 bg-water-500 text-black font-bold flex justify-between"
          {% if collapsed %}data-collapsed{% endif %}>

--- a/integreat_cms/cms/templates/pois/poi_form_sidebar/position_box.html
+++ b/integreat_cms/cms/templates/pois/poi_form_sidebar/position_box.html
@@ -77,7 +77,7 @@
             {% translate "Map" %}
         </label>
         <div id="map"
-             class="aspect-video overflow-hidden"
+             class="aspect-video overflow-hidden relative"
              data-url="{% url "get_address_from_coordinates" region_slug=request.region.slug %}"
              data-bounding-box="{{ request.region.bounding_box.api_representation }}"
              data-change-permission="{{ perms.cms.change_poi }}">

--- a/integreat_cms/cms/templates/pois/poi_form_sidebar/position_box.html
+++ b/integreat_cms/cms/templates/pois/poi_form_sidebar/position_box.html
@@ -77,7 +77,7 @@
             {% translate "Map" %}
         </label>
         <div id="map"
-             class="aspect-video"
+             class="aspect-video overflow-hidden"
              data-url="{% url "get_address_from_coordinates" region_slug=request.region.slug %}"
              data-bounding-box="{{ request.region.bounding_box.api_representation }}"
              data-change-permission="{{ perms.cms.change_poi }}">


### PR DESCRIPTION
### Short description
The POI form "Position" widget map and confirm button extend beyond the rounded border box because the collapsible box wrapper has `max-w-full` but no overflow clipping.

### Proposed changes

- Added `overflow-hidden` to the outer wrapper div class list in `_collapsible_box.html` (line 2)

The wrapper already constrains width with `max-w-full`, but without `overflow-hidden` any content wider than the box (like the map iframe in the position widget) breaks visually through the rounded border. The inner `collapsible-content` div already has its own `overflow-hidden`, but that only clips the content area, not the header row. The outer wrapper needs it too for anything that extends past the box edges.

### Side effects

- This is a shared template used by all collapsible box widgets across the CMS. `overflow-hidden` clips overflow rather than letting it spill, which is the intended behaviour for a bounded box. The shadow and rounded border rendering should not be affected since nothing relies on overflow being visible outside the container.

### Faithfulness to issue description and design
There are no intended deviations from the issue and design.

### How to test
1. Enable machine translations in the CMS settings.
2. Open any location in the editor.
3. Check the "Position" widget: the map and confirm button should now stay within the box's rounded border instead of breaking out.

### Resolved issues
Fixes: #4401

__________________________________________________
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
