### PR TITLE
3726: Fix the tooltip of the restore contact button

### DIFF
--- a/integreat_cms/cms/templates/contacts/contact_form.html
+++ b/integreat_cms/cms/templates/contacts/contact_form.html
@@ -160,7 +160,7 @@
                             </button>
                         {% endif %}
                         {% if perms.cms.archive_contact and archived %}
-                            <button title="{% translate "Restore page" %}"
+                            <button title="{% translate "Restore contact" %}"
                                     class="btn confirmation-button btn-blue"
                                     data-confirmation-title="{{ restore_dialog_title }}"
                                     data-confirmation-text="{{ restore_dialog_text }}"

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -5577,10 +5577,9 @@ msgid "Archival not possible"
 msgstr "Archivieren nicht möglich"
 
 #: cms/templates/contacts/contact_form.html
-#: cms/templates/pages/page_form_sidebar/actions_box.html
-#: cms/templates/pages/pages_page_tree_node.html
-msgid "Restore page"
-msgstr "Seite wiederherstellen"
+#: cms/templates/contacts/contact_list_row.html
+msgid "Restore contact"
+msgstr "Kontakt wiederherstellen"
 
 #: cms/templates/contacts/contact_form.html
 msgid "Restore this contact"
@@ -5746,10 +5745,6 @@ msgstr "Primärkontakt"
 #: cms/templates/organizations/organization_list_row.html
 msgid "To website"
 msgstr "Zur Webseite"
-
-#: cms/templates/contacts/contact_list_row.html
-msgid "Restore contact"
-msgstr "Kontakt wiederherstellen"
 
 #: cms/templates/contacts/contact_list_row.html
 msgid "Copy contact"
@@ -7692,6 +7687,11 @@ msgstr "Archiviert, weil eine übergeordnete Seite archiviert ist"
 #: cms/templates/pages/page_form_sidebar/actions_box.html
 msgid "Mark this page as up-to-date"
 msgstr "Seite als aktuell markieren"
+
+#: cms/templates/pages/page_form_sidebar/actions_box.html
+#: cms/templates/pages/pages_page_tree_node.html
+msgid "Restore page"
+msgstr "Seite wiederherstellen"
 
 #: cms/templates/pages/page_form_sidebar/actions_box.html
 msgid "Restore this page"

--- a/integreat_cms/release_notes/current/unreleased/3726.yml
+++ b/integreat_cms/release_notes/current/unreleased/3726.yml
@@ -1,0 +1,2 @@
+en: Fix the tooltip of the restore button in the contact form
+de: Behebe den Tooltip der Schaltfläche zum Wiederherstellen im Kontaktformular


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->

The restore button on an archived contact's detail/edit form shows the tooltip "Restore page" instead of "Restore contact". The `title` attribute was copy-pasted from the page sidebar; this changes it to the string the contact list row already uses.

### Proposed changes
<!-- Describe this PR in more detail. -->

- `contacts/contact_form.html`: `title="{% translate "Restore page" %}"` → `title="{% translate "Restore contact" %}"`. `contacts/contact_list_row.html` already uses `"Restore contact"` for the same action, so no new msgid is introduced.
- Regenerated `locale/de/LC_MESSAGES/django.po` with `./tools/translate.sh` (only the source-file comments of the two existing entries move).
- Release note for #3726.

I left the button's visible label as "Restore this contact". That mirrors the other form sidebars, which all pair `title="Restore <entity>"` with the label "Restore this <entity>" (pages, POIs), so the forms stay consistent.

No test: there are no assertions on template copy or `title` attributes anywhere in `tests/`, and the nearest comparable change (b4ff5af, the Push Notification -> News rename) added none either. Happy to add one if you'd rather have it pinned.

Small thing I noticed but did not touch: in German both msgids render as "Kontakt wiederherstellen", so the tooltip and the button label now read identically. Pages avoids that with "Seite wiederherstellen" / "Diese Seite wiederherstellen". That is a wording call on the *other* msgid, so I left it out of this PR.

### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None. `"Restore page"` is still used by `pages/page_form_sidebar/actions_box.html` and `pages/pages_page_tree_node.html`, so the msgid stays in the translation file.

### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.

### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->

Archive a contact, open it, scroll to the restore button and hover it. The tooltip should read "Restore contact" / "Kontakt wiederherstellen".

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #3726


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)

---
Used AI assistance on this; I reviewed and tested the change myself.