### PR TITLE
invalidate cache on treebeard node deletion and manager methods

### DIFF
--- a/integreat_cms/cms/models/abstract_tree_node.py
+++ b/integreat_cms/cms/models/abstract_tree_node.py
@@ -16,12 +16,10 @@ from django.db.models import CheckConstraint, Deferrable, F, Q, UniqueConstraint
 from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 from treebeard.exceptions import InvalidPosition
-from treebeard.ns_tree import NS_Node, NS_NodeManager
+from treebeard.ns_tree import NS_Node, NS_NodeManager, NS_NodeQuerySet
 
 if TYPE_CHECKING:
     from typing import Any, Self
-
-    from treebeard.ns_tree import NS_NodeQuerySet
 
 from ..constants import position
 from .abstract_base_model import AbstractBaseModel
@@ -29,10 +27,42 @@ from .abstract_base_model import AbstractBaseModel
 logger = logging.getLogger(__name__)
 
 
+class AbstractTreeNodeQuerySet(NS_NodeQuerySet):
+    """
+    Custom queryset invalidating the cache when tree nodes are deleted
+    """
+
+    def delete(self, *args: Any, **kwargs: Any) -> tuple[int, dict[str, int]]:
+        r"""
+        Delete the nodes of this queryset and invalidate the cache
+
+        :param \*args: The supplied arguments
+        :param \**kwargs: The supplied keyword arguments
+        :return: The number of deleted objects and the number of deletions per object type
+        """
+        self.model.invalidate_tree_cache()
+        try:
+            return super().delete(*args, **kwargs)
+        finally:
+            self.model.invalidate_tree_cache()
+
+
 class AbstractTreeNodeManager(NS_NodeManager):
     """
     Custom manager adding a stdout message to ``AbstractTreeNode.objects.create()``
+    and invalidating the cache around treebeard's tree operations
     """
+
+    def get_queryset(self) -> AbstractTreeNodeQuerySet:
+        """
+        Sets the custom queryset as the default.
+
+        :return: The sorted queryset
+        """
+        return AbstractTreeNodeQuerySet(self.model, using=self._db).order_by(
+            "tree_id",
+            "lft",
+        )
 
     def create(self, *args, **kwargs):  # type: ignore[no-untyped-def]
         """
@@ -70,6 +100,53 @@ class AbstractTreeNodeManager(NS_NodeManager):
         )
         return obj
 
+    # From django-treebeard 7 on, the tree operations are implemented on the manager and
+    # Node.add_child(), MoveNodeForm.save() and TreeAdmin.move_node() all route through it,
+    # so the cache has to be invalidated here as well as on the model methods below.
+    # These overrides are unreachable with django-treebeard 5, which implements the
+    # operations on the node itself.
+
+    def add_child(self, *args: Any, **kwargs: Any) -> AbstractTreeNode:
+        r"""
+        Add a child to the target node and invalidate the cache
+
+        :param \*args: The supplied arguments
+        :param \**kwargs: The supplied keyword arguments
+        :return: The new child
+        """
+        self.model.invalidate_tree_cache()
+        try:
+            return super().add_child(*args, **kwargs)
+        finally:
+            self.model.invalidate_tree_cache()
+
+    def add_sibling(self, *args: Any, **kwargs: Any) -> AbstractTreeNode:
+        r"""
+        Add a new node as a sibling to the target node and invalidate the cache
+
+        :param \*args: The supplied arguments
+        :param \**kwargs: The supplied keyword arguments
+        :return: The new sibling
+        """
+        self.model.invalidate_tree_cache()
+        try:
+            return super().add_sibling(*args, **kwargs)
+        finally:
+            self.model.invalidate_tree_cache()
+
+    def move(self, *args: Any, **kwargs: Any) -> None:
+        r"""
+        Move a node to a new position relative to another node and invalidate the cache
+
+        :param \*args: The supplied arguments
+        :param \**kwargs: The supplied keyword arguments
+        """
+        self.model.invalidate_tree_cache()
+        try:
+            super().move(*args, **kwargs)
+        finally:
+            self.model.invalidate_tree_cache()
+
 
 class AbstractTreeNode(NS_Node, AbstractBaseModel):
     """
@@ -95,6 +172,18 @@ class AbstractTreeNode(NS_Node, AbstractBaseModel):
     )
 
     @classmethod
+    def invalidate_tree_cache(cls) -> None:
+        """
+        Invalidate all cached querysets of this model.
+
+        Treebeard shifts the ``lft``, ``rgt`` and ``tree_id`` of arbitrary other nodes with raw
+        ``QuerySet.update()`` calls. Cacheops only invalidates on ``save()``, ``delete()`` and its
+        own explicit ``invalidated_update()``, so it cannot see those shifts and the whole model
+        has to be invalidated manually. Subclasses can extend this to invalidate related models.
+        """
+        invalidate_model(cls)
+
+    @classmethod
     def get_region_root_nodes(cls, region_slug: str) -> NS_NodeQuerySet:
         """
         Get all root nodes of a specific region
@@ -111,12 +200,13 @@ class AbstractTreeNode(NS_Node, AbstractBaseModel):
         :param \**kwargs: The supplied keyword arguments
         :return: The new child
         """
-        # Adding a child can modify all other nodes via raw sql queries (which are not recognized by cachalot),
-        # so we have to invalidate the whole model manually.
-        invalidate_model(self.__class__)
-        child = super().add_child(**kwargs)
-        invalidate_model(self.__class__)
-        return child
+        # Adding a child can modify all other nodes via raw sql queries (which are not
+        # recognized by cacheops), so we have to invalidate the whole model manually.
+        self.invalidate_tree_cache()
+        try:
+            return super().add_child(**kwargs)
+        finally:
+            self.invalidate_tree_cache()
 
     def add_sibling(self, pos: str | None = None, **kwargs: Any) -> AbstractTreeNode:
         r"""
@@ -126,12 +216,13 @@ class AbstractTreeNode(NS_Node, AbstractBaseModel):
         :param \**kwargs: The supplied keyword arguments
         :return: The new sibling
         """
-        # Adding a sibling can modify all other nodes via raw sql queries (which are not recognized by cachalot),
-        # so we have to invalidate the whole model manually.
-        invalidate_model(self.__class__)
-        sibling = super().add_sibling(pos=pos, **kwargs)
-        invalidate_model(self.__class__)
-        return sibling
+        # Adding a sibling can modify all other nodes via raw sql queries (which are not
+        # recognized by cacheops), so we have to invalidate the whole model manually.
+        self.invalidate_tree_cache()
+        try:
+            return super().add_sibling(pos=pos, **kwargs)
+        finally:
+            self.invalidate_tree_cache()
 
     @classmethod
     def get_tree(cls, parent: AbstractTreeNode | None = None) -> NS_NodeQuerySet:
@@ -295,11 +386,13 @@ class AbstractTreeNode(NS_Node, AbstractBaseModel):
                     self, self.region, target.region
                 )
             )
-        # Moving a node can modify all other nodes via raw sql queries (which are not recognized by cachalot),
-        # so we have to invalidate the whole model manually.
-        invalidate_model(self.__class__)
-        super().move(target, pos)
-        invalidate_model(self.__class__)
+        # Moving a node can modify all other nodes via raw sql queries (which are not
+        # recognized by cacheops), so we have to invalidate the whole model manually.
+        self.invalidate_tree_cache()
+        try:
+            super().move(target, pos)
+        finally:
+            self.invalidate_tree_cache()
 
         # Reload 'self' because lft/rgt may have changed
         self.refresh_from_db()

--- a/integreat_cms/cms/models/pages/page.py
+++ b/integreat_cms/cms/models/pages/page.py
@@ -10,12 +10,15 @@ from django.utils.functional import cached_property
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 from linkcheck.models import Link
-from treebeard.ns_tree import NS_NodeManager, NS_NodeQuerySet
 
 from ...constants import status
 from ...utils.translation_utils import gettext_many_lazy as __
 from ..abstract_content_model import ContentQuerySet
-from ..abstract_tree_node import AbstractTreeNode
+from ..abstract_tree_node import (
+    AbstractTreeNode,
+    AbstractTreeNodeManager,
+    AbstractTreeNodeQuerySet,
+)
 from ..decorators import modify_fields
 from ..utils import format_object_translation
 from .abstract_base_page import AbstractBasePage
@@ -34,7 +37,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class PageQuerySet(NS_NodeQuerySet, ContentQuerySet):
+class PageQuerySet(AbstractTreeNodeQuerySet, ContentQuerySet):
     """
     Custom queryset for pages to inherit methods from both querysets for tree nodes and content objects
     """
@@ -163,7 +166,7 @@ class PageQuerySet(NS_NodeQuerySet, ContentQuerySet):
         return list(self.cache_tree_dict(archived, language_slug).values())
 
 
-class PageManager(NS_NodeManager):
+class PageManager(AbstractTreeNodeManager):
     """
     Custom manager for pages to inherit methods from both managers for tree nodes and content objects
     """
@@ -266,6 +269,16 @@ class Page(AbstractTreeNode, AbstractBasePage):
 
     #: Custom model manager to inherit methods from tree manager as well as the custom content queryset
     objects = PageManager()
+
+    @classmethod
+    def invalidate_tree_cache(cls) -> None:
+        """
+        Invalidate the cached pages as well as the cached page translations, because the latter
+        are related to :class:`~integreat_cms.cms.models.pages.page.Page` and therefore also
+        affected by changes to ``tree_id``, ``lft`` and ``rgt``.
+        """
+        super().invalidate_tree_cache()
+        invalidate_model(PageTranslation)
 
     @staticmethod
     def get_translation_model() -> ModelBase:
@@ -373,19 +386,6 @@ class Page(AbstractTreeNode, AbstractBasePage):
                 "you cannot delete a page that is embedded as live content by another page."
             )
         return True, None
-
-    def move(self, target: Page, pos: str | None = None) -> None:
-        """
-        Moving tree nodes potentially causes changes to the fields tree_id, lft and rgt in :class:`~treebeard.ns_tree.NS_Node`
-        so the cache of page translations has to be cleared, because of it's relation to :class:`~integreat_cms.cms.models.pages.page.Page`
-
-        :param target: The target node which determines the new position
-        :param pos: The new position of the page relative to the target
-                    (choices: :mod:`~integreat_cms.cms.constants.position`)
-        :raises ~treebeard.exceptions.InvalidPosition: If the node is moved to another region
-        """
-        super().move(target, pos)
-        invalidate_model(PageTranslation)
 
     def archive(self) -> None:
         """

--- a/tests/cms/models/test_tree_cache_invalidation.py
+++ b/tests/cms/models/test_tree_cache_invalidation.py
@@ -1,0 +1,219 @@
+"""
+Test that the cache is invalidated around all of treebeard's tree operations.
+
+Treebeard shifts the ``lft``, ``rgt`` and ``tree_id`` of arbitrary other nodes with raw
+``QuerySet.update()`` calls, which cacheops cannot see. If an operation does not invalidate the
+model, a later request can read pre-shift coordinates from the cache and treebeard will then
+insert a node at a position that no longer exists, silently writing the node into the wrong
+branch. Cacheops is disabled in the test settings and needs a redis server, so these tests
+assert that the invalidation happens instead of observing the cache itself.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+import pytest
+from treebeard.ns_tree import NS_NodeManager
+
+from integreat_cms.cms.models import (
+    Language,
+    LanguageTreeNode,
+    Page,
+    PageTranslation,
+    Region,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from django.db.models import Model
+
+#: Whether the tree operations are implemented on the manager, which is the case from
+#: django-treebeard 7 on. Before that, they are implemented on the node itself.
+TREE_OPERATIONS_ON_MANAGER = hasattr(NS_NodeManager, "add_child")
+
+#: Skip the tests for the manager operations if this version of django-treebeard does not have them
+requires_manager_operations = pytest.mark.skipif(
+    not TREE_OPERATIONS_ON_MANAGER,
+    reason="django-treebeard < 7 implements the tree operations on the node, not on the manager",
+)
+
+
+@contextmanager
+def record_invalidated_models() -> Iterator[list[type[Model]]]:
+    """
+    Record which models would be invalidated instead of connecting to redis
+
+    :return: The list the invalidated models are appended to
+    """
+    invalidated: list[type[Model]] = []
+    with (
+        patch(
+            "integreat_cms.cms.models.abstract_tree_node.invalidate_model",
+            invalidated.append,
+        ),
+        patch(
+            "integreat_cms.cms.models.pages.page.invalidate_model",
+            invalidated.append,
+        ),
+    ):
+        yield invalidated
+
+
+def create_page_tree() -> tuple[Page, Page, Page]:
+    """
+    Create a region with a root page and two children
+
+    :return: The root page and both of its children
+    """
+    region = Region.objects.create(name="Testregion")
+    root = Page.add_root(region=region)
+    first_child = root.add_child(region=region)
+    second_child = root.add_child(region=region)
+    return root, first_child, second_child
+
+
+def create_language_tree() -> tuple[LanguageTreeNode, LanguageTreeNode]:
+    """
+    Create a region with a root language tree node and one child
+
+    :return: The root language tree node and its child
+    """
+    region = Region.objects.create(name="Testregion")
+    languages = [
+        Language.objects.create(
+            slug=f"tl{index}",
+            bcp47_tag=f"tl{index}",
+            native_name=f"Testsprache {index}",
+            english_name=f"Test language {index}",
+            text_direction="ltr",
+            primary_country_code="TEST",
+            table_of_contents=f"Inhalt {index}",
+        )
+        for index in range(2)
+    ]
+    root = LanguageTreeNode.add_root(region=region, language=languages[0])
+    child = root.add_child(region=region, language=languages[1])
+    return root, child
+
+
+@pytest.mark.django_db
+def test_add_child_invalidates_cache() -> None:
+    """
+    Test whether adding a child page invalidates the cached pages and page translations
+    """
+    root, _first_child, _second_child = create_page_tree()
+    with record_invalidated_models() as invalidated:
+        root.add_child(region=root.region)
+    assert Page in invalidated
+    assert PageTranslation in invalidated
+
+
+@pytest.mark.django_db
+def test_add_sibling_invalidates_cache() -> None:
+    """
+    Test whether adding a sibling page invalidates the cached pages and page translations
+    """
+    _root, first_child, _second_child = create_page_tree()
+    with record_invalidated_models() as invalidated:
+        first_child.add_sibling(pos="right", region=first_child.region)
+    assert Page in invalidated
+    assert PageTranslation in invalidated
+
+
+@pytest.mark.django_db
+def test_move_invalidates_cache() -> None:
+    """
+    Test whether moving a page invalidates the cached pages and page translations
+    """
+    _root, first_child, second_child = create_page_tree()
+    with record_invalidated_models() as invalidated:
+        first_child.move(second_child, "right")
+    assert Page in invalidated
+    assert PageTranslation in invalidated
+
+
+@pytest.mark.django_db
+def test_delete_invalidates_cache() -> None:
+    """
+    Test whether deleting a page invalidates the cached pages and page translations, because
+    closing the gap in the tree shifts the coordinates of all following nodes
+    """
+    _root, first_child, _second_child = create_page_tree()
+    with record_invalidated_models() as invalidated:
+        first_child.delete()
+    assert Page in invalidated
+    assert PageTranslation in invalidated
+
+
+@pytest.mark.django_db
+def test_queryset_delete_invalidates_cache() -> None:
+    """
+    Test whether deleting pages via the queryset invalidates the cached pages and page translations
+    """
+    _root, first_child, _second_child = create_page_tree()
+    with record_invalidated_models() as invalidated:
+        Page.objects.filter(pk=first_child.pk).delete()
+    assert Page in invalidated
+    assert PageTranslation in invalidated
+
+
+@pytest.mark.django_db
+def test_language_tree_node_delete_invalidates_cache() -> None:
+    """
+    Test whether deleting a language tree node invalidates the cached language tree nodes.
+    This covers the shared manager and queryset instead of the ones overridden for pages.
+    """
+    _root, child = create_language_tree()
+    with record_invalidated_models() as invalidated:
+        child.delete()
+    assert LanguageTreeNode in invalidated
+    assert PageTranslation not in invalidated
+
+
+@requires_manager_operations
+@pytest.mark.django_db
+def test_manager_add_child_invalidates_cache() -> None:
+    """
+    Test whether adding a child page via the manager invalidates the cache. This is the code path
+    ``treebeard.forms.MoveNodeForm.save()`` takes, which is how pages are created in the CMS.
+    """
+    root, _first_child, _second_child = create_page_tree()
+    with record_invalidated_models() as invalidated:
+        Page.objects.add_child(root, create_kwargs={"region": root.region})
+    assert Page in invalidated
+    assert PageTranslation in invalidated
+
+
+@requires_manager_operations
+@pytest.mark.django_db
+def test_manager_add_sibling_invalidates_cache() -> None:
+    """
+    Test whether adding a sibling page via the manager invalidates the cache
+    """
+    _root, first_child, _second_child = create_page_tree()
+    with record_invalidated_models() as invalidated:
+        Page.objects.add_sibling(
+            first_child,
+            pos="right",
+            create_kwargs={"region": first_child.region},
+        )
+    assert Page in invalidated
+    assert PageTranslation in invalidated
+
+
+@requires_manager_operations
+@pytest.mark.django_db
+def test_manager_move_invalidates_cache() -> None:
+    """
+    Test whether moving a page via the manager invalidates the cache. This is the code path
+    ``treebeard.forms.MoveNodeForm.save()`` and ``treebeard.admin.TreeAdmin.move_node()`` take.
+    """
+    _root, first_child, second_child = create_page_tree()
+    with record_invalidated_models() as invalidated:
+        Page.objects.move(first_child, second_child, pos="right")
+    assert Page in invalidated
+    assert PageTranslation in invalidated


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
`treebeard` uses `Queryset.update()` to update nodes when changing a tree, e.g. by moving a page in the page tree or adding a new child page. This does not invalidate the cache, thus we override the methods in `abstract_tree_node.py` to add cache invalidation manually. This PR serves two purposes:
- close the existing gap that node deletion was not covered in our cache invalidation
- make the overrides forward compatible with `treebeard 7`, which will be introduced by #4513 

### Proposed changes
<!-- Describe this PR in more detail. -->

- override the `delete` method of `NS_NodeQuerySet` to add cache invalidation
- override `add_child`, `add_sibling` and `move` methods on `NS_NodeManager` to add cache invalidation for `treebeard >= 7`
- introduce AbstractTreeNode.invalidate_tree_cache() as the single hook all layers call, replacing the inline `invalidate_model(self.__class__)` calls in the model methods
- re-base PageQuerySet on AbstractTreeNodeQuerySet and PageManager on AbstractTreeNodeManager (previously NS_NodeQuerySet / NS_NodeManager) because Page.objects is a PageManager, so overriding only the abstract manager would fix language trees and leave pages uncovered
- AbstractTreeNodeManager.get_queryset() returns the new queryset class
- remove stale `Page.move` method
- add regression tests


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- page translations are now invalidated on add_child, add_sibling and delete too, not only on move as before. Slightly more cache churn
- PageManager now inherits AbstractTreeNodeManager, so Page.objects.create() now emits "Don't use Page.objects.create()" dev warning it previously escaped


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
Start the CMS with the cache enabled and the test data loaded:

    INTEGREAT_CMS_REDIS_CACHE=True ./tools/run.sh

Start with a page tree like
```
...
- page A
- page B
...
```

**Warm the cache for page B**:

    curl -s 'http://localhost:8000/api/v3/augsburg/de/children/?id=<page B id>&depth=1' > /dev/null

**Delete page A** via bulk delete.
Compare cache and database:

    INTEGREAT_CMS_REDIS_CACHE=True integreat-cms-cli shell -c "
    from integreat_cms.cms.models import Region
    region = Region.objects.get(slug=<region>)
    print('cache   ', region.pages.get(id=<page B id>).lft)
    print('database', region.pages.filter(id=<page B id>).nocache().get().lft)
    "

Before this PR the two disagree, with the fix they match.
See this [comment](https://github.com/digitalfabrik/integreat-cms/pull/4513#pullrequestreview-4983113978) on how to test the bug with treebeard 7 without the fix.

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
