### PR TITLE
Fix raw-content endpoint: Filter for current translations by slug only

### DIFF
--- a/integreat_cms/cms/utils/internal_link_utils.py
+++ b/integreat_cms/cms/utils/internal_link_utils.py
@@ -149,7 +149,9 @@ def get_public_translation_for_webapp_link_parts(
         "status": status.PUBLIC,
     }
     if object_type != ImprintPageTranslation:
-        filter_args[f"{foreign_object}__translations__slug"] = object_slug
+        # Old/renamed slugs are intentionally not supported anymore
+        # (see https://github.com/digitalfabrik/integreat-cms/issues/4524).
+        filter_args["slug"] = object_slug
 
     instances = (
         object_type.objects.filter(**filter_args)

--- a/tests/core/management/commands/test_fix_internal_links.py
+++ b/tests/core/management/commands/test_fix_internal_links.py
@@ -100,7 +100,6 @@ def test_fix_internal_links_skips_organization_links(load_test_data: None) -> No
 
 
 old_urls = [
-    "https://integreat.app/augsburg/de/deutsche-sprache/sprachlernangebote/",
     "https://integreat.app/augsburg/de/willkommen/",
     "https://integreat.app/augsburg/de/events/test-veranstaltung/",
     "https://integreat.app/augsburg/de/locations/test-ort/",
@@ -108,12 +107,22 @@ old_urls = [
 ]
 
 new_urls = [
-    "https://integreat.app/augsburg/de/deutsche-sprache/sonstige-sprachlernangebote/",
     "https://integreat.app/augsburg/en/welcome/",
     "https://integreat.app/augsburg/en/events/test-event/",
     "https://integreat.app/augsburg/en/locations/test-location/",
     "https://integreat.app/augsburg/de/test-links/",
 ]
+
+# A link to a page's outdated (renamed) slug, in the same language as the page itself.
+# Historical slug matching was intentionally removed (see #4524, cross-language slug
+# matching returned the wrong page), so such links can no longer be resolved and must
+# be left untouched instead of being rewritten to the page's current slug.
+outdated_slug_url = (
+    "https://integreat.app/augsburg/de/deutsche-sprache/sprachlernangebote/"
+)
+renamed_slug_url = (
+    "https://integreat.app/augsburg/de/deutsche-sprache/sonstige-sprachlernangebote/"
+)
 
 
 @pytest.mark.order("last")
@@ -182,6 +191,10 @@ def test_fix_internal_links_commit(load_test_data_transactional: Any | None) -> 
         assert not Url.objects.filter(url=new_url).exists()
         assert not Link.objects.filter(url__url=new_url).exists()
 
+    outdated_slug_link_count = Link.objects.filter(url__url=outdated_slug_url).count()
+    assert outdated_slug_link_count > 0
+    assert not Url.objects.filter(url=renamed_slug_url).exists()
+
     # Now pass --commit to write changes to database
     with enable_listeners():
         out, err = get_command_output("fix_internal_links", "--commit")
@@ -204,6 +217,16 @@ def test_fix_internal_links_commit(load_test_data_transactional: Any | None) -> 
         assert Link.objects.filter(url__url=new_url).count() == 1, (
             "New link should exist after replacement"
         )
+
+    # A link to a renamed slug in the same language cannot be resolved anymore and
+    # must be left untouched, since historical slug matching is no longer supported
+    assert (
+        Link.objects.filter(url__url=outdated_slug_url).count()
+        == outdated_slug_link_count
+    ), "Links to an outdated slug should not be modified"
+    assert not Url.objects.filter(
+        url=renamed_slug_url,
+    ).exists(), "The renamed slug's URL should not be created"
 
 
 @pytest.mark.order("last")
@@ -237,7 +260,6 @@ def test_fix_internal_links_commit_skips_version_conflicts(
     skipped_url = "https://integreat.app/augsburg/en/welcome/"
     # URLs that fixes of other translations produce
     fixed_urls = [
-        "https://integreat.app/augsburg/de/deutsche-sprache/sonstige-sprachlernangebote/",
         "https://integreat.app/augsburg/de/test-links/",
     ]
     for url in [skipped_url, *fixed_urls]:


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This filters translations only by slugs of current translations


### Proposed changes
<!-- Describe this PR in more detail. -->

- switch from historical slug filtering through the translation's foreign object's translations' slug to the translation's slug (thank you @MizukiTemma for finding the cause of the bug and the solution)


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
Follow the steps to reproduce in the original issue and make sure that a page / event/ location 's translation cannot be accessed through a historical slug


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4524


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
