### PR TITLE
Update Documentation and Devcontainer to python 3.13

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/python:3.11-bookworm
+FROM mcr.microsoft.com/vscode/devcontainers/python:3.13-bookworm
 
 RUN rm -f /etc/apt/sources.list.d/yarn.list
 RUN apt-get update && \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/vscode/devcontainers/python:3.13-bookworm
+FROM mcr.microsoft.com/devcontainers/python:3.13-bookworm
 
 RUN rm -f /etc/apt/sources.list.d/yarn.list
 RUN apt-get update && \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,7 +30,7 @@
       }
     }
   },
-  "postCreateCommand": "./tools/install.sh --python python3.11 && ./tools/migrate.sh && ./tools/loadtestdata.sh",
+  "postCreateCommand": "./tools/install.sh --python python3.13 && ./tools/migrate.sh && ./tools/loadtestdata.sh",
   "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder} && redis-server --daemonize yes --unixsocket /workspace/redis-server.sock --unixsocketperm 770",
   "remoteEnv": {
     "DJANGO_SETTINGS_MODULE": "integreat_cms.core.settings",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -30,7 +30,7 @@
       }
     }
   },
-  "postCreateCommand": "./tools/install.sh --python python3.13 && ./tools/migrate.sh && ./tools/loadtestdata.sh",
+  "postCreateCommand": "./tools/install.sh --python python3.13 && ./tools/migrate.sh",
   "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder} && redis-server --daemonize yes --unixsocket /workspace/redis-server.sock --unixsocketperm 770",
   "remoteEnv": {
     "DJANGO_SETTINGS_MODULE": "integreat_cms.core.settings",
@@ -39,6 +39,7 @@
     "INTEGREAT_CMS_FCM_KEY": "dummy",
     "INTEGREAT_CMS_SECRET_KEY": "dummy",
     "INTEGREAT_CMS_BACKGROUND_TASKS_ENABLED": "0",
-    "INTEGREAT_CMS_LINKCHECK_DISABLE_LISTENERS": "1"
+    "INTEGREAT_CMS_SUMM_AI_API_KEY": "dummy",
+    "INTEGREAT_CMS_LINKCHECK_DISABLE_LISTENERS": "0"
   }
 }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To configure your development environment on your system, please follow these st
 1. Ensure that the following packages are installed alongside your preferred IDE:
    - `npm` version 7 or later
    - `nodejs` version 22 or later
-   - `python3` version 3.13 or later
+   - `python3` version 3.13
    - `python3-pip` (Debian-based distributions) / `python-pip` (Arch-based distributions)
    - `python3-venv` (only on Debian-based distributions)
    - `gettext` for translation features
@@ -58,7 +58,7 @@ To configure your development container, please follow these steps carefully.
 2. Open the project in VSCode.
 3. If you're opening VSCode for the first time, you'll be prompted to install the ["Dev Containers" extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers). Click "Install" to proceed.
 4. Open the command palette (Ctrl + Shift + P or Cmd + Shift + P on macOS) and search for "> Remote-Containers: Open Folder in Container".
-5. VSCode will open the project in a new container, install all further required tools and load the testdata.
+5. VSCode will open the project in a new container, install all further required tools.
 
 
 #### Known Limitations

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To configure your development environment on your system, please follow these st
 1. Ensure that the following packages are installed alongside your preferred IDE:
    - `npm` version 7 or later
    - `nodejs` version 22 or later
-   - `python3` version 3.11 or later
+   - `python3` version 3.13 or later
    - `python3-pip` (Debian-based distributions) / `python-pip` (Arch-based distributions)
    - `python3-venv` (only on Debian-based distributions)
    - `gettext` for translation features

--- a/docs/src/installation.rst
+++ b/docs/src/installation.rst
@@ -61,7 +61,7 @@ In the following, we provide the commands to install all these prerequisites on 
     # Add PPA repository for Python3.9 and above
     sudo add-apt-repository -y ppa:deadsnakes/ppa
     # Install basic requirements
-    sudo apt install -y apt-transport-https curl gettext git pcregrep python3-pip python3.11 python3.11-venv libcairo2
+    sudo apt install -y apt-transport-https curl gettext git pcregrep python3-pip python3.13 python3.13-venv libcairo2
     # Add PPA repository for NodeJS
     curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
     # Add PPA repository for Docker
@@ -131,5 +131,5 @@ And install it using our developer tool :github-source:`tools/install.sh`::
     - This script checks whether the required system-dependencies are installed and installs the project-dependencies via npm and pip.
       If only one of both dependency-managers should be invoked, run ``npm ci`` or ``pip install -e .[dev-pinned,pinned]`` directly.
 
-    - If your system uses Python 3.12 as the default (e.g., Ubuntu 24.04 or similar), you need to install Python 3.11 alongside it, without changing the default python3 symlink.
-      Then, to ensure the CMS uses Python 3.11, run the installation script with the appropriate interpreter: ``./tools/install.sh --python python3.11``
+    - If your system uses Python 3.12 as the default (e.g., Ubuntu 24.04 or similar), you need to install Python 3.13 alongside it, without changing the default python3 symlink.
+      Then, to ensure the CMS uses Python 3.13, run the installation script with the appropriate interpreter: ``./tools/install.sh --python python3.13``

--- a/docs/src/installation.rst
+++ b/docs/src/installation.rst
@@ -15,16 +15,11 @@ Following packages are required before installing the project (install them with
 * `git <https://git-scm.com/>`_
 * `npm <https://www.npmjs.com/>`_ version 7 or later
 * `nodejs <https://nodejs.org/>`_ version 22 or later
-* `python3 <https://www.python.org/>`_ version 3.9 to 3.11 (for above 3.11 see below)
+* `python3 <https://www.python.org/>`_ version 3.13
 * `python3-pip <https://packages.ubuntu.com/search?keywords=python3-pip>`_ (`Debian-based distributions <https://en.wikipedia.org/wiki/Category:Debian-based_distributions>`_, e.g. `Ubuntu <https://ubuntu.com>`__) / `python-pip <https://www.archlinux.de/packages/extra/x86_64/python-pip>`_ (`Arch-based distributions <https://wiki.archlinux.org/index.php/Arch-based_distributions>`_)
 * `python3-venv <https://packages.ubuntu.com/search?keywords=python3+venv>`_ (Only `Debian-based distributions <https://en.wikipedia.org/wiki/Category:Debian-based_distributions>`_, e.g. `Ubuntu <https://ubuntu.com>`__)
 * Either `postgresql <https://www.postgresql.org/>`_ **or** `docker <https://www.docker.com/>`_ to run a local database server
 * `gettext <https://www.gnu.org/software/gettext/>`_ and `pcregrep <https://pcre.org/original/doc/html/pcregrep.html>`_ to use the translation features
-
-.. Note::
-
-    If your distro does not contain python3.9 or later, you first have to add a ppa repository, e.g. ``sudo add-apt-repository ppa:deadsnakes/ppa``.
-
 
 Prerequisites on common distributions
 -------------------------------------

--- a/publiccode.yml
+++ b/publiccode.yml
@@ -56,7 +56,7 @@ dependsOn:
       version: "15"
       optional: false
     - name: "Python"
-      version: "3.11"
+      version: "3.13"
       optional: false
     - name: "Redis"
       optional: true

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -73,7 +73,7 @@ if [[ $(major "$npm_version") -lt "$required_npm_version" ]]; then
     exit 1
 fi
 # Define the required npm version
-required_node_version="18"
+required_node_version="22"
 # Check if nodejs is installed
 if [[ ! -x "$(command -v node)" ]]; then
     echo "The package nodejs is not installed. Please install nodejs version ${required_node_version} or higher manually and run this script again."  | print_error


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
After #4424 Python 3.13 is a mandatory. This PR updates the Devcontainer to 3.13 and updates our documentation that python 3.13 is required.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Bumps up Devcontainer to Python 3.13
- Updates docs
- Some Devcontainer tweeks: No standard loading of testdata after building the container (can cause issues with celery), standard activation of linkcheck listeners (default in the cms config)


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
If you are using the devcontainer, rebuild it (VS code should prompt you to do so).
If you don't use devcontainer, maybe do a sanity check and check the changed docs.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: -


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
