### PR TITLE
Improve explanations for page based statistics

### DIFF
--- a/example-configs/integreat-cms.ini
+++ b/example-configs/integreat-cms.ini
@@ -73,6 +73,9 @@ ALLOWED_HOSTS =
 INTERNAL_URLS =
     tuerantuer.org
     integreat-app.de
+# The wiki page for statistics [optional, defaults to  "WIKI_URL/statistics"]
+STATISTICS_WIKI_URL = https://wiki.integreat-app.de/statistics 
+
 
 [static-files]
 # The directory for static files [required]

--- a/integreat_cms/cms/templates/statistics/statistics_overview.html
+++ b/integreat_cms/cms/templates/statistics/statistics_overview.html
@@ -9,21 +9,56 @@
                     {% translate "Statistics" %}
                 </h1>
             </div>
-            <div class="bg-blue-100 border-l-4 border-blue-500 text-blue-700 px-4 py-3 mb-4"
-                 role="note">
-                <p>
-                    {% blocktranslate trimmed %}
-                        Note: These numbers show only part of the impact of your content.
-                        More and more people find information through AI assistants like ChatGPT –
-                        <strong>there, your texts are used without a page visit being counted</strong>.
-                        This can considerably distort page views in the future.
-                        So use these numbers only for rough orientation.
-                    {% endblocktranslate %}
-                </p>
+            <div class="pt-4 lg:pt-0 3xl:grid grid-cols-2 3xl:grid-cols-[minmax(0px,_1fr)_400px] 4xl:grid-cols-[minmax(0px,_1fr)_816px] gap-4">
+                <div class="flex flex-col flex-wrap col-span-1 3xl:col-span-1 min-w-0">
+                    <div class="py-3 mb-4">
+                        <p>
+                            {% blocktranslate trimmed %}
+                                The <strong>statistics show only part of the impact of your content.</strong>
+                                More and more people find information through AI assistants like ChatGPT.
+                                There, your texts are used without a page visit being counted.
+                                This can considerably distort page views.
+                                <strong>So use these numbers only for rough orientation.</strong>
+                            {% endblocktranslate %}
+                        </p>
+                    </div>
+                </div>
+                <div class="sm:block md:flex sm:mt-4 mb-4 3xl:mt-0 3xl:block 4xl:flex">
+                    <div class="flex items-center justify-end">
+                        <a href="{{ wiki_url }}">
+                            <button class="btn btn-ghost">
+                                <i icon-name="square-arrow-out-up-right" class="mr-2"></i>{% translate "Statistics Documentation" %}
+                            </button>
+                        </a>
+                    </div>
+                </div>
             </div>
             <div class="pt-4 lg:pt-0 3xl:grid grid-cols-2 3xl:grid-cols-[minmax(0px,_1fr)_400px] 4xl:grid-cols-[minmax(0px,_1fr)_816px] gap-4">
                 <div class="flex flex-col flex-wrap col-span-1 3xl:col-span-1 min-w-0">
                     {% include "statistics/statistics_chart.html" with box_id="statistics_chart" %}
+                    <div class="pt-4 pb-4">
+                        <div class="pb-4">
+                            <p>
+                                {% translate "Why does the <strong>total number of visits not match the sum of all page views?</strong>" %}
+                            </p>
+                            <p>
+                                ➔ {% blocktranslate %}<span class="underline">This is normal and to be expected</span>, because the two surveys measure different things.{% endblocktranslate %}
+                            </p>
+                        </div>
+                        <div class="pb-4">
+                            <p>
+                                {% translate "<strong>Total visits</strong> include, among other things, page views within the system (including the Integreat home page), AI requests, other technical requests, and visits to pages or languages that no longer exist." %}
+                            </p>
+                        </div>
+                        <div class="pb-4">
+                            <p>
+                                {% blocktranslate %}<strong>Page views</strong> specifically count <span class="underline">only</span> the visits to published subpages within the web app.{% endblocktranslate %}
+                            </p>
+                            <p>
+                                ➔ {% blocktranslate %}<strong>Therefore, differences exist and are to be expected.</strong> Further details can be found in the <a href="{{ wiki_url }}"><span class="text-blue-600">documentation <i icon-name="square-arrow-out-up-right"></i></span></a>{% endblocktranslate %}
+                            </p>
+                        </div>
+                    </div>
                     {% if show_page_based_statistics %}
                         {% include "statistics/statistics_viewed_pages.html" with box_id="statistics_viewed_pages" %}
                     {% endif %}

--- a/integreat_cms/cms/templates/statistics/statistics_viewed_pages.html
+++ b/integreat_cms/cms/templates/statistics/statistics_viewed_pages.html
@@ -21,6 +21,11 @@
     <div id="page-accesses-loading" class="px-4 text-center">
         <i icon-name="loader" class="animate-spin"></i> {% translate "Loading..." %}
     </div>
+    <div>
+        <p class="pb-4">
+            {% blocktranslate %}All pages with the status <strong>"Published"</strong> are listed.{% endblocktranslate %}
+        </p>
+    </div>
     <form method="post"
           id="statistics-page-access"
           class="table-listing"

--- a/integreat_cms/cms/templates/statistics/statistics_viewed_pages_node.html
+++ b/integreat_cms/cms/templates/statistics/statistics_viewed_pages_node.html
@@ -19,8 +19,9 @@
         {% endfor %}
     </td>
     <td class="total-accesses font-bold ml-4"
-        data-translation-plural="{% translate "Accesses in total" %}"
-        data-translation-singular="{% translate "Access in total" %}"
-        data-translation-no-accesses="{% translate "No Accesses" %}">
+        data-translation-plural="{% translate "Accesses" %}"
+        data-translation-singular="{% translate "Access" %}"
+        data-translation-no-accesses="{% translate "No Accesses" %}"
+        data-translation-incl-childpages="{% translate " in total (incl. child pages)" %}">
     </td>
 </tr>

--- a/integreat_cms/cms/views/statistics/statistics_view.py
+++ b/integreat_cms/cms/views/statistics/statistics_view.py
@@ -98,5 +98,6 @@ class AnalyticsView(TemplateView):
                 "access_legends": access_legends,
                 "is_statistics": True,
                 "show_page_based_statistics": show_page_based_statistics,
+                "wiki_url": settings.STATISTICS_WIKI_URL,
             },
         )

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -120,6 +120,12 @@ WIKI_URL: Final[str] = os.environ.get(
     "https://wiki.integreat-app.de",
 )
 
+#: The URL to the statistics wiki page
+STATISTICS_WIKI_URL: Final[str] = os.environ.get(
+    "INTEGREAT_CMS_STATISTICS_WIKI_URL",
+    WIKI_URL + "/statistics",
+)
+
 #: RSS feed URLs to the Integreat blog
 RSS_FEED_URLS: Final[dict[str, str]] = {
     "en": f"{WEBSITE_URL}/en/feed/",

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8941,6 +8941,7 @@ msgstr "Angezeigte Sprachen"
 
 #: cms/templates/statistics/_statistics_legend.html
 #: cms/templates/statistics/statistics_viewed_pages.html
+#: cms/templates/statistics/statistics_viewed_pages_node.html
 msgid "Accesses"
 msgstr "Zugriffe"
 
@@ -8959,17 +8960,70 @@ msgstr "Gesamtzugriffe"
 
 #: cms/templates/statistics/statistics_overview.html
 msgid ""
-"Note: These numbers show only part of the impact of your content. More and "
-"more people find information through AI assistants like ChatGPT – "
-"<strong>there, your texts are used without a page visit being counted</"
-"strong>. This can considerably distort page views in the future. So use "
-"these numbers only for rough orientation."
+"The <strong>statistics show only part of the impact of your content.</"
+"strong> More and more people find information through AI assistants like "
+"ChatGPT. There, your texts are used without a page visit being counted. This "
+"can considerably distort page views. <strong>So use these numbers only for "
+"rough orientation.</strong>"
 msgstr ""
-"Hinweis: Diese Zahlen zeigen nur einen Teil der Wirkung Ihrer Inhalte. Immer "
-"mehr Menschen finden Informationen über KI-Assistenten wie ChatGPT – "
-"<strong>dort werden Ihre Texte genutzt, ohne dass ein Seitenbesuch gezählt "
-"wird</strong>. Das kann die Seitenaufrufe in Zukunft stark verzerren. Nutzen "
-"Sie die Zahlen also nur zur groben Orientierung."
+"Die <strong>Statistiken zeigen nur einen Teil der Wirkung Ihrer Inhalte.</"
+"strong> Immer mehr Menschen finden Informationen über KI-Assistenten wie "
+"ChatGPT. Dort werden Ihre Texte verwendet, ohne dass ein Seitenbesuch "
+"gezählt wird. Das kann die Seitenaufrufe stark verzerren. <strong>Nutzen Sie "
+"die Zahlen also nur zur groben Orientierung.</strong>"
+
+#: cms/templates/statistics/statistics_overview.html
+msgid "Statistics Documentation"
+msgstr "Statistiken-Dokumentation"
+
+#: cms/templates/statistics/statistics_overview.html
+msgid ""
+"Why does the <strong>total number of visits not match the sum of all page "
+"views?</strong>"
+msgstr ""
+"Warum stimmt die <strong>Zahl der Gesamtzugriffe nicht mit der Summe aller "
+"Seitenzugriffe überein?</strong>"
+
+#: cms/templates/statistics/statistics_overview.html
+msgid ""
+"<span class=\"underline\">This is normal and to be expected</span>, because "
+"the two surveys measure different things."
+msgstr ""
+"<span class=\"underline\">Das ist normal und zu erwarten</span>, denn: beide "
+"Erhebungen messen unterschiedliche Dinge."
+
+#: cms/templates/statistics/statistics_overview.html
+msgid ""
+"<strong>Total visits</strong> include, among other things, page views within "
+"the system (including the Integreat home page), AI requests, other technical "
+"requests, and visits to pages or languages that no longer exist."
+msgstr ""
+"<strong>Gesamtzugriffe</strong> zählen u.a. die Aufrufe von Seiten im System "
+"(inklusive der Integreat Startseite), KI-Aufrufe, andere technische Aufrufe "
+"und Zugriffe auf Seiten oder auch Sprachen, die nicht mehr existieren."
+
+#: cms/templates/statistics/statistics_overview.html
+msgid ""
+"<strong>Page views</strong> specifically count <span "
+"class=\"underline\">only</span> the visits to published subpages within the "
+"web app."
+msgstr ""
+"<strong>Seitenzugriffe</strong> zählen gezielt <span "
+"class=\"underline\">nur</span> die Aufrufe der veröffentlichten Unterseiten "
+"in der Web-App."
+
+#: cms/templates/statistics/statistics_overview.html
+#, python-format
+msgid ""
+"<strong>Therefore, differences exist and are to be expected.</strong> "
+"Further details can be found in the <a href=\"%(wiki_url)s\"><span "
+"class=\"text-blue-600\">documentation <i icon-name=\"square-arrow-out-up-"
+"right\"></i></span></a>"
+msgstr ""
+"<strong>deshalb sind Unterschiede gegeben und zu erwarten.</strong> Mehr "
+"Details dazu in der <a href=\"%(wiki_url)s\"><span class=\"text-"
+"blue-600\">Dokumentation <i icon-name=\"square-arrow-out-up-right\"></i></"
+"span></a>"
 
 #: cms/templates/statistics/statistics_sidebar.html
 msgid "Adjust shown data"
@@ -9023,21 +9077,27 @@ msgstr "Tabellendokument/CSV - Seitenzugriffe"
 msgid "Page views"
 msgstr "Seitenzugriffe"
 
+#: cms/templates/statistics/statistics_viewed_pages.html
+msgid "All pages with the status <strong>\"Published\"</strong> are listed."
+msgstr ""
+"Aufgelistet sind alle Seiten, die den Status <strong>\"Veröffentlicht\"</"
+"strong> haben."
+
 #: cms/templates/statistics/statistics_viewed_pages_node.html
 msgid "This page has no accesses in the selected time span"
 msgstr "Diese Seite hat keine Zugriffe für den ausgewählten Zeitraum"
 
 #: cms/templates/statistics/statistics_viewed_pages_node.html
-msgid "Accesses in total"
-msgstr "Zugriffe insgesamt"
-
-#: cms/templates/statistics/statistics_viewed_pages_node.html
-msgid "Access in total"
-msgstr "Zugriff insgesamt"
+msgid "Access"
+msgstr "Zugriff"
 
 #: cms/templates/statistics/statistics_viewed_pages_node.html
 msgid "No Accesses"
 msgstr "Keine Zugriffe"
+
+#: cms/templates/statistics/statistics_viewed_pages_node.html
+msgid " in total (incl. child pages)"
+msgstr " gesamt (inkl. Unterseiten)"
 
 #: cms/templates/translations/translations_management.html
 msgid "Manage machine translations"
@@ -12030,6 +12090,21 @@ msgstr ""
 #~ msgid "No German translation could be found for {} \"{}\"."
 #~ msgstr "Es konnte keine Deutsche Übersetzung für {} \"{}\" gefunden werden."
 
+#~ msgid "<strong>Page views</strong> specifically count "
+#~ msgstr "<strong>Seitenzugriffe</strong> zählen gezielt "
+
+#~ msgid "only "
+#~ msgstr "nur "
+
+#~ msgid "the visits to published subpages within the web app."
+#~ msgstr "die Aufrufe der veröffentlichten Unterseiten in der Web-App."
+
+#~ msgid "documentation"
+#~ msgstr "Dokumentation"
+
+#~ msgid "This is normal and to be expected"
+#~ msgstr "Das ist normal und zu erwarten"
+
 #~ msgid "Total Access Statistics"
 #~ msgstr "Statistiken für Gesamtzugriffe"
 
@@ -12902,9 +12977,6 @@ msgstr ""
 
 #~ msgid "Link to within the same page (not automatically checked)"
 #~ msgstr "Link innerhalb der gleichen Seite (nicht automatisch geprüft)"
-
-#~ msgid "Missing Document"
-#~ msgstr "Fehlende Datei"
 
 #~ msgid "Page OK but anchor can't be checked"
 #~ msgstr "Seite OK, aber Anker kann nicht überprüft werden"

--- a/integreat_cms/static/src/js/analytics/statistics-page-accesses.ts
+++ b/integreat_cms/static/src/js/analytics/statistics-page-accesses.ts
@@ -106,12 +106,22 @@ const resetTotalAccessesField = (accessFields: HTMLCollectionOf<Element>, isEmpt
 
 const updateAllAccessesField = (accessesField: Element, allAccesses: number) => {
     const allAccessesField = accessesField;
+    const collapsed = allAccessesField.parentElement
+        .querySelector(".toggle-subpages")
+        ?.querySelector("svg")
+        .classList.contains("lucide-chevron-right");
+    let childPageAccessIndicator = "";
+
+    if (collapsed) {
+        childPageAccessIndicator = allAccessesField.getAttribute("data-translation-incl-childpages");
+    }
+
     if (allAccesses === 0) {
         allAccessesField.textContent = allAccessesField.getAttribute("data-translation-no-accesses");
     } else if (allAccesses === 1) {
-        allAccessesField.textContent = `${allAccesses} ${allAccessesField.getAttribute("data-translation-singular")}`;
+        allAccessesField.textContent = `${allAccesses} ${allAccessesField.getAttribute("data-translation-singular")} ${childPageAccessIndicator}`;
     } else {
-        allAccessesField.textContent = `${allAccesses} ${allAccessesField.getAttribute("data-translation-plural")}`;
+        allAccessesField.textContent = `${allAccesses} ${allAccessesField.getAttribute("data-translation-plural")} ${childPageAccessIndicator}`;
     }
 };
 


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR adds some explanations for better understanding of the feature page based statistics.

### Proposed changes
<!-- Describe this PR in more detail. -->
- Remove the blue message on the top of "Statistics" section
- Add a link button to the wiki on the upper right corner
- Add three sentences between the chart and the page access tree
- Add a hint that only published pages are shown in the page tree
- Add " gesamt (inkl. Unterseiten)" behind "n Zugriff(e)" if the page has child pages and collapsed


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->
- Shuold be none


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
Activate the statistics in a region, create some `PageAccesses` by `integreat-cms-cli shell`, see it looks like the new design 

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4438


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
