### PR TITLE
Fetch tunews if cache is empty

### DIFF
--- a/integreat_cms/news_managers/abstract_news_manager.py
+++ b/integreat_cms/news_managers/abstract_news_manager.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_CACHE_MISS = object()
+
 
 class NewsItem(TypedDict):
     id: str
@@ -63,15 +65,28 @@ class AbstractNewsManager(ABC):
         """
         raise NotImplementedError
 
+    def get_cached_news_items(self, language_slug: str) -> list[NewsItem]:
+        """
+        Return the cached news items for the given language.
+
+        If the cache key does not exist yet (i.e. the cache has not been warmed
+        up), the news items are imported from the source on demand and the cache
+        is populated before returning.
+        """
+        cache_key = f"{self.short_name}:{language_slug}"
+        posts = cache.get(cache_key, _CACHE_MISS)
+        if posts is _CACHE_MISS:
+            logger.info("Cache miss for %s; importing news items on demand.", cache_key)
+            self.import_news_items()
+            posts = cache.get(cache_key, [])
+        return posts
+
     def collect_news_items(
         self, region_slug: str, language_slug: str, _channel: str
     ) -> list[NewsItem]:
         """
         Returns news items imported from the source
         """
-        posts = cache.get(f"{self.short_name}:{language_slug}", [])
-        if not posts:
-            return []
         try:
             if not Region.objects.get(slug=region_slug).external_news_enabled:
                 logger.exception("External news not enabled: %s", region_slug)
@@ -79,7 +94,7 @@ class AbstractNewsManager(ABC):
         except Region.DoesNotExist:
             logger.exception("Region not found: %s", region_slug)
             return []
-        return posts
+        return self.get_cached_news_items(language_slug)
 
     def social_media_headers(
         self,
@@ -125,7 +140,7 @@ class AbstractNewsManager(ABC):
         """
         if not region.external_news_enabled:
             raise Http404("External news are not enabled in this region.")
-        posts = cache.get(f"{self.short_name}:{language.slug}", [])
+        posts = self.get_cached_news_items(language.slug)
         post = next(
             (
                 post

--- a/integreat_cms/news_managers/amalnews_manager.py
+++ b/integreat_cms/news_managers/amalnews_manager.py
@@ -74,9 +74,8 @@ class AmalnewsManager(AbstractNewsManager):
                             post.get("id"),
                         )
 
-                if news:
-                    cache.set(f"{self.short_name}:{language.slug}", news, timeout=None)
-                    logger.info("Saving %s news in %s", len(news), language)
+                cache.set(f"{self.short_name}:{language.slug}", news, timeout=None)
+                logger.info("Saving %s news in %s", len(news), language)
 
             except requests.exceptions.RequestException:
                 logger.exception("Failed to fetch posts in %s.", language)

--- a/integreat_cms/news_managers/tunews_manager.py
+++ b/integreat_cms/news_managers/tunews_manager.py
@@ -78,16 +78,15 @@ class TunewsManager(AbstractNewsManager):
                             post.get("id"),
                         )
 
-                if news:
-                    cache.set(f"{self.short_name}:{language.slug}", news, timeout=None)
-                    logger.info("Saving %s news in %s", len(news), language)
-                    logger.info(
-                        "Saved %s news in %s",
-                        len(cache.get(f"{self.short_name}:{language.slug}")),
-                        language,
-                    )
-                    for post in cache.get(f"{self.short_name}:{language.slug}"):
-                        logger.info(post.get("title"))
+                cache.set(f"{self.short_name}:{language.slug}", news, timeout=None)
+                logger.info("Saving %s news in %s", len(news), language)
+                logger.info(
+                    "Saved %s news in %s",
+                    len(cache.get(f"{self.short_name}:{language.slug}")),
+                    language,
+                )
+                for post in cache.get(f"{self.short_name}:{language.slug}"):
+                    logger.info(post.get("title"))
 
             except requests.exceptions.RequestException:
                 logger.exception("Failed to fetch posts in %s.", language)


### PR DESCRIPTION
### Short description
Fill news cache if cache is missed.


### Proposed changes
- We cannot rely on the news cache being warmed up. We do not persist Redis on a hard disk and also the database migrations trigger a flush of the cache.
- This change fetches the news from the remote source if the cache key is not found. If the cache key has an empty value, we assume that there are currently no news.


### Side effects
- Users missing the cache have to wait a bit longer.


### Faithfulness to issue description and design
There are no intended deviations from the issue and design.


### How to test
1. Flush the cache with `redis-cli flushall`
2. curl the news endpoint

### Resolved issues

Fixes: https://chat.tuerantuer.org/digitalfabrik/pl/6oqmwagroty38xk5nr85zuorny


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
