### PR TITLE
Fix broken links marked as valid when ancestor is not public

### DIFF
--- a/integreat_cms/cms/utils/internal_link_checker.py
+++ b/integreat_cms/cms/utils/internal_link_checker.py
@@ -215,7 +215,7 @@ def check_translation_link(
 def check_object_link(
     content_type: str,
     manager: RelatedManager,
-    slug: str,
+    path_components: list[str] | str,
     url: Url,
     region: Region,
     language: Language,
@@ -226,24 +226,27 @@ def check_object_link(
     :param content_type: The content type (``Page``, ``Event`` or ``POI``)
     :param manager: The object manager
     :param url: The internal URL to check
-    :param slug: The slug of the translation
+    :param path_components: Split up path components including slug of the translation
     :param region: The region
     :param language: The language
     """
+    translation_slug = (
+        path_components[-1] if content_type == "Page" else path_components
+    )
     objects = manager.filter(
-        translations__slug=slugify(slug, allow_unicode=True),
+        translations__slug=slugify(translation_slug, allow_unicode=True),
         translations__language=language,
     ).distinct()
     if not objects and region.fallback_translations_enabled:
         objects = manager.filter(
-            translations__slug=slugify(slug, allow_unicode=True),
+            translations__slug=slugify(translation_slug, allow_unicode=True),
             translations__language=region.default_language,
         ).distinct()
     if not objects:
         logger.debug(
             "%s with slug %r does not exist in %r and %r",
             content_type,
-            slug,
+            translation_slug,
             region,
             language,
         )
@@ -252,12 +255,26 @@ def check_object_link(
             _("The link target does not exist in this region and language."),
         )
     elif len(objects) == 1:
+        if content_type == "Page":
+            ancestors = objects[0].get_cached_ancestors()
+            for ancestor in ancestors:
+                if not (
+                    ancestor.get_public_translation(language.slug)
+                    or ancestor.get_public_translation(region.default_language.slug)
+                ):
+                    logger.debug(
+                        "The page ancestor %r of the page %r is not public",
+                        ancestor,
+                        objects[0],
+                    )
+                    mark_invalid(url, _("One of the page ancestors is not public"))
+                    return url.status
         check_translation_link(objects[0], url, language)
     else:
         logger.warning(
             "%s slug %r is not unique in %r and %r (also returned %r)",
             content_type,
-            slug,
+            translation_slug,
             region,
             language,
             objects,
@@ -424,7 +441,7 @@ def check_internal(url: Url) -> bool | None:  # noqa: PLR0911
     return check_object_link(
         "Page",
         region.pages,
-        path_components[-1],
+        path_components,
         url,
         region,
         language,

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -9419,11 +9419,10 @@ msgstr ""
 "Sprachen erfordert."
 
 #: cms/utils/content_utils.py
-msgid ""
-"This contact belongs to a different region and cannot be displayed."
+msgid "This contact belongs to a different region and cannot be displayed."
 msgstr ""
-"Dieser Kontakt gehört zu einer anderen Region und kann nicht angezeigt werden. "
-
+"Dieser Kontakt gehört zu einer anderen Region und kann nicht angezeigt "
+"werden. "
 
 #: cms/utils/content_utils.py
 msgid "Oops! Error displaying contact data"
@@ -9521,6 +9520,10 @@ msgstr "Das Linkziel ist in dieser Sprache nicht öffentlich."
 #: cms/utils/internal_link_checker.py
 msgid "The link target does not exist in this region and language."
 msgstr "Das Linkziel existiert nicht in dieser Region und Sprache."
+
+#: cms/utils/internal_link_checker.py
+msgid "One of the page ancestors is not public"
+msgstr "Eine übergeordnete Seite ist nicht öffentlich"
 
 #: cms/utils/internal_link_checker.py
 msgid "The link target is not unique in this region and language."

--- a/integreat_cms/release_notes/current/unreleased/4325.yml
+++ b/integreat_cms/release_notes/current/unreleased/4325.yml
@@ -1,0 +1,2 @@
+en: Fix that broken links are reported as valid when target page has a ancestor that isn't public.
+de: Behebe das Problem, dass defekte Links als gültig gemeldet werden, wenn die Zielseite eine übergeordnete Seite hat, die nicht öffentlich ist.


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Fixes that broken links are marked as valid when a ancestor is not public

### Proposed changes
<!-- Describe this PR in more detail. -->

- Check if ancestors of the linked page have public translations


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
1. Create page A with status Draft.
2. Create child page B under page A with status Public.
3. Create page C and add a link to page B in its content.
4. Check Broken Links menu.

Also check if linked events and locations work as expected

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4325 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
