### PR TITLE
add additional guardrails for fix_internal_links

### DIFF
--- a/integreat_cms/core/management/commands/fix_internal_links.py
+++ b/integreat_cms/core/management/commands/fix_internal_links.py
@@ -8,12 +8,20 @@ from typing import TYPE_CHECKING
 from urllib.parse import unquote
 
 from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import CommandError
+from django.db import IntegrityError, transaction
 from linkcheck.listeners import tasks_queue
 from linkcheck.models import Url
 from lxml.html import rewrite_links
 
-from ....cms.models import Region
+from ....cms.models import (
+    EventTranslation,
+    ImprintPageTranslation,
+    PageTranslation,
+    POITranslation,
+    Region,
+)
 from ....cms.utils import internal_link_utils
 from ....cms.utils.link_ignore_preservation import preserve_ignored_links
 from ....cms.utils.link_utils import fix_content_link_encoding
@@ -119,6 +127,17 @@ class Command(LogCommand):
             region_links = get_link_query([region])
             query = Url.objects.filter(links__in=region_links).distinct()
 
+        # Only links in content translations can be fixed - other linked models
+        # (e.g. organizations) have neither a language nor versioning
+        translation_content_types = list(
+            ContentType.objects.get_for_models(
+                EventTranslation,
+                ImprintPageTranslation,
+                PageTranslation,
+                POITranslation,
+            ).values(),
+        )
+
         for url in query:
             if not url.internal:
                 continue
@@ -128,7 +147,9 @@ class Command(LogCommand):
             if not source_translation:
                 continue
 
-            for link in url.links.all().prefetch_related("content_object__language"):
+            for link in url.links.filter(
+                content_type__in=translation_content_types,
+            ).prefetch_related("content_object__language"):
                 target_language_slug = link.content_object.language.slug
                 target_translation = source_translation
                 if target_language_slug != source_translation.language.slug:
@@ -137,6 +158,15 @@ class Command(LogCommand):
                             target_language_slug,
                         )
                     )
+
+                if target_translation is None:
+                    logger.debug(
+                        "Skipping link to %r in %r: the link target has no public translation in language %r",
+                        url.url,
+                        link.content_object,
+                        target_language_slug,
+                    )
+                    continue
 
                 target_url = target_translation.full_url
                 source_url = unquote(url.url)
@@ -189,9 +219,20 @@ def replace_links_of_translation(
         rules.keys(),
     )
     if commit:
-        with preserve_ignored_links(translation):
-            translation.links.all().delete()
-            new_translation.save()
+        try:
+            with transaction.atomic(), preserve_ignored_links(translation):
+                translation.links.all().delete()
+                new_translation.save()
+        except IntegrityError as e:
+            if "unique_version" not in str(e):
+                raise
+            # Do not retry with a recomputed version number, since that would
+            # overwrite the concurrently created (and thus newer) content with
+            # this stale copy. The links will be fixed again on the next run.
+            logger.warning(
+                "Skipping %r because a newer version exists - the content was probably edited concurrently",
+                new_translation,
+            )
 
 
 def replace_link_helper(rules: dict[str, str], link: str) -> str:

--- a/tests/core/management/commands/test_fix_internal_links.py
+++ b/tests/core/management/commands/test_fix_internal_links.py
@@ -11,6 +11,9 @@ from django.core.management.base import CommandError
 from linkcheck.listeners import enable_listeners
 from linkcheck.models import Link, Url
 
+from integreat_cms.cms.constants import status
+from integreat_cms.cms.models import Organization, PageTranslation
+
 from ..utils import get_command_output
 
 
@@ -42,6 +45,58 @@ def test_fix_internal_links_non_existing_username(
             get_command_output("fix_internal_links", "--username=non-existing"),
         )
     assert str(exc_info.value) == 'User with username "non-existing" does not exist.'
+
+
+@pytest.mark.django_db
+def test_fix_internal_links_skips_links_without_public_target_translation(
+    load_test_data: None,
+) -> None:
+    """
+    Ensure that a link whose target has no public translation in the language of the
+    linking content is skipped instead of crashing the command
+
+    :param load_test_data: The fixture providing the test data (see :meth:`~tests.conftest.load_test_data`)
+    """
+    # The English translation of the "test-links" page links to the German page
+    # "willkommen". Unpublish the English translation of that page, so that no
+    # public link target exists in the language of the linking content.
+    PageTranslation.objects.filter(page__id=1, language__slug="en").update(
+        status=status.DRAFT,
+    )
+
+    with enable_listeners():
+        out, err = get_command_output("fix_internal_links")
+
+    assert "✔ Finished dry-run of fixing broken internal links." in out
+    assert not err
+
+
+@pytest.mark.django_db
+def test_fix_internal_links_skips_organization_links(load_test_data: None) -> None:
+    """
+    Ensure that links of organizations (which have no language and no versioning)
+    are skipped instead of crashing the command
+
+    :param load_test_data: The fixture providing the test data (see :meth:`~tests.conftest.load_test_data`)
+    """
+    internal_url = "https://integreat.app/augsburg/de/willkommen/"
+    organization = Organization.objects.get(id=1)
+    Organization.objects.filter(id=organization.id).update(website=internal_url)
+    Link.objects.create(
+        url=Url.objects.get(url=internal_url),
+        content_object=organization,
+        field="website",
+        text=organization.name,
+    )
+
+    with enable_listeners():
+        out, err = get_command_output("fix_internal_links")
+
+    assert "✔ Finished dry-run of fixing broken internal links." in out
+    assert not err
+    assert Link.objects.filter(
+        organization__id=organization.id,
+    ).exists(), "The organization link should not be modified"
 
 
 old_urls = [
@@ -148,4 +203,66 @@ def test_fix_internal_links_commit(load_test_data_transactional: Any | None) -> 
         ).exists(), "New URL should exist after replacement"
         assert Link.objects.filter(url__url=new_url).count() == 1, (
             "New link should exist after replacement"
+        )
+
+
+@pytest.mark.order("last")
+@pytest.mark.django_db(transaction=True, serialized_rollback=True)
+def test_fix_internal_links_commit_skips_version_conflicts(
+    load_test_data_transactional: Any | None,
+) -> None:
+    """
+    Ensure that a version number conflict (e.g. because an editor saved a new version
+    while the command was running) only skips the affected translation instead of
+    aborting the whole command and losing its link records
+
+    :param load_test_data_transactional: The fixture providing the test data (see :meth:`~tests.conftest.load_test_data_transactional`)
+    """
+    # Simulate a concurrent editor save: the latest version in the database is newer
+    # than the version the linkcheck data still points to. The English translation of
+    # the "test-links" page is the one whose links to the German page "willkommen",
+    # the event "test-veranstaltung" and the location "test-ort" would be fixed.
+    stale_translation = PageTranslation.objects.get(
+        page__id=27,
+        language__slug="en",
+        version=1,
+    )
+    newer_version = stale_translation.create_new_version_copy()
+    newer_version.save()
+
+    stale_link_count = stale_translation.links.count()
+    assert stale_link_count > 0
+
+    # The URL that only the conflicting translation would produce
+    skipped_url = "https://integreat.app/augsburg/en/welcome/"
+    # URLs that fixes of other translations produce
+    fixed_urls = [
+        "https://integreat.app/augsburg/de/deutsche-sprache/sonstige-sprachlernangebote/",
+        "https://integreat.app/augsburg/de/test-links/",
+    ]
+    for url in [skipped_url, *fixed_urls]:
+        assert not Url.objects.filter(
+            url=url,
+        ).exists(), "The fixed URL should not exist before the command is run"
+
+    with enable_listeners():
+        out, err = get_command_output("fix_internal_links", "--commit")
+
+    assert "✔ Successfully finished fixing broken internal links." in out
+    assert "newer version" in err, (
+        "The skipped version conflict should be reported as a warning"
+    )
+
+    # The conflicting translation must be skipped and keep its link records
+    assert stale_translation.links.count() == stale_link_count, (
+        "The link records of the skipped translation should be preserved"
+    )
+    assert not Url.objects.filter(
+        url=skipped_url,
+    ).exists(), "The links of the conflicting translation should not be replaced"
+
+    # All other translations must still be fixed
+    for url in fixed_urls:
+        assert Link.objects.filter(url__url=url).count() == 1, (
+            "Links in other translations should still be replaced"
         )


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Add guardrails to the `fix_internal_link` management command to make it safe to use in a weekly cronjob. Thus far, the management command could crash if certain conditions were met, making it unsafe to use unsupervised.

### Proposed changes
<!-- Describe this PR in more detail. -->

- wrap changes to links in `transaction.atomic` block
- skip models without language or versioning (i.e. organizations)
- skip links where the target has no public translation in the given language
- add regression tests for the fixed use-cases


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
run the `fix_internal_links` management command and see that it does not produce any errors 

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4235 (partially)


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
