### PR TITLE
Hide the explanation sentences

### DIFF
--- a/integreat_cms/cms/templates/statistics/statistics_overview.html
+++ b/integreat_cms/cms/templates/statistics/statistics_overview.html
@@ -36,30 +36,30 @@
             <div class="pt-4 lg:pt-0 3xl:grid grid-cols-2 3xl:grid-cols-[minmax(0px,_1fr)_400px] 4xl:grid-cols-[minmax(0px,_1fr)_816px] gap-4">
                 <div class="flex flex-col flex-wrap col-span-1 3xl:col-span-1 min-w-0">
                     {% include "statistics/statistics_chart.html" with box_id="statistics_chart" %}
-                    <div class="pt-4 pb-4">
-                        <div class="pb-4">
-                            <p>
-                                {% translate "Why does the <strong>total number of visits not match the sum of all page views?</strong>" %}
-                            </p>
-                            <p>
-                                ➔ {% blocktranslate %}<span class="underline">This is normal and to be expected</span>, because the two surveys measure different things.{% endblocktranslate %}
-                            </p>
-                        </div>
-                        <div class="pb-4">
-                            <p>
-                                {% translate "<strong>Total visits</strong> include, among other things, page views within the system (including the Integreat home page), AI requests, other technical requests, and visits to pages or languages that no longer exist." %}
-                            </p>
-                        </div>
-                        <div class="pb-4">
-                            <p>
-                                {% blocktranslate %}<strong>Page views</strong> specifically count <span class="underline">only</span> the visits to published subpages within the web app.{% endblocktranslate %}
-                            </p>
-                            <p>
-                                ➔ {% blocktranslate %}<strong>Therefore, differences exist and are to be expected.</strong> Further details can be found in the <a href="{{ wiki_url }}"><span class="text-blue-600">documentation <i icon-name="square-arrow-out-up-right"></i></span></a>{% endblocktranslate %}
-                            </p>
-                        </div>
-                    </div>
                     {% if show_page_based_statistics %}
+                        <div class="pt-4 pb-4">
+                            <div class="pb-4">
+                                <p>
+                                    {% translate "Why does the <strong>total number of visits not match the sum of all page views?</strong>" %}
+                                </p>
+                                <p>
+                                    ➔ {% blocktranslate %}<span class="underline">This is normal and to be expected</span>, because the two surveys measure different things.{% endblocktranslate %}
+                                </p>
+                            </div>
+                            <div class="pb-4">
+                                <p>
+                                    {% translate "<strong>Total visits</strong> include, among other things, page views within the system (including the Integreat home page), AI requests, other technical requests, and visits to pages or languages that no longer exist." %}
+                                </p>
+                            </div>
+                            <div class="pb-4">
+                                <p>
+                                    {% blocktranslate %}<strong>Page views</strong> specifically count <span class="underline">only</span> the visits to published subpages within the web app.{% endblocktranslate %}
+                                </p>
+                                <p>
+                                    ➔ {% blocktranslate %}<strong>Therefore, differences exist and are to be expected.</strong> Further details can be found in the <a href="{{ wiki_url }}"><span class="text-blue-600">documentation <i icon-name="square-arrow-out-up-right"></i></span></a>{% endblocktranslate %}
+                                </p>
+                            </div>
+                        </div>
                         {% include "statistics/statistics_viewed_pages.html" with box_id="statistics_viewed_pages" %}
                     {% endif %}
                 </div>


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR is a follow-up for #4472 and hides the new explanation sentences between the statistics chard and page accesses, if the page accesses is hidden for the user

### Proposed changes
<!-- Describe this PR in more detail. -->

Before
<img width="1624" height="771" alt="image" src="https://github.com/user-attachments/assets/51a92b35-abcf-461e-a534-88eb71710d88" />



After
<img width="1792" height="815" alt="image" src="https://github.com/user-attachments/assets/430fd02d-5a85-4a92-afc8-a95130c0baab" />



### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- 


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
- Start the CMS locally
- Activate the statistics for Augsburg and Nürnberg
- Assign the user "Region Manager" to Augsburg and Nürnberg
- Add Augsburg to `PILOT_REGIONS_PAGE_BASED_STATISTICS`
- Log in as a manager user of the region
- Go to the statistics in Nürnberg
- See the explanation sentences are hidden
- Go to the statistics in Augsburg
- See the explanation sentenced are shown


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #/


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
