### PR TITLE
Make Page Based Statistics available to all municipalities

### DIFF
--- a/integreat_cms/cms/templates/statistics/statistics_overview.html
+++ b/integreat_cms/cms/templates/statistics/statistics_overview.html
@@ -34,40 +34,36 @@
             <div class="pt-4 lg:pt-0 3xl:grid grid-cols-2 3xl:grid-cols-[minmax(0px,_1fr)_400px] 4xl:grid-cols-[minmax(0px,_1fr)_816px] gap-4">
                 <div class="flex flex-col flex-wrap col-span-1 3xl:col-span-1 min-w-0">
                     {% include "statistics/statistics_chart.html" with box_id="statistics_chart" %}
-                    {% if show_page_based_statistics %}
-                        <div class="pt-4 pb-4">
-                            <div class="pb-4">
-                                <p>
-                                    {% translate "Why does the <strong>total number of visits not match the sum of all page views?</strong>" %}
-                                </p>
-                                <p>
-                                    ➔ {% blocktranslate %}<span class="underline">This is normal and to be expected</span>, because the two surveys measure different things.{% endblocktranslate %}
-                                </p>
-                            </div>
-                            <div class="pb-4">
-                                <p>
-                                    {% translate "<strong>Total visits</strong> include, among other things, page views within the system (including the Integreat home page), AI requests, other technical requests, and visits to pages or languages that no longer exist." %}
-                                </p>
-                            </div>
-                            <div class="pb-4">
-                                <p>
-                                    {% blocktranslate %}<strong>Page views</strong> specifically count <span class="underline">only</span> the visits to published subpages within the web app.{% endblocktranslate %}
-                                </p>
-                                <p>
-                                    ➔ {% blocktranslate %}<strong>Therefore, differences exist and are to be expected.</strong> Further details can be found in the <a href="{{ wiki_url }}"><span class="text-blue-600">documentation <i icon-name="square-arrow-out-up-right"></i></span></a>{% endblocktranslate %}
-                                </p>
-                            </div>
+                    <div class="pt-4 pb-4">
+                        <div class="pb-4">
+                            <p>
+                                {% translate "Why does the <strong>total number of visits not match the sum of all page views?</strong>" %}
+                            </p>
+                            <p>
+                                ➔ {% blocktranslate %}<span class="underline">This is normal and to be expected</span>, because the two surveys measure different things.{% endblocktranslate %}
+                            </p>
                         </div>
-                        {% include "statistics/statistics_viewed_pages.html" with box_id="statistics_viewed_pages" %}
-                    {% endif %}
+                        <div class="pb-4">
+                            <p>
+                                {% translate "<strong>Total visits</strong> include, among other things, page views within the system (including the Integreat home page), AI requests, other technical requests, and visits to pages or languages that no longer exist." %}
+                            </p>
+                        </div>
+                        <div class="pb-4">
+                            <p>
+                                {% blocktranslate %}<strong>Page views</strong> specifically count <span class="underline">only</span> the visits to published subpages within the web app.{% endblocktranslate %}
+                            </p>
+                            <p>
+                                ➔ {% blocktranslate %}<strong>Therefore, differences exist and are to be expected.</strong> Further details can be found in the <a href="{{ wiki_url }}"><span class="text-blue-600">documentation <i icon-name="square-arrow-out-up-right"></i></span></a>{% endblocktranslate %}
+                            </p>
+                        </div>
+                    </div>
+                    {% include "statistics/statistics_viewed_pages.html" with box_id="statistics_viewed_pages" %}
                 </div>
                 <div class="sm:block md:flex sm:mt-4 3xl:mt-0 3xl:block 4xl:flex">
                     {% include "statistics/statistics_sidebar.html" with box_id="statistics_sidebar" languages=languages access_legends=access_legends %}
                 </div>
             </div>
         </div>
-        {% if show_page_based_statistics %}
-            {% include "../tutorials/page_access_statistics.html" %}
-        {% endif %}
+        {% include "../tutorials/page_access_statistics.html" %}
     {% endblock content %}
 {% endif %}

--- a/integreat_cms/cms/views/statistics/statistics_view.py
+++ b/integreat_cms/cms/views/statistics/statistics_view.py
@@ -74,11 +74,6 @@ class AnalyticsView(TemplateView):
             .cache_tree(archived=False, language_slug=default_language.slug)
         )
 
-        show_page_based_statistics = (
-            request.user.has_perm("cms.test_beta_features")
-            or region.slug in settings.PILOT_REGIONS_PAGE_BASED_STATISTICS
-        )
-
         access_legends = {
             _("Phone App Accesses"): language_color.OFFLINE_ACCESS,
             _("WebApp Accesses"): language_color.WEB_APP_ACCESS,
@@ -97,7 +92,6 @@ class AnalyticsView(TemplateView):
                 "languages": languages,
                 "access_legends": access_legends,
                 "is_statistics": True,
-                "show_page_based_statistics": show_page_based_statistics,
                 "wiki_url": settings.STATISTICS_WIKI_URL,
             },
         )

--- a/integreat_cms/core/settings.py
+++ b/integreat_cms/core/settings.py
@@ -1453,20 +1453,6 @@ CELERY_RESULT_BACKEND = os.environ.get(
     ),
 )
 
-########################
-# Beta test permission #
-########################
-
-# Slugs of regions participating in the pilot phase of page based statistics
-PILOT_REGIONS_PAGE_BASED_STATISTICS: Final[list[str]] = [
-    slug
-    for slug in os.environ.get(
-        "INTEGREAT_CMS_PILOT_REGIONS_PAGE_BASED_STATISTICS",
-        "",
-    ).split(",")
-    if slug
-]
-
 ################
 # Live Content #
 ################

--- a/integreat_cms/release_notes/current/unreleased/4545.yml
+++ b/integreat_cms/release_notes/current/unreleased/4545.yml
@@ -1,0 +1,2 @@
+en: Make page based statistics available to all municipalities
+de: Stelle seitenbasierte Statistiken für alle Kommunen bereit


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
Delete the ` show_page_based_statistics` feature flag, so that all municipalities that have statistics enabled can also see the page based statistics.


### Proposed changes
<!-- Describe this PR in more detail. -->

- delete ` show_page_based_statistics` 
- release note


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None

- Once this PR is released the salt PR should be reverted as mentioned in #4545


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explanation why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
Enable statistics for `Testumgebung` and see that the page based statistics widget shows on the statistics page.


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: #4545


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
