### PR TITLE
Add page title to export of page based statistics

### DIFF
--- a/integreat_cms/cms/templates/pages/_generic_page_tree_node.html
+++ b/integreat_cms/cms/templates/pages/_generic_page_tree_node.html
@@ -40,7 +40,7 @@
     <td>
         <a href="{% url 'edit_page' page_id=page.id region_slug=request.region.slug language_slug=language.slug %}"
            class="block py-1.5 px-2 overflow-hidden max-w-xs whitespace-nowrap text-ellipsis text-gray-800"
-           title="{% if page_translation %} {{ page_translation.title }}{% endif %}">
+           title="{% if page_translation %}{{ page_translation.title }}{% endif %}">
             <div class="title-slug"
                  data-title-slug="{% if page_translation %}{{ page_translation.slug }}{% endif %}">
                 {% if page_translation %}

--- a/integreat_cms/static/src/js/analytics/statistics-page-accesses.ts
+++ b/integreat_cms/static/src/js/analytics/statistics-page-accesses.ts
@@ -242,9 +242,12 @@ const updateExportTable = (data: AjaxResponse) => {
         const accesses = data[pageId];
         const pageElement = document.getElementById(`page-${pageId}`);
         const pageSlug = pageElement?.querySelector(".title-slug").getAttribute("data-title-slug");
-        if (pageElement && pageSlug) {
+        const pageTitle = pageElement?.querySelector(`a[href*='${pageId}/edit/']`).getAttribute("title");
+        if (pageElement && pageSlug && pageTitle) {
             // Page Title needs to be utf-8 encoded for btoa to work in exportPageAccessesData()
             const pageSlugEncoded = new TextEncoder().encode(pageSlug);
+            // Wrap page title with quot to avoid titles containing commas get separated in CSV
+            const pageTitleEncoded = new TextEncoder().encode(`"${pageTitle.replace(/"/g, `""`)}"`);
             let allAccesses: number = 0;
 
             visibleDatasetSlugs?.forEach((languageSlug, i) => {
@@ -257,6 +260,7 @@ const updateExportTable = (data: AjaxResponse) => {
             });
             exportTableEntry[visibleDatasetSlugs.length] = String(allAccesses);
             exportTableEntry.unshift(String.fromCharCode(...pageSlugEncoded));
+            exportTableEntry.unshift(String.fromCharCode(...pageTitleEncoded));
             exportTableEntry.unshift(pageId);
             exportTable.push(exportTableEntry);
         }
@@ -308,7 +312,7 @@ const exportPageAccessesData = (): void => {
         document.getElementById("no-language-selected-error")?.classList.remove("hidden");
     } else {
         const exportSelection = document.getElementById("export-statistics") as HTMLSelectElement;
-        const exportLabels: string[] = ["ID", "Slug", ...visibleDatasetSlugs, "Total Accesses"];
+        const exportLabels: string[] = ["ID", "Page Title", "Slug", ...visibleDatasetSlugs, "Total Accesses"];
         const filename = `Integreat ${exportSelection.getAttribute("data-filename-prefix")} - Page Based`;
         // Create matrix with labels in the first row and the hits per page and language in the subsequent rows
         const csvMatrix: string[][] = [exportLabels].concat(exportTable);


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds page title to CSV export of page accesses.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Read the title of selected pages from the rendered html
- Create a new column and put them into the CSV together with other data


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- Should be none?


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
- Set up so the page based statistics is available in the region you want to use for testing
- Populate with some `PageAccesses` objects by `integreat-cms-cli shell` or use dump data and the command
- Check the export works
- Check page titles are exported too (in German)

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4420



__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
