### PR TITLE
Fix error when a lower cased slug is being used already

### DIFF
--- a/integreat_cms/cms/views/events/event_form_view.py
+++ b/integreat_cms/cms/views/events/event_form_view.py
@@ -359,25 +359,41 @@ class EventFormView(
                     slug=user_slug,
                     language=language,
                 ).first()
-                other_translation_link = other_translation.backend_edit_link
-                message = _(
-                    "The slug was changed from '{user_slug}' to '{slug}', "
-                    "because '{user_slug}' is already used by <a>{translation}</a> or one of its previous versions.",
-                ).format(
-                    user_slug=user_slug,
-                    slug=cleaned_slug,
-                    translation=other_translation,
-                )
-                messages.warning(
-                    request,
-                    translate_link(
-                        message,
-                        attributes={
-                            "href": other_translation_link,
-                            "class": "underline hover:no-underline",
-                        },
-                    ),
-                )
+                if other_translation:
+                    other_translation_link = other_translation.backend_edit_link
+                    message = _(
+                        "The slug was changed from '{user_slug}' to '{slug}', "
+                        "because '{user_slug}' is already used by <a>{translation}</a> or one of its previous versions.",
+                    ).format(
+                        user_slug=user_slug,
+                        slug=cleaned_slug,
+                        translation=other_translation,
+                    )
+                    messages.warning(
+                        request,
+                        translate_link(
+                            message,
+                            attributes={
+                                "href": other_translation_link,
+                                "class": "underline hover:no-underline",
+                            },
+                        ),
+                    )
+                else:
+                    logger.warning(
+                        "Slug was changed from the one the user provided, but we can't find the translation that already used it: %s (cleaned to %s)",
+                        user_slug,
+                        event_translation_form.cleaned_data["slug"],
+                    )
+                    messages.warning(
+                        request,
+                        _(
+                            "The slug was changed from '{user_slug}' to '{slug}'."
+                        ).format(
+                            user_slug=user_slug,
+                            slug=event_translation_form.cleaned_data["slug"],
+                        ),
+                    )
 
     def add_success_message(
         self,

--- a/integreat_cms/cms/views/pages/page_form_view.py
+++ b/integreat_cms/cms/views/pages/page_form_view.py
@@ -571,12 +571,13 @@ class PageFormView(
                         page_translation_form.cleaned_data["slug"],
                     )
                     messages.warning(
+                        request,
                         _(
                             "The slug was changed from '{user_slug}' to '{slug}'."
                         ).format(
                             user_slug=user_slug,
                             slug=page_translation_form.cleaned_data["slug"],
-                        )
+                        ),
                     )
 
     def set_dependent_translations_to_draft(

--- a/integreat_cms/cms/views/pois/poi_form_view.py
+++ b/integreat_cms/cms/views/pois/poi_form_view.py
@@ -302,23 +302,23 @@ class POIFormView(
         """
         Shows a message to the user if the slug they provided was not unique and therefore changed.
         """
-        if user_slug:
-            cleaned_slug = poi_translation_form.cleaned_data["slug"]
-            if user_slug != cleaned_slug:
-                if user_slug.lower() == cleaned_slug:
-                    message_uppercase = _(
-                        "The slug was changed from '{user_slug}' to '{slug}', because uppercase letters are not allowed."
-                    ).format(
-                        user_slug=user_slug,
-                        slug=cleaned_slug,
-                    )
-                    messages.warning(request, message_uppercase)
-                else:
-                    other_translation = POITranslation.objects.filter(
-                        poi__region=region,
-                        slug=user_slug,
-                        language=language,
-                    ).first()
+        cleaned_slug = poi_translation_form.cleaned_data["slug"]
+        if user_slug and user_slug != cleaned_slug:
+            if user_slug.lower() == cleaned_slug:
+                message_uppercase = _(
+                    "The slug was changed from '{user_slug}' to '{slug}', because uppercase letters are not allowed."
+                ).format(
+                    user_slug=user_slug,
+                    slug=cleaned_slug,
+                )
+                messages.warning(request, message_uppercase)
+            else:
+                other_translation = POITranslation.objects.filter(
+                    poi__region=region,
+                    slug=user_slug,
+                    language=language,
+                ).first()
+                if other_translation:
                     other_translation_link = other_translation.backend_edit_link
                     message = _(
                         "The slug was changed from '{user_slug}' to '{slug}', "
@@ -336,6 +336,21 @@ class POIFormView(
                                 "href": other_translation_link,
                                 "class": "underline hover:no-underline",
                             },
+                        ),
+                    )
+                else:
+                    logger.warning(
+                        "Slug was changed from the one the user provided, but we can't find the translation that already used it: %s (cleaned to %s)",
+                        user_slug,
+                        poi_translation_form.cleaned_data["slug"],
+                    )
+                    messages.warning(
+                        request,
+                        _(
+                            "The slug was changed from '{user_slug}' to '{slug}'."
+                        ).format(
+                            user_slug=user_slug,
+                            slug=poi_translation_form.cleaned_data["slug"],
                         ),
                     )
 

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -2247,9 +2247,9 @@ msgid ""
 "time because it is in draft status. Once the page is published, the content "
 "will be visible again."
 msgstr ""
-"Die aktuell als Live-Inhalt ausgewählte Seite ist für Nutzende zur Zeit nicht "
-"sichtbar, da sie sich im Entwurfs-Status befindet. Sobald die Seite veröffentlicht "
-"wird, werden die Inhalte wieder sichtbar."
+"Die aktuell als Live-Inhalt ausgewählte Seite ist für Nutzende zur Zeit "
+"nicht sichtbar, da sie sich im Entwurfs-Status befindet. Sobald die Seite "
+"veröffentlicht wird, werden die Inhalte wieder sichtbar."
 
 #: cms/forms/pages/page_filter_form.py
 msgid "Translation status"
@@ -9043,8 +9043,7 @@ msgstr "Bitte wählen Sie mindestens eine Seite aus."
 
 #: cms/templates/statistics/statistics_sidebar.html
 msgid "Please select at least one language."
-msgstr ""
-"Bitte wählen Sie mindestens eine Sprache aus."
+msgstr "Bitte wählen Sie mindestens eine Sprache aus."
 
 #: cms/templates/statistics/statistics_sidebar.html
 msgid "Please select at least one page and one language."
@@ -10129,6 +10128,12 @@ msgstr ""
 "'{user_slug}' bereits von <a>{translation}</a> oder einer vorherigen Version "
 "davon verwendet wird."
 
+#: cms/views/events/event_form_view.py cms/views/pages/page_form_view.py
+#: cms/views/pois/poi_form_view.py
+#, python-brace-format
+msgid "The slug was changed from '{user_slug}' to '{slug}'."
+msgstr "Der URL-Parameter wurde von '{user_slug}' zu '{slug}' geändert."
+
 #: cms/views/events/event_form_view.py
 msgid "Event \"{}\" was successfully created"
 msgstr "Veranstaltung \"{}\" wurde erfolgreich erstellt"
@@ -10982,11 +10987,6 @@ msgid ""
 msgstr ""
 "Der URL-Parameter wurde von '{user_slug}' zu '{slug}' geändert, da "
 "'{user_slug}' bereits von <a>{translation}</a> verwendet wird."
-
-#: cms/views/pages/page_form_view.py
-#, python-brace-format
-msgid "The slug was changed from '{user_slug}' to '{slug}'."
-msgstr "Der URL-Parameter wurde von '{user_slug}' zu '{slug}' geändert."
 
 #: cms/views/pages/page_form_view.py
 msgid "Page \"{}\" was successfully created and submitted for approval"

--- a/tests/cms/views/events/test_event_form.py
+++ b/tests/cms/views/events/test_event_form.py
@@ -622,3 +622,66 @@ def test_bulk_delete_events(
     assert_bulk_delete(
         Event, instance_ids, url, (client, role), caplog, settings, [fail_reason]
     )
+
+
+@pytest.mark.django_db
+def test_case_insensitive_unique_slug(
+    client: Client,
+    load_test_data: None,
+    settings: SettingsWrapper,
+) -> None:
+    """
+    Test that an appropriate message is shown to users and the view does not crash when slug is updated for uniqueness
+    """
+    settings.LANGUAGE_CODE = "en"
+
+    region = Region.objects.get(slug="augsburg")
+    language = Language.objects.get(slug="de")
+
+    event = Event.objects.create(
+        start=timezone.now(),
+        end=timezone.now() + timedelta(days=1),
+        region=region,
+    )
+    EventTranslation.objects.create(event=event, language=language, slug="slug")
+
+    assert EventTranslation.objects.filter(slug="slug").count() == 1
+    assert EventTranslation.objects.filter(slug="slug-2").count() == 0
+
+    user = get_user_model().objects.get(username="service_team")
+    client.force_login(user)
+
+    new_event_url = reverse(
+        "new_event",
+        kwargs={
+            "region_slug": region.slug,
+            "language_slug": language.slug,
+        },
+    )
+
+    response = client.post(
+        new_event_url,
+        data={
+            "content": "",
+            "title": "Slug",
+            "slug": "Slug",
+            "start_date": "2030-01-01",
+            "end_date": "2030-01-02",
+            "is_all_day": True,
+            "is_long_term": True,
+            "status": status.PUBLIC,
+            "has_not_location": True,
+        },
+    )
+
+    assert response.status_code == 302
+
+    redirect_url = response.headers.get("location")
+
+    assert (
+        "The slug was changed from &#x27;Slug&#x27; to &#x27;slug-2&#x27;."
+        in client.get(redirect_url).content.decode("utf-8")
+    )
+
+    assert EventTranslation.objects.filter(slug="slug").count() == 1
+    assert EventTranslation.objects.filter(slug="slug-2").count() == 1

--- a/tests/cms/views/pages/test_page_form.py
+++ b/tests/cms/views/pages/test_page_form.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from django.test.client import Client
+    from pytest_django.fixtures import SettingsWrapper
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from integreat_cms.cms.models import Language, Page, PageTranslation, Region
+
+
+@pytest.mark.django_db
+def test_case_insensitive_unique_slug(
+    client: Client,
+    load_test_data: None,
+    settings: SettingsWrapper,
+    create_page: Callable[..., Page],
+) -> None:
+    """
+    Test that an appropriate message is shown to users and the view does not crash when slug is updated for uniqueness
+    """
+    settings.LANGUAGE_CODE = "en"
+
+    region = Region.objects.get(slug="augsburg")
+    language = Language.objects.get(slug="de")
+
+    page = create_page(region=region)
+    PageTranslation.objects.create(page=page, language=language, slug="slug")
+
+    assert PageTranslation.objects.filter(slug="slug").count() == 1
+    assert PageTranslation.objects.filter(slug="slug-2").count() == 0
+
+    user = get_user_model().objects.get(username="service_team")
+    client.force_login(user)
+
+    new_page_url = reverse(
+        "new_page",
+        kwargs={
+            "region_slug": region.slug,
+            "language_slug": language.slug,
+        },
+    )
+
+    response = client.post(
+        new_page_url,
+        data={
+            "status": "PUBLIC",
+            "content": "",
+            "title": "Slug",
+            "slug": "Slug",
+            "icon": "",
+            "_ref_node_id": 2,
+            "_position": "right",
+            "parent": "",
+            "mirrored_page_region": "",
+            "mirrored_page_first": True,
+            "api_token": "",
+            "authors": "",
+            "editors": "",
+            "organization": "",
+            "minor_edit": False,
+        },
+    )
+
+    assert response.status_code == 302
+
+    redirect_url = response.headers.get("location")
+
+    assert (
+        "The slug was changed from &#x27;Slug&#x27; to &#x27;slug-2&#x27;."
+        in client.get(redirect_url).content.decode("utf-8")
+    )
+
+    assert PageTranslation.objects.filter(slug="slug").count() == 1
+    assert PageTranslation.objects.filter(slug="slug-2").count() == 1

--- a/tests/cms/views/poi/test_poi_form.py
+++ b/tests/cms/views/poi/test_poi_form.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import timedelta
 from typing import TYPE_CHECKING
 
@@ -24,6 +25,7 @@ from integreat_cms.cms.models import (
     POITranslation,
     Region,
 )
+from integreat_cms.cms.models.pois.poi import get_default_opening_hours
 from tests.cms.views.bulk_actions import assert_bulk_delete, BulkActionIDs
 from tests.conftest import (
     ANONYMOUS,
@@ -489,3 +491,78 @@ def test_bulk_delete_pois(
     assert_bulk_delete(
         POI, instance_ids, url, (client, role), caplog, settings, [fail_reason]
     )
+
+
+@pytest.mark.django_db
+def test_case_insensitive_unique_slug(
+    client: Client,
+    load_test_data: None,
+    settings: SettingsWrapper,
+) -> None:
+    """
+    Test that an appropriate message is shown to users and the view does not crash when slug is updated for uniqueness
+    """
+    settings.LANGUAGE_CODE = "en"
+
+    region = Region.objects.get(slug="augsburg")
+    language = Language.objects.get(slug="de")
+
+    poi_category = POICategory.objects.first()
+    poi = POI.objects.create(
+        region=region,
+        address="Test Street 1",
+        postcode="00000",
+        city="Augsburg",
+        country="Deutschland",
+        latitude="48.3780446",
+        longitude="10.8879783",
+        category=poi_category,
+    )
+    POITranslation.objects.create(poi=poi, language=language, slug="slug")
+
+    assert POITranslation.objects.filter(slug="slug").count() == 1
+    assert POITranslation.objects.filter(slug="slug-2").count() == 0
+
+    user = get_user_model().objects.get(username="service_team")
+    client.force_login(user)
+
+    new_event_url = reverse(
+        "new_poi",
+        kwargs={
+            "region_slug": region.slug,
+            "language_slug": language.slug,
+        },
+    )
+
+    response = client.post(
+        new_event_url,
+        data={
+            "content": "",
+            "title": "Slug",
+            "slug": "Slug",
+            "address": "Viktoriastraße 1",
+            "postcode": "86150",
+            "city": "Augsburg",
+            "country": "Deutschland",
+            "latitude": 48.36599805,
+            "longitude": 10.886110466584793,
+            "status": status.DRAFT,
+            "category": poi_category.id,
+            "opening_hours": json.dumps(get_default_opening_hours()),
+            "primary_email": "",
+            "primary_website": "",
+            "primary_phone_number": "",
+        },
+    )
+
+    assert response.status_code == 302
+
+    redirect_url = response.headers.get("location")
+
+    assert (
+        "The slug was changed from &#x27;Slug&#x27; to &#x27;slug-2&#x27;."
+        in client.get(redirect_url).content.decode("utf-8")
+    )
+
+    assert POITranslation.objects.filter(slug="slug").count() == 1
+    assert POITranslation.objects.filter(slug="slug-2").count() == 1


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR fixes the bug that user faces Internal Server Error when an upper case slug is modified to a new slug with lower case but it's already being used by another page/event/place.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Add missing `request` to `messages.warning()` in the page form
- Add `else` for cases where `other_translation` cannot be found


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None?


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4426 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
