### PR TITLE
Fix whatsapp and signal preview in social media headers

### DIFF
--- a/integreat_cms/api/v3/templates/social_media_headers.html
+++ b/integreat_cms/api/v3/templates/social_media_headers.html
@@ -2,9 +2,11 @@
 
 {% block headers %}
     <meta name="apple-mobile-web-app-title" content="{{ title }}">
-    <meta name="twitter:title " content="{{ title }}">
+    <meta name="twitter:title" content="{{ title }}">
     <meta name="twitter:card" content="summary">
+    <meta property="og:site_name" content="{{ site_name }}">
     <meta property="og:title" content="{{ title }}">
+    <meta property="og:type" content="website">
     {% if excerpt %}
         <meta name="description" content="{{ excerpt }}">
         <meta property="og:description" content="{{ excerpt }}">

--- a/integreat_cms/cms/utils/social_media_utils.py
+++ b/integreat_cms/cms/utils/social_media_utils.py
@@ -74,6 +74,7 @@ def render_social_media_headers(
         request,
         "social_media_headers.html",
         {
+            "site_name": f"{settings.BRANDING_TITLE}",
             "title": title,
             "excerpt": excerpt,
             "url": url,

--- a/integreat_cms/release_notes/current/unreleased/3983.yml
+++ b/integreat_cms/release_notes/current/unreleased/3983.yml
@@ -1,0 +1,2 @@
+en: Fix whatsapp and signal preview in social media headers.
+de: Behebe die WhatsApp und Signal-Vorschau in Social-Media-Header.

--- a/tests/api/expected-outputs/social.html
+++ b/tests/api/expected-outputs/social.html
@@ -4,9 +4,11 @@
 
         
     <meta name="apple-mobile-web-app-title" content="Integreat | Web-App | Lokale Informationen für Dich">
-    <meta name="twitter:title " content="Integreat | Web-App | Lokale Informationen für Dich">
+    <meta name="twitter:title" content="Integreat | Web-App | Lokale Informationen für Dich">
     <meta name="twitter:card" content="summary">
+    <meta property="og:site_name" content="Integreat">
     <meta property="og:title" content="Integreat | Web-App | Lokale Informationen für Dich">
+    <meta property="og:type" content="website">
     
     <meta property="og:image" content="http://localhost:8000/static/logos/integreat/social-media-preview.png" />
     <meta name="twitter:image" content="http://localhost:8000/static/logos/integreat/social-media-preview.png" />

--- a/tests/api/expected-outputs/social_augsburg.html
+++ b/tests/api/expected-outputs/social_augsburg.html
@@ -4,9 +4,11 @@
 
         
     <meta name="apple-mobile-web-app-title" content="Augsburg | Integreat">
-    <meta name="twitter:title " content="Augsburg | Integreat">
+    <meta name="twitter:title" content="Augsburg | Integreat">
     <meta name="twitter:card" content="summary">
+    <meta property="og:site_name" content="Integreat">
     <meta property="og:title" content="Augsburg | Integreat">
+    <meta property="og:type" content="website">
     
     <meta property="og:image" content="http://localhost:8000/static/logos/integreat/social-media-preview.png" />
     <meta name="twitter:image" content="http://localhost:8000/static/logos/integreat/social-media-preview.png" />

--- a/tests/api/expected-outputs/social_augsburg_de.html
+++ b/tests/api/expected-outputs/social_augsburg_de.html
@@ -4,9 +4,11 @@
 
         
     <meta name="apple-mobile-web-app-title" content="Augsburg | Integreat">
-    <meta name="twitter:title " content="Augsburg | Integreat">
+    <meta name="twitter:title" content="Augsburg | Integreat">
     <meta name="twitter:card" content="summary">
+    <meta property="og:site_name" content="Integreat">
     <meta property="og:title" content="Augsburg | Integreat">
+    <meta property="og:type" content="website">
     
     <meta property="og:image" content="http://localhost:8000/static/logos/integreat/social-media-preview.png" />
     <meta name="twitter:image" content="http://localhost:8000/static/logos/integreat/social-media-preview.png" />

--- a/tests/api/expected-outputs/social_augsburg_de_child_page.html
+++ b/tests/api/expected-outputs/social_augsburg_de_child_page.html
@@ -4,9 +4,11 @@
 
         
     <meta name="apple-mobile-web-app-title" content="Gesundheitsamt - Augsburg | Integreat">
-    <meta name="twitter:title " content="Gesundheitsamt - Augsburg | Integreat">
+    <meta name="twitter:title" content="Gesundheitsamt - Augsburg | Integreat">
     <meta name="twitter:card" content="summary">
+    <meta property="og:site_name" content="Integreat">
     <meta property="og:title" content="Gesundheitsamt - Augsburg | Integreat">
+    <meta property="og:type" content="website">
     
         <meta name="description" content="Leistungen des Gesundheitsamtes: Beratung zur Gesundheitsfragen Beratung für Menschen, die an einer …">
         <meta property="og:description" content="Leistungen des Gesundheitsamtes: Beratung zur Gesundheitsfragen Beratung für Menschen, die an einer …">

--- a/tests/api/expected-outputs/social_augsburg_de_event.html
+++ b/tests/api/expected-outputs/social_augsburg_de_event.html
@@ -4,9 +4,11 @@
 
         
     <meta name="apple-mobile-web-app-title" content="Test-Veranstaltung mit neuem Titel - Augsburg | Integreat">
-    <meta name="twitter:title " content="Test-Veranstaltung mit neuem Titel - Augsburg | Integreat">
+    <meta name="twitter:title" content="Test-Veranstaltung mit neuem Titel - Augsburg | Integreat">
     <meta name="twitter:card" content="summary">
+    <meta property="og:site_name" content="Integreat">
     <meta property="og:title" content="Test-Veranstaltung mit neuem Titel - Augsburg | Integreat">
+    <meta property="og:type" content="website">
     
         <meta name="description" content="Dies ist die Beschreibung einer Test-Veranstaltung.">
         <meta property="og:description" content="Dies ist die Beschreibung einer Test-Veranstaltung.">

--- a/tests/api/expected-outputs/social_augsburg_de_location.html
+++ b/tests/api/expected-outputs/social_augsburg_de_location.html
@@ -4,9 +4,11 @@
 
         
     <meta name="apple-mobile-web-app-title" content="Test-Ort - Augsburg | Integreat">
-    <meta name="twitter:title " content="Test-Ort - Augsburg | Integreat">
+    <meta name="twitter:title" content="Test-Ort - Augsburg | Integreat">
     <meta name="twitter:card" content="summary">
+    <meta property="og:site_name" content="Integreat">
     <meta property="og:title" content="Test-Ort - Augsburg | Integreat">
+    <meta property="og:type" content="website">
     
         <meta name="description" content="Beschreibung des Test-Ortes">
         <meta property="og:description" content="Beschreibung des Test-Ortes">

--- a/tests/api/expected-outputs/social_augsburg_de_page.html
+++ b/tests/api/expected-outputs/social_augsburg_de_page.html
@@ -4,10 +4,12 @@
 
         
     <meta name="apple-mobile-web-app-title" content="Willkommen - Augsburg | Integreat">
-    <meta name="twitter:title " content="Willkommen - Augsburg | Integreat">
+    <meta name="twitter:title" content="Willkommen - Augsburg | Integreat">
     <meta name="twitter:card" content="summary">
+    <meta property="og:site_name" content="Integreat">
     <meta property="og:title" content="Willkommen - Augsburg | Integreat">
-    
+    <meta property="og:type" content="website">
+
         <meta name="description" content="Willkommen in Augsburg">
         <meta property="og:description" content="Willkommen in Augsburg">
         <meta name="twitter:description" content="Willkommen in Augsburg">

--- a/tests/api/expected-outputs/social_augsburg_de_page.html
+++ b/tests/api/expected-outputs/social_augsburg_de_page.html
@@ -9,7 +9,7 @@
     <meta property="og:site_name" content="Integreat">
     <meta property="og:title" content="Willkommen - Augsburg | Integreat">
     <meta property="og:type" content="website">
-
+    
         <meta name="description" content="Willkommen in Augsburg">
         <meta property="og:description" content="Willkommen in Augsburg">
         <meta name="twitter:description" content="Willkommen in Augsburg">

--- a/tests/api/expected-outputs/social_augsburg_de_pn.html
+++ b/tests/api/expected-outputs/social_augsburg_de_pn.html
@@ -9,7 +9,7 @@
     <meta property="og:site_name" content="Integreat">
     <meta property="og:title" content="Test DE - Augsburg | Integreat">
     <meta property="og:type" content="website">
-
+    
         <meta name="description" content="Test DE Inhalt">
         <meta property="og:description" content="Test DE Inhalt">
         <meta name="twitter:description" content="Test DE Inhalt">

--- a/tests/api/expected-outputs/social_augsburg_de_pn.html
+++ b/tests/api/expected-outputs/social_augsburg_de_pn.html
@@ -4,10 +4,12 @@
 
         
     <meta name="apple-mobile-web-app-title" content="Test DE - Augsburg | Integreat">
-    <meta name="twitter:title " content="Test DE - Augsburg | Integreat">
+    <meta name="twitter:title" content="Test DE - Augsburg | Integreat">
     <meta name="twitter:card" content="summary">
+    <meta property="og:site_name" content="Integreat">
     <meta property="og:title" content="Test DE - Augsburg | Integreat">
-    
+    <meta property="og:type" content="website">
+
         <meta name="description" content="Test DE Inhalt">
         <meta property="og:description" content="Test DE Inhalt">
         <meta name="twitter:description" content="Test DE Inhalt">

--- a/tests/api/expected-outputs/social_landing.html
+++ b/tests/api/expected-outputs/social_landing.html
@@ -4,9 +4,11 @@
 
         
     <meta name="apple-mobile-web-app-title" content="Integreat | Web-App | Lokale Informationen für Dich">
-    <meta name="twitter:title " content="Integreat | Web-App | Lokale Informationen für Dich">
+    <meta name="twitter:title" content="Integreat | Web-App | Lokale Informationen für Dich">
     <meta name="twitter:card" content="summary">
+    <meta property="og:site_name" content="Integreat">
     <meta property="og:title" content="Integreat | Web-App | Lokale Informationen für Dich">
+    <meta property="og:type" content="website">
     
     <meta property="og:image" content="http://localhost:8000/static/logos/integreat/social-media-preview.png" />
     <meta name="twitter:image" content="http://localhost:8000/static/logos/integreat/social-media-preview.png" />

--- a/tests/api/expected-outputs/social_landing_de.html
+++ b/tests/api/expected-outputs/social_landing_de.html
@@ -4,9 +4,11 @@
 
         
     <meta name="apple-mobile-web-app-title" content="Integreat | Web-App | Lokale Informationen für Dich">
-    <meta name="twitter:title " content="Integreat | Web-App | Lokale Informationen für Dich">
+    <meta name="twitter:title" content="Integreat | Web-App | Lokale Informationen für Dich">
     <meta name="twitter:card" content="summary">
+    <meta property="og:site_name" content="Integreat">
     <meta property="og:title" content="Integreat | Web-App | Lokale Informationen für Dich">
+    <meta property="og:type" content="website">
     
     <meta property="og:image" content="http://localhost:8000/static/logos/integreat/social-media-preview.png" />
     <meta name="twitter:image" content="http://localhost:8000/static/logos/integreat/social-media-preview.png" />

--- a/tests/api/expected-outputs/social_landing_en.html
+++ b/tests/api/expected-outputs/social_landing_en.html
@@ -4,9 +4,11 @@
 
         
     <meta name="apple-mobile-web-app-title" content="Integreat">
-    <meta name="twitter:title " content="Integreat">
+    <meta name="twitter:title" content="Integreat">
     <meta name="twitter:card" content="summary">
+    <meta property="og:site_name" content="Integreat">
     <meta property="og:title" content="Integreat">
+    <meta property="og:type" content="website">
     
         <meta name="description" content="Integreat is your digital companion for Germany. Here you can find local information, advice centres and services.">
         <meta property="og:description" content="Integreat is your digital companion for Germany. Here you can find local information, advice centres and services.">


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This PR is supposed to fix the preview not being shown for whatsapp and signal in social media headers.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Remove extra space in `twitter:title`
- Add `og:type` 
- Add `og:site_name` which can improve brand clarity and help format cards correctly as it is mentioned from @dkehne analyses suggestion :nerd_face: 


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- none is intended


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
Not testable locally

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3983 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
