### PR TITLE
Add Amal News as external news source

### DIFF
--- a/docs/src/api-docs.rst
+++ b/docs/src/api-docs.rst
@@ -737,7 +737,7 @@ Response
                },
                ...
             ],
-         "source": String,                      // The source of the news ('local', 'tuNews' or 'amalNews')
+         "source": String,                      // The source of the news ('local', 'tunews' or 'amalnews')
          "externalUrl": String,                 // The link to the news
       }
    ]
@@ -773,7 +773,7 @@ Response
             },
             ...
          ],
-      "source": String,                      // The source of the news ('local', 'tuNews' or 'amalNews')
+      "source": String,                      // The source of the news ('local', 'tunews' or 'amalnews')
       "externalUrl": String,                 // The link to the news
    }
 

--- a/integreat_cms/api/urls.py
+++ b/integreat_cms/api/urls.py
@@ -192,9 +192,14 @@ social_media_api_urlpatterns = [
                     name="social_region_reserved_local_news",
                 ),
                 path(
-                    "news/tuNews/",
+                    "news/tunews/",
                     region_social_media_headers,
                     name="social_region_reserved_tunews",
+                ),
+                path(
+                    "news/amalnews/",
+                    region_social_media_headers,
+                    name="social_region_reserved_amalnews",
                 ),
                 *(
                     path(

--- a/integreat_cms/api/v3/news.py
+++ b/integreat_cms/api/v3/news.py
@@ -114,7 +114,7 @@ def single_news(
         (
             news_manager
             for news_manager in registry.CHOICES
-            if news_manager.name == news_type
+            if news_manager.short_name == news_type
         ),
         None,
     )

--- a/integreat_cms/api/v3/social_media_headers.py
+++ b/integreat_cms/api/v3/social_media_headers.py
@@ -256,7 +256,7 @@ def news_social_media_headers(
     :param request: The current request
     :param language_slug: The language slug of the language, which the news item belongs to
     :param slug: The news-source-specific identifier of the news item (e.g. /news/<news_type>/<slug>/)
-    :param news_type: The :attr:`~integreat_cms.news_managers.abstract_news_manager.AbstractNewsManager.name` of the news source the slug refers to (e.g. ``"local"``, ``"tuNews"``)
+    :param news_type: The :attr:`~integreat_cms.news_managers.abstract_news_manager.AbstractNewsManager.short_name` of the news source the slug refers to (e.g. ``"local"``, ``"tunews"``, ``"amalnews"``)
 
     :return: HTML social meta headers required by social media platforms if the news page exists
     """
@@ -264,7 +264,8 @@ def news_social_media_headers(
     language = region.get_language_or_404(language_slug, only_active=True)
 
     news_manager = next(
-        (manager for manager in registry.CHOICES if manager.name == news_type), None
+        (manager for manager in registry.CHOICES if manager.short_name == news_type),
+        None,
     )
 
     if not news_manager:

--- a/integreat_cms/news_managers/abstract_news_manager.py
+++ b/integreat_cms/news_managers/abstract_news_manager.py
@@ -1,14 +1,25 @@
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
+from io import StringIO
 from typing import TYPE_CHECKING, TypedDict
+
+from django.core.cache import cache
+from django.http import Http404, JsonResponse
+from lxml import etree
+
+from ..cms.models import Region
+from ..cms.utils.social_media_utils import render_social_media_headers
 
 if TYPE_CHECKING:
     from datetime import datetime
 
-    from django.http import HttpRequest, HttpResponse, JsonResponse
+    from django.http import HttpRequest, HttpResponse
 
-    from ..cms.models import Language, Region
+    from ..cms.models import Language
+
+logger = logging.getLogger(__name__)
 
 
 class NewsItem(TypedDict):
@@ -23,7 +34,24 @@ class NewsItem(TypedDict):
     externalUrl: str
 
 
+def clean_html(html_string: str) -> str:
+    """
+    Remove unnecessary HTML elements from a Tü News post body.
+    """
+    root = etree.parse(  # noqa: S320
+        StringIO("<main>" + html_string + "</main>"), etree.HTMLParser()
+    )
+    xpath_pvc = '//*[contains(@class, "pvc_")]'
+
+    for pvc in root.xpath(xpath_pvc):
+        pvc.getparent().remove(pvc)
+    main = root.xpath("body/main")[0]
+
+    return etree.tostring(main, pretty_print=True).decode("utf-8")
+
+
 class AbstractNewsManager(ABC):
+    short_name: str
     name: str
 
     @abstractmethod
@@ -35,18 +63,24 @@ class AbstractNewsManager(ABC):
         """
         raise NotImplementedError
 
-    @abstractmethod
     def collect_news_items(
-        self, region_slug: str, language_slug: str, channel: str
+        self, region_slug: str, language_slug: str, _channel: str
     ) -> list[NewsItem]:
         """
         Returns news items imported from the source
-
-        To be implemented in the inheriting model
         """
-        raise NotImplementedError
+        posts = cache.get(f"{self.short_name}:{language_slug}", [])
+        if not posts:
+            return []
+        try:
+            if not Region.objects.get(slug=region_slug).external_news_enabled:
+                logger.exception("External news not enabled: %s", region_slug)
+                return []
+        except Region.DoesNotExist:
+            logger.exception("Region not found: %s", region_slug)
+            return []
+        return posts
 
-    @abstractmethod
     def social_media_headers(
         self,
         request: HttpRequest,
@@ -56,11 +90,17 @@ class AbstractNewsManager(ABC):
     ) -> HttpResponse:
         """
         Tries rendering the social media headers for a news page in a specified region and language
-        To be implemented in the inheriting model
         """
-        raise NotImplementedError
+        post = self.find_post(region, language, news_raw_id)
 
-    @abstractmethod
+        return render_social_media_headers(
+            request=request,
+            title=post["title"],
+            language_code=language.bcp47_tag,
+            excerpt=post["content"],
+            url=post["externalUrl"],
+        )
+
     def get_single_news(
         self,
         request: HttpRequest,
@@ -71,4 +111,32 @@ class AbstractNewsManager(ABC):
         """
         Returns a news item that is imported from the source and matches the id
         """
-        raise NotImplementedError
+        post = self.find_post(region, language, news_id)
+        return JsonResponse(post, safe=False)
+
+    def find_post(
+        self,
+        region: Region,
+        language: Language,
+        news_raw_id: str,
+    ) -> NewsItem:
+        """
+        Find and return a news item which matches the given ID
+        """
+        if not region.external_news_enabled:
+            raise Http404("External news are not enabled in this region.")
+        posts = cache.get(f"{self.short_name}:{language.slug}", [])
+        post = next(
+            (
+                post
+                for post in posts
+                if post["id"] == f"{self.short_name}-{news_raw_id}"
+            ),
+            None,
+        )
+
+        if not post:
+            raise Http404(
+                f"{self.name} post not found in this region with this news ID."
+            )
+        return post

--- a/integreat_cms/news_managers/amalnews_manager.py
+++ b/integreat_cms/news_managers/amalnews_manager.py
@@ -13,42 +13,40 @@ from .abstract_news_manager import AbstractNewsManager, clean_html, NewsItem
 logger = logging.getLogger(__name__)
 
 
-class _TunewsRenderedField(TypedDict):
+class _AmalnewsRenderedField(TypedDict):
     rendered: str
 
 
-class _TunewsACF(TypedDict):
-    integreat: bool
-
-
-class _TunewsPost(TypedDict):
+class _AmalnewsPost(TypedDict):
     """
-    The subset of fields we rely on from the upstream Tü News WordPress API.
+    The subset of fields we rely on from the upstream Amal News WordPress API.
     """
 
     id: int
     date: str
     link: str
-    title: _TunewsRenderedField
-    content: _TunewsRenderedField
-    acf: _TunewsACF
+    title: _AmalnewsRenderedField
+    content: _AmalnewsRenderedField
 
 
-class TunewsManager(AbstractNewsManager):
-    short_name = "tunews"
-    name = "Tü News"
+class AmalnewsManager(AbstractNewsManager):
+    short_name = "amalnews"
+    name = "Amal News"
 
     def import_news_items(self) -> None:
         """
-        Imports Tü News posts and save them as cache
+        Imports Amal News posts and save them as cache
         """
         for language in Language.objects.all():
+            # Amal News uses a non-standard slug for Ukrainian
+            language_slug = language.slug if language.slug != "uk" else "ua"
             try:
+                headers = {"User-Agent": ""}
                 response = requests.get(
-                    f"https://tuenews.de/wp-json/wp/v2/posts/?lang={language.slug}",
+                    f"https://amalnews.de/wp-json/wp/v2/news?lang={language_slug}",
+                    headers=headers,
                     timeout=10,
                 )
-
                 if response.status_code != 200:
                     logger.error(
                         "Could not find posts in %s.",
@@ -68,8 +66,6 @@ class TunewsManager(AbstractNewsManager):
 
                 for post in posts:
                     try:
-                        if not post["acf"]["integreat"]:
-                            continue
                         news.append(self.transform_post(post))
                     except (KeyError, TypeError, ValueError):
                         logger.exception(
@@ -85,9 +81,9 @@ class TunewsManager(AbstractNewsManager):
             except requests.exceptions.RequestException:
                 logger.exception("Failed to fetch posts in %s.", language)
 
-    def transform_post(self, post: _TunewsPost) -> NewsItem:
+    def transform_post(self, post: _AmalnewsPost) -> NewsItem:
         """
-        Transforms a post of Tü News so it can be used by the news endpoint directly
+        Transforms a post of Amal News so it can be used by the news endpoint directly
         """
         date = datetime.fromisoformat(post["date"] + "+00:00")
         return {

--- a/integreat_cms/news_managers/pushnews_manager.py
+++ b/integreat_cms/news_managers/pushnews_manager.py
@@ -51,7 +51,8 @@ def _query_sent_translations(
 
 
 class PushnewsManager(AbstractNewsManager):
-    name = "local"
+    short_name = "local"
+    name = "Local News"
 
     def import_news_items(self) -> None:
         """
@@ -148,18 +149,18 @@ class PushnewsManager(AbstractNewsManager):
         :return: data necessary for API
         """
         available_languages_dict = {
-            translation.language.slug: {"id": f"{self.name}-{translation.id}"}
+            translation.language.slug: {"id": f"{self.short_name}-{translation.id}"}
             for translation in pnt.push_notification.translations.all()
         }
         return {
-            "id": f"{self.name}-{pnt.pk!s}",
+            "id": f"{self.short_name}-{pnt.pk!s}",
             "title": pnt.get_title(),
             "content": pnt.get_text(),
             "last_updated": timezone.localtime(pnt.last_updated),
             "display_date": pnt.display_date,
             "channel": pnt.push_notification.channel,
             "available_languages": available_languages_dict,
-            "source": "local",
+            "source": self.short_name,
             "externalUrl": f"{settings.WEBAPP_URL}{pnt.get_absolute_url()}",
         }
 

--- a/integreat_cms/news_managers/registry.py
+++ b/integreat_cms/news_managers/registry.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from .amalnews_manager import AmalnewsManager
 from .pushnews_manager import PushnewsManager
 from .tunews_manager import TunewsManager
 
@@ -16,5 +17,6 @@ if TYPE_CHECKING:
 
 PUSHNEWS: Final[PushnewsManager] = PushnewsManager()
 TUNEWS: Final[TunewsManager] = TunewsManager()
+AMALNEWS: Final[AmalnewsManager] = AmalnewsManager()
 
-CHOICES: Final[list[AbstractNewsManager]] = [PUSHNEWS, TUNEWS]
+CHOICES: Final[list[AbstractNewsManager]] = [PUSHNEWS, TUNEWS, AMALNEWS]

--- a/tests/api/test_news_endpoint.py
+++ b/tests/api/test_news_endpoint.py
@@ -64,11 +64,31 @@ def test_news_endpoint(load_test_data: None, clean_news_cache: None) -> None:
     # state — we can assert their relative positions without needing to know
     # what already exists.
     now = datetime.now(tz=UTC)
-    pn_high_time = now + timedelta(hours=3)
+    pn_high_time = now + timedelta(hours=4)
+    amalnews_time = now + timedelta(hours=3)
     tunews_time = now + timedelta(hours=2)
     pn_low_time = now + timedelta(hours=1)
 
-    tunews_id = "tuNews-42"
+    amalnews_id = "amalnews-42"
+    cache.set(
+        f"amalnews:{language_slug}",
+        [
+            {
+                "id": amalnews_id,
+                "title": "Amal News Post",
+                "content": "Amal News",
+                "last_updated": amalnews_time,
+                "display_date": amalnews_time,
+                "channel": None,
+                "available_languages": None,
+                "source": "amalnews",
+                "externalUrl": "https://dummydummy.com",
+            }
+        ],
+        timeout=None,
+    )
+
+    tunews_id = "tunews-42"
     cache.set(
         f"tunews:{language_slug}",
         [
@@ -80,7 +100,7 @@ def test_news_endpoint(load_test_data: None, clean_news_cache: None) -> None:
                 "display_date": tunews_time,
                 "channel": None,
                 "available_languages": None,
-                "source": "tuNews",
+                "source": "tunews",
                 "externalUrl": "https://dummy.com",
             }
         ],
@@ -95,9 +115,9 @@ def test_news_endpoint(load_test_data: None, clean_news_cache: None) -> None:
     )
 
     result = client.get(url).json()
-    top_ids = [item["id"] for item in result[:3]]
+    top_ids = [item["id"] for item in result[:4]]
 
-    assert top_ids == [pn_high_id, tunews_id, pn_low_id]
+    assert top_ids == [pn_high_id, amalnews_id, tunews_id, pn_low_id]
 
 
 @pytest.mark.django_db
@@ -169,7 +189,8 @@ def test_news_endpoint_source_filter(
     client = Client()
 
     now = datetime.now(tz=UTC)
-    tunews_id = "tuNews-99"
+
+    tunews_id = "tunews-99"
     cache.set(
         f"tunews:{language_slug}",
         [
@@ -181,12 +202,32 @@ def test_news_endpoint_source_filter(
                 "display_date": now,
                 "channel": None,
                 "available_languages": None,
-                "source": "tuNews",
+                "source": "tunews",
                 "externalUrl": "https://dummy.com",
             }
         ],
         timeout=None,
     )
+
+    amalnews_id = "amalnews-99"
+    cache.set(
+        f"amalnews:{language_slug}",
+        [
+            {
+                "id": amalnews_id,
+                "title": "Amal News Post",
+                "content": "Amal News",
+                "last_updated": now,
+                "display_date": now,
+                "channel": None,
+                "available_languages": None,
+                "source": "amalnews",
+                "externalUrl": "https://dummydummy.com",
+            }
+        ],
+        timeout=None,
+    )
+
     pn_id = f"local-{_create_push_notification(region_slug, language_slug, now)}"
 
     # Filter by local — only push notifications
@@ -194,18 +235,28 @@ def test_news_endpoint_source_filter(
     assert all(item["source"] == "local" for item in local_result)
     assert any(item["id"] == pn_id for item in local_result)
     assert not any(item["id"] == tunews_id for item in local_result)
+    assert not any(item["id"] == amalnews_id for item in local_result)
 
     # Filter by tunews — only tüNews items
-    tunews_result = client.get(url, {"source": "tuNews"}).json()
-    assert all(item["source"] == "tuNews" for item in tunews_result)
+    tunews_result = client.get(url, {"source": "tunews"}).json()
+    assert all(item["source"] == "tunews" for item in tunews_result)
     assert any(item["id"] == tunews_id for item in tunews_result)
     assert not any(item["id"] == pn_id for item in tunews_result)
+    assert not any(item["id"] == amalnews_id for item in tunews_result)
 
-    # Multi-valued filter — both sources together (?source=local&source=tuNews)
-    both_result = client.get(url, {"source": ["local", "tuNews"]}).json()
-    assert {item["source"] for item in both_result} == {"local", "tuNews"}
-    assert any(item["id"] == pn_id for item in both_result)
-    assert any(item["id"] == tunews_id for item in both_result)
+    # Filter by amalnews — only amalnews items
+    amalnews_result = client.get(url, {"source": "amalnews"}).json()
+    assert all(item["source"] == "amalnews" for item in amalnews_result)
+    assert any(item["id"] == amalnews_id for item in amalnews_result)
+    assert not any(item["id"] == pn_id for item in amalnews_result)
+    assert not any(item["id"] == tunews_id for item in amalnews_result)
+
+    # Multi-valued filter — both sources together (?source=local&source=tunews)
+    multi_source_result = client.get(url, {"source": ["local", "tunews"]}).json()
+    assert {item["source"] for item in multi_source_result} == {"local", "tunews"}
+    assert any(item["id"] == pn_id for item in multi_source_result)
+    assert any(item["id"] == tunews_id for item in multi_source_result)
+    assert not any(item["id"] == amalnews_id for item in multi_source_result)
 
 
 @pytest.mark.django_db
@@ -223,9 +274,9 @@ def test_single_news_endpoint(load_test_data: None, clean_news_cache: None) -> N
 
     now = datetime.now(tz=UTC)
 
-    tunews_id_1 = "tuNews-1"
-    tunews_id_2 = "tuNews-2"
-    tunews_id_non_existing = "tuNews-42"
+    tunews_id_1 = "tunews-1"
+    tunews_id_2 = "tunews-2"
+    tunews_id_non_existing = "tunews-42"
     cache.set(
         f"tunews:{language_slug}",
         [
@@ -237,7 +288,7 @@ def test_single_news_endpoint(load_test_data: None, clean_news_cache: None) -> N
                 "display_date": now,
                 "channel": None,
                 "available_languages": None,
-                "source": "tuNews",
+                "source": "tunews",
                 "externalUrl": "https://dummy.com",
             },
             {
@@ -248,7 +299,7 @@ def test_single_news_endpoint(load_test_data: None, clean_news_cache: None) -> N
                 "display_date": now,
                 "channel": None,
                 "available_languages": None,
-                "source": "tuNews",
+                "source": "tunews",
                 "externalUrl": "https://dummy.com",
             },
         ],
@@ -258,6 +309,38 @@ def test_single_news_endpoint(load_test_data: None, clean_news_cache: None) -> N
     pn_id_1 = f"local-{_create_push_notification(region_slug, language_slug, now)}"
     _create_push_notification(region_slug, language_slug, now)
     pn_id_non_existing = "local-0"
+
+    amalnews_id_1 = "amalnews-1"
+    amalnews_id_2 = "amalnews-2"
+    amalnews_id_non_existing = "amalnews-42"
+    cache.set(
+        f"amalnews:{language_slug}",
+        [
+            {
+                "id": amalnews_id_1,
+                "title": "Amal News Post",
+                "content": "Amal News",
+                "last_updated": now,
+                "display_date": now,
+                "channel": None,
+                "available_languages": None,
+                "source": "amalnews",
+                "externalUrl": "https://dummydummy.com",
+            },
+            {
+                "id": amalnews_id_2,
+                "title": "Amal News Post",
+                "content": "Amal News",
+                "last_updated": now,
+                "display_date": now,
+                "channel": None,
+                "available_languages": None,
+                "source": "amalnews",
+                "externalUrl": "https://dummydummy.com",
+            },
+        ],
+        timeout=None,
+    )
 
     url = reverse(
         "api:single_news",
@@ -286,12 +369,23 @@ def test_single_news_endpoint(load_test_data: None, clean_news_cache: None) -> N
         kwargs={
             "region_slug": region_slug,
             "language_slug": language_slug,
+            "news_id": amalnews_id_1,
+        },
+    )
+    amalnews_result = client.get(url).json()
+    assert amalnews_result["id"] == amalnews_id_1
+
+    url = reverse(
+        "api:single_news",
+        kwargs={
+            "region_slug": region_slug,
+            "language_slug": language_slug,
             "news_id": tunews_id_non_existing,
         },
     )
     tunews_result_non_existing = client.get(url).json()
     assert tunews_result_non_existing == {
-        "error": "Tü news post not found in this region with this news ID."
+        "error": "Tü News post not found in this region with this news ID."
     }
 
     url = reverse(
@@ -305,4 +399,17 @@ def test_single_news_endpoint(load_test_data: None, clean_news_cache: None) -> N
     local_result_non_existing = client.get(url).json()
     assert local_result_non_existing == {
         "error": "Push Notification not found in this region with this language."
+    }
+
+    url = reverse(
+        "api:single_news",
+        kwargs={
+            "region_slug": region_slug,
+            "language_slug": language_slug,
+            "news_id": amalnews_id_non_existing,
+        },
+    )
+    amalnews_result_non_existing = client.get(url).json()
+    assert amalnews_result_non_existing == {
+        "error": "Amal News post not found in this region with this news ID."
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -198,7 +198,7 @@ def clean_news_cache(load_test_data: None) -> Generator[None, None, None]:
     """
     keys = [
         f"tunews:{slug}" for slug in Language.objects.values_list("slug", flat=True)
-    ]
+    ] + [f"amalnews:{slug}" for slug in Language.objects.values_list("slug", flat=True)]
     for key in keys:
         cache.delete(key)
     yield

--- a/tests/news_managers/test_tunews_manager.py
+++ b/tests/news_managers/test_tunews_manager.py
@@ -6,12 +6,17 @@ from unittest.mock import patch
 import pytest
 from django.core.cache import cache
 
-from integreat_cms.news_managers.tunews_manager import clean_html, TunewsManager
+from integreat_cms.news_managers.abstract_news_manager import clean_html
+from integreat_cms.news_managers.amalnews_manager import AmalnewsManager
+from integreat_cms.news_managers.tunews_manager import TunewsManager
+
+tu_short_name = "tunews"
+amal_short_name = "amalnews"
 
 not_integreat_news = {
     "id": 1,
     "date": "2026-04-29T16:58:38",
-    "link": "https://tuenews.de/news-post-1/",
+    "link": "https://externalnews.de/news-post-1/",
     "title": {"rendered": "Titel der Nachricht 1"},
     "content": {"rendered": "Eine interessante Tatsache", "protected": False},
     "acf": {
@@ -19,47 +24,91 @@ not_integreat_news = {
     },
 }
 
-malformed_news_1 = {
+news_without_acf = {
     "id": 2,
     "date": "2026-04-29T16:58:38",
-    "link": "https://tuenews.de/news-post-2/",
-    "title": {"rendered": "Kaputte Nachricht 1"},
+    "link": "https://externalnews.de/news-post-2/",
+    "title": {"rendered": "Nachricht 2"},
     "content": {"rendered": "Eine interessante Tatsache", "protected": False},
 }
-malformed_news_2 = {
+
+news_without_content = {
     "id": 3,
     "date": "2026-04-29T16:58:38",
-    "link": "https://tuenews.de/news-post-3/",
-    "title": {"rendered": "Kaputte Nachricht 2"},
+    "link": "https://externalnews.de/news-post-3/",
+    "title": {"rendered": "Nachricht 3"},
     "acf": {
         "integreat": True,
     },
 }
+
 valid_news = {
     "id": 4,
     "date": "2026-04-29T16:58:38",
-    "link": "https://tuenews.de/news-post-4/",
+    "link": "https://externalnews.de/news-post-4/",
     "title": {"rendered": "Gültige Nachricht"},
     "content": {"rendered": "Eine interessante Tatsache", "protected": False},
     "acf": {
         "integreat": True,
     },
 }
-expected_result = [
+
+expected_result_tunews = [
     {
-        "id": "tuNews-4",
+        "id": f"{tu_short_name}-4",
         "title": "Gültige Nachricht",
         "content": "<main>Eine interessante Tatsache</main>\n",
         "last_updated": datetime(2026, 4, 29, 16, 58, 38, tzinfo=UTC),
         "display_date": datetime(2026, 4, 29, 16, 58, 38, tzinfo=UTC),
         "channel": None,
         "available_languages": None,
-        "source": "tuNews",
-        "externalUrl": "https://tuenews.de/news-post-4/",
+        "source": tu_short_name,
+        "externalUrl": "https://externalnews.de/news-post-4/",
     }
 ]
 
-dummy_news_items = [not_integreat_news, malformed_news_1, malformed_news_2, valid_news]
+expected_result_amalnews = [
+    {
+        "id": f"{amal_short_name}-1",
+        "title": "Titel der Nachricht 1",
+        "content": "<main>Eine interessante Tatsache</main>\n",
+        "last_updated": datetime(2026, 4, 29, 16, 58, 38, tzinfo=UTC),
+        "display_date": datetime(2026, 4, 29, 16, 58, 38, tzinfo=UTC),
+        "channel": None,
+        "available_languages": None,
+        "source": amal_short_name,
+        "externalUrl": "https://externalnews.de/news-post-1/",
+    },
+    {
+        "id": f"{amal_short_name}-2",
+        "title": "Nachricht 2",
+        "content": "<main>Eine interessante Tatsache</main>\n",
+        "last_updated": datetime(2026, 4, 29, 16, 58, 38, tzinfo=UTC),
+        "display_date": datetime(2026, 4, 29, 16, 58, 38, tzinfo=UTC),
+        "channel": None,
+        "available_languages": None,
+        "source": amal_short_name,
+        "externalUrl": "https://externalnews.de/news-post-2/",
+    },
+    {
+        "id": f"{amal_short_name}-4",
+        "title": "Gültige Nachricht",
+        "content": "<main>Eine interessante Tatsache</main>\n",
+        "last_updated": datetime(2026, 4, 29, 16, 58, 38, tzinfo=UTC),
+        "display_date": datetime(2026, 4, 29, 16, 58, 38, tzinfo=UTC),
+        "channel": None,
+        "available_languages": None,
+        "source": amal_short_name,
+        "externalUrl": "https://externalnews.de/news-post-4/",
+    },
+]
+
+dummy_news_items = [
+    not_integreat_news,
+    news_without_acf,
+    news_without_content,
+    valid_news,
+]
 
 
 @pytest.mark.django_db
@@ -70,11 +119,17 @@ def test_import_news_item(load_test_data: None, clean_news_cache: None) -> None:
         fake_tunews_server.return_value.status_code = 200
         fake_tunews_server.return_value.json.return_value = dummy_news_items
 
-        assert not cache.get("tunews:de")
+        assert not cache.get(f"{tu_short_name}:de")
 
         TunewsManager().import_news_items()
 
-        assert cache.get("tunews:de") == expected_result
+        assert cache.get(f"{tu_short_name}:de") == expected_result_tunews
+
+        assert not cache.get(f"{amal_short_name}:de")
+
+        AmalnewsManager().import_news_items()
+
+        assert cache.get(f"{amal_short_name}:de") == expected_result_amalnews
 
 
 def test_clean_html_keeps_plain_text() -> None:


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds Amal News as a new source of external news

### Proposed changes
<!-- Describe this PR in more detail. -->
- Add Amal News in the same way with Tü News
- Update related tests
- Remove some duplicated codes

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- `find_post` and `clean_html` are moved to `AbstractNewsManager`
- `collect_news_items` and `get_single_post` are now implemented in `AbstractNewsManager` and `PushnewsManager` is overriding them
- Cache key was changed from "tunews" to "tuNews"

### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
- The command `import_external_news` works works as before and collects posts from Amal News too
- The common endpoint `news/` and single endpoint `news/<id>`/ returns a post or "not found" message for all type of news


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4175 
Fixes: #4435 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
