### PR TITLE
Fix flaky test: `test_api_raw_content.py::test_api_result`

### DIFF
--- a/docs/src/testing.rst
+++ b/docs/src/testing.rst
@@ -267,23 +267,45 @@ Common Pitfalls
 2. **Don't use** ``serialized_rollback=True`` — it has FK ordering issues
    with PostgreSQL. Use ``load_test_data_transactional`` instead.
 
-3. **Clean up state you attach to session-scoped fixtures** — database changes
-   are rolled back after every non-transactional test, but the Python objects
-   returned by session-scoped fixtures are not: they live for the whole worker
-   process. The most common case is the ``Client`` returned by
-   ``login_role_user``, whose cookies survive the test that set them::
+3. **Watch for state that outlives the per-test DB rollback** — database
+   changes are rolled back after every non-transactional test, but not
+   everything a test touches lives in the database. Two recurring cases,
+   with opposite fixes:
 
-       @pytest.mark.django_db
-       def test_pagination_cookie(login_role_user):
-           client, role = login_role_user
-           client.cookies["page_size"] = "50"
-           try:
-               ...
-           finally:
-               client.cookies.pop("page_size", None)
+   a. **Objects returned by a session-scoped fixture** are not reset between
+      tests — they live for the whole worker process. The most common case
+      is the ``Client`` returned by ``login_role_user``, whose cookies
+      survive the test that set them. There is no framework mechanism for
+      this, so clean up manually::
 
-   The same applies to anything else cached in the fixture's return value —
-   only the rows it points at are reset between tests, not the object itself.
+          @pytest.mark.django_db
+          def test_pagination_cookie(login_role_user):
+              client, role = login_role_user
+              client.cookies["page_size"] = "50"
+              try:
+                  ...
+              finally:
+                  client.cookies.pop("page_size", None)
+
+      The same applies to anything else cached in the fixture's return
+      value — only the rows it points at are reset between tests, not the
+      object itself.
+
+   b. **Django settings** must be changed through the ``settings`` fixture,
+      never ``from django.conf import settings; settings.X = value``. Here a
+      framework mechanism *does* exist — the fixture restores the original
+      value after the test regardless of outcome — so the bug is bypassing
+      it, not forgetting to clean up by hand. This is especially dangerous
+      for ``LANGUAGE_CODE``: a view with ``lang: str = settings.LANGUAGE_CODE``
+      as a default argument bakes in whatever value is live *the first time
+      that module is imported*, which happens lazily on the first URL
+      resolution of the worker — i.e. whatever an earlier, unrelated test
+      last (mis)set it to::
+
+          @pytest.mark.django_db
+          def test_something(settings):
+              settings.LANGUAGE_CODE = "en"
+              ...
 
 4. **Import role constants from** ``tests.constants``, not ``tests.conftest``.
 

--- a/integreat_cms/api/v3/raw_content.py
+++ b/integreat_cms/api/v3/raw_content.py
@@ -100,7 +100,7 @@ def get_content(
 @partial_content_response
 def root_content(
     request: HttpRequest,
-    language_slug: str = settings.LANGUAGE_CODE,
+    language_slug: str | None = None,
 ) -> HttpResponse:
     """
     Renders the raw HTML content for a root page
@@ -110,7 +110,10 @@ def root_content(
 
     :return: Raw HTML content of the root page
     """
-    language = get_object_or_404(Language, slug=language_slug)
+    language = get_object_or_404(
+        Language,
+        slug=language_slug or settings.LANGUAGE_CODE,
+    )
     title = language.social_media_webapp_title or settings.BRANDING_TITLE
 
     return render(

--- a/tests/api/test_api_raw_content.py
+++ b/tests/api/test_api_raw_content.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from collections.abc import Callable
 
+    from pytest_django import Settings
+
 import pytest
 from django.core.cache import cache
 from django.test.client import Client
@@ -59,6 +61,7 @@ def _create_push_notification(
 def test_api_result(
     load_test_data: None,
     django_assert_num_queries: Callable,
+    settings: Settings,
     endpoint: str,
     expected_result: str,
     expected_code: int,
@@ -71,11 +74,15 @@ def test_api_result(
 
     :param load_test_data: The fixture providing the test data (see :meth:`~tests.conftest.load_test_data`)
     :param django_assert_num_queries: The fixture providing the query assertion
+    :param settings: The fixture providing the django settings
     :param endpoint: The url of the new Django pattern
     :param expected_result: The path to the html file that contains the expected result
     :param expected_code: The expected HTTP status code
     :param expected_queries: The expected number of SQL queries
     """
+    # Other tests might raw-mutate settings.LANGUAGE_CODE without restoring it; pin it
+    # explicitly since /api/v3/raw-content/ relies on the default language.
+    settings.LANGUAGE_CODE = "de"
     client = Client()
     with django_assert_num_queries(expected_queries):
         response = client.get(endpoint, format="html")

--- a/tests/cms/models/chat/test_user_chat.py
+++ b/tests/cms/models/chat/test_user_chat.py
@@ -1,11 +1,17 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pytest_django import Settings
+
 import pytest
-from django.conf import settings
 
 from integreat_cms.cms.models import UserChat
 
 
 @pytest.mark.django_db
-def test_update_mt_budget(load_test_data: None) -> None:
+def test_update_mt_budget(load_test_data: None, settings: Settings) -> None:
     """
     Test if words are being correctly added to the used MT budget and chat word count
     in :meth:`~integreat_cms.cms.models.chat.user_chat.Chat.update_mt_budget`
@@ -13,7 +19,6 @@ def test_update_mt_budget(load_test_data: None) -> None:
     # Set custom setting for test
     WORDS_GENERATED = 155
     CUSTOM_BUDGET_WEIGHT = 5
-    budget_weight_before = settings.INTEGREAT_CHAT_BUDGET_WEIGHT
     settings.INTEGREAT_CHAT_BUDGET_WEIGHT = CUSTOM_BUDGET_WEIGHT
 
     chat = UserChat.objects.get(pk=1)
@@ -34,6 +39,3 @@ def test_update_mt_budget(load_test_data: None) -> None:
     chat.save()
     assert chat.region.mt_budget_used == mt_budget_before
     assert chat.total_words_generated == total_words_generated_before
-
-    # Reset setting
-    settings.INTEGREAT_CHAT_BUDGET_WEIGHT = budget_weight_before

--- a/tests/cms/views/contacts/test_contact_from_existing_data.py
+++ b/tests/cms/views/contacts/test_contact_from_existing_data.py
@@ -1,6 +1,12 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from django.test.client import Client
+    from pytest_django import Settings
+
 import pytest
-from django.conf import settings
-from django.test.client import Client
 from django.urls import reverse
 
 from tests.constants import ANONYMOUS
@@ -10,6 +16,7 @@ from tests.constants import ANONYMOUS
 def test_suggest_contacts_is_shown(
     load_test_data: None,
     login_role_user: tuple[Client, str],
+    settings: Settings,
 ) -> None:
     settings.LANGUAGE_CODE = "en"
     client, role = login_role_user


### PR DESCRIPTION
### Short description
<!-- Describe this PR in one or two sentences. -->
The test ` test_api_raw_content.py::test_api_result` flakes on the CI (for example here: https://app.circleci.com/pipelines/github/digitalfabrik/integreat-cms?branch=develop ) , because it relies on the default language being set to German, but there is one other test - which if run before that test cause it to fail -, that falsely mutate settings.LANGUAGE_CODE, instead of using the settings fixture, which is not reset between tests. Also the endpoint `root_content` bakes in the default for the language_slug into the function signature, instead of loading it freshly during runtime.

### Proposed changes
<!-- Describe this PR in more detail. -->

- Fix root_content baking a stale settings.LANGUAGE_CODE into its default
- Use settings fixture instead of directly mutating django.conf.settings 
- explicitly set default language for the flaky test on the settings fixture
- add a 'Common Pitfalls' paragraph to the documentation


### Side effects
<!-- List all related components that have not been explicitly changed but may be affected by this PR -->

- None


### Faithfulness to issue description and design
<!-- If the implementation is different from the issue description and design, replace the following with an explaination why. -->
There are no intended deviations from the issue and design.


### How to test
<!-- Non-trivial prerequisites and notes on how to test this
     (e.g. specific environment variables and settings to be set, and things to pay attention to) -->
Observer over the next 20 or so pipeline runs, that the test wont fail again. 


### Resolved issues
<!-- List all issues which should be closed when this PR is merged. -->

Fixes: 


__________________________________________________
<!-- Keep this link for the potential reviewer -->
[Pull Request Review Guidelines](https://digitalfabrik.github.io/integreat-cms/pull-request-review-guide.html)
