### PR TITLE
fix: allow regular patch updates of the CircleCI runner image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,12 +6,15 @@ orbs:
 jobs:
   pip-install:
     docker:
-      - image: cimg/python:3.13.11
+      - image: cimg/python:3.13
     resource_class: small
     steps:
       - checkout
+      - run:
+          name: Record interpreter identity for the cache key
+          command: python3 -VV > .python-build-id
       - restore_cache:
-          key: pip-{{ checksum "pyproject.toml" }}-v1
+          key: pip-{{ checksum ".python-build-id" }}-{{ checksum "pyproject.toml" }}-v1
       - run:
           name: Install pip dependencies
           command: |
@@ -24,7 +27,7 @@ jobs:
               pip install -e .[dev-pinned,pinned]
             fi
       - save_cache:
-          key: pip-{{ checksum "pyproject.toml" }}-v1
+          key: pip-{{ checksum ".python-build-id" }}-{{ checksum "pyproject.toml" }}-v1
           paths:
             - .venv
             - integreat_cms.egg-info
@@ -36,7 +39,7 @@ jobs:
             - integreat_cms.egg-info
   djlint:
     docker:
-      - image: cimg/python:3.13.11
+      - image: cimg/python:3.13
     resource_class: small
     steps:
       - checkout
@@ -50,7 +53,7 @@ jobs:
           command: djlint --check --lint integreat_cms
   ruff:
     docker:
-      - image: cimg/python:3.13.11
+      - image: cimg/python:3.13
     resource_class: small
     steps:
       - checkout
@@ -66,7 +69,7 @@ jobs:
             ruff format --check
   mypy:
     docker:
-      - image: cimg/python:3.13.11
+      - image: cimg/python:3.13
     resource_class: small
     steps:
       - checkout
@@ -77,7 +80,7 @@ jobs:
           command: ./tools/mypy.sh
   check-release-notes:
     docker:
-      - image: cimg/python:3.13.11
+      - image: cimg/python:3.13
     resource_class: small
     steps:
       - checkout
@@ -97,7 +100,7 @@ jobs:
           command: ./tools/make_release_notes.sh --format=raw --all
   check-translations:
     docker:
-      - image: cimg/python:3.13.11
+      - image: cimg/python:3.13
     resource_class: small
     steps:
       - checkout
@@ -111,7 +114,7 @@ jobs:
           command: ./tools/check_translations.sh
   compile-translations:
     docker:
-      - image: cimg/python:3.13.11
+      - image: cimg/python:3.13
     resource_class: small
     steps:
       - checkout
@@ -222,7 +225,7 @@ jobs:
             - integreat_cms/webpack-stats.json
   check-migrations:
     docker:
-      - image: cimg/python:3.13.11
+      - image: cimg/python:3.13
       - image: cimg/postgres:17.10
         environment:
           POSTGRES_USER: integreat
@@ -244,7 +247,7 @@ jobs:
           command: integreat-cms-cli makemigrations cms --check --settings=integreat_cms.core.circleci_settings
   test:
     docker:
-      - image: cimg/python:3.13.11
+      - image: cimg/python:3.13
       - image: cimg/postgres:17.10
         environment:
           POSTGRES_USER: integreat
@@ -296,7 +299,7 @@ jobs:
           path: integreat-cms.log
   build-package:
     docker:
-      - image: cimg/python:3.13.11
+      - image: cimg/python:3.13
     resource_class: small
     steps:
       - checkout
@@ -317,7 +320,7 @@ jobs:
             - dist
   publish-package:
     docker:
-      - image: cimg/python:3.13.11
+      - image: cimg/python:3.13
     resource_class: small
     steps:
       - checkout
@@ -331,7 +334,7 @@ jobs:
           command: twine upload --non-interactive ./dist/integreat_cms-*.tar.gz
   build-documentation:
     docker:
-      - image: cimg/python:3.13.11
+      - image: cimg/python:3.13
     resource_class: large
     steps:
       - checkout
@@ -357,7 +360,7 @@ jobs:
             - docs/dist
   deploy-documentation:
     docker:
-      - image: cimg/python:3.13.11
+      - image: cimg/python:3.13
     resource_class: small
     environment:
       BRANCH: gh-pages
@@ -401,7 +404,7 @@ jobs:
             git push origin $BRANCH
   bump-dev-version:
     docker:
-      - image: cimg/python:3.13.11
+      - image: cimg/python:3.13
     resource_class: large
     steps:
       - checkout
@@ -451,7 +454,7 @@ jobs:
             - integreat_cms/_manifest
   bump-rc-version:
     docker:
-      - image: cimg/python:3.13.11
+      - image: cimg/python:3.13
     resource_class: large
     steps:
       - checkout
@@ -502,7 +505,7 @@ jobs:
             - integreat_cms/_manifest
   bump-version:
     docker:
-      - image: cimg/python:3.13.11
+      - image: cimg/python:3.13
     resource_class: large
     steps:
       - checkout
@@ -582,7 +585,7 @@ jobs:
           command: git checkout develop && git merge main --commit --no-edit && git push
   create-release:
     docker:
-      - image: cimg/python:3.13.11
+      - image: cimg/python:3.13
     resource_class: small
     steps:
       - checkout

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ cms-django.iml
 integreat-cms.iml
 webpack-stats.json
 
+# Interpreter fingerprint for the CircleCI pip cache key
+.python-build-id
+
 # Location file of redis unix socket
 .redis_socket_location
 .redis.sock

--- a/docs/src/continuous-integration.rst
+++ b/docs/src/continuous-integration.rst
@@ -35,6 +35,13 @@ pip-install
 This job executes ``pip install -e .[dev-pinned,pinned]`` and makes use of the `CircleCI Dependency Cache <https://circleci.com/docs/2.0/caching/>`__.
 It passes the virtual environment ``.venv`` to the subsequent jobs.
 
+Since a virtual environment is only valid for the interpreter which created it, the cache key contains not only the
+checksum of ``pyproject.toml``, but also the checksum of ``.python-build-id``, a file which is written by the job itself
+with the output of ``python3 -VV``. This means the cache is invalidated whenever the Python version of the Docker image
+changes, and the image can be referenced by its minor version (``cimg/python:3.13``) to receive patch updates
+automatically. Do not replace this with an environment variable: values which are exported to ``$BASH_ENV`` are not
+visible to the interpolation of cache keys.
+
 .. _circleci-webpack:
 
 webpack


### PR DESCRIPTION
### Short description

The CircleCI pip cache key did not identify the Python interpreter, so a virtualenv built by a different interpreter could be restored and silently reused. Fixing the key allows the runner image to be referenced by its minor version (`cimg/python:3.13`) and thus to receive patch updates automatically.

### Proposed changes

- Write the output of `python3 -VV` to `.python-build-id` in the `pip-install` job and add its checksum to the pip cache key. Unlike variables exported to `$BASH_ENV`, files are visible to the interpolation of cache keys.
- Reference the Docker image as `cimg/python:3.13` instead of `cimg/python:3.13.11` in all 17 places. Since the virtualenv is built once in `pip-install` and handed to the other jobs via `persist_to_workspace`, all Python jobs have to resolve the same tag — otherwise the mismatch is merely moved somewhere else.
- Ignore `.python-build-id` and document the mechanism in the `pip-install` section of `docs/src/continuous-integration.rst`, including a warning not to retry the `$BASH_ENV` approach.

### Side effects

- The first pipeline after merging will do a full `pip install`, because the shape of the cache key changed and no cache exists under the new key. Subsequent runs are cached as before.
- Whenever the upstream image is patched, one pipeline pays for a full reinstall (~1 min). This is the intended behaviour, not a regression.
- A floating tag means an upstream image update can break an unrelated PR. The failure mode is at least honest now: the virtualenv is rebuilt against the new interpreter, so a real incompatibility surfaces as a real dependency error instead of a `ModuleNotFoundError` from a stale environment.
- If a new patch version is published while a pipeline is running, `pip-install` and a later job could theoretically resolve different patch versions. This is rare and resolves itself on a rerun, but it is the one guarantee the pinned tag gave us.
- `pyproject.toml` declares `requires-python = ">=3.13,<3.14"`, so the floating tag cannot drift out of the supported range.
- The `-v1` suffix of the cache key is kept: it is still the only way to manually evict a cache after changes which no checksum covers, e.g. a different set of `save_cache` paths or different extras in the install command.

### Faithfulness to issue description and design

There are no intended deviations from the issue and design.

### How to test

There is nothing to test locally, the change only affects CI. To verify the cache behaviour on this branch:

1. Let the pipeline run once, so a cache is written under the new key. `pip-install` performs a full install.
2. Re-run the pipeline without any change. `pip-install` logs `Virtual environment restored from cache, skipping pip install`, so caching still works.
3. Push a commit which changes only the image tag (e.g. to `cimg/python:3.12`), and confirm that `pip-install` installs from scratch instead of restoring the cache. Revert it afterwards.

Also worth a look in the job output of the first step:

```
python3 -VV > .python-build-id
```

The cached key in the `restore_cache`/`save_cache` step output should contain two checksums.

### Resolved issues

Fixes: #4488

Related: #1732 (same root cause, closed in 2022 by pinning the patch version instead of fixing the cache key)

__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
