### PR TITLE
Allow releasing a region from API management

### DIFF
--- a/integreat_cms/cms/forms/regions/region_form.py
+++ b/integreat_cms/cms/forms/regions/region_form.py
@@ -236,10 +236,16 @@ class RegionForm(CustomModelForm):
             # silently display the wrong one.
             for field_name in region_api_settings.WRITABLE_FIELDS:
                 self.fields[field_name].disabled = True
-        else:
+        elif self.instance.mt_budget_booked in dict(machine_translation_budget.CHOICES):
             # The model no longer restricts the budget to the predefined package sizes, because the
             # API may push arbitrary values. Regions maintained in the CMS should still get the
             # dropdown with the known sizes, so the choices are defined on the form instead.
+            #
+            # A budget outside those sizes keeps the plain integer field, for the same reason the
+            # API-managed branch above does: a dropdown without a matching option displays the
+            # wrong one, and the next save of this form would silently write that wrong value.
+            # This is not hypothetical -- it is exactly the state of a region that was released
+            # from API management while the API had pushed an arbitrary word count.
             self.fields["mt_budget_booked"] = forms.TypedChoiceField(
                 choices=machine_translation_budget.CHOICES,
                 coerce=int,

--- a/integreat_cms/cms/templates/regions/region_form.html
+++ b/integreat_cms/cms/templates/regions/region_form.html
@@ -36,10 +36,11 @@
                     {% endwith %}
                 </p>
                 {% if perms.cms.change_region %}
-                    <button title="{% translate "Edit these settings here again" %}"
+                    <button type="button"
+                            title="{% translate "Edit these settings here again" %}"
                             class="btn btn-blue mt-2 confirmation-button"
                             data-confirmation-title="{% translate "Please confirm that you want to maintain these settings here again." %}"
-                            data-confirmation-text="{% translate "The connected system will no longer be the source for the booked features and the translation budget." %} {% translate "If it pushes settings again, they will become read-only here once more." %}"
+                            data-confirmation-text="{% translate "The connected system will no longer be the source for the booked features and the translation budget." %} {% translate "If it pushes settings again, it overwrites the values maintained here and they become read-only once more." %}"
                             data-confirmation-subject="{{ form.name.value }}"
                             data-action="{% url 'release_api_management' slug=form.instance.slug %}">
                         <i icon-name="unlock"></i>

--- a/integreat_cms/cms/templates/regions/region_form.html
+++ b/integreat_cms/cms/templates/regions/region_form.html
@@ -35,6 +35,17 @@
                         {% endblocktranslate %}
                     {% endwith %}
                 </p>
+                {% if perms.cms.change_region %}
+                    <button title="{% translate "Edit these settings here again" %}"
+                            class="btn btn-blue mt-2 confirmation-button"
+                            data-confirmation-title="{% translate "Please confirm that you want to maintain these settings here again." %}"
+                            data-confirmation-text="{% translate "The connected system will no longer be the source for the booked features and the translation budget." %} {% translate "If it pushes settings again, they will become read-only here once more." %}"
+                            data-confirmation-subject="{{ form.name.value }}"
+                            data-action="{% url 'release_api_management' slug=form.instance.slug %}">
+                        <i icon-name="unlock"></i>
+                        {% translate "Edit these settings here again" %}
+                    </button>
+                {% endif %}
             </div>
         {% endif %}
         <div class="grid xl:grid-cols-2 2xl:grid-cols-3 gap-4">

--- a/integreat_cms/cms/urls/protected.py
+++ b/integreat_cms/cms/urls/protected.py
@@ -320,6 +320,11 @@ urlpatterns: list[URLPattern] = [
                                 regions.delete_region,
                                 name="delete_region",
                             ),
+                            path(
+                                "release-api-management/",
+                                regions.release_api_management,
+                                name="release_api_management",
+                            ),
                         ],
                     ),
                 ),

--- a/integreat_cms/cms/views/regions/__init__.py
+++ b/integreat_cms/cms/views/regions/__init__.py
@@ -4,6 +4,6 @@ This package contains all views related to regions
 
 from __future__ import annotations
 
-from .region_actions import delete_region
+from .region_actions import delete_region, release_api_management
 from .region_list_view import RegionListView
 from .region_update_view import RegionUpdateView

--- a/integreat_cms/cms/views/regions/region_actions.py
+++ b/integreat_cms/cms/views/regions/region_actions.py
@@ -158,7 +158,8 @@ def release_api_management(
     messages.info(
         request,
         _(
-            "If the connected system pushes settings again, they will become read-only once more.",
+            "If the connected system pushes settings again, it overwrites the values maintained "
+            "here and they become read-only once more.",
         ),
     )
 

--- a/integreat_cms/cms/views/regions/region_actions.py
+++ b/integreat_cms/cms/views/regions/region_actions.py
@@ -109,6 +109,62 @@ def delete_region(
     return redirect("regions")
 
 
+@require_POST
+@permission_required("cms.change_region")
+def release_api_management(
+    request: HttpRequest,
+    *args: Any,
+    **kwargs: Any,
+) -> HttpResponseRedirect:
+    r"""
+    This view releases a region from being managed by an external system via the API.
+
+    It only clears :attr:`~integreat_cms.cms.models.regions.region.Region.api_settings_synced_at`,
+    which is what marks a region as API-managed and makes the synced settings read-only in the
+    region form. Nothing else is changed: the settings themselves keep the values the external
+    system pushed last.
+
+    The release is deliberately not permanent. If the connected system pushes again, the region is
+    marked as API-managed once more and the fields become read-only again -- which is the desired
+    semantics: the release states "we maintain these settings here from now on", and a subsequent
+    push visibly contradicts that instead of failing silently.
+
+    :param request: The current request
+    :param \*args: The supplied arguments
+    :param \**kwargs: The supplied keyword arguments
+    :return: A redirection to the region form
+    """
+    region = get_object_or_404(Region, slug=kwargs.get("slug"))
+
+    if not region.is_api_managed:
+        messages.info(
+            request,
+            _('The settings of the region "{}" are not managed via the API.').format(
+                region.name,
+            ),
+        )
+        return redirect("edit_region", slug=region.slug)
+
+    region.api_settings_synced_at = None
+    region.save(update_fields=["api_settings_synced_at"])
+    logger.info("%r released %r from API management", request.user, region)
+
+    messages.success(
+        request,
+        _('The settings of the region "{}" can be edited here again.').format(
+            region.name,
+        ),
+    )
+    messages.info(
+        request,
+        _(
+            "If the connected system pushes settings again, they will become read-only once more.",
+        ),
+    )
+
+    return redirect("edit_region", slug=region.slug)
+
+
 @shared_task
 def async_delete_region(region_id: int) -> None:
     region = Region.objects.get(id=region_id)

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8475,9 +8475,12 @@ msgstr ""
 "Funktionen und das Übersetzungsbudget."
 
 #: cms/templates/regions/region_form.html
-msgid "If it pushes settings again, they will become read-only here once more."
+msgid ""
+"If it pushes settings again, it overwrites the values maintained here and "
+"they become read-only once more."
 msgstr ""
-"Überträgt es erneut Einstellungen, sind diese hier wieder schreibgeschützt."
+"Überträgt es erneut Einstellungen, überschreibt es die hier gepflegten Werte "
+"und sie sind wieder schreibgeschützt."
 
 #: cms/templates/regions/region_form.html
 msgid "Center of the region"
@@ -11407,11 +11410,11 @@ msgstr ""
 
 #: cms/views/regions/region_actions.py
 msgid ""
-"If the connected system pushes settings again, they will become read-only "
-"once more."
+"If the connected system pushes settings again, it overwrites the values "
+"maintained here and they become read-only once more."
 msgstr ""
-"Überträgt das angebundene System erneut Einstellungen, sind diese wieder "
-"schreibgeschützt."
+"Überträgt das angebundene System erneut Einstellungen, überschreibt es die "
+"hier gepflegten Werte und sie sind wieder schreibgeschützt."
 
 #: cms/views/regions/region_update_view.py
 msgid "The cloning procedure for this region is not finished yet."

--- a/integreat_cms/locale/de/LC_MESSAGES/django.po
+++ b/integreat_cms/locale/de/LC_MESSAGES/django.po
@@ -8457,6 +8457,29 @@ msgstr ""
 "System geändert werden."
 
 #: cms/templates/regions/region_form.html
+msgid "Edit these settings here again"
+msgstr "Diese Einstellungen wieder hier pflegen"
+
+#: cms/templates/regions/region_form.html
+msgid "Please confirm that you want to maintain these settings here again."
+msgstr ""
+"Bitte bestätigen Sie, dass diese Einstellungen wieder hier gepflegt werden "
+"sollen."
+
+#: cms/templates/regions/region_form.html
+msgid ""
+"The connected system will no longer be the source for the booked features "
+"and the translation budget."
+msgstr ""
+"Das angebundene System ist dann nicht mehr die Quelle für die gebuchten "
+"Funktionen und das Übersetzungsbudget."
+
+#: cms/templates/regions/region_form.html
+msgid "If it pushes settings again, they will become read-only here once more."
+msgstr ""
+"Überträgt es erneut Einstellungen, sind diese hier wieder schreibgeschützt."
+
+#: cms/templates/regions/region_form.html
 msgid "Center of the region"
 msgstr "Mittelpunkt der Region"
 
@@ -9003,9 +9026,9 @@ msgid ""
 "right\"></i></span></a>"
 msgstr ""
 "<strong>deshalb sind Unterschiede gegeben und zu erwarten.</strong> Mehr "
-"Details dazu in der <a href=\"%(wiki_url)s\"><span class=\"text-blue-"
-"600\">Dokumentation <i icon-name=\"square-arrow-out-up-right\"></i></span></"
-"a>"
+"Details dazu in der <a href=\"%(wiki_url)s\"><span class=\"text-"
+"blue-600\">Dokumentation <i icon-name=\"square-arrow-out-up-right\"></i></"
+"span></a>"
 
 #: cms/templates/statistics/statistics_sidebar.html
 msgid "Adjust shown data"
@@ -11371,6 +11394,24 @@ msgstr "Region \"{}\" wird gelöscht"
 #: cms/views/regions/region_actions.py
 msgid "This procedure can take several minutes."
 msgstr "Dieser Vorgang kann mehrere Minuten dauern."
+
+#: cms/views/regions/region_actions.py
+msgid "The settings of the region \"{}\" are not managed via the API."
+msgstr ""
+"Die Einstellungen der Region \"{}\" werden nicht über die API verwaltet."
+
+#: cms/views/regions/region_actions.py
+msgid "The settings of the region \"{}\" can be edited here again."
+msgstr ""
+"Die Einstellungen der Region \"{}\" können hier wieder bearbeitet werden."
+
+#: cms/views/regions/region_actions.py
+msgid ""
+"If the connected system pushes settings again, they will become read-only "
+"once more."
+msgstr ""
+"Überträgt das angebundene System erneut Einstellungen, sind diese wieder "
+"schreibgeschützt."
 
 #: cms/views/regions/region_update_view.py
 msgid "The cloning procedure for this region is not finished yet."

--- a/integreat_cms/release_notes/current/unreleased/4558.yml
+++ b/integreat_cms/release_notes/current/unreleased/4558.yml
@@ -1,0 +1,2 @@
+en: Allow releasing a region from being managed via the API, so its booked features and translation budget can be maintained in the CMS again
+de: Ermögliche das Lösen einer Region aus der Verwaltung über die API, sodass die gebuchten Funktionen und das Übersetzungsbudget wieder im CMS gepflegt werden können

--- a/tests/cms/views/regions/test_release_api_management.py
+++ b/tests/cms/views/regions/test_release_api_management.py
@@ -118,7 +118,13 @@ def test_release_of_a_region_which_is_not_api_managed(
     )
 
     assert response.status_code == 200
-    assert "not managed via the API" in response.content.decode("utf-8")
+    region.refresh_from_db()
+    assert not region.is_api_managed
+    # The message level is asserted instead of its text, which is translated: a hint, not a
+    # success -- nothing was released, so claiming otherwise would be misleading.
+    emitted = list(response.context["messages"])
+    assert len(emitted) == 1
+    assert emitted[0].level_tag == "info"
 
 
 @pytest.mark.django_db

--- a/tests/cms/views/regions/test_release_api_management.py
+++ b/tests/cms/views/regions/test_release_api_management.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from django.conf import settings
+from django.urls import reverse
+from django.utils import timezone
+
+from integreat_cms.cms.models import Region
+from tests.constants import ANONYMOUS, PRIV_STAFF_ROLES
+
+if TYPE_CHECKING:
+    from django.test.client import Client
+
+REGION_SLUG = "augsburg"
+
+
+def mark_as_api_managed(slug: str = REGION_SLUG) -> Region:
+    """
+    Mark a region as managed by an external system via the API
+
+    :param slug: The slug of the region
+    :return: The region
+    """
+    region = Region.objects.get(slug=slug)
+    region.api_settings_synced_at = timezone.now()
+    region.save(update_fields=["api_settings_synced_at"])
+    return region
+
+
+@pytest.mark.django_db
+def test_release_api_management(
+    load_test_data: None,
+    login_role_user: tuple[Client, str],
+) -> None:
+    """
+    Test that only privileged staff can release a region from API management
+
+    :param load_test_data: The fixture providing the test data (see :meth:`~tests.conftest.load_test_data`)
+    :param login_role_user: The fixture providing the http client and the current role
+    """
+    client, role = login_role_user
+    region = mark_as_api_managed()
+    assert region.is_api_managed
+
+    url = reverse("release_api_management", kwargs={"slug": REGION_SLUG})
+    response = client.post(url)
+
+    region.refresh_from_db()
+    if role in PRIV_STAFF_ROLES:
+        assert response.status_code == 302
+        assert response.headers.get("location") == reverse(
+            "edit_region",
+            kwargs={"slug": REGION_SLUG},
+        )
+        assert region.api_settings_synced_at is None
+        assert not region.is_api_managed
+    elif role == ANONYMOUS:
+        assert response.status_code == 302
+        assert response.headers.get("location") == f"{settings.LOGIN_URL}?next={url}"
+        assert region.is_api_managed
+    else:
+        assert response.status_code == 403
+        assert region.is_api_managed
+
+
+@pytest.mark.django_db
+def test_release_keeps_the_synced_settings(
+    load_test_data: None,
+    admin_client: Client,
+) -> None:
+    """
+    Test that releasing a region only lifts the lock and does not reset any setting
+
+    The values the external system pushed last stay in place -- the release states who maintains
+    them from now on, not what they should be.
+
+    :param load_test_data: The fixture providing the test data (see :meth:`~tests.conftest.load_test_data`)
+    :param admin_client: The fixture providing the http client of the superuser
+    """
+    region = mark_as_api_managed()
+    region.mt_budget_booked = 123456
+    region.mt_renewal_month = 7
+    region.events_enabled = False
+    region.save(
+        update_fields=["mt_budget_booked", "mt_renewal_month", "events_enabled"],
+    )
+
+    admin_client.post(
+        reverse("release_api_management", kwargs={"slug": REGION_SLUG}),
+    )
+
+    region.refresh_from_db()
+    assert region.api_settings_synced_at is None
+    assert region.mt_budget_booked == 123456
+    assert region.mt_renewal_month == 7
+    assert region.events_enabled is False
+
+
+@pytest.mark.django_db
+def test_release_of_a_region_which_is_not_api_managed(
+    load_test_data: None,
+    admin_client: Client,
+) -> None:
+    """
+    Test that releasing a region which is not API-managed is a no-op with a hint
+
+    :param load_test_data: The fixture providing the test data (see :meth:`~tests.conftest.load_test_data`)
+    :param admin_client: The fixture providing the http client of the superuser
+    """
+    region = Region.objects.get(slug=REGION_SLUG)
+    assert not region.is_api_managed
+
+    response = admin_client.post(
+        reverse("release_api_management", kwargs={"slug": REGION_SLUG}),
+        follow=True,
+    )
+
+    assert response.status_code == 200
+    assert "not managed via the API" in response.content.decode("utf-8")
+
+
+@pytest.mark.django_db
+def test_release_requires_post(
+    load_test_data: None,
+    admin_client: Client,
+) -> None:
+    """
+    Test that the release cannot be triggered by a GET request
+
+    :param load_test_data: The fixture providing the test data (see :meth:`~tests.conftest.load_test_data`)
+    :param admin_client: The fixture providing the http client of the superuser
+    """
+    region = mark_as_api_managed()
+
+    response = admin_client.get(
+        reverse("release_api_management", kwargs={"slug": REGION_SLUG}),
+    )
+
+    assert response.status_code == 405
+    region.refresh_from_db()
+    assert region.is_api_managed

--- a/tests/cms/views/regions/test_release_api_management.py
+++ b/tests/cms/views/regions/test_release_api_management.py
@@ -7,6 +7,8 @@ from django.conf import settings
 from django.urls import reverse
 from django.utils import timezone
 
+from integreat_cms.cms.constants import machine_translation_budget, region_api_settings
+from integreat_cms.cms.forms.regions.region_form import RegionForm
 from integreat_cms.cms.models import Region
 from tests.constants import ANONYMOUS, PRIV_STAFF_ROLES
 
@@ -118,8 +120,6 @@ def test_release_of_a_region_which_is_not_api_managed(
     )
 
     assert response.status_code == 200
-    region.refresh_from_db()
-    assert not region.is_api_managed
     # The message level is asserted instead of its text, which is translated: a hint, not a
     # success -- nothing was released, so claiming otherwise would be misleading.
     emitted = list(response.context["messages"])
@@ -147,3 +147,107 @@ def test_release_requires_post(
     assert response.status_code == 405
     region.refresh_from_db()
     assert region.is_api_managed
+
+
+@pytest.mark.django_db
+def test_released_settings_are_editable_again(
+    load_test_data: None,
+    admin_client: Client,
+) -> None:
+    """
+    Test that the synced settings are no longer read-only after the release
+
+    This is what the whole action is for, so it is asserted directly on the form rather than
+    inferred from the absence of the banner.
+
+    :param load_test_data: The fixture providing the test data (see :meth:`~tests.conftest.load_test_data`)
+    :param admin_client: The fixture providing the http client of the superuser
+    """
+    region = mark_as_api_managed()
+    assert RegionForm(instance=region).fields["events_enabled"].disabled
+
+    admin_client.post(
+        reverse("release_api_management", kwargs={"slug": REGION_SLUG}),
+    )
+
+    region.refresh_from_db()
+    for field_name in region_api_settings.WRITABLE_FIELDS:
+        assert not RegionForm(instance=region).fields[field_name].disabled, (
+            f"{field_name} is still read-only after the release"
+        )
+
+
+@pytest.mark.django_db
+def test_released_budget_outside_the_package_sizes_survives_a_save(
+    load_test_data: None,
+    admin_client: Client,
+) -> None:
+    """
+    Test that a budget the API pushed is not lost once the region is maintained in the CMS again
+
+    The API may push any word count, the form offers a dropdown of package sizes. A value outside
+    those sizes has no matching option, so the browser would submit the first one and the next
+    save of the region form -- even one that only toggles an unrelated switch -- would silently
+    reduce the budget. The field therefore has to stay a plain integer input in that case.
+
+    :param load_test_data: The fixture providing the test data (see :meth:`~tests.conftest.load_test_data`)
+    :param admin_client: The fixture providing the http client of the superuser
+    """
+    region = mark_as_api_managed()
+    region.mt_budget_booked = 77777
+    region.save(update_fields=["mt_budget_booked"])
+    assert 77777 not in dict(machine_translation_budget.CHOICES)
+
+    admin_client.post(
+        reverse("release_api_management", kwargs={"slug": REGION_SLUG}),
+    )
+
+    region.refresh_from_db()
+    field = RegionForm(instance=region).fields["mt_budget_booked"]
+    assert not hasattr(field, "choices"), (
+        "The budget is offered as a dropdown although the current value is not among its "
+        "options, so the next save would overwrite it"
+    )
+
+
+@pytest.mark.django_db
+def test_region_form_renders_the_release_button(
+    load_test_data: None,
+    admin_client: Client,
+) -> None:
+    """
+    Test that the region form of an API-managed region renders
+
+    The button sits inside ``{% if form.instance.is_api_managed %}``, which no other test
+    reaches. A broken ``{% url %}`` tag in it would raise NoReverseMatch and return HTTP 500 for
+    exactly the regions this feature is meant for.
+
+    :param load_test_data: The fixture providing the test data (see :meth:`~tests.conftest.load_test_data`)
+    :param admin_client: The fixture providing the http client of the superuser
+    """
+    mark_as_api_managed()
+
+    response = admin_client.get(reverse("edit_region", kwargs={"slug": REGION_SLUG}))
+
+    assert response.status_code == 200
+    assert reverse(
+        "release_api_management", kwargs={"slug": REGION_SLUG}
+    ) in response.content.decode("utf-8")
+
+
+@pytest.mark.django_db
+def test_release_of_an_unknown_region(
+    load_test_data: None,
+    admin_client: Client,
+) -> None:
+    """
+    Test that an unknown slug results in 404 instead of a server error
+
+    :param load_test_data: The fixture providing the test data (see :meth:`~tests.conftest.load_test_data`)
+    :param admin_client: The fixture providing the http client of the superuser
+    """
+    response = admin_client.post(
+        reverse("release_api_management", kwargs={"slug": "does-not-exist"}),
+    )
+
+    assert response.status_code == 404


### PR DESCRIPTION
### Short description

Adds a way to release a region from being managed via the API, so its booked features and translation budget can be maintained in the CMS again.

### Proposed changes

- New action `release_api_management` in `cms/views/regions/region_actions.py`, modelled on `delete_region`: `@require_POST`, `@permission_required("cms.change_region")`, redirecting back to the region form. It sets `api_settings_synced_at = None` and changes nothing else.
- A release button **inside the yellow banner** that explains the lock, so the way out sits where the problem is stated. It uses the existing `confirmation-button` idiom, with `type="button"` so it cannot submit the region form if the confirmation JS has not loaded yet.
- The confirmation text and the messages state the full consequence: the external system is no longer the source, and a later push overwrites the values maintained here in the meantime and locks them again.
- `region_form.py` now uses the package-size dropdown for `mt_budget_booked` **only when the current value is one of the choices**. A budget the API pushed is rarely one of the six sizes, and a value with no matching option made the browser select the first one, so the next save of the region form — even one only toggling an unrelated switch — silently wrote `50000`. The reasoning was already in the code for the API-managed branch; the release created exactly the state that comment warns about.
- Release note `4558.yml`, and German translations for all new strings.

### Side effects

- **`region_form.py` affects every region, not only released ones.** A CMS-maintained region whose `mt_budget_booked` is not one of the package sizes now gets a plain integer input instead of the dropdown. Before this PR such a region could only come from an API push; the model has carried no `choices` since #4467, so the value is valid either way.
- **`api_settings_synced_at` is the only state the release touches.** The settings keep the values the external system pushed last — the release states who maintains them from now on, not what they should be.
- **`last_updated`** is not advanced, because `update_fields` excludes the `auto_now` field. This matches what the API endpoint does and is left as is.
- **The unsaved-warning interaction** applies to this button as it does to the delete button: with unsaved changes on the page, confirming triggers the native `beforeunload` dialog. Handled separately in #4560 / #4561, not here.

### Faithfulness to issue description and design

There are no intended deviations from the issue and design.

### How to test

1. Pick a test region and push settings to it via `POST /api/v3/<slug>/settings/` with a personal API token of a user holding `cms.change_region`. Use a budget that is **not** one of the package sizes, for example `{"mt_budget_booked": 77777}`.
2. Open the region form. The yellow banner appears, the synced fields are read-only, and the budget shows 77777.
3. Click "Edit these settings here again" and confirm.
4. The banner is gone, the fields are editable, and every value is unchanged — including the budget.
5. Save the form once without touching the budget, then reload: the budget must still be 77777. (Before this PR it became 50000 here.)
6. Push again via the API and verify the region is locked once more.

Also worth checking as a non-privileged user: without `cms.change_region` the button is not rendered and a direct `POST` returns 403.

### Resolved issues

Fixes: #4558

---

**Testing:** full suite through `./tools/test.sh` (the CI-mirroring container): 4822 passed, 2 skipped, 1 xfailed. `ruff check`, `ruff format`, `djlint` and `mypy` clean; no empty or fuzzy translation entries.

**Note on the translation file:** it contains one hunk that is not mine — a rewrap of an existing `text-blue-600` string. `makemessages` produces it in the CI image, and the workflow passed with it (`check-translations` included), so it is what CI expects rather than drift against it. Resetting the file to `develop` and regenerating reproduces the rewrap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
