### PR TITLE
Pin version for postcss (Fix for wrongly rendered icons)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8110,9 +8110,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8134,9 +8131,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8158,9 +8152,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8182,9 +8173,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8206,9 +8194,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8230,9 +8215,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8440,9 +8422,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8460,9 +8439,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8480,9 +8456,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8500,9 +8473,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8520,9 +8490,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8540,9 +8507,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9909,9 +9873,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9926,9 +9887,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9943,9 +9901,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9960,9 +9915,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9977,9 +9929,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9994,9 +9943,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10011,9 +9957,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10028,9 +9971,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10045,9 +9985,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -10062,9 +9999,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -17856,9 +17790,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -17880,9 +17811,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -17904,9 +17832,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -17928,9 +17853,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -19271,9 +19193,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.25",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
-      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -83,5 +83,8 @@
   },
   "engines": {
     "node": ">=22"
+  },
+  "overrides": {
+    "postcss": "8.5.23"
   }
 }


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This pins the npm package `postcss` to `8.5.23` and fixes the css build bug introduced there


### Proposed changes
<!-- Describe this PR in more detail. -->

- Pins postcss to 8.5.23 via overrides in package.json, forcing every dependency that pulls in postcss (tailwindcss, autoprefixer, postcss-preset-env, css-loader, css-minimizer-webpack-plugin, postcss-loader, postcss-cli, postcss-import, and transitively vite/vitest) to use this older version instead of whatever they'd naturally resolve to (8.5.25).
- This is a workaround for an upstream postcss regression, already tracked here: postcss/postcss#2133 (https://github.com/postcss/postcss/issues/2133) (exact change: commit 9a114f6 (https://github.com/postcss/postcss/commit/9a114f6)). As of that thread, the root cause is now understood more precisely: sass-loader/dart-sass emits a BOM/charset marker on the individually-compiled CSS module (in our case, the flagpack-dart-sass module, which contains a non-ASCII \00a0 character). postcss ≤8.5.23 silently stripped this; 8.5.24 "fixed" that by faithfully preserving it — which breaks any build (like ours) that concatenates multiple postcss-processed CSS fragments into one file via css-loader/MiniCssExtractPlugin. There's a related sass-loader issue too: webpack/sass-loader#1335 (https://github.com/webpack/sass-loader/issues/1335), plus a pending (contested) fix PR upstream in postcss (#2136 (https://github.com/postcss/postcss/pull/2136)).
- Alternative fix worth knowing about, not applied here: the sass-loader issue reports that setting sassOptions.charset: false in the loader options avoids the BOM entirely, without needing to touch postcss's version at all. Didn't pursue it since the overrides pin is smaller/more contained, but it may be the more "correct" long-term fix once someone verifies it doesn't have side effects on this project's font/encoding-sensitive CSS.
- We lose two unrelated upstream fixes that shipped in 8.5.25/8.5.26 (a list.split() fix and a source-map symlink-tracking fix) — neither is exercised by this build.
- package-lock.json also has unrelated noise: a few optional platform packages lost a "libc" metadata field, from regenerating the lockfile with a slightly different npm patch version. Doesn't change any resolved package version.
- **Follow-up needed**: remove this override once postcss ships an accepted fix (track #2133(https://github.com/postcss/postcss/issues/2133)/#2136 (https://github.com/postcss/postcss/pull/2136)), or switch to the sassOptions.charset: false approach if that turns out cleaner.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.

### How to reproduce locally
On develop (before merge into develop)
- In the file `run.sh` comment out the line 39 ` # deescalate_privileges npm run dev 2>&1 | print_prefix "webpack" 36 &`
- run `npm ci`
- run `npm run prod`
- run `tools/run.sh`
=> See that the icons are wrongly rendered

### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
On feature branch:
Follow steps in **How to reproduce locally**


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4517


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
