### PR TITLE
Keep filter state after copy and delete action in Events

### DIFF
--- a/integreat_cms/cms/templates/events/event_list_row.html
+++ b/integreat_cms/cms/templates/events/event_list_row.html
@@ -156,10 +156,9 @@
                     <i icon-name="pencil"></i>
                 </a>
                 {% if not event.external_calendar %}
-                    <form action="{% url 'copy_event' event_id=event.id region_slug=request.region.slug language_slug=language.slug %}"
+                    <form action="{% url 'copy_event' event_id=event.id region_slug=request.region.slug language_slug=language.slug %}?{{ request.GET.urlencode }}"
                           method="post">
                         {% csrf_token %}
-                        <input type="hidden" name="query_string" value="{{ request.GET.urlencode }}">
                         <button class="btn-icon" title="{% translate "Copy event" %}">
                             <i icon-name="copy"></i>
                         </button>
@@ -195,7 +194,7 @@
                     data-confirmation-title="{{ delete_dialog_title }}"
                     data-confirmation-text="{{ delete_dialog_text }}"
                     data-confirmation-subject="{{ event_translation.title }}"
-                    data-action="{% url 'delete_event' event_id=event.id region_slug=request.region.slug language_slug=language.slug %}">
+                    data-action="{% url 'delete_event' event_id=event.id region_slug=request.region.slug language_slug=language.slug %}?{{ request.GET.urlencode }}">
                 <i icon-name="trash-2"></i>
             </button>
         {% endif %}

--- a/integreat_cms/cms/templates/events/event_list_row.html
+++ b/integreat_cms/cms/templates/events/event_list_row.html
@@ -159,6 +159,7 @@
                     <form action="{% url 'copy_event' event_id=event.id region_slug=request.region.slug language_slug=language.slug %}"
                           method="post">
                         {% csrf_token %}
+                        <input type="hidden" name="query_string" value="{{ request.GET.urlencode }}">
                         <button class="btn-icon" title="{% translate "Copy event" %}">
                             <i icon-name="copy"></i>
                         </button>

--- a/integreat_cms/cms/templates/generic_confirmation_dialog.html
+++ b/integreat_cms/cms/templates/generic_confirmation_dialog.html
@@ -25,7 +25,6 @@
             </p>
             <form method="post" action="#">
                 {% csrf_token %}
-                <input type="hidden" name="query_string" value="{{ request.GET.urlencode }}">
                 <div class="flex justify-end gap-2">
                     <button id="close-confirmation-popup" class="btn btn-ghost">
                         {% translate "Cancel" %}

--- a/integreat_cms/cms/templates/generic_confirmation_dialog.html
+++ b/integreat_cms/cms/templates/generic_confirmation_dialog.html
@@ -25,6 +25,7 @@
             </p>
             <form method="post" action="#">
                 {% csrf_token %}
+                <input type="hidden" name="query_string" value="{{ request.GET.urlencode }}">
                 <div class="flex justify-end gap-2">
                     <button id="close-confirmation-popup" class="btn btn-ghost">
                         {% translate "Cancel" %}

--- a/integreat_cms/cms/utils/event_utils.py
+++ b/integreat_cms/cms/utils/event_utils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
-from urllib.parse import parse_qsl, urlencode
 
 from django.shortcuts import reverse
 
@@ -24,6 +23,6 @@ def get_filtered_events_url(
     event_url = reverse(
         "events", kwargs={"region_slug": region_slug, "language_slug": language_slug}
     )
-    if params := parse_qsl(request.POST.get("query_string", "")):
-        event_url = f"{event_url}?{urlencode(params)}"
+    if query_string := request.GET.urlencode():
+        event_url = f"{event_url}?{query_string}"
     return event_url

--- a/integreat_cms/cms/utils/event_utils.py
+++ b/integreat_cms/cms/utils/event_utils.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from urllib.parse import parse_qsl, urlencode
+
+from django.shortcuts import reverse
+
+if TYPE_CHECKING:
+    from django.http import HttpRequest
+
+
+def get_filtered_events_url(
+    request: HttpRequest, region_slug: str, language_slug: str
+) -> str:
+    """
+    Build the events list URL, preserving any active filter query string from the request.
+
+    :param request: The current HTTP request
+    :param region_slug: Slug of the region
+    :param language_slug: Current GUI language slug
+
+    :return: The events list URL with optional filter query string
+    """
+    event_url = reverse(
+        "events", kwargs={"region_slug": region_slug, "language_slug": language_slug}
+    )
+    if params := parse_qsl(request.POST.get("query_string", "")):
+        event_url = f"{event_url}?{urlencode(params)}"
+    return event_url

--- a/integreat_cms/cms/views/events/event_actions.py
+++ b/integreat_cms/cms/views/events/event_actions.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 from django.contrib import messages
 from django.db.models import OuterRef, Subquery
-from django.shortcuts import get_object_or_404, redirect, render
+from django.shortcuts import get_object_or_404, redirect, render, reverse
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_POST
 
@@ -79,6 +79,13 @@ def copy(
     region = request.region
     event = get_object_or_404(region.events, id=event_id)
 
+    query_string = request.POST.get("query_string", "")
+    events_url = reverse(
+        "events", kwargs={"region_slug": region_slug, "language_slug": language_slug}
+    )
+    if query_string:
+        events_url = f"{events_url}?{query_string}"
+
     try:
         event.copy(request.user)
     except CouldNotBeCopied:
@@ -86,18 +93,12 @@ def copy(
             request,
             _("Event couldn't be copied because it's from an external calendar"),
         )
-        return redirect(
-            "events",
-            **{"region_slug": region_slug, "language_slug": language_slug},
-        )
+        return redirect(events_url)
 
     logger.debug("%r copied by %r", event, request.user)
     messages.success(request, _("Event was successfully copied"))
 
-    return redirect(
-        "events",
-        **{"region_slug": region_slug, "language_slug": language_slug},
-    )
+    return redirect(events_url)
 
 
 @require_POST
@@ -159,13 +160,13 @@ def delete(
     event.delete()
     messages.success(request, _("Event was successfully deleted"))
 
-    return redirect(
-        "events",
-        **{
-            "region_slug": region_slug,
-            "language_slug": language_slug,
-        },
+    query_string = request.POST.get("query_string", "")
+    events_url = reverse(
+        "events", kwargs={"region_slug": region_slug, "language_slug": language_slug}
     )
+    if query_string:
+        events_url = f"{events_url}?{query_string}"
+    return redirect(events_url)
 
 
 @require_POST

--- a/integreat_cms/cms/views/events/event_actions.py
+++ b/integreat_cms/cms/views/events/event_actions.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 from django.contrib import messages
 from django.db.models import OuterRef, Subquery
-from django.shortcuts import get_object_or_404, redirect, render, reverse
+from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.translation import gettext_lazy as _
 from django.views.decorators.http import require_POST
 
@@ -18,6 +18,7 @@ from ...constants import status
 from ...decorators import permission_required
 from ...models import POITranslation, Region
 from ...models.events.event import CouldNotBeCopied
+from ...utils.event_utils import get_filtered_events_url
 
 if TYPE_CHECKING:
     from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
@@ -79,13 +80,6 @@ def copy(
     region = request.region
     event = get_object_or_404(region.events, id=event_id)
 
-    query_string = request.POST.get("query_string", "")
-    events_url = reverse(
-        "events", kwargs={"region_slug": region_slug, "language_slug": language_slug}
-    )
-    if query_string:
-        events_url = f"{events_url}?{query_string}"
-
     try:
         event.copy(request.user)
     except CouldNotBeCopied:
@@ -93,12 +87,12 @@ def copy(
             request,
             _("Event couldn't be copied because it's from an external calendar"),
         )
-        return redirect(events_url)
+        return redirect(get_filtered_events_url(request, region_slug, language_slug))
 
     logger.debug("%r copied by %r", event, request.user)
     messages.success(request, _("Event was successfully copied"))
 
-    return redirect(events_url)
+    return redirect(get_filtered_events_url(request, region_slug, language_slug))
 
 
 @require_POST
@@ -160,13 +154,7 @@ def delete(
     event.delete()
     messages.success(request, _("Event was successfully deleted"))
 
-    query_string = request.POST.get("query_string", "")
-    events_url = reverse(
-        "events", kwargs={"region_slug": region_slug, "language_slug": language_slug}
-    )
-    if query_string:
-        events_url = f"{events_url}?{query_string}"
-    return redirect(events_url)
+    return redirect(get_filtered_events_url(request, region_slug, language_slug))
 
 
 @require_POST

--- a/integreat_cms/release_notes/current/unreleased/2396.yml
+++ b/integreat_cms/release_notes/current/unreleased/2396.yml
@@ -1,2 +1,2 @@
-en: Keep filter status after copy/delete action of events
-de: Filtermodus nach dem Kopieren oder Löschen von Ereignissen beibehalten
+en: Keep filter state after copying or deleting events
+de: Filter nach dem Kopieren oder Löschen von Veranstaltungen beibehalten

--- a/integreat_cms/release_notes/current/unreleased/2396.yml
+++ b/integreat_cms/release_notes/current/unreleased/2396.yml
@@ -1,0 +1,2 @@
+en: Keep filter status after copy/delete action of events
+de: Filtermodus nach dem Kopieren oder Löschen von Ereignissen beibehalten

--- a/integreat_cms/static/src/js/utils/confirmation-popup.ts
+++ b/integreat_cms/static/src/js/utils/confirmation-popup.ts
@@ -80,7 +80,7 @@ export const showConfirmationPopup = (event: Event, onSubmit?: (event: Event) =>
     if (action) {
         const url = new URL(action, window.location.origin);
         if (url.origin === window.location.origin) {
-            confirmationPopup.querySelector("form").action = url.pathname;
+            confirmationPopup.querySelector("form").action = url.pathname + url.search;
         }
     }
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Preserve the filter state in "Events" after `Copy` or `Delete` of an event, so that the user returns to the same filtered view before after the action.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Pass the current query string as a hidden `query_string` in the form. There is a separate form for copy(`event_list_row.py:159`) and delete(`generic_confirmation_dialog.html`)
- The copy and delete views are updated in `event_actions.py` to add it to the redirect URL. This should preserve the filter state on redirect.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design. It was decided to add "Delete" in addition to "Copy" as actions which preserve the filter state.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->

- Open 'Events' for any region and language
- Apply any filter (e.g. select "Past events" in the time range filter and submit)
- Click "Copy" or "Delete" on any event in the list
- Verify that after the copy, the events list still shows only past events or any other filter you added (i.e. filter is preserved)
- Also verify that with no filters active, copy and delete still redirect to the plain unfiltered events list

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2396 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
