### PR TITLE
2308: Return server errors in json for API

### DIFF
--- a/integreat_cms/cms/views/error_handler/error_handler.py
+++ b/integreat_cms/cms/views/error_handler/error_handler.py
@@ -49,7 +49,7 @@ def render_error_template(context: dict[str, Any]) -> SafeString:
     return render_to_string("error_handler/http_error.html", context)
 
 
-def render_error_response(context: dict[str, Any]) -> HttpResponse:
+def _render_error_response(context: dict[str, Any]) -> HttpResponse:
     """
     Render the HTTP error response
 
@@ -78,7 +78,7 @@ def handler400(request: HttpRequest, exception: BadRequest) -> HttpResponse:
         "message": _("There was an error in your request."),
     }
     logger.debug(exception)
-    return render_error_response(context)
+    return _render_error_response(context)
 
 
 def handler403(
@@ -99,7 +99,7 @@ def handler403(
         "message": _("You don't have the permission to access this page."),
     }
     logger.debug(exception)
-    return render_error_response(context)
+    return _render_error_response(context)
 
 
 def handler404(request: HttpRequest, exception: Http404) -> HttpResponse:
@@ -117,7 +117,7 @@ def handler404(request: HttpRequest, exception: Http404) -> HttpResponse:
         "message": _("The page you requested could not be found."),
     }
     logger.debug(exception)
-    return render_error_response(context)
+    return _render_error_response(context)
 
 
 def handler500(request: HttpRequest) -> HttpResponse:
@@ -133,7 +133,7 @@ def handler500(request: HttpRequest) -> HttpResponse:
         "title": _("Internal Server Error"),
         "message": _("An unexpected error has occurred."),
     }
-    return render_error_response(context)
+    return _render_error_response(context)
 
 
 def csrf_failure(request: HttpRequest, reason: str) -> HttpResponse:
@@ -151,4 +151,4 @@ def csrf_failure(request: HttpRequest, reason: str) -> HttpResponse:
         "message": _("Please try to reload the page."),
     }
     logger.debug(reason)
-    return render_error_response(context)
+    return _render_error_response(context)

--- a/integreat_cms/cms/views/error_handler/error_handler.py
+++ b/integreat_cms/cms/views/error_handler/error_handler.py
@@ -4,12 +4,7 @@ import logging
 from typing import TYPE_CHECKING
 
 from django.conf import settings
-from django.http import (
-    HttpResponseBadRequest,
-    HttpResponseForbidden,
-    HttpResponseNotFound,
-    HttpResponseServerError,
-)
+from django.http import HttpResponse, JsonResponse
 from django.template.loader import render_to_string
 from django.utils.translation import gettext_lazy as _
 
@@ -21,6 +16,19 @@ if TYPE_CHECKING:
     from django.utils.safestring import SafeString
 
 logger = logging.getLogger(__name__)
+
+
+def is_api_request(request: HttpRequest) -> bool:
+    """
+    Check whether the given request is directed at the API
+
+    :param request: Object representing the user call
+    :return: Whether the request belongs to the API namespace
+    """
+    if request.resolver_match:
+        return request.resolver_match.app_name == "api"
+    # If the url could not be resolved at all, fall back to the url prefix of the API
+    return request.path.startswith("/api/")
 
 
 def render_error_template(context: dict[str, Any]) -> SafeString:
@@ -41,13 +49,27 @@ def render_error_template(context: dict[str, Any]) -> SafeString:
     return render_to_string("error_handler/http_error.html", context)
 
 
-def handler400(request: HttpRequest, exception: BadRequest) -> HttpResponseBadRequest:
+def render_error_response(context: dict[str, Any]) -> HttpResponse:
+    """
+    Render the HTTP error response
+
+    Requests to the API always return JSON, all other requests return the rendered HTML error template.
+
+    :param context: The context data for the error
+    :return: The error response
+    """
+    if is_api_request(context["request"]):
+        return JsonResponse({"error": context["message"]}, status=context["code"])
+    return HttpResponse(render_error_template(context), status=context["code"])
+
+
+def handler400(request: HttpRequest, exception: BadRequest) -> HttpResponse:
     """
     Render a HTTP 400 Error code
 
     :param request: Object representing the user call
     :param exception: Exception (unused)
-    :return: The rendered template response
+    :return: The error response
     """
     context = {
         "request": request,
@@ -56,19 +78,19 @@ def handler400(request: HttpRequest, exception: BadRequest) -> HttpResponseBadRe
         "message": _("There was an error in your request."),
     }
     logger.debug(exception)
-    return HttpResponseBadRequest(render_error_template(context))
+    return render_error_response(context)
 
 
 def handler403(
     request: HttpRequest,
     exception: PermissionDenied,
-) -> HttpResponseForbidden:
+) -> HttpResponse:
     """
     Render a HTTP 403 Error code
 
     :param request: Object representing the user call
     :param exception: Exception (unused)
-    :return: The rendered template response
+    :return: The error response
     """
     context = {
         "request": request,
@@ -77,16 +99,16 @@ def handler403(
         "message": _("You don't have the permission to access this page."),
     }
     logger.debug(exception)
-    return HttpResponseForbidden(render_error_template(context))
+    return render_error_response(context)
 
 
-def handler404(request: HttpRequest, exception: Http404) -> HttpResponseNotFound:
+def handler404(request: HttpRequest, exception: Http404) -> HttpResponse:
     """
     Render a HTTP 404 Error code
 
     :param request: Object representing the user call
     :param exception: Exception (unused)
-    :return: The rendered template response
+    :return: The error response
     """
     context = {
         "request": request,
@@ -95,15 +117,15 @@ def handler404(request: HttpRequest, exception: Http404) -> HttpResponseNotFound
         "message": _("The page you requested could not be found."),
     }
     logger.debug(exception)
-    return HttpResponseNotFound(render_error_template(context))
+    return render_error_response(context)
 
 
-def handler500(request: HttpRequest) -> HttpResponseServerError:
+def handler500(request: HttpRequest) -> HttpResponse:
     """
     Render a HTTP 500 Error code
 
     :param request: Object representing the user call
-    :return: The rendered template response
+    :return: The error response
     """
     context = {
         "request": request,
@@ -111,16 +133,16 @@ def handler500(request: HttpRequest) -> HttpResponseServerError:
         "title": _("Internal Server Error"),
         "message": _("An unexpected error has occurred."),
     }
-    return HttpResponseServerError(render_error_template(context))
+    return render_error_response(context)
 
 
-def csrf_failure(request: HttpRequest, reason: str) -> HttpResponseForbidden:
+def csrf_failure(request: HttpRequest, reason: str) -> HttpResponse:
     """
     Render a CSRF failure notice
 
     :param request: Object representing the user call
     :param reason: Description of reason for CSRF failure
-    :return: The rendered template response
+    :return: The error response
     """
     context = {
         "request": request,
@@ -129,4 +151,4 @@ def csrf_failure(request: HttpRequest, reason: str) -> HttpResponseForbidden:
         "message": _("Please try to reload the page."),
     }
     logger.debug(reason)
-    return HttpResponseForbidden(render_error_template(context))
+    return render_error_response(context)

--- a/integreat_cms/release_notes/current/unreleased/2308.yml
+++ b/integreat_cms/release_notes/current/unreleased/2308.yml
@@ -1,0 +1,2 @@
+en: Fix errors not being returned as JSON for the API
+de: Behebe Fehler, die für die API nicht als JSON zurückgegeben wurden


### PR DESCRIPTION
### Short description
The API should always return JSON, even if an error occurs.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Added an `is_api_request` helper that checks `request.resolver_match.app_name` against `"api"`, falling back to a `request.path` prefix check when the URL couldn't be resolved.
- Added a `render_error_response` function that returns a `JsonResponse` for API requests and otherwise falls back to `HttpResponse` wrapping the existing `render_error_template`.
- Updated `handler400`, `handler403`, `handler404`, `handler500`, and `csrf_failure` to use `render_error_response` instead of constructing the response classes directly.
- Changed the return type for the handlers from `HttpResponseBadRequest`, `HttpResponseForbidden`, `HttpResponseNotFound`, and `HttpResponseServerError` to the generic `HttpResponse`.



### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

None.


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->

- Launch the server in non debug mode I used this command (Debug=0):
```
source .venv/bin/activate

DJANGO_SETTINGS_MODULE=integreat_cms.core.docker_settings \
INTEGREAT_CMS_DEBUG=0 \
INTEGREAT_CMS_SECRET_KEY=dummy \
DYLD_FALLBACK_LIBRARY_PATH=/opt/homebrew/lib \
integreat-cms-cli runserver --insecure localhost:8000
```
Note: `DYLD_FALLBACK_LIBRARY_PATH` is a macOS/Homebrew workaround for `cairocffi` skip it on Linux.

- Test non-existent url paths like:
    - For the Api : http://localhost:8000/api/v3/non-existing
    - For any other pages: http://localhost:8000/regions/foo


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #2308


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
