### PR TITLE
4288: Fix hover text of the Access to network area status

### DIFF
--- a/integreat_cms/cms/templates/users/user_list_row.html
+++ b/integreat_cms/cms/templates/users/user_list_row.html
@@ -47,11 +47,11 @@
     </td>
     <td class="pr-2">
         {% if user.is_staff %}
-            <span title="{% translate "Staff member" %}">
+            <span title="{% translate "Access to network area" %}">
                 <i icon-name="check" class="text-green-500"></i>
             </span>
         {% else %}
-            <span title="{% translate "No staff member" %}">
+            <span title="{% translate "No access to network area" %}">
                 <i icon-name="x" class="text-red-500"></i>
             </span>
         {% endif %}

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -2575,7 +2575,7 @@ msgid "Administrator"
 msgstr "Administrator:in"
 
 #: cms/forms/users/user_filter_form.py cms/forms/users/user_form.py
-#: cms/templates/users/user_list.html
+#: cms/templates/users/user_list.html cms/templates/users/user_list_row.html
 msgid "Access to network area"
 msgstr "Zugang zum Netzwerkbereich"
 
@@ -9380,12 +9380,8 @@ msgid "The regions to which the account has quick access"
 msgstr "Die Regionen, zu denen das Konto Schnellzugriff hat"
 
 #: cms/templates/users/user_list_row.html
-msgid "Staff member"
-msgstr "Teammitglied"
-
-#: cms/templates/users/user_list_row.html
-msgid "No staff member"
-msgstr "Kein Teammitglied"
+msgid "No access to network area"
+msgstr "Kein Zugang zum Netzwerkbereich"
 
 #: cms/templates/users/user_list_row.html
 msgid "No administrator"
@@ -12016,6 +12012,12 @@ msgid "This page belongs to another region ({})."
 msgstr ""
 "Diese Seite konnte nicht importiert werden, da sie zu einer anderen Region "
 "gehört ({})."
+
+#~ msgid "Staff member"
+#~ msgstr "Teammitglied"
+
+#~ msgid "No staff member"
+#~ msgstr "Kein Teammitglied"
 
 #~ msgid "Budget year start differs from the renewal date"
 #~ msgstr "Unterjähriger Start des Abrechnungszeitraums"

--- a/integreat_cms/release_notes/current/unreleased/4288.yml
+++ b/integreat_cms/release_notes/current/unreleased/4288.yml
@@ -1,0 +1,2 @@
+en: Fix the hover text of the network area access status in the user list
+de: Behebe den Hover-Text des Status "Zugang zum Netzwerkbereich" in der Benutzer:innen-Liste


### PR DESCRIPTION
### Short description
In the user list view in network management the "Staff member" wording got changed to "Access to network area" and one hover text is still using the old wording.


### Proposed changes
<!-- Describe this PR in more detail. -->

- Just replaced the text.


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

N/A


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->

1. Go to Network Management
2. Go to Users
3. Hover over "Access to network management" status for a user

### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4288


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
