### PR TITLE
Add timeout for textlab API call

### DIFF
--- a/integreat_cms/cms/views/utils/hix.py
+++ b/integreat_cms/cms/views/utils/hix.py
@@ -79,6 +79,13 @@ def lookup_hix_score_helper(text: str) -> TextlabResult:
             settings.TEXTLAB_API_USERNAME,
             settings.TEXTLAB_API_KEY,
         ).benchmark(normalized_text)
+    except TimeoutError as e:
+        logger.warning(
+            "HIX benchmark API call timed out after %s seconds: %r",
+            settings.TEXTLAB_API_TIMEOUT,
+            e,
+        )
+        raise CacheMeIfYouCan from e
     except (URLError, OSError) as e:
         logger.warning("HIX benchmark API call failed: %r", e)
         raise CacheMeIfYouCan from e

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -382,6 +382,12 @@ TEXTLAB_API_DEFAULT_BENCHMARK_ID: Final[int] = env_int(
     420,
 )
 
+#: How many seconds to wait for the Textlab API to respond before giving up
+TEXTLAB_API_TIMEOUT: Final[float] = env_float(
+    "INTEGREAT_CMS_TEXTLAB_API_TIMEOUT",
+    30,
+)
+
 #: The minimum HIX score required for machine translation
 HIX_REQUIRED_FOR_MT: Final[float] = env_float(
     "INTEGREAT_CMS_HIX_REQUIRED_FOR_MT",

--- a/integreat_cms/textlab_api/textlab_api_client.py
+++ b/integreat_cms/textlab_api/textlab_api_client.py
@@ -113,5 +113,5 @@ class TextlabClient:
             request.add_header("authorization", f"Bearer {auth_token}")
         request.add_header("Content-Type", "application/json")
         request.add_header("User-Agent", "")
-        with urlopen(request) as response:  # noqa: S310
+        with urlopen(request, timeout=settings.TEXTLAB_API_TIMEOUT) as response:  # noqa: S310
             return json.loads(response.read().decode("utf-8"))

--- a/tests/cms/views/utils/test_hix.py
+++ b/tests/cms/views/utils/test_hix.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+import json
 import math
+import socket
+import time
 from copy import deepcopy
 from typing import TYPE_CHECKING
 
 import pytest
+from werkzeug.wrappers import Request, Response
 
 from integreat_cms.cms.constants.administrative_division import MUNICIPALITY
 from integreat_cms.cms.constants.region_status import ACTIVE
@@ -27,6 +31,8 @@ from tests.utils import disable_hix_post_save_signal
 
 if TYPE_CHECKING:
     from pytest_django.fixtures import SettingsWrapper
+
+    from tests.mock import MockServer
 
 
 def create_dummy_region() -> tuple[Language, Region]:
@@ -349,3 +355,52 @@ def test_contact_card_gets_filtered_out() -> None:
 
     assert result is not None
     assert result["score"] is None
+
+
+def test_hix_lookup_times_out_instead_of_hanging(
+    settings: SettingsWrapper,
+    mock_server: MockServer,
+) -> None:
+    """
+    If the Textlab API accepts the connection but never responds, ``lookup_hix_score()``
+    must give up after :attr:`~integreat_cms.core.settings.TEXTLAB_API_TIMEOUT` instead
+    of blocking forever (see #<issue-number>).
+    """
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    port = listener.getsockname()[1]
+
+    def black_hole(request: Request) -> Response:
+        mock_server.requests_counter += 1
+        time.sleep(2)
+        return Response(
+            json.dumps(
+                {
+                    "formulaHix": 15.12345678,
+                    "moreSentencesInClauses": [4, 5, 6],
+                    "moreSentencesInWords": [],
+                }
+            ),
+            status=200,
+        )
+
+    mock_server.configure("/user/login", 200, {"token": "dummy"})
+    mock_server.http_server.expect_request("/benchmark/420").respond_with_handler(
+        black_hole
+    )
+
+    settings.TEXTLAB_API_ENABLED = True
+    settings.TEXTLAB_API_URL = f"http://127.0.0.1:{port}"
+    settings.TEXTLAB_API_TIMEOUT = 0.2
+
+    start = time.monotonic()
+    result = lookup_hix_score(
+        "Unique text for test_hix_lookup_times_out_instead_of_hanging",
+    )
+    elapsed = time.monotonic() - start
+
+    assert result is None
+    assert elapsed < 1, (
+        "lookup_hix_score() should give up after TEXTLAB_API_TIMEOUT, not hang"
+    )


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This adds a timeout for the textlab API call in `textlab_api_client.py`


### Proposed changes
<!-- Describe this PR in more detail. -->

- 30 second timeout for the API call
- logging when running into timeout
- test for timeout


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
Follow the instructions in the bug ticket


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4482


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
