### PR TITLE
prefetch public_or_draft_translations without content

### DIFF
--- a/integreat_cms/cms/models/pages/page.py
+++ b/integreat_cms/cms/models/pages/page.py
@@ -12,6 +12,7 @@ from django.utils.translation import gettext_lazy as _
 from linkcheck.models import Link
 from treebeard.ns_tree import NS_NodeQuerySet
 
+from ...constants import status
 from ...utils.translation_utils import gettext_many_lazy as __
 from ..abstract_content_model import ContentQuerySet
 from ..abstract_tree_node import AbstractTreeNode
@@ -67,6 +68,25 @@ class PageQuerySet(NS_NodeQuerySet, ContentQuerySet):
         queryset = self
         if should_prefetch_nonpublic_translations:
             queryset = queryset.prefetch_translations()
+
+        # Prefetch the translations backing latest_public_or_draft_version, which is
+        # evaluated via translation_state for every page in the tree — without this
+        # prefetch it falls back to one query per page, loading full translation
+        # contents. The content field is deferred because the state calculation only
+        # needs the translation metadata.
+        queryset = queryset.prefetch_related(
+            models.Prefetch(
+                "translations",
+                queryset=PageTranslation.objects.filter(
+                    status__in=[status.DRAFT, status.PUBLIC],
+                )
+                .order_by("page_id", "language_id", "-version")
+                .distinct("page_id", "language_id")
+                .select_related("language")
+                .defer("content"),
+                to_attr="prefetched_public_or_draft_translations",
+            ),
+        )
 
         for page in queryset.prefetch_public_translations().order_by("tree_id", "lft"):
             page._cached_ancestors = []

--- a/tests/api/api_config.py
+++ b/tests/api/api_config.py
@@ -51,14 +51,14 @@ API_ENDPOINTS: Final[list[tuple[str, str, str, int, int]]] = [
         "/augsburg/de/wp-json/extensions/v3/pages/",
         "tests/api/expected-outputs/augsburg_de_pages.json",
         200,
-        6,
+        7,
     ),
     (
         "/api/v3/augsburg/ar/pages/",
         "/augsburg/ar/wp-json/extensions/v3/pages/",
         "tests/api/expected-outputs/augsburg_ar_pages.json",
         200,
-        6,
+        7,
     ),
     (
         "/api/v3/augsburg/non-existing/pages/",
@@ -121,14 +121,14 @@ API_ENDPOINTS: Final[list[tuple[str, str, str, int, int]]] = [
         "/augsburg/de/wp-json/extensions/v3/children/",
         "tests/api/expected-outputs/augsburg_de_children.json",
         200,
-        5,
+        6,
     ),
     (
         "/api/v3/augsburg/de/children/?depth=3&url=/augsburg/de/behörden-und-beratung/behörden/",
         "/augsburg/de/wp-json/extensions/v3/children/?depth=3&url=/augsburg/de/behörden-und-beratung/behörden/",
         "tests/api/expected-outputs/augsburg_de_children_archived_descendants.json",
         200,
-        13,
+        14,
     ),
     (
         "/augsburg/de/wp-json/extensions/v3/page/?url=/augsburg/de/behörden-und-beratung/behörden/archiviertes-amt/",
@@ -142,7 +142,7 @@ API_ENDPOINTS: Final[list[tuple[str, str, str, int, int]]] = [
         "/augsburg/de/wp-json/extensions/v3/children/?depth=2",
         "tests/api/expected-outputs/augsburg_de_children_depth_2.json",
         200,
-        5,
+        6,
     ),
     (
         "/api/v3/augsburg/de/events/",


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
hotfix: prevent per-page DB queries loading full page content in page-tree rendering

### Proposed changes
<!-- Describe this PR in more detail. -->

the latest release changed the translation-status calculation (translation_state) to also look up the newest draft-or-public version of each translation . the page-tree renderer (cache_tree_dict) doesn't prefetch this set of translations, so every page-tree render (pages list, statistics page tree) falls back to one extra DB query per page, each loading full translations.
this fix adds the missing prefetch in cache_tree_dict (integreat_cms/cms/models/pages/page.py): the latest draft/public translation per page and language is now fetched in one query up front, with the content field deferred since it's not needed.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- 


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
