### PR TITLE
change error message for incorrect date in events

### DIFF
--- a/integreat_cms/cms/forms/events/event_form.py
+++ b/integreat_cms/cms/forms/events/event_form.py
@@ -235,10 +235,10 @@ class EventForm(CustomModelForm):
                 )
             ):
                 self.add_error(
-                    "end_date",
+                    "start_date",
                     forms.ValidationError(
                         _(
-                            "The end of the event can't be in the past. Please choose today or a future date and time."
+                            "The event can't be in the past. Please choose today or a future date and time."
                         ),
                         code="invalid",
                     ),

--- a/integreat_cms/cms/forms/events/event_form.py
+++ b/integreat_cms/cms/forms/events/event_form.py
@@ -227,22 +227,34 @@ class EventForm(CustomModelForm):
                     ),
                 )
             today = timezone.now()
-            if not cleaned_data.get("is_recurring") and (
-                end_date < today.date()
-                or (
+            if not cleaned_data.get("is_recurring"):
+                if end_date < today.date():
+                    self.add_error(
+                        (
+                            "end_date"
+                            if cleaned_data.get("is_long_term")
+                            else "start_date"
+                        ),
+                        forms.ValidationError(
+                            _(
+                                "The event can't be in the past. Please choose today or a future date and time."
+                            ),
+                            code="invalid",
+                        ),
+                    )
+                elif (
                     end_date == today.date()
                     and cleaned_data.get("end_time") < today.time()
-                )
-            ):
-                self.add_error(
-                    "start_date",
-                    forms.ValidationError(
-                        _(
-                            "The event can't be in the past. Please choose today or a future date and time."
+                ):
+                    self.add_error(
+                        "end_time",
+                        forms.ValidationError(
+                            _(
+                                "The event can't be in the past. Please choose today or a future date and time."
+                            ),
+                            code="invalid",
                         ),
-                        code="invalid",
-                    ),
-                )
+                    )
 
         # If everything looks good until now, combine the dates and times into timezone-aware datetimes
         if not self.errors:

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -2015,11 +2015,11 @@ msgstr "Das Ende der Veranstaltung kann nicht vor ihrem Beginn sein"
 
 #: cms/forms/events/event_form.py
 msgid ""
-"The end of the event can't be in the past. Please choose today or a future "
-"date and time."
+"The event can't be in the past. Please choose today or a future date and "
+"time."
 msgstr ""
-"Das Ende der Veranstaltung darf nicht in der Vergangenheit liegen. Bitte "
-"wählen Sie heute oder ein zukünftiges Datum und Uhrzeit."
+"Die Veranstaltung darf nicht in der Vergangenheit liegen. Bitte wählen Sie "
+"heute oder ein zukünftiges Datum und Uhrzeit."
 
 #: cms/forms/events/recurrence_rule_form.py
 msgid "No recurrence frequency selected"

--- a/integreat_cms/release_notes/current/unreleased/4243.yml
+++ b/integreat_cms/release_notes/current/unreleased/4243.yml
@@ -1,0 +1,2 @@
+en: Fix error message and validation when creating one-time event in the past
+de: Fehlermeldung und Validierung beim Anlegen eines einmaligen Ereignisses in der Vergangenheit beheben


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fixes error message when creating a one-time event with a start date in the past

### Proposed changes
<!-- Describe this PR in more detail. -->

- The error message should refer to the 'start_date'. Currently it is referring to the 'end_date'


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
- Go to 'Events'
- Click on 'Create Event'
- Fill the title and select start date on the One-time or recurrent tab in the past.
- Select any location and click "Publish"
- Check Error message. It should be - `start date: The event can't be in the past. Please choose today or a future date and time`


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4243


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
