### PR TITLE
Fix: Exclude historical slugs in raw content and social media header endpoints

### DIFF
--- a/integreat_cms/cms/utils/internal_link_utils.py
+++ b/integreat_cms/cms/utils/internal_link_utils.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from urllib.parse import unquote, urlparse
 
 from django.conf import settings
+from django.db.models import Exists, OuterRef
 
 from ..constants import status
 from ..models import (
@@ -149,12 +150,21 @@ def get_public_translation_for_webapp_link_parts(
         "status": status.PUBLIC,
     }
     if object_type != ImprintPageTranslation:
-        # Old/renamed slugs are intentionally not supported anymore
-        # (see https://github.com/digitalfabrik/integreat-cms/issues/4524).
         filter_args["slug"] = object_slug
 
+    newer_public_version = object_type.objects.filter(
+        **{
+            foreign_object: OuterRef(foreign_object),
+            "language": OuterRef("language"),
+            "status": status.PUBLIC,
+            "version__gt": OuterRef("version"),
+        }
+    )
+
+    # old/renamed slugs are intentionally excluded
     instances = (
         object_type.objects.filter(**filter_args)
+        .exclude(Exists(newer_public_version))
         .select_related("language", f"{foreign_object}__region")
         .order_by("-version")
     )

--- a/tests/api/test_api_raw_content.py
+++ b/tests/api/test_api_raw_content.py
@@ -156,6 +156,31 @@ def test_local_news_text_is_escaped(load_test_data: None) -> None:
 
 
 @pytest.mark.django_db
+def test_page_content_rejects_outdated_slug(load_test_data: None) -> None:
+    """
+    A page's outdated (renamed) slug must not resolve to its current content anymore, even
+    though the superseded translation version which used it is still marked as ``PUBLIC``
+    (see https://github.com/digitalfabrik/integreat-cms/issues/4524).
+
+    :param load_test_data: The fixture providing the test data (see :meth:`~tests.conftest.load_test_data`)
+    """
+    # Page 22 was renamed from "sprachlernangebote" (v1) to "sonstige-sprachlernangebote" (v2),
+    # both versions are still stored with status PUBLIC.
+    outdated_slug_response = Client().get(
+        f"/api/v3/raw-content/{REGION_SLUG}/{LANGUAGE_SLUG}/deutsche-sprache/sprachlernangebote/"
+    )
+    assert outdated_slug_response.status_code == 404
+
+    current_slug_response = Client().get(
+        f"/api/v3/raw-content/{REGION_SLUG}/{LANGUAGE_SLUG}/deutsche-sprache/sonstige-sprachlernangebote/"
+    )
+    assert current_slug_response.status_code == 200
+    assert "Sonstige Sprachlernangebote" in current_slug_response.content.decode(
+        "utf-8"
+    )
+
+
+@pytest.mark.django_db
 def test_external_news_content_is_sanitized(
     load_test_data: None, clean_news_cache: None
 ) -> None:


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
This is a fix to the fix in: #4536 . That original PR limited the reference to the requested language, but failed to limit to the current version only (allowing historical slugs)


### Proposed changes
<!-- Describe this PR in more detail. -->

- Use a subquery to determine if there is a newer version than the ones found by applying the filters and excluding such.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- This adds more complexity to the query and might slow things down a little


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
- Create a page with a slug `a`
- Update the page and change slug to slug b -> only slug `b` still found in the endpoint (`a` returns 404)
- Edit: Update the page again with slug `c` and let it AUTOSAVE -> still only slug `b` should be found (`c` returns 404)
- [Optional - once merged] Check for EXPLAIN ANALYZE for new query, to make sure we are still performant
<details>
<summary> SQL query and Query Plan before change</summary>
Shell:

``` 
In [2]: from integreat_cms.cms.utils.internal_link_utils import get_public_trans
      ⋮ lation_for_webapp_link_parts
In [15]: from django.db import connection
In [16]: from django.test.utils import CaptureQueriesContext
In [17]: with CaptureQueriesContext(connection) as ctx:
    ...:     result = get_public_translation_for_webapp_link_parts('testumgebung
       ⋮ ','de',['willkommen'])
    ...: 
In [18]: for q in ctx.captured_queries:
    ...:     print(q['sql'])
```
SQL: 
```
SELECT "cms_pagetranslation"."id", "cms_pagetranslation"."title", "cms_pagetranslation"."slug", "cms_pagetranslation"."status", "cms_pagetranslation"."content", "cms_pagetranslation"."language_id", "cms_pagetranslation"."currently_in_translation", "cms_pagetranslation"."machine_translated", "cms_pagetranslation"."version", "cms_pagetranslation"."minor_edit", "cms_pagetranslation"."last_updated", "cms_pagetranslation"."published_at", "cms_pagetranslation"."creator_id", "cms_pagetranslation"."automatic_translation", "cms_pagetranslation"."page_id", "cms_pagetranslation"."hix_score", "cms_pagetranslation"."hix_feedback", "cms_language"."id", "cms_language"."slug", "cms_language"."bcp47_tag", "cms_language"."native_name", "cms_language"."english_name", "cms_language"."text_direction", "cms_language"."primary_country_code", "cms_language"."secondary_country_code", "cms_language"."language_color", "cms_language"."created_date", "cms_language"."last_updated", "cms_language"."table_of_contents", "cms_language"."social_media_webapp_title", "cms_language"."social_media_webapp_description", "cms_language"."message_content_not_available", "cms_language"."message_partial_live_content_not_available", "cms_page"."id", "cms_page"."created_date", "cms_page"."do_not_translate_title", "cms_page"."lft", "cms_page"."rgt", "cms_page"."tree_id", "cms_page"."depth", "cms_page"."parent_id", "cms_page"."region_id", "cms_page"."explicitly_archived", "cms_page"."icon_id", "cms_page"."mirrored_page_id", "cms_page"."mirrored_page_first", "cms_page"."organization_id", "cms_page"."api_token", "cms_page"."hix_ignore", "cms_region"."id", "cms_region"."name", "cms_region"."common_id", "cms_region"."slug", "cms_region"."status", "cms_region"."administrative_division", "cms_region"."aliases", "cms_region"."custom_prefix", "cms_region"."events_enabled", "cms_region"."locations_enabled", "cms_region"."contacts_enabled", "cms_region"."push_notifications_enabled", "cms_region"."term_explanations_enabled", "cms_region"."latitude", "cms_region"."longitude", "cms_region"."longitude_min", "cms_region"."latitude_min", "cms_region"."longitude_max", "cms_region"."latitude_max", "cms_region"."postal_code", "cms_region"."admin_mail", "cms_region"."timezone", "cms_region"."created_date", "cms_region"."last_updated", "cms_region"."statistics_enabled", "cms_region"."seo_enabled", "cms_region"."matomo_id", "cms_region"."matomo_token", "cms_region"."page_permissions_enabled", "cms_region"."icon_id", "cms_region"."administrative_division_included", "cms_region"."short_urls_enabled", "cms_region"."external_news_enabled", "cms_region"."fallback_translations_enabled", "cms_region"."hix_enabled", "cms_region"."mt_budget_booked", "cms_region"."mt_renewal_month", "cms_region"."mt_budget_adjustment", "cms_region"."mt_budget_used", "cms_region"."api_settings_synced_at", "cms_region"."machine_translate_pages", "cms_region"."machine_translate_events", "cms_region"."machine_translate_pois", "cms_region"."machine_translate_pushnotifications", "cms_region"."integreat_chat_enabled", "cms_region"."zammad_url", "cms_region"."zammad_access_token", "cms_region"."zammad_webhook_token", "cms_region"."zammad_privacy_policy", "cms_region"."chat_beta_tester_percentage" FROM "cms_pagetranslation" INNER JOIN "cms_language" ON ("cms_pagetranslation"."language_id" = "cms_language"."id") INNER JOIN "cms_page" ON ("cms_pagetranslation"."page_id" = "cms_page"."id") INNER JOIN "cms_region" ON ("cms_page"."region_id" = "cms_region"."id") WHERE ("cms_language"."slug" = 'de' AND "cms_region"."slug" = 'testumgebung' AND "cms_pagetranslation"."slug" = 'willkommen' AND "cms_pagetranslation"."status" = 'PUBLIC') ORDER BY "cms_pagetranslation"."version" DESC LIMIT 1
```

with query plan: 

```
                                                                                  QUERY PLAN                                                                                   
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=51.45..51.45 rows=1 width=2164) (actual time=10.247..10.249 rows=1 loops=1)
   ->  Sort  (cost=51.45..51.45 rows=1 width=2164) (actual time=10.245..10.247 rows=1 loops=1)
         Sort Key: cms_pagetranslation.version DESC
         Sort Method: quicksort  Memory: 29kB
         ->  Nested Loop  (cost=0.99..51.44 rows=1 width=2164) (actual time=9.551..10.193 rows=1 loops=1)
               ->  Nested Loop  (cost=0.85..50.91 rows=3 width=1312) (actual time=0.092..7.584 rows=1047 loops=1)
                     ->  Nested Loop  (cost=0.56..28.25 rows=3 width=1235) (actual time=0.072..3.492 rows=1047 loops=1)
                           ->  Seq Scan on cms_language  (cost=0.00..3.60 rows=1 width=326) (actual time=0.013..0.029 rows=1 loops=1)
                                 Filter: ((slug)::text = 'de'::text)
                                 Rows Removed by Filter: 47
                           ->  Index Scan using idx_pt_slug_lang_page on cms_pagetranslation  (cost=0.56..24.62 rows=3 width=909) (actual time=0.054..2.827 rows=1047 loops=1)
                                 Index Cond: (((slug)::text = 'willkommen'::text) AND (language_id = cms_language.id))
                                 Filter: ((status)::text = 'PUBLIC'::text)
                                 Rows Removed by Filter: 888
                     ->  Index Scan using cms_page_pkey on cms_page  (cost=0.29..7.55 rows=1 width=77) (actual time=0.003..0.003 rows=1 loops=1047)
                           Index Cond: (id = cms_pagetranslation.page_id)
               ->  Index Scan using cms_region_pkey on cms_region  (cost=0.14..0.17 rows=1 width=852) (actual time=0.002..0.002 rows=0 loops=1047)
                     Index Cond: (id = cms_page.region_id)
                     Filter: ((slug)::text = 'testumgebung'::text)
                     Rows Removed by Filter: 1
 Planning Time: 4.948 ms
 Execution Time: 10.487 ms
(22 rows)
```
</details>

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4524


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
