### PR TITLE
Fix translation of warning message for page based statistics export

### DIFF
--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -9043,11 +9043,11 @@ msgstr "Bitte wählen Sie mindestens eine Seite für den Export aus."
 #: cms/templates/statistics/statistics_sidebar.html
 msgid "Please select at least one language to export"
 msgstr ""
-"Bitte wählen Sie mindestens eine Sprache für den export aus."
+"Bitte wählen Sie mindestens eine Sprache für den Export aus."
 
 #: cms/templates/statistics/statistics_sidebar.html
 msgid "Please select at least one page and one language to export"
-msgstr "Bitte wählen Sie mindestens eine Seite und eine Sprache für den export aus."
+msgstr "Bitte wählen Sie mindestens eine Seite und eine Sprache für den Export aus."
 
 #: cms/templates/statistics/statistics_sidebar.html
 msgid "Choose statistics to export"


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes small spelling mistakes in the warnings of page based statistics export.

### Proposed changes
<!-- Describe this PR in more detail. -->
- "export" -> "Export"


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- Better UX 😁 


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->

- Go to the region list, select one
- Check "Activate statistics" and set a Matomo token
- Set the user language setting to German
- Go to the region and click "Statistics"
- Select "Table Document/CSV - Page Accesses" in the bulk action and click "Export" without selecting any language and/or page
- See the error  with "Export" (not "export")

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4400 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
