### PR TITLE
Do not let the unsaved-warning cancel a confirmed action

### DIFF
--- a/integreat_cms/release_notes/current/unreleased/4560.yml
+++ b/integreat_cms/release_notes/current/unreleased/4560.yml
@@ -1,0 +1,2 @@
+en: Fix a confirmed action being cancelled silently when the page had unsaved changes
+de: Behebe, dass eine bestätigte Aktion stillschweigend abgebrochen wurde, wenn die Seite ungespeicherte Änderungen hatte

--- a/integreat_cms/static/src/js/__tests__/unsaved-warning.test.ts
+++ b/integreat_cms/static/src/js/__tests__/unsaved-warning.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { expect, test } from "vitest";
+
+/**
+ * Dispatch a cancelable beforeunload event and report whether the warning kicked in.
+ */
+const warningShown = (): boolean => {
+    const event = new Event("beforeunload", { cancelable: true });
+    window.dispatchEvent(event);
+    return event.defaultPrevented;
+};
+
+test("a confirmed action is not interrupted by the unsaved-warning", async () => {
+    document.body.innerHTML = `
+        <form data-unsaved-warning>
+            <input id="field" type="text" />
+        </form>
+        <div id="confirmation-dialog">
+            <form id="confirmation-form" method="post"></form>
+        </div>
+    `;
+
+    // Registers the beforeunload handler and, on load, the form listeners
+    await import("../unsaved-warning");
+    window.dispatchEvent(new Event("load"));
+
+    expect(warningShown()).toBe(false);
+
+    // The user edits something
+    document.getElementById("field").dispatchEvent(new Event("input", { bubbles: true }));
+    expect(warningShown()).toBe(true);
+
+    // The user triggers a confirmation button and confirms. The dialog is a separate form, so
+    // without clearing the flag the browser would ask a second time -- and staying on the page
+    // would silently swallow the action the user just confirmed.
+    document.getElementById("confirmation-form").dispatchEvent(new Event("submit", { bubbles: true }));
+    expect(warningShown()).toBe(false);
+});

--- a/integreat_cms/static/src/js/unsaved-warning.ts
+++ b/integreat_cms/static/src/js/unsaved-warning.ts
@@ -37,4 +37,12 @@ window.addEventListener("load", () => {
         dirty = false;
         console.debug("Autosave, disabled beforeunload warning");
     });
+    // A confirmed action navigates away by submitting the confirmation dialog, which is a
+    // separate form — so the submit listener above never fires. Without this the browser would
+    // ask a second time, and staying on the page would silently swallow an action the user has
+    // just explicitly confirmed.
+    document.querySelector("#confirmation-dialog form")?.addEventListener("submit", () => {
+        dirty = false;
+        console.debug("confirmation dialog submitted, disabled beforeunload warning");
+    });
 });


### PR DESCRIPTION
### Short description

Clears the unsaved-warning flag when the confirmation dialog is submitted, so a confirmed action is no longer cancelled silently by the browser's `beforeunload` prompt.

### Proposed changes

- `unsaved-warning.ts` now also clears `dirty` on `submit` of `#confirmation-dialog form`, next to the existing `autosave` listener that exists for the same class of reason.
- A vitest test drives the actual sequence in jsdom — edit a field, confirm the dialog, unload — and asserts the warning appears after the edit and is gone after the confirmation.
- Release note `4560.yml`.

### Side effects

- **Affects every `confirmation-button`, not just one page.** Deleting a region, deleting a page, discarding an offer embedding: after this PR none of them is interrupted by a second browser prompt. That is the intent, and it applies repo-wide.
- **The warning itself is unchanged** for the ordinary case: editing a field and navigating away without saving and without a confirmation still warns.
- **Typed edits are still discarded** when a confirmed action navigates away — that has always been the case. The difference is that it now happens without a prompt that could cancel the confirmed action.
- **No new dependency.** jsdom is already present, and the module needed no refactoring to be testable.

### Faithfulness to issue description and design

There are no intended deviations from the issue and design. The fix is the one proposed in #4560.

### How to test

1. Open the region form of any region as a user with `cms.change_region`
2. Change any field, for example the region name — do **not** save
3. Click "Delete this region" and confirm in the dialog
4. The deletion happens on the first confirmation; no `beforeunload` prompt appears

Regression check, so the warning is not lost altogether:

5. Change a field again and navigate away via the menu without confirming anything
6. The warning must still appear

### Resolved issues

Fixes: #4560

---

**Testing:** all 3 vitest files pass, `eslint` and `prettier` clean, webpack bundle builds. Counter-check: without the new listener the test fails with `expected true to be false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
