### PR TITLE
Hotfix: Remove the populate_published_at function

### DIFF
--- a/integreat_cms/cms/migrations/0158_eventtranslation_published_at_and_more.py
+++ b/integreat_cms/cms/migrations/0158_eventtranslation_published_at_and_more.py
@@ -1,47 +1,4 @@
-from __future__ import annotations
-
-from typing import TYPE_CHECKING
-
 from django.db import migrations, models
-from django.db.models import OuterRef, Subquery
-
-from ..constants import status
-
-if TYPE_CHECKING:
-    from django.apps.registry import Apps
-    from django.db.backends.base.schema import BaseDatabaseSchemaEditor
-
-
-def populate_published_at(
-    apps: Apps,
-    _schema_editor: BaseDatabaseSchemaEditor,
-) -> None:
-    """
-    Populate the new ``published_at`` field of existing content translations with the
-    ``last_updated`` timestamp of the earliest public version of the same translation
-    (i.e. per content object and language)
-
-    :param apps: The configuration of installed applications
-    """
-    for translation_model_name, foreign_field in [
-        ("EventTranslation", "event"),
-        ("ImprintPageTranslation", "page"),
-        ("PageTranslation", "page"),
-        ("POITranslation", "poi"),
-    ]:
-        translation_model = apps.get_model("cms", translation_model_name)
-        first_publication = (
-            translation_model.objects.filter(
-                **{foreign_field: OuterRef(foreign_field)},
-                language=OuterRef("language"),
-                status=status.PUBLIC,
-            )
-            .order_by("last_updated")
-            .values("last_updated")[:1]
-        )
-        translation_model.objects.filter(published_at__isnull=True).update(
-            published_at=Subquery(first_publication)
-        )
 
 
 class Migration(migrations.Migration):
@@ -78,5 +35,4 @@ class Migration(migrations.Migration):
                 blank=True, null=True, verbose_name="publication date"
             ),
         ),
-        migrations.RunPython(populate_published_at, migrations.RunPython.noop),
     ]


### PR DESCRIPTION
### Short description
Currently at Test-cms its failing while migrating at `0158_eventtranslation_published_at_and_more` for more details check: https://chat.tuerantuer.org/digitalfabrik/pl/5x6xbgwqb7djbgz9ds3rsqikee



### Proposed changes
<!-- Describe this PR in more detail. -->

- The endpoints are already have a fallback to lastUpdated so no need to fill the empty published_at at migration so I removed that function.

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- Hope none.


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
     
 - Launch the docker and run the cms server.
- open Postman or any alternative and try to query a Get request for ex:
```
- Events: http://localhost:8000/api/v3/augsburg/de/events/
- Pages: http://localhost:8000/api/v3/augsburg/de/pages/
- Locations: http://localhost:8000/api/v3/augsburg/de/locations/
```


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->
Related to: #4300 
Fixes: #


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
