### PR TITLE
Bugfix: Show UP_TO_DATE translation status when a translation is manually updated without changes

### DIFF
--- a/integreat_cms/cms/forms/custom_content_model_form.py
+++ b/integreat_cms/cms/forms/custom_content_model_form.py
@@ -119,13 +119,12 @@ class CustomContentModelForm(CustomModelForm):
         self.data["slug"] = unique_slug
         return unique_slug
 
-    def save(self, commit: bool = True, foreign_form_changed: bool = False) -> Any:
+    def save(self, commit: bool = True) -> Any:
         """
         This method extends the default ``save()``-method of the base :class:`~django.forms.ModelForm` to set attributes
         which are not directly determined by input fields.
 
         :param commit: Whether or not the changes should be written to the database
-        :param foreign_form_changed: Whether or not the foreign form of this translation form was changed
         :return: The saved content translation object
         """
 
@@ -133,8 +132,9 @@ class CustomContentModelForm(CustomModelForm):
             # Delete now outdated link objects
             self.instance.links.all().delete()
 
-        # If none of the text content fields were changed, but the foreign form was, treat as minor edit (even if checkbox isn't clicked)
-        if {"title", "content"}.isdisjoint(self.changed_data) and foreign_form_changed:
+        # If none of the text content fields were changed, treat as minor edit (even if checkbox isn't clicked)
+        # so that existing translations in other languages are not incorrectly flagged as outdated
+        if {"title", "content"}.isdisjoint(self.changed_data):
             self.logger.debug("Set 'minor_edit=True' since the content did not change")
             self.instance.minor_edit = True
 

--- a/integreat_cms/cms/forms/machine_translation_form.py
+++ b/integreat_cms/cms/forms/machine_translation_form.py
@@ -139,22 +139,14 @@ class MachineTranslationForm(CustomContentModelForm):
     def save(
         self,
         commit: bool = True,
-        foreign_form_changed: bool = False,
     ) -> EventTranslation | (PageTranslation | POITranslation):
         """
         Create machine translations and save them to the database
 
         :param commit: Whether or not the changes should be written to the database
-        :param foreign_form_changed: Whether or not the foreign form of this translation form was changed
         :return: The saved content translation object
         """
-        # If no text content changed, mark the source translation as minor edit so that
-        # existing translations in other languages are not incorrectly flagged as outdated
-        if {"title", "content"}.isdisjoint(self.changed_data):
-            self.instance.minor_edit = True
-        self.instance: EventTranslation | PageTranslation | POITranslation = (
-            super().save(commit, foreign_form_changed)
-        )
+        self.instance = super().save(commit)
 
         language_nodes = self.cleaned_data["mt_translations_to_create"].union(
             self.cleaned_data["mt_translations_to_update"],

--- a/integreat_cms/cms/models/abstract_content_translation.py
+++ b/integreat_cms/cms/models/abstract_content_translation.py
@@ -481,7 +481,8 @@ class AbstractContentTranslation(AbstractBaseModel):
 
         :return: A string describing the state of the translation, one of :data:`~integreat_cms.cms.constants.translation_status.CHOICES`
         """
-        if not (translation := self.major_version):
+        translation = self.latest_public_or_draft_version or self.major_version
+        if not translation:
             # If the page does not have a major public version, it is considered "missing" (keep in mind that it might
             # have draft versions or public versions that are marked as "minor edit")
             return translation_status.MISSING
@@ -490,8 +491,6 @@ class AbstractContentTranslation(AbstractBaseModel):
         if not self.source_language:
             # If the language of this translation is the root of this region's language tree, it is always "up to date"
             return translation_status.UP_TO_DATE
-
-        latest_translation = self.latest_public_or_draft_version or translation
         if (
             # If the source language does not have a major public version, the translation is considered "outdated",
             # because the content is not in sync with its source translation
@@ -499,7 +498,7 @@ class AbstractContentTranslation(AbstractBaseModel):
             # If the source translation is already outdated, this translation is as well
             or source_translation.translation_state == translation_status.OUTDATED
             # If the translation was edited before the last major change in the source language, it is outdated
-            or latest_translation.last_updated <= source_translation.last_updated
+            or translation.last_updated <= source_translation.last_updated
         ):
             return translation_status.OUTDATED
         if translation.machine_translated:

--- a/integreat_cms/cms/views/events/event_form_view.py
+++ b/integreat_cms/cms/views/events/event_form_view.py
@@ -167,11 +167,7 @@ class EventFormView(
                     request, event_form, recurrence_rule_form
                 )
             ):
-                event_translation_instance = event_translation_form.save(
-                    foreign_form_changed=(
-                        event_form.has_changed() or recurrence_rule_form.has_changed()
-                    ),
-                )
+                event_translation_form.save()
 
                 self.update_recurrence_rule(event_form, recurrence_rule_form)
 

--- a/integreat_cms/cms/views/pages/page_form_view.py
+++ b/integreat_cms/cms/views/pages/page_form_view.py
@@ -227,9 +227,7 @@ class PageFormView(
             if self.validate_and_save_page(
                 request, page_form
             ) and self.validate_page_translation(request, page_translation_form):
-                page_translation_instance = page_translation_form.save(
-                    foreign_form_changed=page_form.has_changed(),
-                )
+                page_translation_form.save()
 
                 if page_translation_form.instance.status == status.DRAFT:
                     self.set_dependent_translations_to_draft(

--- a/integreat_cms/cms/views/pois/poi_form_ajax_view.py
+++ b/integreat_cms/cms/views/pois/poi_form_ajax_view.py
@@ -109,9 +109,7 @@ class POIFormAjaxView(TemplateView, POIContextMixin):
             website = poi_form.data.get("primary_website")
 
             poi_translation_form.instance.poi = poi
-            poi_translation = poi_translation_form.save(
-                foreign_form_changed=poi_form.has_changed(),
-            )
+            poi_translation = poi_translation_form.save()
 
             generate_primary_contact_from_poi(
                 website,

--- a/integreat_cms/cms/views/pois/poi_form_view.py
+++ b/integreat_cms/cms/views/pois/poi_form_view.py
@@ -193,9 +193,7 @@ class POIFormView(
                 )
             ):
                 poi_translation_form.instance.poi = poi_form.instance
-                poi_translation_instance = poi_translation_form.save(
-                    foreign_form_changed=poi_form.has_changed(),
-                )
+                poi_translation_form.save()
 
                 generate_primary_contact_from_poi(
                     website,

--- a/integreat_cms/core/management/commands/import_pois_from_csv.py
+++ b/integreat_cms/core/management/commands/import_pois_from_csv.py
@@ -266,6 +266,6 @@ class Command(LogCommand):
                         )
                 # Save forms
                 poi_translation_form.instance.poi = poi_form.save()
-                poi_translation_form.save(foreign_form_changed=poi_form.has_changed())
+                poi_translation_form.save()
                 logger.success("Imported %r", poi_form.instance)  # type: ignore[attr-defined]
         logger.success("✔ Imported CSV file %s", csv_filename)  # type: ignore[attr-defined]

--- a/integreat_cms/release_notes/current/unreleased/4397.yml
+++ b/integreat_cms/release_notes/current/unreleased/4397.yml
@@ -1,0 +1,2 @@
+en: Show UP_TO_DATE translation status when a translation is manually updated without changes
+de: Zeige den Übersetzungsstatus UP_TO_DATE an, wenn eine Übersetzung manuell ohne Änderungen aktualisiert wird


### PR DESCRIPTION
### Short description
For some historical reasons, when a user saved a translation without content changes, we saved it as a major edit.
Only if there were any other changes on the form, except for the title or content fields, did we save it as a minor edit.

After [this change](https://github.com/digitalfabrik/integreat-cms/pull/4273) was introduced, we started saving translations without content changes as minor edits. 
This introduced the following side effect:
When a user manually updated a machine-translated page without any content changes, it did not change the status from "machine translated" to "up-to-date" (check mark).
Because we defined translation state based on the last major version.


### Proposed changes
- When a translation has no content changes, always save it as a minor edit _(Previous behavior: only when translation had no content changes BUT other fields on the form were changed, it was saved as a minor edit)_
- Adjust the `translation_state` property: use the last public or draft version to determine the translation state _(Previous behavior: the last major version was used)_


### Side effects
I could not find any, but careful testing is needed.


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
- Check that the reported issue is not reproduced https://github.com/digitalfabrik/integreat-cms/issues/4397
- Check that the previously fixed related issue was not broken again:
https://github.com/digitalfabrik/integreat-cms/issues/4254
https://github.com/digitalfabrik/integreat-cms/issues/4284
- Analyze whether any other cases could be affected.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4397


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
