### PR TITLE
Allow users to archive places if all referencing events and contacts are archived

### DIFF
--- a/integreat_cms/cms/models/contact/contact.py
+++ b/integreat_cms/cms/models/contact/contact.py
@@ -445,6 +445,9 @@ class Contact(AbstractBaseModel):
         self.archived = False
         self.save()
 
+        if self.location.archived:
+            self.location.restore()
+
     def copy(self, add_suffix: bool = True) -> Contact:
         """
         Copies the contact

--- a/integreat_cms/cms/models/events/event.py
+++ b/integreat_cms/cms/models/events/event.py
@@ -62,6 +62,14 @@ class EventQuerySet(ContentQuerySet):
             ),
         )
 
+    def filter_upcoming_non_archived(self) -> Self:
+        """
+        Filter all upcoming events that are not archived
+
+        :return: The Queryset of events that are upcoming and not archived
+        """
+        return self.filter_upcoming().exclude(archived=True)
+
     def filter_completed(self, to_date: date | None = None) -> Self:
         """
         Filter all events that are not ongoing and don't have any occurrences in the future. This is, per definition, if
@@ -294,6 +302,9 @@ class Event(AbstractContentModel):
         for translation in self.translations.distinct("event__pk", "language__pk"):
             # The post_save signal will create link objects from the content
             translation.save(update_timestamp=False)
+
+        if self.location and self.location.archived:
+            self.location.restore()
 
     def delete(self, *args: Any, **kwargs: Any) -> tuple[int, dict[str, int]]:
         """

--- a/integreat_cms/cms/models/pois/poi.py
+++ b/integreat_cms/cms/models/pois/poi.py
@@ -11,6 +11,7 @@ from integreat_cms.cms.models.utils import get_default_opening_hours
 
 if TYPE_CHECKING:
     from django.db.models.base import ModelBase
+    from django.db.models.query import QuerySet
 
 
 from django.utils.translation import gettext_lazy as _
@@ -146,7 +147,7 @@ class POI(AbstractContentModel):
         Archives the poi and removes all links of this poi from the linkchecker
         """
         was_successful = False
-        if not self.is_currently_used:
+        if self.can_be_archived:
             self.archived = True
             self.save()
             # Delete related link objects as they are no longer required
@@ -173,12 +174,21 @@ class POI(AbstractContentModel):
     @property
     def referring_contacts_exist(self) -> bool:
         """
-        return: whether there are contact objects referring the POI.
-        If the contact module is disabled in the region, it's always False
+        :return: whether there are contact objects referring the POI.
+            If the contact module is disabled in the region, it's always False
         """
         if not self.region.contacts_enabled:
             return False
         return self.contacts.exists()
+
+    @property
+    def non_archived_contacts(self) -> QuerySet:
+        """
+        :return: contacts that are not archived and referencing the POI
+        """
+        if not self.region.contacts_enabled:
+            return self.contacts.none()
+        return self.contacts.exclude(archived=True)
 
     @property
     def is_used(self) -> bool:
@@ -188,13 +198,14 @@ class POI(AbstractContentModel):
         return self.events.exists() or self.referring_contacts_exist
 
     @property
-    def is_currently_used(self) -> bool:
+    def can_be_archived(self) -> bool:
         """
-        :return: whether this poi is used by a contact or an upcoming event
+        :return: whether this poi can be archived
         """
-        upcoming_events = self.events.filter_upcoming()
-
-        return self.referring_contacts_exist or upcoming_events.exists()
+        return (
+            not self.non_archived_contacts.exists()
+            and not self.events.filter_upcoming_non_archived().exists()
+        )
 
     @cached_property
     def short_address(self) -> str:

--- a/integreat_cms/cms/templates/contacts/contact_form.html
+++ b/integreat_cms/cms/templates/contacts/contact_form.html
@@ -165,6 +165,7 @@
                                     data-confirmation-title="{{ restore_dialog_title }}"
                                     data-confirmation-text="{{ restore_dialog_text }}"
                                     data-confirmation-subject="{{ contact_form.instance.name }}"
+                                    {% if contact_form.instance.location.archived %} data-confirmation-referenced-location-title="{{ referenced_location_title }}" data-confirmation-referenced-location-subject="{{ contact_form.instance.location }}" {% endif %}
                                     data-action="{% url 'restore_contact' contact_id=contact_form.instance.id region_slug=request.region.slug %}">
                                 <i icon-name="refresh-ccw" class="mr-2"></i> {% translate "Restore this contact" %}
                             </button>

--- a/integreat_cms/cms/templates/contacts/contact_list_row.html
+++ b/integreat_cms/cms/templates/contacts/contact_list_row.html
@@ -83,6 +83,7 @@
                         class="confirmation-button btn-icon"
                         data-confirmation-title="{{ restore_dialog_title }}"
                         data-confirmation-subject="{{ contact.name }}"
+                        {% if contact.location.archived %} data-confirmation-referenced-location-title="{{ referenced_location_title }}" data-confirmation-referenced-location-subject="{{ contact.location }}" {% endif %}
                         data-action="{% url 'restore_contact' contact_id=contact.id region_slug=request.region.slug %}">
                     <i icon-name="refresh-ccw"></i>
                 </button>

--- a/integreat_cms/cms/templates/events/event_form_sidebar/actions_box.html
+++ b/integreat_cms/cms/templates/events/event_form_sidebar/actions_box.html
@@ -2,6 +2,7 @@
 {% load i18n %}
 {% load static %}
 {% load content_filters %}
+{% load poi_filters %}
 {% load widget_tweaks %}
 {% block collapsible_box_icon %}
     wrench
@@ -19,6 +20,7 @@
                     data-confirmation-title="{{ restore_dialog_title }}"
                     data-confirmation-text="{{ restore_dialog_text }}"
                     data-confirmation-subject="{{ event_translation_form.instance.title }}"
+                    {% if event_form.instance.location and event_form.instance.location.archived %} data-confirmation-referenced-location-title="{{ referenced_location_title }}" data-confirmation-referenced-location-subject="{{ event_form.instance.location|poi_translation_title:current_language }}" {% endif %}
                     data-action="{% url 'restore_event' event_id=event_form.instance.id region_slug=request.region.slug language_slug=language.slug %}">
                 <i icon-name="refresh-ccw" class="mr-2"></i>
                 {% translate "Restore this event" %}

--- a/integreat_cms/cms/templates/events/event_list_row.html
+++ b/integreat_cms/cms/templates/events/event_list_row.html
@@ -182,6 +182,7 @@
                         data-confirmation-title="{{ restore_dialog_title }}"
                         data-confirmation-text="{{ restore_dialog_text }}"
                         data-confirmation-subject="{{ event_translation.title }}"
+                        {% if event.location and event.location.archived %} data-confirmation-referenced-location-title="{{ referenced_location_title }}" data-confirmation-referenced-location-subject="{{ event.location|poi_translation_title:current_language }}" {% endif %}
                         data-action="{% url 'restore_event' event_id=event.id region_slug=request.region.slug language_slug=language.slug %}">
                     <i icon-name="refresh-ccw"></i>
                 </button>

--- a/integreat_cms/cms/templates/generic_confirmation_dialog.html
+++ b/integreat_cms/cms/templates/generic_confirmation_dialog.html
@@ -16,6 +16,11 @@
             </h2>
             <h3 id="confirmation-subject" class="text-center mt-4 mb-6 break-words">
             </h3>
+            <h2 id="confirmation-referenced-location-title">
+            </h2>
+            <h3 id="confirmation-referenced-location-subject"
+                class="text-center mt-4 mb-6 break-words">
+            </h3>
             <p id="confirmation-text" class="mt-4 mb-6 whitespace-pre-line">
             </p>
             <form method="post" action="#">

--- a/integreat_cms/cms/templates/pois/poi_form_sidebar/action_box.html
+++ b/integreat_cms/cms/templates/pois/poi_form_sidebar/action_box.html
@@ -28,22 +28,22 @@
             <label class="mt-0">
                 {% translate "Archive location" %}
             </label>
-            {% if poi_form.instance.is_currently_used %}
-                {% if poi_form.instance.events.filter_upcoming.exists %}
+            {% if not poi_form.instance.can_be_archived %}
+                {% if poi_form.instance.events.filter_upcoming_non_archived.exists %}
                     <div class="mb-5">
                         <div class="bg-orange-100 border-l-4 border-orange-500 text-orange-700 px-4 py-3 mb-5"
                              role="alert">
                             <p>
-                                {% translate "You cannot archive a location which is referenced by an event." %}
+                                {% translate "You cannot archive a location which is referenced by a non-archived event." %}
                                 <br />
-                                {% blocktranslate count counter=poi_form.instance.events.count trimmed %}
-                                    To archive this location, you have to delete this event first:
+                                {% blocktranslate count counter=poi_form.instance.events.filter_upcoming_non_archived.count trimmed %}
+                                    To archive this location, you have to archive or delete this event first:
                                 {% plural %}
-                                    To archive this location, you have to delete these events first:
+                                    To archive this location, you have to archive or delete these events first:
                                 {% endblocktranslate %}
                             </p>
                         </div>
-                        {% for event in poi_form.instance.events.filter_upcoming %}
+                        {% for event in poi_form.instance.events.filter_upcoming_non_archived %}
                             <a href="{% url 'edit_event' event_id=event.id region_slug=request.region.slug language_slug=language.slug %}"
                                class="block pt-2 hover:underline">
                                 <i icon-name="pen-square" class="mr-2"></i> {{ event.best_translation.title }}
@@ -51,21 +51,21 @@
                         {% endfor %}
                     </div>
                 {% endif %}
-                {% if request.region.contacts_enabled and poi_form.instance.contacts.exists %}
+                {% if request.region.contacts_enabled and poi_form.instance.non_archived_contacts.exists %}
                     <div class="mb-5">
                         <div class="bg-orange-100 border-l-4 border-orange-500 text-orange-700 px-4 py-3 mb-5"
                              role="alert">
                             <p>
-                                {% translate "You cannot archive a location which is referenced by a contact." %}
+                                {% translate "You cannot archive a location which is referenced by a non-archived contact." %}
                                 <br />
-                                {% blocktranslate count counter=poi_form.instance.contacts.count trimmed %}
-                                    To archive this location, you have to delete this contact first:
+                                {% blocktranslate count counter=poi_form.instance.non_archived_contacts.count trimmed %}
+                                    To archive this location, you have to archive or delete this contact first:
                                 {% plural %}
-                                    To archive this location, you have to delete these contacts first:
+                                    To archive this location, you have to archive or delete these contacts first:
                                 {% endblocktranslate %}
                             </p>
                         </div>
-                        {% for contact in poi_form.instance.contacts.all %}
+                        {% for contact in poi_form.instance.non_archived_contacts.all %}
                             <a href="{% url 'edit_contact' contact_id=contact.id region_slug=request.region.slug %}"
                                class="block pt-2 hover:underline">
                                 <i icon-name="pen-square" class="mr-2"></i> {{ contact.label_in_reference_list }}

--- a/integreat_cms/cms/templates/pois/poi_list_row.html
+++ b/integreat_cms/cms/templates/pois/poi_list_row.html
@@ -154,7 +154,7 @@
                         <i icon-name="copy"></i>
                     </button>
                 </form>
-                {% if poi.is_currently_used %}
+                {% if not poi.can_be_archived %}
                     <button title="{{ cannot_archive_title }}" class="btn-icon" disabled>
                         <i icon-name="archive"></i>
                     </button>

--- a/integreat_cms/cms/views/bulk_action_views.py
+++ b/integreat_cms/cms/views/bulk_action_views.py
@@ -361,7 +361,7 @@ class BulkArchiveView(BulkActionView):
             title = content_object.best_translation.title
             if self.model is Page and content_object.mirroring_pages.exists():
                 archive_failed_because_embedded.append(title)
-            elif self.model is POI and content_object.is_currently_used:
+            elif self.model is POI and not content_object.can_be_archived:
                 archive_failed_because_reference.append(title)
             elif content_object.archived:
                 archive_unchanged.append(title)

--- a/integreat_cms/cms/views/contacts/contact_context_mixin.py
+++ b/integreat_cms/cms/views/contacts/contact_context_mixin.py
@@ -42,6 +42,9 @@ class ContactContextMixin(ContextMixin):
                 "restore_dialog_title": _(
                     "Please confirm that you really want to restore this contact",
                 ),
+                "referenced_location_title": _(
+                    "The following linked content will also be restored:",
+                ),
                 "delete_dialog_title": _(
                     "Please confirm that you really want to delete this contact",
                 ),

--- a/integreat_cms/cms/views/events/event_context_mixin.py
+++ b/integreat_cms/cms/views/events/event_context_mixin.py
@@ -38,6 +38,9 @@ class EventContextMixin(ContextMixin):
                 "restore_dialog_title": _(
                     "Please confirm that you really want to restore this event",
                 ),
+                "referenced_location_title": _(
+                    "The following linked content will also be restored:",
+                ),
                 "restore_dialog_text": _(
                     "All translations of this event will also be restored.",
                 ),

--- a/integreat_cms/cms/views/pois/poi_actions.py
+++ b/integreat_cms/cms/views/pois/poi_actions.py
@@ -51,7 +51,9 @@ def archive_poi(
     else:
         messages.error(
             request,
-            _("This location cannot be archived because it is referenced by an event."),
+            _(
+                "This location cannot be archived because it is referenced by an event or a contact that is not archived."
+            ),
         )
 
     return redirect(

--- a/integreat_cms/cms/views/pois/poi_context_mixin.py
+++ b/integreat_cms/cms/views/pois/poi_context_mixin.py
@@ -60,7 +60,7 @@ class POIContextMixin(ContextMixin):
                     "All translations of this location will also be deleted.",
                 ),
                 "cannot_archive_title": _(
-                    "You cannot archive a location which is used by an upcoming event or a contact. \nThis also involves archived events and contacts",
+                    "You cannot archive a location which is used by an upcoming event or a contact.",
                 ),
                 "cannot_delete_title": _(
                     "You cannot delete a location which is used by an event or a contact. \nThis also involves archived events and contacts",

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8100,29 +8100,42 @@ msgid "Archive location"
 msgstr "Ort archivieren"
 
 #: cms/templates/pois/poi_form_sidebar/action_box.html
-msgid "You cannot archive a location which is referenced by an event."
+msgid ""
+"You cannot archive a location which is referenced by a non-archived event."
 msgstr ""
-"Der Ort kann nicht archiviert werden, da er von einer Veranstaltung "
-"verwendet wird."
+"Der Ort kann nicht archiviert werden, da er von einer nicht-archivierten "
+"Veranstaltung verwendet wird."
 
 #: cms/templates/pois/poi_form_sidebar/action_box.html
-msgid "To archive this location, you have to delete this event first:"
-msgid_plural "To archive this location, you have to delete these events first:"
-msgstr[0] "Löschen Sie zuerst diese Veranstaltung, um den Ort zu archivieren:"
-msgstr[1] ""
-"Löschen Sie zuerst diese Veranstaltungen, um den Ort zu archivieren:"
-
-#: cms/templates/pois/poi_form_sidebar/action_box.html
-msgid "You cannot archive a location which is referenced by a contact."
-msgstr ""
-"Der Ort kann nicht archiviert werden, da er von einem Kontakt verwendet wird."
-
-#: cms/templates/pois/poi_form_sidebar/action_box.html
-msgid "To archive this location, you have to delete this contact first:"
+msgid ""
+"To archive this location, you have to archive or delete this event first:"
 msgid_plural ""
-"To archive this location, you have to delete these contacts first:"
-msgstr[0] "Löschen Sie zuerst diesen Kontakt, um den Ort zu archivieren:"
-msgstr[1] "Löschen Sie zuerst diese Kontakte, um den Ort zu archivieren:"
+"To archive this location, you have to archive or delete these events first:"
+msgstr[0] ""
+"Archivieren oder löschen Sie zuerst diese Veranstaltung, um den Ort zu "
+"archivieren:"
+msgstr[1] ""
+"Archivieren oder löschen Sie zuerst diese Veranstaltungen, um den Ort zu "
+"archivieren:"
+
+#: cms/templates/pois/poi_form_sidebar/action_box.html
+msgid ""
+"You cannot archive a location which is referenced by a non-archived contact."
+msgstr ""
+"Der Ort kann nicht archiviert werden, da er von einem nicht-archivierten "
+"Kontakt verwendet wird."
+
+#: cms/templates/pois/poi_form_sidebar/action_box.html
+msgid ""
+"To archive this location, you have to archive or delete this contact first:"
+msgid_plural ""
+"To archive this location, you have to archive or delete these contacts first:"
+msgstr[0] ""
+"Archivieren oder löschen Sie zuerst diesen Kontakt, um den Ort zu "
+"archivieren:"
+msgstr[1] ""
+"Archivieren oder löschen Sie zuerst diese Kontakte, um den Ort zu "
+"archivieren:"
 
 #: cms/templates/pois/poi_form_sidebar/action_box.html
 msgid "Archive this location"
@@ -9882,6 +9895,11 @@ msgstr ""
 "Bitte bestätigen Sie, dass dieser Kontakt wiederhergestellt werden soll"
 
 #: cms/views/contacts/contact_context_mixin.py
+#: cms/views/events/event_context_mixin.py
+msgid "The following linked content will also be restored:"
+msgstr "Folgende verknüpfte Inhalte werden ebenfalls wiederhergestellt:"
+
+#: cms/views/contacts/contact_context_mixin.py
 msgid "Please confirm that you really want to delete this contact"
 msgstr "Bitte bestätigen Sie, dass dieser Kontakt gelöscht werden soll"
 
@@ -11081,10 +11099,12 @@ msgid "Location was successfully archived"
 msgstr "Ort wurde erfolgreich archiviert"
 
 #: cms/views/pois/poi_actions.py
-msgid "This location cannot be archived because it is referenced by an event."
+msgid ""
+"This location cannot be archived because it is referenced by an event or a "
+"contact that is not archived."
 msgstr ""
-"Dieser Ort kann nicht archiviert werden, da er von einer Veranstaltung oder "
-"einem Kontakt verwendet wird."
+"Dieser Ort kann nicht archiviert werden, da er von einer nicht-archivierten "
+"Veranstaltung oder einem nicht-archivierten Kontakt verwendet wird."
 
 #: cms/views/pois/poi_actions.py
 msgid "Location was successfully restored"
@@ -11138,12 +11158,10 @@ msgstr "Alle Übersetzungen dieses Ortes werden gelöscht."
 #: cms/views/pois/poi_context_mixin.py
 msgid ""
 "You cannot archive a location which is used by an upcoming event or a "
-"contact. \n"
-"This also involves archived events and contacts"
+"contact."
 msgstr ""
 "Sie können keinen Ort archivieren, der von einer zukünftigen Veranstaltung "
-"oder einem Kontakt verwendet wird. \n"
-"Dies betrifft auch archivierte Veranstaltungen und Kontakte"
+"oder einem Kontakt verwendet wird."
 
 #: cms/views/pois/poi_context_mixin.py
 msgid ""
@@ -12105,6 +12123,15 @@ msgstr ""
 #~ msgid "This is normal and to be expected"
 #~ msgstr "Das ist normal und zu erwarten"
 
+#~ msgid ""
+#~ "You cannot archive a location which is used by an upcoming event or a "
+#~ "contact. \n"
+#~ "This also involves archived events and contacts"
+#~ msgstr ""
+#~ "Sie können keinen Ort archivieren, der von einer zukünftigen "
+#~ "Veranstaltung oder einem Kontakt verwendet wird. \n"
+#~ "Dies betrifft auch archivierte Veranstaltungen und Kontakte"
+
 #~ msgid "Total Access Statistics"
 #~ msgstr "Statistiken für Gesamtzugriffe"
 
@@ -12605,11 +12632,6 @@ msgstr ""
 
 #~ msgid "Back to the location form"
 #~ msgstr "Zurück zum Orts-Formular"
-
-#~ msgid "You cannot archive a location which is used by an event."
-#~ msgstr ""
-#~ "Der Ort kann nicht archiviert werden, da er von einer Veranstaltung "
-#~ "verwendet wird."
 
 #~ msgid "\"{} {}\" was not in translation process."
 #~ msgid_plural "The following \"{}\" were not in translation process: \"{}\""

--- a/integreat_cms/release_notes/current/unreleased/4154.yml
+++ b/integreat_cms/release_notes/current/unreleased/4154.yml
@@ -1,0 +1,2 @@
+en: Make it possible to archive a place if all referencing events and contacts are archived
+de: Ermögliche das Archivieren eines Ortes, wenn alle darauf verweisenden Veranstaltungen und Kontakte archiviert sind

--- a/integreat_cms/static/src/js/utils/confirmation-popup.ts
+++ b/integreat_cms/static/src/js/utils/confirmation-popup.ts
@@ -72,6 +72,10 @@ export const showConfirmationPopup = (event: Event, onSubmit?: (event: Event) =>
         button.getAttribute("data-confirmation-text"),
         onSubmit
     );
+    const referencedLocationTitle = button.getAttribute("data-confirmation-referenced-location-title");
+    document.getElementById("confirmation-referenced-location-title").textContent = referencedLocationTitle ?? "";
+    const referencedLocationSubject = button.getAttribute("data-confirmation-referenced-location-subject");
+    document.getElementById("confirmation-referenced-location-subject").textContent = referencedLocationSubject ?? "";
     const action = button.getAttribute("data-action");
     if (action) {
         const url = new URL(action, window.location.origin);

--- a/tests/cms/models/contacts/test_contacts.py
+++ b/tests/cms/models/contacts/test_contacts.py
@@ -8,7 +8,15 @@ if TYPE_CHECKING:
 
 import pytest
 
-from integreat_cms.cms.models import Contact
+from integreat_cms.cms.constants import poicategory
+from integreat_cms.cms.models import (
+    Contact,
+    Language,
+    POI,
+    POICategory,
+    POITranslation,
+    Region,
+)
 
 
 @pytest.mark.django_db
@@ -85,3 +93,48 @@ def test_restoring_contact_works(
 
     assert Contact.objects.all().count() == 6
     assert contact.archived is False
+
+
+@pytest.mark.django_db
+def test_contact_restore_with_referenced_poi() -> None:
+    """
+    Tests restoring a contact restores its location together.
+    """
+    region = Region.objects.create(name="new-region")
+    language = Language.objects.create(slug="da", primary_country_code="de")
+
+    poi_category = POICategory.objects.create(
+        icon=poicategory.OTHER,
+        color=poicategory.DARK_BLUE,
+    )
+    poi = POI.objects.create(
+        region=region,
+        address="Adress 42",
+        postcode="00000",
+        city="Augsburg",
+        country="Deutschland",
+        latitude="48.3780446",
+        longitude="10.8879783",
+        category=poi_category,
+        archived=True,
+    )
+    POITranslation.objects.create(poi=poi, language=language, slug="new-poi-slug")
+
+    contact = Contact.objects.create(
+        email="",
+        phone_number="+49 123456789",
+        website="",
+        area_of_responsibility="Title",
+        name="Contact",
+        location=poi,
+        archived=True,
+    )
+
+    assert contact.archived
+    assert poi.archived
+    assert contact.location.id == poi.id
+
+    contact.restore()
+
+    assert not contact.archived
+    assert not poi.archived

--- a/tests/cms/models/events/test_events.py
+++ b/tests/cms/models/events/test_events.py
@@ -1,0 +1,61 @@
+from datetime import timedelta
+
+import pytest
+from django.utils import timezone
+
+from integreat_cms.cms.constants import poicategory
+from integreat_cms.cms.models import (
+    Event,
+    EventTranslation,
+    Language,
+    POI,
+    POICategory,
+    POITranslation,
+    Region,
+)
+
+
+@pytest.mark.django_db
+def test_event_restore_with_referenced_poi() -> None:
+    """
+    Tests restoring an event restores its location together.
+    """
+    region = Region.objects.create(name="new-region")
+    language = Language.objects.create(slug="da", primary_country_code="de")
+
+    poi_category = POICategory.objects.create(
+        icon=poicategory.OTHER,
+        color=poicategory.DARK_BLUE,
+    )
+    poi = POI.objects.create(
+        region=region,
+        address="Adress 42",
+        postcode="00000",
+        city="Augsburg",
+        country="Deutschland",
+        latitude="48.3780446",
+        longitude="10.8879783",
+        category=poi_category,
+        archived=True,
+    )
+    POITranslation.objects.create(poi=poi, language=language, slug="new-poi-slug")
+
+    event = Event.objects.create(
+        start=timezone.now(),
+        end=timezone.now() + timedelta(days=1),
+        region=region,
+        archived=True,
+        location=poi,
+    )
+    EventTranslation.objects.create(
+        event=event, language=language, slug="new-event-slug"
+    )
+
+    assert event.archived
+    assert poi.archived
+    assert event.location.id == poi.id
+
+    event.restore()
+
+    assert not event.archived
+    assert not poi.archived

--- a/tests/cms/views/poi/test_poi_form.py
+++ b/tests/cms/views/poi/test_poi_form.py
@@ -18,6 +18,7 @@ from django.utils import timezone
 
 from integreat_cms.cms.constants import status
 from integreat_cms.cms.models import (
+    Contact,
     Event,
     Language,
     POI,
@@ -70,7 +71,7 @@ def test_barrier_free_and_organization_box_appear(
 REGION_SLUG = "augsburg"
 
 
-def create_used_poi(region_slug: str, name_add: str = "") -> int:
+def create_poi_used_by_event(region_slug: str, name_add: str = "") -> int:
     """
     A helper function to create a new POI used in an event
     """
@@ -103,6 +104,43 @@ def create_used_poi(region_slug: str, name_add: str = "") -> int:
     event.save()
 
     assert used_poi.events.count() > 0
+
+    return used_poi.id
+
+
+def create_poi_used_by_contact(region_slug: str, name_add: str = "") -> int:
+    """
+    helper function to create a new POI that is used in a contact
+    """
+    region = Region.objects.filter(slug=region_slug).first()
+    contact = Contact.objects.filter(location__region=region).first()
+    poi_category = POICategory.objects.first()
+
+    used_poi = POI.objects.create(
+        region_id=region.id,
+        address="Adress 42",
+        postcode="00000",
+        city="Augsburg",
+        country="Deutschland",
+        latitude="48.3780446",
+        longitude="10.8879783",
+        category=poi_category,
+    )
+
+    german_language = Language.objects.filter(slug="de").first()
+    POITranslation.objects.create(
+        title="Ort" + name_add,
+        slug="ort" + name_add,
+        status=status.PUBLIC,
+        content="",
+        language=german_language,
+        poi=used_poi,
+    )
+
+    contact.location = used_poi
+    contact.save()
+
+    assert used_poi.contacts.count() > 0
 
     return used_poi.id
 
@@ -182,7 +220,7 @@ def create_unused_poi(region_slug: str, name_add: str = "") -> int:
 
 
 @pytest.mark.django_db
-def test_poi_currently_in_use_cannot_be_archived(
+def test_poi_currently_used_by_event_cannot_be_archived(
     load_test_data: None,
     login_role_user: tuple[Client, str],
     caplog: LogCaptureFixture,
@@ -190,12 +228,13 @@ def test_poi_currently_in_use_cannot_be_archived(
 ) -> None:
     """
     Checks whether a POI is protected from archiving if it is currently used in an event
+    but can be archived if referencing events are archived
     """
     settings.LANGUAGE_CODE = "en"
     client, role = login_role_user
 
     # Make sure the target POI is used in an event
-    poi_id = create_used_poi("augsburg")
+    poi_id = create_poi_used_by_event("augsburg")
 
     # Try to archive the POI
     archive_poi = reverse(
@@ -212,7 +251,7 @@ def test_poi_currently_in_use_cannot_be_archived(
         )
     elif role in PRIV_STAFF_ROLES + WRITE_ROLES:
         assert_message_in_log(
-            "ERROR    This location cannot be archived because it is referenced by an event.",
+            "ERROR    This location cannot be archived because it is referenced by an event or a contact that is not archived.",
             caplog,
         )
     else:
@@ -220,6 +259,96 @@ def test_poi_currently_in_use_cannot_be_archived(
 
     # Check the POI is not archived
     assert not POI.objects.filter(id=poi_id).first().archived
+
+    # Archive referencing events
+    for event in POI.objects.filter(id=poi_id).first().events.all():
+        event.archived = True
+        event.save()
+
+    # Try to archive the POI
+    response = client.post(archive_poi)
+
+    if role == ANONYMOUS:
+        assert response.status_code == 302
+        assert (
+            response.headers.get("location")
+            == f"{settings.LOGIN_URL}?next={archive_poi}"
+        )
+    elif role in PRIV_STAFF_ROLES + WRITE_ROLES:
+        assert_message_in_log(
+            "SUCCESS  Location was successfully archived",
+            caplog,
+        )
+        # Check the POI is archived
+        assert POI.objects.filter(id=poi_id).first().archived
+    else:
+        assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_poi_currently_used_by_contact_cannot_be_archived(
+    load_test_data: None,
+    login_role_user: tuple[Client, str],
+    caplog: LogCaptureFixture,
+    settings: SettingsWrapper,
+) -> None:
+    """
+    Checks whether a POI is protected from archiving if it is currently used in a contact
+    but can be archived if referencing contacts are archived
+    """
+    settings.LANGUAGE_CODE = "en"
+    client, role = login_role_user
+
+    # Make sure the target POI is used in a contact
+    poi_id = create_poi_used_by_contact("augsburg")
+
+    # Try to archive the POI
+    archive_poi = reverse(
+        "archive_poi",
+        kwargs={"region_slug": "augsburg", "language_slug": "de", "poi_id": poi_id},
+    )
+    response = client.post(archive_poi)
+
+    if role == ANONYMOUS:
+        assert response.status_code == 302
+        assert (
+            response.headers.get("location")
+            == f"{settings.LOGIN_URL}?next={archive_poi}"
+        )
+    elif role in PRIV_STAFF_ROLES + WRITE_ROLES:
+        assert_message_in_log(
+            "ERROR    This location cannot be archived because it is referenced by an event or a contact that is not archived.",
+            caplog,
+        )
+    else:
+        assert response.status_code == 403
+
+    # Check the POI is not archived
+    assert not POI.objects.filter(id=poi_id).first().archived
+
+    # Archive referencing contacts
+    for contact in POI.objects.filter(id=poi_id).first().contacts.all():
+        contact.archived = True
+        contact.save()
+
+    # Try to archive the POI
+    response = client.post(archive_poi)
+
+    if role == ANONYMOUS:
+        assert response.status_code == 302
+        assert (
+            response.headers.get("location")
+            == f"{settings.LOGIN_URL}?next={archive_poi}"
+        )
+    elif role in PRIV_STAFF_ROLES + WRITE_ROLES:
+        assert_message_in_log(
+            "SUCCESS  Location was successfully archived",
+            caplog,
+        )
+        # Check the POI is archived
+        assert POI.objects.filter(id=poi_id).first().archived
+    else:
+        assert response.status_code == 403
 
 
 @pytest.mark.django_db
@@ -260,6 +389,49 @@ def test_poi_used_by_past_event_can_be_archived(
 
 
 @pytest.mark.django_db
+def test_poi_archive_not_crash(
+    load_test_data: None,
+    login_role_user: tuple[Client, str],
+    caplog: LogCaptureFixture,
+    settings: SettingsWrapper,
+) -> None:
+    """
+    Checks whether a POI can be archived successfully in a region that does not use contact feature (regression found in #4436)
+    """
+    settings.LANGUAGE_CODE = "en"
+    client, role = login_role_user
+
+    poi_id = create_poi_used_by_contact("augsburg")
+
+    region = Region.objects.filter(slug="augsburg").first()
+    region.contacts_enabled = False
+    region.save()
+
+    archive_poi = reverse(
+        "archive_poi",
+        kwargs={
+            "region_slug": "augsburg",
+            "language_slug": "de",
+            "poi_id": poi_id,
+        },
+    )
+    response = client.post(archive_poi)
+
+    if role == ANONYMOUS:
+        assert response.status_code == 302
+        assert (
+            response.headers.get("location")
+            == f"{settings.LOGIN_URL}?next={archive_poi}"
+        )
+    elif role in PRIV_STAFF_ROLES + WRITE_ROLES:
+        assert_message_in_log("SUCCESS  Location was successfully archived", caplog)
+        # Check the POI is archived
+        assert POI.objects.get(id=poi_id).archived
+    else:
+        assert response.status_code == 403
+
+
+@pytest.mark.django_db
 def test_poi_in_use_not_deleted(
     load_test_data: None,
     caplog: LogCaptureFixture,
@@ -274,7 +446,7 @@ def test_poi_in_use_not_deleted(
     settings.LANGUAGE_CODE = "en"
 
     # Make sure the target POI is used in an event
-    poi_id = create_used_poi("augsburg")
+    poi_id = create_poi_used_by_event("augsburg")
 
     # Try to delete the POI
     delete_poi = reverse(
@@ -317,7 +489,7 @@ def test_poi_in_use_not_bulk_archived(
     client, role = login_role_user
 
     # Make sure the target POI is used in an event
-    poi_id = create_used_poi("augsburg")
+    poi_id = create_poi_used_by_event("augsburg")
 
     # Try to archive the POI by bulk action
     bulk_archive_pois = reverse(
@@ -477,7 +649,8 @@ def test_bulk_delete_pois(
         create_unused_poi("augsburg", f"-{i}") for i in range(num_deletable)
     ]
     undeletable_pois = [
-        create_used_poi("augsburg", f"-{i}-used") for i in range(num_undeletable)
+        create_poi_used_by_event("augsburg", f"-{i}-used")
+        for i in range(num_undeletable)
     ]
     instance_ids: BulkActionIDs = {
         "deletable": deletable_pois,


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR makes it possible for users to archive a place (location/POI) if all events and contacts that are referencing it are archived (without deletion).

### Proposed changes
<!-- Describe this PR in more detail. -->

- Change the condition for archiving


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Should be none


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
- Create a place
- See it can be archived
- Create or select an event or contact, make it reference the newly created place
- See the place cannot be archived
- Archive all referencing contacts and events
- See the place can be archived
 
### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4154 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
