### PR TITLE
Fix overflow in the position widget in the poi form

### DIFF
--- a/integreat_cms/cms/templates/pois/poi_form.html
+++ b/integreat_cms/cms/templates/pois/poi_form.html
@@ -166,14 +166,14 @@
             </div>
             <div class="sm:block md:flex sm:mt-4 3xl:mt-0 3xl:block 4xl:flex">
                 <div id="left-sidebar-column"
-                     class="flex flex-col flex-auto mt-4 md:mt-0 md:mr-4 3xl:mr-0 md:w-full 4xl:mr-4">
+                     class="flex flex-col flex-auto min-w-0 mt-4 md:mt-0 md:mr-4 3xl:mr-0 md:w-full 4xl:mr-4">
                     {% if is_edit and perms.cms.change_poi %}
                         {% include "./poi_form_sidebar/minor_edit_box.html" with box_id="poi-minor-edit" %}
                     {% endif %}
                     {% include "./poi_form_sidebar/position_box.html" with box_id="poi-position" %}
                 </div>
                 <div id="right-sidebar-column"
-                     class="flex flex-col flex-wrap 3xl:col-end-3 4xl:col-end-auto md:w-full">
+                     class="flex flex-col min-w-0 3xl:col-end-3 4xl:col-end-auto md:w-full">
                     {% include "./poi_form_sidebar/contact_box.html" with box_id="poi-contact" %}
                     {% if perms.cms.view_contact and request.region.contacts_enabled %}
                         {% include "./poi_form_sidebar/related_contacts_box.html" with box_id="poi-related-contacts" %}

--- a/integreat_cms/release_notes/current/unreleased/4401.yml
+++ b/integreat_cms/release_notes/current/unreleased/4401.yml
@@ -1,0 +1,2 @@
+en: Fix overflow in the position widget in the poi form
+de: Behebe den Überlauf im Positions-Widget des POI-Formulars


### PR DESCRIPTION
### Short description
The map and the "Confirm" button in the "Position" widget overflow the widget's boundaries (see the issue description for details).


### Proposed changes
- Add `min-w-0` to the form columns.


### Side effects
- couldn't find any


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
The original issue is only reproduced when the "Position" widget is located in the right column.
Testing different layouts is required:
- zoom in / zoom out in the browser
- enable / disable machine translations (since this also influences the layout)


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4401


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
